### PR TITLE
[hannk] Don't mark Tensors as input or output

### DIFF
--- a/apps/hannk/configure_cmake.sh
+++ b/apps/hannk/configure_cmake.sh
@@ -23,6 +23,11 @@ CMAKE_GENERATOR=Ninja
 fi
 echo Using build tool=${CMAKE_GENERATOR}
 
+if [ -z "${CMAKE_BUILD_TYPE}" ]; then
+CMAKE_BUILD_TYPE=Release
+fi
+echo Using CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+
 EXTRAS=
 # TODO: this doesn't work (yet); crosscompiling in CMake is painful.
 if [[ "${HL_TARGET}" =~ ^arm-64-android.* ]]; then
@@ -36,7 +41,7 @@ fi
 cmake \
   ${EXTRAS} \
   -G "${CMAKE_GENERATOR}" \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
   -DHalide_DIR="${HALIDE_INSTALL_PATH}" \
   -DCMAKE_PREFIX_PATH="${HALIDE_INSTALL_PATH}" \
   -DHalide_TARGET=${HL_TARGET} \

--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -296,7 +296,6 @@ public:
                 continue;
             }
             auto t = GetTensorById(context, tensor_id);
-            t->set_input(true);
             inputs.push_back(t);
             if (options_.verbosity >= 2) {
                 HLOG(INFO) << "Delegate " << (void *)this << (t->is_constant() ? " Const" : "") << " Input tensor: " << tensor_id << "\n";
@@ -314,7 +313,6 @@ public:
                 HLOG(INFO) << "Delegate " << (void *)this << " Output tensor: " << tensor_id << "\n";
             }
             auto t = GetTensorById(context, tensor_id);
-            t->set_output(true);
             outputs.push_back(t);
         }
 

--- a/apps/hannk/interpreter/model.cpp
+++ b/apps/hannk/interpreter/model.cpp
@@ -58,6 +58,24 @@ void Op::set_output(TensorPtr t) {
     set_output(0, std::move(t));
 }
 
