### PR TITLE
Allow negative output shifts in depthwise_conv

### DIFF
--- a/apps/hannk/halide/depthwise_conv_generator.cpp
+++ b/apps/hannk/halide/depthwise_conv_generator.cpp
@@ -37,7 +37,7 @@ public:
     Input<int> dilation_y_{"dilation_y"};
 
     Input<int32_t> output_multiplier_{"output_multiplier"};
-    Input<uint32_t> output_shift_{"output_shift"};
+    Input<int32_t> output_shift_{"output_shift"};
     Input<uint8_t> output_zero_{"output_zero"};
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -814,7 +814,6 @@ void depthwise_conv_uint8(
     halide_buffer_t *input, halide_buffer_t *filter, halide_buffer_t *bias,
     int depth_multiplier, const MultiplyParams &params, const std::array<int, 2> &stride, const std::array<int, 2> &dilation,
     const Interval &output_range, halide_buffer_t *output) {
-    assert(params.c.exponent() <= 0);
     if (depth_multiplier >= output->dim[0].extent) {
         depthwise_conv_broadcast_uint8(
             input, (uint8_t)params.a_zero, filter, (uint8_t)params.b_zero, bias, depth_multiplier,


### PR DESCRIPTION
At least one tflite model found in the wild uses this, so we must support it.