### PR TITLE
Upgrade d8 version for wasm testing

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -73,9 +73,14 @@ if (WITH_WASM_SHELL)
     # this might be a canary version (if needed to get the updates to v8 that we need)
     # but should be carefully tested before landing.
     #
-    # Note that V8 8.9.238 is the first version claiming to implement the final simd spec;
+    # Note that V8 9.1+ is apparently first version of V8/D8 that really does properly
+    # implement the final WASM SIMD spec; versions 8.9 and 9.0 weren't quite complete
+    # (there were some opcode renumberings) so they should be specifically avoided.
+    # As of this writing, v9.1 is still in beta; the shell version below should be updated
+    # to a proper release version (vs canary) once it is final.
+    #
     # see https://github.com/WebAssembly/simd/blob/master/proposals/simd/ImplementationStatus.md
-    set(WASM_SHELL_VERSION 8.9.238)
+    set(WASM_SHELL_VERSION 9.1.269)
     set(WASM_SHELL_URL "https://storage.googleapis.com/chromium-v8/official/canary/v8-${WASM_SHELL_PLATFORM}-rel-${WASM_SHELL_VERSION}.zip")
     message(STATUS "Fetching WASM_SHELL ${WASM_SHELL_URL}...")
     FetchContent_Declare(wasm_shell URL "${WASM_SHELL_URL}")


### PR DESCRIPTION
We were using a variant of v8.9, but various late-breaking variations in the final spec implementation didn't make it into V8 until v9.1; using top-of-tree LLVM and EMCC require v9.1+ to avoid obscure errors.