### PR TITLE
Fix dubious "gather" intrinsic for hvx

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -2240,7 +2240,7 @@ class ScatterGatherGenerator : public IRMutator {
         Expr new_index = mutate(cast(ty.with_code(Type::Int), index));
         dst_index = mutate(dst_index);
 
-        return Call::make(ty, "gather", {std::move(dst_base), dst_index, src, size - 1, new_index},
+        return Call::make(ty, Call::hvx_gather, {std::move(dst_base), dst_index, src, size - 1, new_index},
                           Call::Intrinsic);
     }
 


### PR DESCRIPTION
I'm not sure if this is a bug (per se) or not, but: We define an intrinsic for `Call::hvx_gather`, and at several points check for `is_intrinsic(Call::hvx_gather)`, but we never actually create such a Call. Instead, `make_gather` just uses the naked string `"gather"`, which is not the same thing. How is this working? (Is it working?)

Opening this as a PR to gather input (no pun intended) about what's going on here.