### PR TITLE
Update LoopNest.cpp

### DIFF
--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -1041,7 +1041,6 @@ const Bound &LoopNest::get_bounds(const FunctionDAG::Node *f) const {
 
     // Compute the region required
     if (f->is_output && is_root()) {
-        internal_assert(f->outgoing_edges.empty()) << "Outputs that access other outputs not yet supported\n";
         // It's an output. Use the bounds estimate.
         for (int i = 0; i < f->dimensions; i++) {
             bound->region_required(i) = f->estimated_region_required[i];


### PR DESCRIPTION
I believe this assert is not necessary anymore. It also prohibits the Adams auto scheduler to be used in more complex scenarios as this is a pretty hard restriction.
However, I am not that confident. Hence, I'd kindly like to ask @benoitsteiner to look over this as he was the original author of this.