### PR TITLE
Convert some Intrinsic calls to PureIntrinsic

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -277,7 +277,7 @@ class SloppyUnpredicateLoadsAndStores : public IRMutator {
                                    const_true(op->type.lanes()), op->alignment);
 
             return Call::make(op->type, Call::if_then_else,
-                              {condition, load, make_zero(op->type)}, Call::Intrinsic);
+                              {condition, load, make_zero(op->type)}, Call::PureIntrinsic);
         } else {
             // It's a predicated vector gather. Just scalarize. We'd
             // prefer to keep it in a loop, but that would require
@@ -287,7 +287,7 @@ class SloppyUnpredicateLoadsAndStores : public IRMutator {
             Expr load = Load::make(op->type, op->name, index, op->image, op->param,
                                    const_true(op->type.lanes()), op->alignment);
             return Call::make(op->type, Call::if_then_else,
-                              {predicate, load, make_zero(op->type)}, Call::Intrinsic);
+                              {predicate, load, make_zero(op->type)}, Call::PureIntrinsic);
         }
     }
 
@@ -2099,7 +2099,7 @@ void CodeGen_Hexagon::visit(const Select *op) {
         // Implement scalar conditions on vector values with if-then-else.
         value = codegen(Call::make(op->type, Call::if_then_else,
                                    {op->condition, op->true_value, op->false_value},
-                                   Call::Intrinsic));
+                                   Call::PureIntrinsic));
     } else {
         CodeGen_Posix::visit(op);
     }

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -464,7 +464,7 @@ Expr lower_euclidean_div(Expr a, Expr b) {
         if (!can_prove(!b_is_const_zero)) {
             b = b | cast(a.type(), b_is_const_zero);
         }
-        q = Call::make(a.type(), Call::div_round_to_zero, {a, b}, Call::Intrinsic);
+        q = Call::make(a.type(), Call::div_round_to_zero, {a, b}, Call::PureIntrinsic);
         q = select(b_is_const_zero, 0, q);
     } else {
         internal_assert(a.type().is_int());
@@ -506,7 +506,7 @@ Expr lower_euclidean_div(Expr a, Expr b) {
         // If a is negative, add one to it to get the rounding to work out.
         a -= a_neg;
         // Do the C-style division
-        q = Call::make(a.type(), Call::div_round_to_zero, {a, b}, Call::Intrinsic);
+        q = Call::make(a.type(), Call::div_round_to_zero, {a, b}, Call::PureIntrinsic);
         // If a is negative, either add or subtract one, depending on
         // the sign of b, to fix the rounding. This can't overflow,
         // because we move the result towards zero in either case (we
@@ -530,7 +530,7 @@ Expr lower_euclidean_mod(Expr a, Expr b) {
         if (!can_prove(!b_is_const_zero)) {
             b = b | cast(a.type(), b_is_const_zero);
         }
-        q = Call::make(a.type(), Call::mod_round_to_zero, {a, b}, Call::Intrinsic);
+        q = Call::make(a.type(), Call::mod_round_to_zero, {a, b}, Call::PureIntrinsic);
         q = select(b_is_const_zero, make_zero(a.type()), q);
     } else {
         internal_assert(a.type().is_int());
@@ -560,7 +560,7 @@ Expr lower_euclidean_mod(Expr a, Expr b) {
         // If a is negative, add one to get the rounding to work out
         a -= a_neg;
         // Do the mod, avoiding taking mod by zero
-        q = Call::make(a.type(), Call::mod_round_to_zero, {a, (b | b_zero)}, Call::Intrinsic);
+        q = Call::make(a.type(), Call::mod_round_to_zero, {a, (b | b_zero)}, Call::PureIntrinsic);
         // If a is negative, we either need to add b - 1 to the
         // result, or -b - 1, depending on the sign of b.
         q += (a_neg & ((b ^ b_neg) + ~b_neg));

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2373,7 +2373,7 @@ void CodeGen_LLVM::codegen_predicated_vector_load(const Load *op) {
         Expr pred_load = Call::make(load_expr.type(),
                                     Call::if_then_else,
                                     {op->predicate, load_expr, make_zero(load_expr.type())},
-                                    Internal::Call::Intrinsic);
+                                    Internal::Call::PureIntrinsic);
         value = codegen(pred_load);
     }
 }
@@ -2963,7 +2963,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             value = create_alloca_at_entry(halide_buffer_t_type, 1);
         } else {
             const int64_t *sz = as_const_int(op->args[0]);
-            internal_assert(sz);
+            internal_assert(sz != nullptr);
             if (op->type == type_of<struct halide_dimension_t *>()) {
                 value = create_alloca_at_entry(dimension_t_type, *sz / sizeof(halide_dimension_t));
             } else {

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -357,7 +357,7 @@ private:
                     // it's not exact.
                     debug(1)
                         << "Shared allocation for " << s.name
-                        << " has a size that is non-monontonic in the gpu block variable " << op->name
+                        << " has a size that is non-monotonic in the gpu block variable " << op->name
                         << ": " << s.size << "\n";
                     if (get_compiler_logger()) {
                         get_compiler_logger()->record_non_monotonic_loop_var(op->name, s.size);

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -58,7 +58,7 @@ Expr stringify(const std::vector<Expr> &args) {
     }
 
     return Internal::Call::make(type_of<const char *>(), Internal::Call::stringify,
-                                args, Internal::Call::Intrinsic);
+                                args, Internal::Call::PureIntrinsic);
 }
 
 Expr combine_strings(const std::vector<Expr> &args) {
@@ -1499,7 +1499,7 @@ Expr mux(const Expr &id, const std::vector<Expr> &values) {
     }
     std::vector<Expr> result{id};
     result.insert(result.end(), values.begin(), values.end());
-    return Internal::Call::make(t, Internal::Call::mux, result, Internal::Call::Intrinsic);
+    return Internal::Call::make(t, Internal::Call::mux, result, Internal::Call::PureIntrinsic);
 }
 
 Expr mux(const Expr &id, const Tuple &tup) {
@@ -1520,7 +1520,7 @@ Expr unsafe_promise_clamped(const Expr &value, const Expr &min, const Expr &max)
     return Internal::Call::make(value.type(),
                                 Internal::Call::unsafe_promise_clamped,
                                 {value, n_min_val, n_max_val},
-                                Internal::Call::Intrinsic);
+                                Internal::Call::PureIntrinsic);
 }
 
 namespace Internal {
@@ -1533,7 +1533,7 @@ Expr promise_clamped(const Expr &value, const Expr &min, const Expr &max) {
     return Internal::Call::make(value.type(),
                                 Internal::Call::promise_clamped,
                                 {value, n_min_val, n_max_val},
-                                Internal::Call::Intrinsic);
+                                Internal::Call::PureIntrinsic);
 }
 }  // namespace Internal
 
