### PR TITLE
[hannk] Remove unused Op::clone() methods

### DIFF
--- a/apps/hannk/interpreter/model.cpp
+++ b/apps/hannk/interpreter/model.cpp
@@ -7,21 +7,6 @@
 
 namespace hannk {
 
-const TensorPtr &apply(TensorMap &map, const TensorPtr &t) {
-    auto i = map.find(t);
-    if (i != map.end()) {
-        return i->second;
-    }
-
-    if (t->is_constant()) {
-        // Share constant tensors across users.
-        return t;
-    } else {
-        // Remember this cloned tensor for later applications of the mapping.
-        return map[t] = std::make_shared<Tensor>(*t);
-    }
-}
-
 namespace {
 
 HalideBuffer<void> make_buffer(halide_type_t type, const Box &bounds) {
@@ -363,24 +348,6 @@ void OpGroup::remove(const Op *op) {
             return;
         }
     }
-}
-
-OpPtr OpGroup::clone(TensorMap &tensor_map) const {
-    std::vector<TensorPtr> inputs;
-    for (int i = 0; i < input_count(); i++) {
-        inputs.push_back(apply(tensor_map, input(i)));
-    }
-    std::vector<TensorPtr> outputs;
-    for (int i = 0; i < output_count(); i++) {
-        outputs.push_back(apply(tensor_map, output(i)));
-    }
-
-    std::vector<OpPtr> ops;
-    for (int i = 0; i < op_count(); i++) {
-        ops.push_back(op(i)->clone(tensor_map));
-    }
-
-    return make_op<OpGroup>(std::move(inputs), std::move(outputs), std::move(ops));
 }
 
 void OpGroup::accept(OpVisitor *v) {

--- a/apps/hannk/interpreter/model.h
+++ b/apps/hannk/interpreter/model.h
@@ -251,13 +251,6 @@ public:
     void dump(std::ostream &os) const;
 };
 
-// A mapping from old tensors to new tensors, when cloning an op.
-using TensorMap = std::map<const TensorPtr, TensorPtr>;
-
-// Apply a tensor map to a list of tensors. This is used to support
-// cloning ops referring to different tensors.
-const TensorPtr &apply(TensorMap &map, const TensorPtr &t);
-
 // A mapping from an output x to required input coordinates [min, max].
 // [min, max] = (x / inv_stride) * stride + bounds
 struct DimMap {
@@ -514,9 +507,6 @@ public:
     // Execute the op on a given crop.
     virtual void execute() = 0;
 
-    // Clone this op, replacing tensors using the mapping in tensor_map.
-    virtual OpPtr clone(TensorMap &tensor_map) const = 0;
-
     virtual void accept(OpVisitor *v) = 0;
 
     virtual void dump(std::ostream &os) const = 0;
@@ -590,7 +580,6 @@ public:
         return ops_[i].get();
     }
 
-    OpPtr clone(TensorMap &tensor_map) const;
     void accept(OpVisitor *v);
     void dump(std::ostream &os) const;
 };

--- a/apps/hannk/interpreter/ops.h
+++ b/apps/hannk/interpreter/ops.h
@@ -54,12 +54,6 @@ public:
         : ElementwiseOp({a, b}, {output}), op_(op), activation_(activation) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<BinaryOp>(
-            apply(map, input(0)), apply(map, input(1)),
-            apply(map, output()), op_, activation_);
-    }
-
     void accept(OpVisitor *v);
 
     void execute();
@@ -83,15 +77,6 @@ public:
     }
     void set_no_op() {
         is_no_op_ = true;
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        std::vector<TensorPtr> inputs;
-        for (int i = 0; i < input_count(); i++) {
-            inputs.push_back(apply(map, input(i)));
-        }
-        return make_op<ConcatenationOp>(
-            std::move(inputs), apply(map, output()), axis_);
     }
 
     void accept(OpVisitor *v);
@@ -120,12 +105,6 @@ public:
           dilation_(dilation),
           padding_(padding),
           activation_(activation) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<Conv2DOp>(
-            apply(map, input()), apply(map, filter()), apply(map, bias()),
-            apply(map, output()), stride_, dilation_, padding_, activation_);
     }
 
     void accept(OpVisitor *v);
@@ -175,13 +154,6 @@ public:
           activation_(activation) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<DepthwiseConv2DOp>(
-            apply(map, input()), apply(map, filter()), apply(map, bias()),
-            apply(map, output()), depth_multiplier_, stride_, dilation_,
-            padding_, activation_);
-    }
-
     void accept(OpVisitor *v);
 
     const TensorPtr &filter() const {
@@ -218,18 +190,6 @@ public:
         : ElementwiseOp(std::move(inputs), std::move(outputs)), program_(program) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        std::vector<TensorPtr> inputs, outputs;
-        for (int i = 0; i < input_count(); i++) {
-            inputs.push_back(apply(map, input(i)));
-        }
-        for (int i = 0; i < output_count(); i++) {
-            inputs.push_back(apply(map, output(i)));
-        }
-        return make_op<ElementwiseProgramOp>(
-            std::move(inputs), std::move(outputs), program_);
-    }
-
     void accept(OpVisitor *v);
 
     void execute();
