### PR TITLE
Strengthen constant upper bound logic slightly

### DIFF
--- a/src/BoundSmallAllocations.cpp
+++ b/src/BoundSmallAllocations.cpp
@@ -89,6 +89,9 @@ class BoundSmallAllocations : public IRMutator {
             bool found_non_constant_extent = false;
             for (Range &r : region) {
                 Expr bound = find_constant_bound(r.extent, Direction::Upper, scope);
+                // We can allow non-constant extents for now, as long as all
+                // remaining dimensions are 1 (so the stride is unused, which
+                // will be non-constant).
                 user_assert(!found_non_constant_extent || is_const_one(bound))
                     << "Was unable to infer constant upper bound on extent of realization "
                     << op->name << ". Use Func::bound_extent to specify it manually.";

--- a/src/BoundSmallAllocations.cpp
+++ b/src/BoundSmallAllocations.cpp
@@ -86,12 +86,14 @@ class BoundSmallAllocations : public IRMutator {
         if (must_be_constant(op->memory_type)) {
             Region region = op->bounds;
             bool changed = false;
+            bool found_non_constant_extent = false;
             for (Range &r : region) {
                 Expr bound = find_constant_bound(r.extent, Direction::Upper, scope);
-                user_assert(bound.defined())
-                    << "Was unable to infer constant upper bound on extent of allocation "
+                user_assert(!found_non_constant_extent || is_const_one(bound))
+                    << "Was unable to infer constant upper bound on extent of realization "
                     << op->name << ". Use Func::bound_extent to specify it manually.";
-                if (!bound.same_as(r.extent)) {
+                found_non_constant_extent = found_non_constant_extent || !bound.defined();
+                if (bound.defined() && !bound.same_as(r.extent)) {
                     r.extent = bound;
                     changed = true;
                 }


### PR DESCRIPTION
This allows more code to compile without an error about lacking constant bounds for `MemoryType::Register` by relaxing the requirements a little. We now allow non-constant bound before storage flattening as long as there are no uses of the strides of the later dimensions. This allows us to potentially find a constant upper bound later in lowering, which is more likely due to extra simplification.

This also more aggressively simplifies the bounds from allocation bounds inference.