### PR TITLE
Mark various HVX intrinsics as "pure"

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -2241,7 +2241,7 @@ class ScatterGatherGenerator : public IRMutator {
         dst_index = mutate(dst_index);
 
         return Call::make(ty, Call::hvx_gather, {std::move(dst_base), dst_index, src, size - 1, new_index},
-                          Call::Intrinsic);
+                          Call::PureIntrinsic);
     }
 
     // Checks if the Store node can be replaced with a scatter_accumulate.
@@ -2305,7 +2305,7 @@ class ScatterGatherGenerator : public IRMutator {
         Expr index = mutate(cast(ty.with_code(Type::Int), ty.bytes() * op->index));
         value = mutate(value);
         Stmt scatter = Evaluate::make(Call::make(ty, intrinsic,
-                                                 {buffer, size - 1, index, value}, Call::Intrinsic));
+                                                 {buffer, size - 1, index, value}, Call::PureIntrinsic));
         return scatter;
     }
 };
@@ -2396,7 +2396,7 @@ public:
         // Wrap the stmt with scatter-release if any hazard was detected.
         if (sync.find(&s) != sync.end()) {
             Stmt scatter_sync =
-                Evaluate::make(Call::make(Int(32), Call::hvx_scatter_release, {sync[&s]}, Call::Intrinsic));
+                Evaluate::make(Call::make(Int(32), Call::hvx_scatter_release, {sync[&s]}, Call::PureIntrinsic));
             return Block::make(scatter_sync, new_s);
         }
         return new_s;


### PR DESCRIPTION
While investigating #6067, I noticed that the four HVX-specific intrinsics are being called as nonpure; I don't know the exact semantics of these, but I suspect that at least some of them could be marked as pure, which would improve hoisting possibilities. Opening this change as a draft PR to get input from folks who have more knowledge of these instructions than I.
