### PR TITLE
Rework cross-compiling integration test to use simpler two-stage build

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -123,6 +123,7 @@ if (CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
 
     add_test(NAME cross_compile_aarch64
              COMMAND
+             tree &&
              ${CMAKE_CTEST_COMMAND}
              --build-and-test "${CMAKE_CURRENT_LIST_DIR}/xc" "${CMAKE_CURRENT_BINARY_DIR}/xc-aarch64"
              --build-generator Ninja

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -129,5 +129,9 @@ if (CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
              --build-options
              -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_LIST_DIR}/../../cmake/toolchain.linux-aarch64.cmake
              -DCMAKE_BUILD_TYPE=Release
+             -Dxc-generators_ROOT="${CMAKE_CURRENT_BINARY_DIR}/xc-host"
              --test-command ${CMAKE_CTEST_COMMAND} --output-on-failure)
+
+    set_tests_properties(cross_compile_host PROPERTIES FIXTURES_SETUP xc-host)
+    set_tests_properties(cross_compile_aarch64 PROPERTIES FIXTURES_REQUIRED xc-host)
 endif ()

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -123,14 +123,13 @@ if (CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
 
     add_test(NAME cross_compile_aarch64
              COMMAND
-             tree &&
              ${CMAKE_CTEST_COMMAND}
              --build-and-test "${CMAKE_CURRENT_LIST_DIR}/xc" "${CMAKE_CURRENT_BINARY_DIR}/xc-aarch64"
              --build-generator Ninja
              --build-options
              -DCMAKE_TOOLCHAIN_FILE=${CMAKE_CURRENT_LIST_DIR}/../../cmake/toolchain.linux-aarch64.cmake
              -DCMAKE_BUILD_TYPE=Release
-             -Dxc-generators_ROOT="${CMAKE_CURRENT_BINARY_DIR}/xc-host"
+             "-Dxc-generators_ROOT=${CMAKE_CURRENT_BINARY_DIR}/xc-host"
              --test-command ${CMAKE_CTEST_COMMAND} --output-on-failure)
 
     set_tests_properties(cross_compile_host PROPERTIES FIXTURES_SETUP xc-host)

--- a/test/integration/xc/CMakeLists.txt
+++ b/test/integration/xc/CMakeLists.txt
@@ -1,59 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
-project(xc LANGUAGES NONE)
+project(xc)
 
 enable_testing()
 
-if (NOT CMAKE_CROSSCOMPILING)
-    # There is a bug with CTest's build-and-test that forwards environment
-    # variables, such as those set by the toolchain, to child processes. By
-    # not enabling CXX in the cross-compiling scenario, we can work around
-    # this bug. The alternative would be to not use build-and-test in the
-    # testing code, but it's used in every other location. This approach
-    # also has the benefit of being marginally faster because it doesn't
-    # waste a few seconds detecting a compiler that won't be used.
-    # https://gitlab.kitware.com/cmake/cmake/-/issues/22043
-    enable_language(CXX)
-
-    # Do things the easy way when not cross compiling
-    add_subdirectory(generators)
-    add_subdirectory(add)
+if (CMAKE_CROSSCOMPILING)
+    find_package(xc-generators REQUIRED)
 else ()
-    # When cross compiling, use ExternalProject to stage building the
-    # generators with a host toolchain before passing the resulting
-    # package to the library build, which will use the target toolchain.
-    include(ExternalProject)
-
-    set(xc_HOST_TOOLCHAIN_FILE ""
-        CACHE FILEPATH "Toolchain file to use when compiling generators")
-
-    ExternalProject_Add(
-            generators
-            SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/generators"
-            INSTALL_COMMAND ""
-            BUILD_ALWAYS YES
-            CMAKE_ARGS
-            -DCMAKE_TOOLCHAIN_FILE=${xc_HOST_TOOLCHAIN_FILE}
-            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-    )
-
-    ExternalProject_Get_Property(generators BINARY_DIR)
-
-    ExternalProject_Add(
-            add
-            SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/add"
-            INSTALL_COMMAND ""
-            BUILD_ALWAYS YES
-            CMAKE_ARGS
-            -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-            -Dxc-generators_ROOT=${BINARY_DIR}
-    )
-
-    ExternalProject_Add_StepDependencies(add configure generators)
-
-    ExternalProject_Get_Property(add BINARY_DIR)
-
-    add_test(NAME run-tests
-             COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-             WORKING_DIRECTORY ${BINARY_DIR})
+    add_subdirectory(generators)
 endif ()
+
+add_subdirectory(add)

--- a/test/integration/xc/add/CMakeLists.txt
+++ b/test/integration/xc/add/CMakeLists.txt
@@ -1,54 +1,13 @@
-cmake_minimum_required(VERSION 3.16)
-project(xc-add)
-
-enable_testing()
-
-##
-## Dependencies
-##
-
-if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    # Need to load generators from stage when cross compiling
-    find_package(xc-generators REQUIRED)
-endif ()
-
+# Only need the platform-independent / source-only helpers.
 find_package(HalideHelpers REQUIRED)
-
-##
-## Generate library
-##
 
 add_halide_library(add FROM xc::add_gen
                    TARGETS cmake
                    REGISTRATION add_reg_cpp)
 add_library(xc::add ALIAS add)
 
-##
-## Helper runner
-##
-
 add_executable(run_add ${add_reg_cpp})
 target_link_libraries(run_add PRIVATE add Halide::RunGenMain)
 
-##
-## Test helper
-##
-
 add_test(NAME run_add
          COMMAND run_add --output_extents=[10,10] --benchmarks=all)
-
-##
-## Installation
-##
-
-include(GNUInstallDirs)
-
-set(xc-add_INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATADIR}/cmake/xc-add"
-    CACHE PATH "Path to CMake files")
-
-install(TARGETS add add.runtime
-        EXPORT xc-add-config)
-
-install(EXPORT xc-add-config
-        DESTINATION "${xc-add_INSTALL_CMAKEDIR}"
-        NAMESPACE xc::)

--- a/test/integration/xc/generators/CMakeLists.txt
+++ b/test/integration/xc/generators/CMakeLists.txt
@@ -21,4 +21,4 @@ target_link_libraries(add_gen PRIVATE Halide::Generator)
 
 export(TARGETS add_gen
        NAMESPACE xc::
-       FILE "${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/xc-generators/xc-generators-config.cmake")
+       FILE "${CMAKE_BINARY_DIR}/share/xc-generators/xc-generators-config.cmake")


### PR DESCRIPTION
ExternalProject makes me sad. This gets rid of a lot of code without really making anything harder to use or more complex.

Skipping buildbots because this is only tested on GHA