### PR TITLE
Allow hannk-delegate input and output tensors to share memory with tflite

### DIFF
--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -10,6 +10,7 @@
 #include "tensorflow/lite/builtin_ops.h"
 #include "tensorflow/lite/c/builtin_op_data.h"
 #include "tensorflow/lite/c/c_api.h"
+#include "tensorflow/lite/context_util.h"
 #include "util/error_util.h"
 
 // Use a List-Of-X approach here to ensure that places we handle ops are kept in sync
@@ -52,6 +53,8 @@
 
 namespace hannk {
 namespace {
+
+using tflite::TfLiteIntArrayView;
 
 constexpr char kDelegateName[] = "HannkDelegate";
 constexpr int kDelegateVersion = 1;
@@ -228,7 +231,9 @@ TensorPtr ConvertTfLiteTensor(const TfLiteTensor &tensor) {
         HalideBuffer<void> buffer(type, const_cast<void *>(read_only_data), shape);
         assert(tensor.bytes == buffer.size_in_bytes());
 
-        return std::make_shared<Tensor>(name, std::move(buffer), std::move(quantization));
+        auto p = std::make_shared<Tensor>(name, std::move(buffer), std::move(quantization));
+        p->set_constant();
+        return p;
     }
 
     // Create an "unallocated" Buffer, which points to null.
@@ -245,8 +250,7 @@ public:
     }
 
     // Init() will be called exactly once per instance.
-    TfLiteStatus Init(TfLiteContext *context,
-                      const TfLiteDelegateParams *params) {
+    TfLiteStatus Init(TfLiteContext *context, const TfLiteDelegateParams *params) {
         if (options_.verbosity >= 1) {
             HLOG(INFO) << "Delegate " << (void *)this << " Init\n";
         }
@@ -359,15 +363,37 @@ public:
             return kTfLiteDelegateError;
         }
 
+        // All inputs and outputs that aren't dynamic are marked as 'external',
+        // so that we can share memory between TFLite and Hannk. (Note that the
+        // TFLite Tensors haven't been allocated yet; we must update the host
+        // pointers in Eval.)
+        const auto set_external = [this, context](int tensor_id) {
+            assert(tensor_id != kTfLiteOptionalTensor);
+            auto t = GetTensorById(context, tensor_id);
+            if (!t->is_dynamic()) {
+                t->set_external();
+            }
+        };
+
+        // Mark all inputs and outputs as 'external'; we'll rely on TFLite
+        // to allocate the memory for these, and our internal hannk Tensors
+        // will shadow that memory, to save both space & copying time.
+        for (int tensor_id : TfLiteIntArrayView(node->inputs)) {
+            set_external(tensor_id);
+        }
+        for (int tensor_id : TfLiteIntArrayView(node->outputs)) {
+            set_external(tensor_id);
+        }
+
         interpreter_ = std::unique_ptr<Interpreter>(new Interpreter(std::move(model_)));
 
-        for (int i = 0; i < node->outputs->size; i++) {
-            const int tensor_id = node->outputs->data[i];
+        for (int tensor_id : TfLiteIntArrayView(node->outputs)) {
             if (tensor_id == kTfLiteOptionalTensor) {
                 continue;
             }
             auto t = GetTensorById(context, tensor_id);
             if (t && t->is_dynamic()) {
+                assert(!t->is_external());
                 if (options_.verbosity >= 2) {
                     HLOG(INFO) << "SetTensorToDynamic " << tensor_id;
                 }
@@ -390,42 +416,45 @@ public:
             return kTfLiteDelegateError;
         }
 
-        // Copy the non-constant Tensor inputs. TODO: avoid this by sharing pointers.
-        for (int i = 0; i < node->inputs->size; i++) {
-            const int tensor_id = node->inputs->data[i];
-            if (tensor_id == kTfLiteOptionalTensor) {
-                continue;
-            }
-            assert(tensor_id >= 0 && tensor_id < (int)context->tensors_size);
-            const TfLiteTensor &tensor = context->tensors[tensor_id];
+        const auto set_host = [this, context](int tensor_id) {
+            assert(tensor_id != kTfLiteOptionalTensor);
             auto t = GetTensorById(context, tensor_id);
-            assert(t->is_constant() == IsConstantTensor(tensor));
-            if (t->is_constant()) {
-                continue;
+            if (t->is_external()) {
+                assert(!t->is_dynamic());
+                TfLiteTensor &tensor = context->tensors[tensor_id];
+                // TODO: should this be upgraded to a runtime-check-and-return-error?
+                assert(t->buffer().size_in_bytes() == tensor.bytes);
+                // We must reset it every time, as the tensor's data pointer
+                // can vary between calls in some scenatrios.
+                t->set_external_host(tensor.data.data);
             }
-            assert(t->is_input() && !t->is_constant() && t->is_allocated());
-            auto buf = t->buffer();
-            assert(buf.size_in_bytes() == tensor.bytes);
-            memcpy(buf.data(), tensor.data.data, tensor.bytes);
+        };
+
+        for (int tensor_id : TfLiteIntArrayView(node->inputs)) {
+            set_host(tensor_id);
+        }
+        for (int tensor_id : TfLiteIntArrayView(node->outputs)) {
+            set_host(tensor_id);
         }
 
         // TODO: execute needs to return an error code.
         interpreter_->execute();
 
-        // Copy the Tensor outputs. TODO: avoid this by sharing pointers.
-        for (int i = 0; i < node->outputs->size; i++) {
-            const int tensor_id = node->outputs->data[i];
-            if (tensor_id == kTfLiteOptionalTensor) {
-                continue;
-            }
-            assert(tensor_id >= 0 && tensor_id < (int)context->tensors_size);
-            TfLiteTensor &tensor = context->tensors[tensor_id];
-            assert(!IsConstantTensor(tensor));
+        // Dynamic tensors can't share their memory, because we didn't
+        // necessarily know the size until the pipeline was executed,
+        // so we need to resize the TFLite tensor and copy the data
+        // back over. This is regrettable, but dynamic tensors tend to
+        // to be uncommon.
+        for (int tensor_id : TfLiteIntArrayView(node->outputs)) {
+            assert(tensor_id != kTfLiteOptionalTensor);
             auto t = GetTensorById(context, tensor_id);
-            assert(t->is_output() && !t->is_constant() && t->is_allocated());
             if (t->is_dynamic()) {
-                HCHECK(IsDynamicTensor(tensor));
+                TfLiteTensor &tensor = context->tensors[tensor_id];
+                assert(IsDynamicTensor(tensor));
                 const Box b = t->bounds();
+                if (options_.verbosity >= 2) {
+                    HLOG(INFO) << "ResizeTensor " << tensor_id << " to " << b;
+                }
                 TfLiteIntArray *new_size = TfLiteIntArrayCreate((int)b.size());
                 for (size_t i = 0; i < b.size(); i++) {
                     new_size->data[b.size() - i - 1] = b[i].extent();
@@ -436,13 +465,13 @@ public:
                     TF_LITE_KERNEL_LOG(context, "ResizeTensor() failed:", status);
                     return status;
                 }
-            }
-            auto buf = t->buffer();
-            assert(tensor.data.data != nullptr);
-            assert(buf.data() != nullptr);
-            assert(buf.size_in_bytes() == tensor.bytes);
+                auto buf = t->buffer();
+                assert(tensor.data.data != nullptr);
+                assert(buf.data() != nullptr);
+                assert(buf.size_in_bytes() == tensor.bytes);
 
-            memcpy(tensor.data.data, buf.data(), tensor.bytes);
+                memcpy(tensor.data.data, buf.data(), tensor.bytes);
+            }
         }
 
         // Eval() could be called again with the same graph -- don't destroy the interpreter_ yet.
@@ -693,6 +722,7 @@ private:
             if (params) {
                 HalideBuffer<int32_t> shape_data(const_cast<int32_t *>(params->shape), params->num_dimensions);
                 shape_tensor = std::make_shared<Tensor>(input->name() + "_shape", shape_data);
+                shape_tensor->set_constant();
             }
         }
         return make_op<ReshapeOp>(input, shape_tensor, output);

--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -93,9 +93,11 @@ bool IsConstantTensor(const TfLiteTensor &tensor) {
     return tensor.allocation_type == kTfLiteMmapRo;
 }
 
+#ifndef NDEBUG
 bool IsDynamicTensor(const TfLiteTensor &tensor) {
     return tensor.allocation_type == kTfLiteDynamic;
 }
+#endif
 
 void SetTensorToDynamic(TfLiteContext *context, int tensor_id) {
     TfLiteTensor &tensor = context->tensors[tensor_id];

--- a/apps/hannk/interpreter/interval.h
+++ b/apps/hannk/interpreter/interval.h
@@ -154,6 +154,18 @@ public:
     }
 };
 
+template<typename T, size_t Capacity>
+inline std::ostream &operator<<(std::ostream &s, const SmallVector<T, Capacity> &v) {
+    s << "{";
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (i > 0) {
+            s << ", ";
+        }
+        s << v[i];
+    }
+    return s << "}";
+}
+
 // Compute a / b, rounding down.
 inline int floor_div(int a, int b) {
     assert(a >= 0 && b >= 0);

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -78,6 +78,12 @@ bool maybe_alias_tensors(TensorPtr input, TensorPtr output, SmallVector<int, max
         return false;
     }
 
+    // If either tensor is external, can't alias them.
+    // TODO: maybe we can, but it's not clear how to update storage_.host in that case?
+    if (input->is_external() || output->is_external()) {
+        return false;
+    }
+
     if (input->rank() != output->rank()) {
         // TODO: We should be able to alias reshapes.
         return false;
@@ -238,6 +244,7 @@ class PadForOps : public OpVisitor {
             padding_data(1, r - i - 1) = (required[i].extent() - input->extent(i) + 1) / 2;
         }
         TensorPtr padding = std::make_shared<Tensor>(input->name() + "_padding", padding_data);
+        padding->set_constant();
 
         // Add the new tensor, op, and update the input.
         OpPtr pad = make_op<PadOp>(input, padding, padded);

--- a/apps/hannk/tflite/tflite_parser.cpp
+++ b/apps/hannk/tflite/tflite_parser.cpp
@@ -126,7 +126,9 @@ public:
                 HalideBuffer<void> buffer(type, const_cast<void *>(data), shape);
                 assert(tflite_buffer->size() == buffer.size_in_bytes());
 
-                return make_op<Tensor>(t->name()->str(), std::move(buffer), std::move(quantization));
+                auto p = make_op<Tensor>(t->name()->str(), std::move(buffer), std::move(quantization));
+                p->set_constant();
+                return p;
             }
         }
 
@@ -277,6 +279,7 @@ public:
                 shape_data(i) = options->new_shape()->Get(i);
             }
             shape_tensor = std::make_shared<Tensor>(input->name() + "_shape", shape_data);
+            shape_tensor->set_constant();
         }
         return make_op<ReshapeOp>(input, shape_tensor, output);
     }


### PR DESCRIPTION
We previously allocated duplicate memory buffers for the input and output tensors, and just copied them back and forth as needed, which wastes memory and cycles.

Now, we declare the input and output tensors to be 'external', and update the host pointer before every interpreter run.

Note that dynamic tensors are still a bit of a special case: we still do duplicate allocations there (plus memcpy), because in the most general case we can't know the final size needed until we run the pipeline, but we need to allocate that output to run the pipeline. There are ways we could finesse this -- e.g., give dynamic tensors a lambda callback to allow them to resize the TFLite tensor and then use that storage -- but since dynamic tensors don't seem to be common or large in our test cases, I'm doing it this way for now. (I may circle back and try the lambda approach later.)

Note that this moves the implicit init of `is_constant_` out of the Tensor ctor, and instead always requires an explicit call to `set_constant()`, which I think makes the situation much clearer.