+bool Op::is_input(const TensorPtr &t) const {
+    for (auto &i : inputs_) {
+        if (i == t) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Op::is_output(const TensorPtr &t) const {
+    for (auto &o : outputs_) {
+        if (o == t) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void OpGroup::execute() {
     for (int i = 0; i < op_count(); i++) {
         op(i)->execute();

--- a/apps/hannk/interpreter/model.h
+++ b/apps/hannk/interpreter/model.h
@@ -321,6 +321,9 @@ public:
     void set_input(TensorPtr t);
     void set_output(TensorPtr t);
 
+    bool is_input(const TensorPtr &t) const;
+    bool is_output(const TensorPtr &t) const;
+
     // Movable but not copyable.
     Op() = delete;
     Op(const Op &) = delete;

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -84,10 +84,6 @@ class Tensor {
     bool is_constant_ = false;
     // If true, this Tensor's storage is externally owned and must not be freed.
     bool is_external_ = false;
-    // If true, the Tensor is one of the inputs to the Model.
-    bool is_input_ = false;
-    // If true, the Tensor is one of the outputs to the Model.
-    bool is_output_ = false;
     // If true, this Tensor is 'dynamic' (i.e., it's an output whose size
     // is calculated during evaluation, rather than ahead of time).  It is an error
     // for a Tensor to be dynamic if it is also constant or external.
@@ -182,22 +178,6 @@ public:
     void set_dynamic(bool dynamic = true) {
         assert(!(dynamic && (is_constant() || is_external())));
         is_dynamic_ = dynamic;
-    }
-
-    bool is_input() const {
-        return is_input_;
-    }
-
-    bool is_output() const {
-        return is_output_;
-    }
-
-    void set_input(bool is_input) {
-        is_input_ = is_input;
-    }
-
-    void set_output(bool is_output) {
-        is_output_ = is_output;
     }
 
     template<class T = void>

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -25,42 +25,59 @@ T *cast_op(Op *x) {
     }
 }
 
+class RemoveDeadOps {
+    const Op *const root_;
+
+    bool is_root_output(const TensorPtr &t) const {
+        return t->is_output();
+    };
+
+public:
+    explicit RemoveDeadOps(Op *root)
+        : root_(root) {
+    }
+
+    void remove_in_group(OpGroup *op_group) {
+        // Find ops with outputs that are unused.
+        // Go in reverse order so removing a dead op
+        // enables earlier ops to be seen as dead.
+        for (int i = op_group->op_count() - 1; i >= 0; --i) {
+            Op *op = op_group->op(i);
+            if (OpGroup *group = cast_op<OpGroup>(op)) {
+                remove_in_group(group);
+            }
+            bool dead = true;
+            for (int j = 0; dead && j < op->input_count(); j++) {
+                if (is_root_output(op->input(j))) {
+                    dead = false;
+                    break;
+                }
+            }
+            for (int j = 0; dead && j < op->output_count(); j++) {
+                // An op isn't dead if its output is an output
+                // of the graph.
+                if (is_root_output(op->output(j))) {
+                    dead = false;
+                    break;
+                }
+
+                if (!op->output(j)->consumers().empty()) {
+                    dead = false;
+                    break;
+                }
+            }
+
+            if (dead) {
+                op_group->remove(op);
+            }
+        }
+    }
+};
+
 }  // namespace
 
 void remove_dead_ops(OpGroup *root) {
-    // Find ops with outputs that are unused.
-    // Go in reverse order so removing a dead op
-    // enables earlier ops to be seen as dead.
-    for (int i = root->op_count() - 1; i >= 0; --i) {
-        Op *op = root->op(i);
-        if (OpGroup *group = cast_op<OpGroup>(op)) {
-            remove_dead_ops(group);
-        }
-        bool dead = true;
-        for (int j = 0; dead && j < op->input_count(); j++) {
-            if (op->input(j)->is_output()) {
-                dead = false;
-                break;
-            }
-        }
-        for (int j = 0; dead && j < op->output_count(); j++) {
-            // An op isn't dead if its output is an output
-            // of the graph.
-            if (op->output(j)->is_output()) {
-                dead = false;
-                break;
-            }
-
-            if (!op->output(j)->consumers().empty()) {
-                dead = false;
-                break;
-            }
-        }
-
-        if (dead) {
-            root->remove(op);
-        }
-    }
+    RemoveDeadOps(root).remove_in_group(root);
 }
 
 namespace {
@@ -70,72 +87,72 @@ bool has_storage(const TensorPtr &t) {
     return t->is_alias() || t->is_allocated();
 }
 
-// We can alias two tensors if the input is not used after the output is written,
-// and we meet a number of other requirements.
-bool maybe_alias_tensors(TensorPtr input, TensorPtr output, SmallVector<int, max_rank> offset = {}) {
-    // If the input is used anywhere else, we should not alias it.
-    // TODO: This is conservative, we could alias it if it is the *last* use.
-    if (input->consumers().size() != 1) {
-        return false;
-    }
-
-    // If either tensor is dynamic, can't alias them.
-    if (input->is_dynamic() || output->is_dynamic()) {
-        return false;
-    }
-
-    // If either tensor is external, can't alias them.
-    // TODO: maybe we can, but it's not clear how to update storage_.host in that case?
-    if (input->is_external() || output->is_external()) {
-        return false;
-    }
-
-    if (input->rank() != output->rank()) {
-        // TODO: We should be able to alias reshapes.
-        return false;
-    }
-
-    if (input->type().bytes() != output->type().bytes()) {
-        // We can't alias tensors with types of different size.
-        return false;
-    }
-
-    // We can't alias an input that is an input or output.
-    // TODO: We could, if we don't change the shape.
-    if (input->is_input() || input->is_output()) {
-        return false;
-    }
-
-    // We can't grow the bounds of the tensor we alias with.
-    // TODO: We could, if we allowed non-zero mins. We also
-    // could allow the max to grow, just not the min.
-    Box input_bounds_with_offset = input->bounds();
-    Box output_bounds_with_negative_offset = output->bounds();
-    for (int i = 0; i < (int)offset.size(); ++i) {
-        input_bounds_with_offset[i] += offset[i];
-        output_bounds_with_negative_offset[i] -= offset[i];
-    }
-    bool input_subset_of_output = is_subset_of(input_bounds_with_offset, output->bounds());
-    bool output_subset_of_input = is_subset_of(output_bounds_with_negative_offset, input->bounds());
-    if (input_subset_of_output && !has_storage(input)) {
-        input->set_alias_of(output, offset);
-        return true;
-    } else if (output_subset_of_input && !has_storage(output)) {
-        for (int &i : offset) {
-            i = -i;
-        }
-        output->set_alias_of(input, offset);
-        return true;
-    }
-
-    return false;
-}
-
 // Try to alias outputs to inputs when it is safe.
 class InPlace : public OpVisitor {
     using OpVisitor::visit;
 
-    void maybe_alias_elementwise(ElementwiseOp *op) {
+    // We can alias two tensors if the input is not used after the output is written,
+    // and we meet a number of other requirements.
+    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, SmallVector<int, max_rank> offset = {}) const {
+        // If the input is used anywhere else, we should not alias it.
+        // TODO: This is conservative, we could alias it if it is the *last* use.
+        if (input->consumers().size() != 1) {
+            return false;
+        }
+
+        // If either tensor is dynamic, can't alias them.
+        if (input->is_dynamic() || output->is_dynamic()) {
+            return false;
+        }
+
+        // If either tensor is external, can't alias them.
+        // TODO: maybe we can, but it's not clear how to update storage_.host in that case?
+        if (input->is_external() || output->is_external()) {
+            return false;
+        }
+
+        if (input->rank() != output->rank()) {
+            // TODO: We should be able to alias reshapes.
+            return false;
+        }
+
+        if (input->type().bytes() != output->type().bytes()) {
+            // We can't alias tensors with types of different size.
+            return false;
+        }
+
+        // We can't alias an input that is an input or output of the root graph.
+        // TODO: We could, if we don't change the shape.
+        if (is_root_input_or_output(input)) {
+            return false;
+        }
+
+        // We can't grow the bounds of the tensor we alias with.
+        // TODO: We could, if we allowed non-zero mins. We also
+        // could allow the max to grow, just not the min.
+        Box input_bounds_with_offset = input->bounds();
+        Box output_bounds_with_negative_offset = output->bounds();
+        for (int i = 0; i < (int)offset.size(); ++i) {
+            input_bounds_with_offset[i] += offset[i];
+            output_bounds_with_negative_offset[i] -= offset[i];
+        }
+        bool input_subset_of_output = is_subset_of(input_bounds_with_offset, output->bounds());
+        bool output_subset_of_input = is_subset_of(output_bounds_with_negative_offset, input->bounds());
+        if (input_subset_of_output && !has_storage(input)) {
+            input->set_alias_of(output, offset);
+            return true;
+        } else if (output_subset_of_input && !has_storage(output)) {
+            for (int &i : offset) {
+                i = -i;
+            }
+            output->set_alias_of(input, offset);
+            return true;
+        }
+
+        return false;
+    }
+
+    void maybe_alias_elementwise(ElementwiseOp *op) const {
         for (int j = 0; j < op->output_count(); j++) {
             for (int i = 0; i < op->input_count(); i++) {
                 if (maybe_alias_tensors(op->input(i), op->output(j))) {
@@ -211,12 +228,23 @@ class InPlace : public OpVisitor {
             op->op(i)->accept(this);
         }
     }
+
+    const Op *const root_;
+
+    bool is_root_input_or_output(const TensorPtr &t) const {
+        return t->is_input() || t->is_output();
+    };
+
+public:
+    explicit InPlace(Op *root)
+        : root_(root) {
+    }
 };
 
 }  // namespace
 
 void in_place(Op *op) {
-    InPlace v;
+    InPlace v(op);
     op->accept(&v);
 }
 

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -29,7 +29,7 @@ class RemoveDeadOps {
     const Op *const root_;
 
     bool is_root_output(const TensorPtr &t) const {
-        return t->is_output();
+        return root_->is_output(t);
     };
 
 public:
@@ -232,7 +232,7 @@ class InPlace : public OpVisitor {
     const Op *const root_;
 
     bool is_root_input_or_output(const TensorPtr &t) const {
-        return t->is_input() || t->is_output();
+        return root_->is_input(t) || root_->is_output(t);
     };
 
 public:

--- a/apps/hannk/tflite/tflite_parser.cpp
+++ b/apps/hannk/tflite/tflite_parser.cpp
@@ -511,12 +511,10 @@ public:
 
         std::vector<TensorPtr> inputs;
         for (int i : *subgraph->inputs()) {
-            tensors_[i]->set_input(true);
             inputs.push_back(tensors_[i]);
         }
         std::vector<TensorPtr> outputs;
         for (int i : *subgraph->outputs()) {
-            tensors_[i]->set_output(true);
             outputs.push_back(tensors_[i]);
         }
 


### PR DESCRIPTION
It's redundant information that can be wrong and requires the builder of the Model to set the right flags on the right Tensors. Instead, build sets of the inputs and/or outputs at the spots we care and check for membership in those. Root-level inputs and outputs should generally be small in count so performance should be a wash.

Also: drive-by change to configure_cmake.sh to allow changing the build type.