### PR TITLE
Call simplify and remove_likelies for find_constant_bounds

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -66,7 +66,8 @@ Expr find_constant_bound(const Expr &e, Direction d, const Scope<Interval> &scop
 }
 
 Interval find_constant_bounds(const Expr &e, const Scope<Interval> &scope) {
-    Interval interval = bounds_of_expr_in_scope(e, scope, FuncValueBounds(), true);
+    Expr expr = simplify(remove_likelies(e));
+    Interval interval = bounds_of_expr_in_scope(expr, scope, FuncValueBounds(), true);
     interval.min = simplify(interval.min);
     interval.max = simplify(interval.max);
 


### PR DESCRIPTION
Lots of calls to `find_constant_bounds` are unsimplified Exprs / have `likely` or `likely_if_innermost` in them. This was discovered from logging while working on bounds inference.