### PR TITLE
[hannk] Rework the InPlace pass to make Arena allocation easier

### DIFF
--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -423,10 +423,13 @@ public:
                 assert(!t->is_dynamic());
                 TfLiteTensor &tensor = context->tensors[tensor_id];
                 // TODO: should this be upgraded to a runtime-check-and-return-error?
-                assert(t->buffer().size_in_bytes() == tensor.bytes);
+                const auto &old_buf = t->buffer();
+                assert(old_buf.size_in_bytes() == tensor.bytes);
                 // We must reset it every time, as the tensor's data pointer
                 // can vary between calls in some scenatrios.
-                t->set_external_host(tensor.data.data);
+                const auto *raw_buf = old_buf.raw_buffer();
+                HalideBuffer<void> buf(raw_buf->type, tensor.data.data, raw_buf->dimensions, raw_buf->dim);
+                t->set_external_buffer(std::move(buf));
             }
         };
 

--- a/apps/hannk/interpreter/interpreter.cpp
+++ b/apps/hannk/interpreter/interpreter.cpp
@@ -32,13 +32,60 @@ class AllocateAll : public OpVisitor {
     }
 };
 
+size_t size_in_elements(const TensorDimensions &dimensions) {
+    ptrdiff_t begin_offset = 0;
+    ptrdiff_t end_offset = 0;
+    for (int i = 0; i < (int)dimensions.size(); i++) {
+        const int stride = dimensions[i].stride;
+        if (stride < 0) {
+            begin_offset += stride * (ptrdiff_t)(dimensions[i].extent - 1);
+        } else /* stride >= 0 */ {
+            end_offset += stride * (ptrdiff_t)(dimensions[i].extent - 1);
+        }
+    }
+    end_offset += 1;
+    assert(end_offset >= begin_offset);
+    return (size_t)(end_offset - begin_offset);
+}
+
 }  // namespace
 
 void Interpreter::init(InterpreterOptions options) {
     pad_for_ops(model_.get());
-    in_place(model_.get());
+    auto alias_groups = calculate_in_place_aliases(model_.get());
     fold_constants(model_.get());
     remove_dead_ops(model_.get());
+
+    for (const auto &g : alias_groups) {
+        // Allocate them all as uint types, for simplicity
+        const size_t size_in_bytes = size_in_elements(g.dimensions) * g.element_size_in_bytes;
+        aliased_tensor_storage_.emplace_back(new char[size_in_bytes]);
+        void* shared_host = aliased_tensor_storage_.back().get();
+
+        HLOG(INFO) << "Aliasing a group of " << g.tensors.size() << " tensors, shared size " << size_in_bytes << " bytes...\n";
+
+        for (const auto &it : g.tensors) {
+            const TensorPtr &tensor = it.first;
+            const TensorOffset &offset = it.second;
+            HCHECK(!tensor->is_allocated());
+            HCHECK(!tensor->is_dynamic());
+            HCHECK(!tensor->is_external());
+            const HalideBuffer<void> &old_buf = tensor->buffer();
+            // We need to construct the new buf with the shared dimensions, then offset it,
+            // to ensure that host is updated correctly.
+            HalideBuffer<void> new_buf(old_buf.type(), shared_host, g.dimensions.size(), g.dimensions.data());
+            for (int i = 0; i < new_buf.dimensions(); i++) {
+                Interval dim_o(old_buf.dim(i).min(), old_buf.dim(i).max());
+                if (i < (int)offset.size()) {
+                    dim_o += offset[i];
+                }
+                new_buf.crop(i, dim_o.min, dim_o.extent());
+                new_buf.translate(i, -dim_o.min);
+            }
+            tensor->set_external();
+            tensor->set_external_buffer(std::move(new_buf));
+        }
+    }
 
     // TODO: Find a better schedule for executing the ops, including
     // better lifetime management for these allocations.

--- a/apps/hannk/interpreter/interpreter.cpp
+++ b/apps/hannk/interpreter/interpreter.cpp
@@ -62,7 +62,7 @@ void Interpreter::init(InterpreterOptions options) {
         aliased_tensor_storage_.emplace_back(new char[size_in_bytes]);
         void* shared_host = aliased_tensor_storage_.back().get();
 
-        HLOG(INFO) << "Aliasing a group of " << g.tensors.size() << " tensors, shared size " << size_in_bytes << " bytes...\n";
+        // HLOG(INFO) << "Aliasing a group of " << g.tensors.size() << " tensors, shared size " << size_in_bytes << " bytes...\n";
 
         for (const auto &it : g.tensors) {
             const TensorPtr &tensor = it.first;
@@ -90,6 +90,7 @@ void Interpreter::init(InterpreterOptions options) {
     // TODO: Find a better schedule for executing the ops, including
     // better lifetime management for these allocations.
     AllocateAll allocate_all;
+
     model_->accept(&allocate_all);
 }
 

--- a/apps/hannk/interpreter/interpreter.cpp
+++ b/apps/hannk/interpreter/interpreter.cpp
@@ -60,7 +60,7 @@ void Interpreter::init(InterpreterOptions options) {
         // Allocate them all as uint types, for simplicity
         const size_t size_in_bytes = size_in_elements(g.dimensions) * g.element_size_in_bytes;
         aliased_tensor_storage_.emplace_back(new char[size_in_bytes]);
-        void* shared_host = aliased_tensor_storage_.back().get();
+        void *shared_host = aliased_tensor_storage_.back().get();
 
         // HLOG(INFO) << "Aliasing a group of " << g.tensors.size() << " tensors, shared size " << size_in_bytes << " bytes...\n";
 

--- a/apps/hannk/interpreter/interpreter.h
+++ b/apps/hannk/interpreter/interpreter.h
@@ -18,6 +18,11 @@ struct InterpreterOptions {
 
 class Interpreter {
     std::unique_ptr<OpGroup> model_;
+    // TODO: this is a temporary placeholder for aliased Tensor allocs;
+    // it will soob be replaced with an intelligent arena allocator with
+    // knowledge about Tensor lifetimes
+    // std::vector<HalideBuffer<void>> aliased_tensor_buffers_;
+    std::vector<std::unique_ptr<char[]>> aliased_tensor_storage_;
 
     void init(InterpreterOptions options);
 

--- a/apps/hannk/interpreter/tensor.cpp
+++ b/apps/hannk/interpreter/tensor.cpp
@@ -7,7 +7,7 @@ namespace {
 
 HalideBuffer<void> make_buffer(halide_type_t type, const Box &bounds) {
     // TODO: Avoid this dynamic allocation. Halide's API requires std::vector here.
-    SmallVector<halide_dimension_t, max_rank> dims(bounds.size());
+    TensorDimensions dims(bounds.size());
     int stride = 1;
     for (int i = 0; i < (int)bounds.size(); i++) {
         dims[i].min = bounds[i].min;
@@ -142,7 +142,7 @@ void Tensor::resize(const Box &new_shape) {
     assert(is_dynamic());
     assert(!is_external());
 
-    SmallVector<halide_dimension_t, max_rank> new_dims;
+    TensorDimensions new_dims;
 
     const halide_dimension_t *old_dims = buffer_.raw_buffer()->dim;
 

--- a/apps/hannk/interpreter/tensor.cpp
+++ b/apps/hannk/interpreter/tensor.cpp
@@ -20,36 +20,6 @@ HalideBuffer<void> make_buffer(halide_type_t type, const Box &bounds) {
 
 }  // namespace
 
-TensorStorage::TensorStorage(halide_type_t type, int rank, const halide_dimension_t *dimensions)
-    : buffer_(type, nullptr, rank, dimensions) {
-}
-
-void TensorStorage::add_use(halide_type_t type, const Box &bounds) {
-    if (buffer_.dimensions() == 0) {
-        buffer_ = make_buffer(type, bounds);
-    } else {
-        assert(buffer_.type() == type);
-        assert(buffer_.dimensions() == (int)bounds.size());
-        assert(!buffer_.data());
-
-        // Check that the storage is big enough for this buffer.
-        for (int i = 0; i < buffer_.dimensions(); i++) {
-            assert(bounds[i].min >= buffer_.dim(i).min());
-            assert(bounds[i].max <= buffer_.dim(i).max());
-        }
-    }
-}
-
-bool TensorStorage::is_allocated() const {
-    return buffer_.data() != nullptr;
-}
-
-void TensorStorage::allocate() {
-    if (!buffer_.data()) {
-        buffer_ = HalideBuffer<void>::make_with_shape_of(buffer_);
-    }
-}
-
 Tensor::Tensor(std::string name, HalideBuffer<void> buffer, QuantizationInfo quantization)
     : name_(std::move(name)),
       buffer_(std::move(buffer)),
@@ -76,13 +46,6 @@ void Tensor::remove_producer(Op *op) {
     producers_.remove(op);
 }
 
-std::shared_ptr<TensorStorage> Tensor::storage() {
-    if (!storage_) {
-        storage_ = std::make_shared<TensorStorage>(buffer_.type(), buffer_.dimensions(), buffer_.raw_buffer()->dim);
-    }
-    return storage_;
-}
-
 bool Tensor::is_allocated() const {
     return buffer_.data() != nullptr;
 }
@@ -95,29 +58,12 @@ void Tensor::set_external_buffer(HalideBuffer<void> external_buffer) {
     // so don't assert that host is currently null (or already equal to the new value)
     // assert(!is_allocated());
 
-    // TODO: we don't allow aliasing of external tensors right now.
-    // If we do, we need to maintain and update storage_ appropriately.
-    assert(storage_ == nullptr);
-
-    // TODO: NDEBUG
     for (int i = 0; i < buffer_.dimensions(); i++) {
-        HCHECK(external_buffer.dim(i).min() == buffer_.dim(i).min());
-        HCHECK(external_buffer.dim(i).extent() == buffer_.dim(i).extent());
+        assert(external_buffer.dim(i).min() == buffer_.dim(i).min());
+        assert(external_buffer.dim(i).extent() == buffer_.dim(i).extent());
     }
     buffer_ = std::move(external_buffer);
 }
-
-namespace {
-
-// Copy a Halide buffer without the internal reference counting.
-// This reduces overhead of buffer copies, and is unnecessary because
-// we do our own reference counting.
-template<typename T>
-HalideBuffer<T> drop_reference(const HalideBuffer<T> &buf) {
-    return HalideBuffer<T>(buf.type(), buf.data(), buf.dimensions(), buf.raw_buffer()->dim);
-}
-
-}  // namespace
 
 void Tensor::allocate() {
     if (buffer_.data()) {
@@ -128,21 +74,7 @@ void Tensor::allocate() {
         return;
     }
 
-    storage()->allocate();
-    HalideBuffer<void> buffer = drop_reference(storage()->buffer());
-    for (int i = 0; i < buffer.dimensions(); i++) {
-        Interval dim_i(buffer_.dim(i).min(), buffer_.dim(i).max());
-        if (i < (int)storage_offset_.size()) {
-            dim_i += storage_offset_[i];
-        }
-        assert(buffer.dim(i).min() <= dim_i.min);
-        assert(buffer.dim(i).max() >= dim_i.max);
-        buffer.crop(i, dim_i.min, dim_i.extent());
-        buffer.translate(i, -dim_i.min);
-        assert(buffer.dim(i).min() == buffer_.dim(i).min());
-        assert(buffer.dim(i).max() == buffer_.dim(i).max());
-    }
-    buffer_ = buffer;
+    buffer_.allocate();
 }
 
 void Tensor::resize(const Box &new_shape) {
@@ -179,26 +111,6 @@ void Tensor::resize(const Box &new_shape) {
         new_buffer.copy_from(buffer_);
     }
     buffer_ = std::move(new_buffer);
-    storage_ = nullptr;
-}
-
-bool Tensor::is_alias() const {
-    // TODO: This check could incorrectly return true, if the tensor has been
-    // allocated already via storage(), but isn't an alias.
-    return storage_ != nullptr;
-}
-
-void Tensor::set_alias_of(const TensorPtr &t, const SmallVector<int, max_rank> &storage_offset) {
-    assert(!is_dynamic() && !is_external());
-
-    storage_ = t->storage();
-    storage_offset_ = storage_offset;
-
-    Box offset_bounds = bounds();
-    for (int i = 0; i < (int)storage_offset_.size(); i++) {
-        offset_bounds[i] += storage_offset_[i];
-    }
-    storage_->add_use(type(), offset_bounds);
 }
 
 void Tensor::replace_all_consumers_with(const TensorPtr &other) {

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -43,39 +43,6 @@ using TensorPtr = std::shared_ptr<Tensor>;
 using TensorOffset = SmallVector<int, max_rank>;
 using TensorDimensions = SmallVector<halide_dimension_t, max_rank>;
 
-// Storage for a tensor. This can be shared among several tensors aliasing
-// the same memory. All aliases use the strides of the buffer in this storage
-// buffer.
-class TensorStorage {
-    HalideBuffer<void> buffer_;
-
-public:
-    TensorStorage(halide_type_t type, int rank, const halide_dimension_t *dimensions);
-
-    TensorStorage() = delete;
-    TensorStorage(const TensorStorage &) = delete;
-    TensorStorage &operator=(const TensorStorage &) = delete;
-    TensorStorage(TensorStorage &&) = delete;
-    TensorStorage &operator=(TensorStorage &&) = delete;
-
-    // Grow the bounds of the storage to accommodate a new user.
-    // The type and dimensionality must match the existing storage.
-    void add_use(halide_type_t, const Box &bounds);
-
-    template<class T = void>
-    const HalideBuffer<T> &buffer() {
-        return buffer_.as<T>();
-    }
-
-    template<class T = void>
-    const HalideBuffer<const T> &buffer() const {
-        return buffer_.as_const().as<const T>();
-    }
-
-    bool is_allocated() const;
-    void allocate();
-};
-
 class Tensor {
     std::string name_;
     HalideBuffer<void> buffer_;
@@ -93,16 +60,9 @@ class Tensor {
     // Currently only used in conjunction with the TFLite delegate.
     bool is_dynamic_ = false;
 
-    // Possibly shared storage for this tensor.
-    std::shared_ptr<TensorStorage> storage_;
-    // The offset of this tensor into the storage buffer.
-    TensorOffset storage_offset_;
-
     // A list of ops that use this tensor as an output or an input, respectively.
     std::list<Op *> producers_;
     std::list<Op *> consumers_;
-
-    std::shared_ptr<TensorStorage> storage();
 
 public:
     Tensor() = delete;
@@ -205,9 +165,6 @@ public:
     void allocate();
 
     void resize(const Box &new_shape);
-
-    bool is_alias() const;
-    void set_alias_of(const TensorPtr &t, const TensorOffset &offset = {});
 
     void add_consumer(Op *op);
     void add_producer(Op *op);

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -84,7 +84,8 @@ class Tensor {
     // (It may actually refer to read-only external memory, or it may simply be marked this may as
     // the result of a transform.)
     bool is_constant_ = false;
-    // If true, this Tensor's storage is externally owned and must not be freed.
+    // If true, this Tensor's buffer was externally created and must not be modified,
+    // (aside from allowing the buffer's dtor to run normally).
     bool is_external_ = false;
     // If true, this Tensor is 'dynamic' (i.e., it's an output whose size
     // is calculated during evaluation, rather than ahead of time).  It is an error
@@ -171,7 +172,11 @@ public:
         is_external_ = external;
     }
 
-    void set_external_host(void *host);
+    // Requires that set_external() has already been called.
+    // external_buffer must have the same dimensions, mins, and extents
+    // as the current buffer (but the strides need not match).
+    // external_buffer must *not* have a null host pointer.
+    void set_external_buffer(HalideBuffer<void> external_buffer);
 
     bool is_dynamic() const {
         return is_dynamic_;

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -40,6 +40,8 @@ class Op;
 
 class Tensor;
 using TensorPtr = std::shared_ptr<Tensor>;
+using TensorOffset = SmallVector<int, max_rank>;
+using TensorDimensions = SmallVector<halide_dimension_t, max_rank>;
 
 // Storage for a tensor. This can be shared among several tensors aliasing
 // the same memory. All aliases use the strides of the buffer in this storage
@@ -93,7 +95,7 @@ class Tensor {
     // Possibly shared storage for this tensor.
     std::shared_ptr<TensorStorage> storage_;
     // The offset of this tensor into the storage buffer.
-    SmallVector<int, max_rank> storage_offset_;
+    TensorOffset storage_offset_;
 
     // A list of ops that use this tensor as an output or an input, respectively.
     std::list<Op *> producers_;
@@ -200,7 +202,7 @@ public:
     void resize(const Box &new_shape);
 
     bool is_alias() const;
-    void set_alias_of(const TensorPtr &t, const SmallVector<int, max_rank> &offset = {});
+    void set_alias_of(const TensorPtr &t, const TensorOffset &offset = {});
 
     void add_consumer(Op *op);
     void add_producer(Op *op);

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -93,7 +93,7 @@ class InPlace : public OpVisitor {
 
     // We can alias two tensors if the input is not used after the output is written,
     // and we meet a number of other requirements.
-    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, SmallVector<int, max_rank> offset = {}) const {
+    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, TensorOffset offset = {}) const {
         // If the input is used anywhere else, we should not alias it.
         // TODO: This is conservative, we could alias it if it is the *last* use.
         if (input->consumers().size() != 1) {
@@ -177,7 +177,7 @@ class InPlace : public OpVisitor {
 
     void visit(ConcatenationOp *op) {
         bool is_no_op = true;
-        SmallVector<int, max_rank> offset(op->axis() + 1);
+        TensorOffset offset(op->axis() + 1);
         for (int i = 0; i < op->input_count(); i++) {
             is_no_op = is_no_op && maybe_alias_tensors(op->input(i), op->output(), offset);
             is_no_op = is_no_op && op->input(i)->quantization() == op->output()->quantization();
@@ -191,7 +191,7 @@ class InPlace : public OpVisitor {
 
     void visit(SplitOp *op) {
         bool is_no_op = true;
-        SmallVector<int, max_rank> offset(op->axis() + 1);
+        TensorOffset offset(op->axis() + 1);
         for (int i = 0; i < op->output_count(); i++) {
             is_no_op = is_no_op && maybe_alias_tensors(op->input(), op->output(i), offset);
             is_no_op = is_no_op && op->output(i)->quantization() == op->input()->quantization();
@@ -211,7 +211,7 @@ class InPlace : public OpVisitor {
 
         auto padding = op->input(1)->buffer<const int32_t>();
 
-        SmallVector<int, max_rank> offset(padding.extent(1));
+        TensorOffset offset(padding.extent(1));
         for (int d = 0; d < padding.extent(1); d++) {
             offset[d] = padding(0, d);
         }

--- a/apps/hannk/interpreter/transforms.h
+++ b/apps/hannk/interpreter/transforms.h
@@ -5,8 +5,19 @@
 
 namespace hannk {
 
-// Rewrites ops to be in-place operations when possible.
-void in_place(Op *op);
+struct AliasGroup {
+    // The TensorDimensions and type-size used for the common allocation.
+    TensorDimensions dimensions;
+    size_t element_size_in_bytes;
+
+    // Each Tensor that will share the storage, along with the
+    // offset needed from the min
+    std::vector<std::pair<TensorPtr, TensorOffset>> tensors;
+};
+
+// Calculates which Tensors can be aliased onto each other to allow for in-place operations.
+// Doesn't actually mutate any tensors.
+std::vector<AliasGroup> calculate_in_place_aliases(Op *op);
 
 // Remove ops that are unused.
 void remove_dead_ops(OpGroup *op);


### PR DESCRIPTION
This reworks the way that aliased Tensor storage works to move the smarts out of Tensor itself -- TensorStorage is removed entirely -- and instead, have the InPlace visitor build up a list of aliased-tensor candidates, which then requires the caller (eg Interpreter) to use those to produce shared external buffers for aliasing. This should allow subsequent PRs to introduce further memory allocation improvements in a more straightforward manner.

(I recommend reading the changes on a per-commit basis, which may make the change progression easier to follow.)