### PR TITLE
[hannk] Fix various build glitches for Bazel/Blaze

### DIFF
--- a/apps/hannk/interpreter/tensor.cpp
+++ b/apps/hannk/interpreter/tensor.cpp
@@ -1,5 +1,4 @@
 #include "interpreter/tensor.h"
-#include "interpreter/model.h"
 
 namespace hannk {
 
@@ -192,19 +191,6 @@ void Tensor::set_alias_of(const TensorPtr &t, const SmallVector<int, max_rank> &
         offset_bounds[i] += storage_offset_[i];
     }
     storage_->add_use(type(), offset_bounds);
-}
-
-void Tensor::replace_all_consumers_with(const TensorPtr &other) {
-    // We need to make a copy of the list of consumers so it doesn't get invalidated
-    // by set_input below.
-    auto consumers = consumers_;
-    for (Op *i : consumers) {
-        for (int j = 0; j < i->input_count(); j++) {
-            if (i->input(j).get() == this) {
-                i->set_input(j, other);
-            }
-        }
-    }
 }
 
 void Tensor::dump(std::ostream &os) const {

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -214,8 +214,6 @@ public:
         return consumers_;
     }
 
-    void replace_all_consumers_with(const TensorPtr &other);
-
     void dump(std::ostream &os) const;
 };
 

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -250,6 +250,19 @@ void in_place(Op *op) {
 
 namespace {
 
+void replace_consumers(const TensorPtr &from, const TensorPtr &to) {
+    // We need to make a copy of the list of consumers so it doesn't get invalidated
+    // by set_input below.
+    auto consumers = from->consumers();
+    for (Op *i : consumers) {
+        for (int j = 0; j < i->input_count(); j++) {
+            if (i->input(j).get() == from.get()) {
+                i->set_input(j, to);
+            }
+        }
+    }
+}
+
 // Find ops that need padding and add an explicit pad op.
 class PadForOps : public OpVisitor {
     void pad_for_op(Op *op, int input_idx, int output_idx) {
@@ -303,7 +316,7 @@ class PadForOps : public OpVisitor {
             TensorPtr tiled =
                 std::make_shared<Tensor>(filter->name() + "_tiled", type, tiled_shape, quantization);
             // Maybe more than one op uses this same filter...?
-            filter->replace_all_consumers_with(tiled);
+            replace_consumers(filter, tiled);
 
             OpPtr tile = make_op<TileConvFilterOp>(filter, tiled);
             new_ops.emplace_back(std::move(tile));

--- a/apps/hannk/util/small_vector.h
+++ b/apps/hannk/util/small_vector.h
@@ -1,6 +1,13 @@
 #ifndef HANNK_SMALL_VECTOR_H
 #define HANNK_SMALL_VECTOR_H
 
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <initializer_list>
+#include <iostream>
+#include <utility>
+
 // This class mimics std::vector, but never dynamically allocates memory.
 // It can only grow to Capacity elements.
 template<typename T, size_t Capacity>


### PR DESCRIPTION
- Make small_vector.h standalone-compilable
- Move Tensor::replace_all_consumers_with() to a local function near PadForOps to dodge a circular include dep between Tensor and Model