### PR TITLE
Fix Windows ZIP package script.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,7 +98,8 @@
         "BUILD_SHARED_LIBS": "YES",
         "CMAKE_INSTALL_BINDIR": "bin/$<CONFIG>",
         "CMAKE_INSTALL_LIBDIR": "lib/$<CONFIG>",
-        "Halide_INSTALL_CMAKEDIR": "lib/cmake/Halide"
+        "Halide_INSTALL_CMAKEDIR": "lib/cmake/Halide",
+        "Halide_INSTALL_HELPERSDIR": "lib/cmake/HalideHelpers"
       }
     },
     {

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -6,10 +6,10 @@ include(CMakePackageConfigHelpers)
 ##
 
 set(Halide_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/Halide"
-    CACHE STRING "Path to Halide cmake files")
+    CACHE STRING "Path to Halide CMake files")
 
 set(Halide_INSTALL_HELPERSDIR "${CMAKE_INSTALL_LIBDIR}/cmake/HalideHelpers"
-    CACHE STRING "Path to Halide cmake files")
+    CACHE STRING "Path to Halide platform-independent CMake files")
 
 set(Halide_INSTALL_PLUGINDIR "${CMAKE_INSTALL_LIBDIR}"
     CACHE STRING "Path to Halide plugins folder")


### PR DESCRIPTION
Skipping buildbots because the testbranch builders don't run the package scripts.