### PR TITLE
Invaldiate alignment info if the type can't represent it

### DIFF
--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -20,6 +20,10 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
             }
             bounds->max_defined = false;
         }
+        if (!op->type.can_represent(bounds->alignment.modulus) ||
+            !op->type.can_represent(bounds->alignment.remainder)) {
+            bounds->alignment = ModulusRemainder();
+        }
     }
 
     if (may_simplify(op->type) && may_simplify(op->value.type())) {


### PR DESCRIPTION
Fixes #6029