@@ -246,12 +206,6 @@ public:
     FullyConnectedOp(const TensorPtr &input, const TensorPtr &filter, const TensorPtr &bias, const TensorPtr &output,
                      ActivationFunction activation = ActivationFunction::None)
         : Op({input, filter, bias}, {output}), activation_(activation) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<FullyConnectedOp>(
-            apply(map, input()), apply(map, filter()), apply(map, bias()),
-            apply(map, output()), activation_);
     }
 
     void accept(OpVisitor *v);
@@ -286,10 +240,6 @@ public:
         : Op({input, indices}, {output}), axis_(axis) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<GatherOp>(apply(map, input(0)), apply(map, input(1)), apply(map, output()), axis_);
-    }
-
     void accept(OpVisitor *v);
 
     BoundsMap map_bounds(int input_idx, int output_idx) const;
@@ -305,10 +255,6 @@ class L2NormalizationOp : public Op {
 public:
     L2NormalizationOp(const TensorPtr &input, const TensorPtr &output)
         : Op({input}, {output}) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<L2NormalizationOp>(apply(map, input()), apply(map, output()));
     }
 
     void accept(OpVisitor *v);
@@ -329,11 +275,6 @@ public:
         if (input->rank() == 0 || !padding->is_constant()) {
             output->set_dynamic();
         }
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<PadOp>(
-            apply(map, input(0)), apply(map, input(1)), apply(map, output()));
     }
 
     void accept(OpVisitor *v);
@@ -375,11 +316,6 @@ public:
           activation_(activation) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<Pool2DOp>(
-            apply(map, input()), apply(map, output()), stride_, filter_size_, padding_, op_, activation_);
-    }
-
     Operator op() const {
         return op_;
     }
@@ -416,11 +352,6 @@ public:
         : Op({input, indices}, {output}), op_(op) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<ReductionOp>(
-            apply(map, input()), apply(map, input(1)), apply(map, output()), op_);
-    }
-
     BoundsMap map_bounds(int input_idx, int output_idx) const;
 
     void accept(OpVisitor *v);
@@ -443,10 +374,6 @@ public:
         }
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<ReshapeOp>(apply(map, input()), apply(map, input(1)), apply(map, output()));
-    }
-
     void accept(OpVisitor *v);
 
     BoundsMap map_bounds(int input_idx, int output_idx) const;
@@ -462,10 +389,6 @@ class ShapeOp : public Op {
 public:
     ShapeOp(const TensorPtr &input, const TensorPtr &output)
         : Op({input}, {output}) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<ShapeOp>(apply(map, input()), apply(map, output()));
     }
 
     void accept(OpVisitor *v);
@@ -487,10 +410,6 @@ public:
         : Op({input}, {output}), beta_(beta) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<SoftmaxOp>(apply(map, input()), apply(map, output()), beta_);
-    }
-
     void accept(OpVisitor *v);
 
     BoundsMap map_bounds(int input_idx, int output_idx) const;
@@ -508,10 +427,6 @@ class SpaceDepthOp : public Op {
 public:
     SpaceDepthOp(const TensorPtr &input, const TensorPtr &output, int block_size)
         : Op({input}, {output}), block_size_(block_size) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<SpaceDepthOp>(apply(map, input()), apply(map, output()), block_size_);
     }
 
     void accept(OpVisitor *v);
@@ -533,15 +448,6 @@ class SplitOp : public Op {
 public:
     SplitOp(const TensorPtr &input, std::vector<TensorPtr> outputs, int axis)
         : Op({input}, std::move(outputs)), axis_(axis) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        std::vector<TensorPtr> outputs;
-        for (int i = 0; i < output_count(); i++) {
-            outputs.push_back(apply(map, output(i)));
-        }
-        return make_op<SplitOp>(
-            apply(map, input()), std::move(outputs), axis_);
     }
 
     int axis() const {
@@ -568,10 +474,6 @@ public:
         : Op({input}, {output}) {
     }
 
-    OpPtr clone(TensorMap &map) const {
-        return make_op<TileConvFilterOp>(apply(map, input()), apply(map, output()));
-    }
-
     void accept(OpVisitor *v);
 
     BoundsMap map_bounds(int input_idx, int output_idx) const;
@@ -587,10 +489,6 @@ class TransposeOp : public Op {
 public:
     TransposeOp(const TensorPtr &input, const TensorPtr &dims, const TensorPtr &output)
         : Op({input, dims}, {output}) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<TransposeOp>(apply(map, input(0)), apply(map, input(1)), apply(map, output()));
     }
 
     void accept(OpVisitor *v);
@@ -624,11 +522,6 @@ private:
 public:
     UnaryOp(const TensorPtr &input, const TensorPtr &output, Operator op)
         : ElementwiseOp({input}, {output}), op_(op) {
-    }
-
-    OpPtr clone(TensorMap &map) const {
-        return make_op<UnaryOp>(
-            apply(map, input()), apply(map, output()), op_);
     }
 
     void accept(OpVisitor *v);


### PR DESCRIPTION
We don't call these anymore, so remove them and the related TensorMap code.