### PR TITLE
Fix for upstream LLVM (Fixes #6079)

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -676,7 +676,11 @@ void get_target_options(const llvm::Module &module, llvm::TargetOptions &options
     options.HonorSignDependentRoundingFPMathOption = !per_instruction_fast_math_flags;
     options.NoZerosInBSS = false;
     options.GuaranteedTailCallOpt = false;
+#if LLVM_VERSION >= 13
+    // nothing
+#else
     options.StackAlignmentOverride = 0;
+#endif
     options.FunctionSections = true;
     options.UseInitArray = true;
     options.FloatABIType =

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -613,7 +613,11 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     options.HonorSignDependentRoundingFPMathOption = false;
     options.NoZerosInBSS = false;
     options.GuaranteedTailCallOpt = false;
+#if LLVM_VERSION >= 13
+    // nothing
+#else
     options.StackAlignmentOverride = 0;
+#endif
 
     std::unique_ptr<TargetMachine>
         target_machine(llvm_target->createTargetMachine(triple.str(),


### PR DESCRIPTION
(Note: this may cause failures with our current LLVM nightly builds, but will be necessary for tomorrow's LLVM nightlies. Just getting it ready to land when necessary.)