@@ -2509,7 +2509,7 @@ Expr div_round_to_zero(Expr x, Expr y) {
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::div_round_to_zero,
                                 {std::move(x), std::move(y)},
-                                Internal::Call::Intrinsic);
+                                Internal::Call::PureIntrinsic);
 }
 
 Expr mod_round_to_zero(Expr x, Expr y) {
@@ -2524,7 +2524,7 @@ Expr mod_round_to_zero(Expr x, Expr y) {
     Type t = x.type();
     return Internal::Call::make(t, Internal::Call::mod_round_to_zero,
                                 {std::move(x), std::move(y)},
-                                Internal::Call::Intrinsic);
+                                Internal::Call::PureIntrinsic);
 }
 
 Expr random_float(Expr seed) {

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1520,7 +1520,7 @@ Expr unsafe_promise_clamped(const Expr &value, const Expr &min, const Expr &max)
     return Internal::Call::make(value.type(),
                                 Internal::Call::unsafe_promise_clamped,
                                 {value, n_min_val, n_max_val},
-                                Internal::Call::PureIntrinsic);
+                                Internal::Call::Intrinsic);
 }
 
 namespace Internal {
@@ -1533,7 +1533,7 @@ Expr promise_clamped(const Expr &value, const Expr &min, const Expr &max) {
     return Internal::Call::make(value.type(),
                                 Internal::Call::promise_clamped,
                                 {value, n_min_val, n_max_val},
-                                Internal::Call::PureIntrinsic);
+                                Internal::Call::Intrinsic);
 }
 }  // namespace Internal
 

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -649,7 +649,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                 return Internal::Call::make(op->type,
                                             Call::if_then_else,
                                             {std::move(cond_value), std::move(true_value), std::move(false_value)},
-                                            Call::PureIntrinsic);
+                                            op->call_type);
             }
         }
     } else if (op->is_intrinsic(Call::mux)) {

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -649,7 +649,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
                 return Internal::Call::make(op->type,
                                             Call::if_then_else,
                                             {std::move(cond_value), std::move(true_value), std::move(false_value)},
-                                            op->call_type);
+                                            Call::PureIntrinsic);
             }
         }
     } else if (op->is_intrinsic(Call::mux)) {
@@ -690,7 +690,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         if (unchanged) {
             return op;
         } else {
-            return Call::make(op->type, Call::mux, mutated_args, op->call_type);
+            return Call::make(op->type, Call::mux, mutated_args, Call::PureIntrinsic);
         }
     } else if (op->call_type == Call::PureExtern) {
         // TODO: This could probably be simplified into a single map-lookup

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -457,7 +457,7 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name, bool trace_pipeline,
                 Internal::Call::make(type_of<const char *>(),
                                      Internal::Call::stringify,
                                      strings,
-                                     Internal::Call::Intrinsic);
+                                     Internal::Call::PureIntrinsic);
             s = Block::make(Evaluate::make(builder.build()), s);
         }
 

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -2102,10 +2102,10 @@ void check_unreachable() {
     check(IfThenElse::make(x != 0, Evaluate::make(unreachable()), not_no_op(y)),
           not_no_op(y));
 
-    check(y + Call::make(Int(32), Call::if_then_else, {x != 0, unreachable(), unreachable()}, Call::Intrinsic),
+    check(y + Call::make(Int(32), Call::if_then_else, {x != 0, unreachable(), unreachable()}, Call::PureIntrinsic),
           unreachable());
-    check(Call::make(Int(32), Call::if_then_else, {x != 0, y, unreachable()}, Call::Intrinsic), y);
-    check(Call::make(Int(32), Call::if_then_else, {x != 0, unreachable(), y}, Call::Intrinsic), y);
+    check(Call::make(Int(32), Call::if_then_else, {x != 0, y, unreachable()}, Call::PureIntrinsic), y);
+    check(Call::make(Int(32), Call::if_then_else, {x != 0, unreachable(), y}, Call::PureIntrinsic), y);
 
     check(Block::make(not_no_op(y), For::make("i", 0, 1, ForType::Serial, DeviceAPI::None, Evaluate::make(unreachable()))),
           Evaluate::make(unreachable()));
@@ -2130,11 +2130,11 @@ int main(int argc, char **argv) {
     Expr x = Var("x"), y = Var("y");
 
     // Check that constant args to a stringify get combined
-    check(Call::make(type_of<const char *>(), Call::stringify, {3, std::string(" "), 4}, Call::Intrinsic),
+    check(Call::make(type_of<const char *>(), Call::stringify, {3, std::string(" "), 4}, Call::PureIntrinsic),
           std::string("3 4"));
 
-    check(Call::make(type_of<const char *>(), Call::stringify, {3, x, 4, std::string(", "), 3.4f}, Call::Intrinsic),
-          Call::make(type_of<const char *>(), Call::stringify, {std::string("3"), x, std::string("4, 3.400000")}, Call::Intrinsic));
+    check(Call::make(type_of<const char *>(), Call::stringify, {3, x, 4, std::string(", "), 3.4f}, Call::PureIntrinsic),
+          Call::make(type_of<const char *>(), Call::stringify, {std::string("3"), x, std::string("4, 3.400000")}, Call::PureIntrinsic));
 
     {
         // Check that contiguous prefetch call get collapsed


### PR DESCRIPTION
While investigating https://github.com/halide/Halide/issues/6067, I noticed that a handful of intrinsics that should probably be called as PureIntrinsic are being called as Intrinsic, thus missing out on hoisting opportunities:
- div_round_to_zero
- mod_round_to_zero
- stringify
- mux
- if_then_else (but only sometimes)

(Note that Call::size_of_halide_buffer_t should *not* be called as pure; the only use of it is typically `alloca()`, which already special-cases it efficiently, and hoisting it into a var would just require more fiddling at codegen time, for likely no gain.)
