### PR TITLE
[hannk] Replace Tensor::set_external_host with set_external_buffer

### DIFF
--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -423,10 +423,13 @@ public:
                 assert(!t->is_dynamic());
                 TfLiteTensor &tensor = context->tensors[tensor_id];
                 // TODO: should this be upgraded to a runtime-check-and-return-error?
-                assert(t->buffer().size_in_bytes() == tensor.bytes);
+                const auto &old_buf = t->buffer();
+                assert(old_buf.size_in_bytes() == tensor.bytes);
                 // We must reset it every time, as the tensor's data pointer
                 // can vary between calls in some scenatrios.
-                t->set_external_host(tensor.data.data);
+                const auto *raw_buf = old_buf.raw_buffer();
+                HalideBuffer<void> buf(raw_buf->type, tensor.data.data, raw_buf->dimensions, raw_buf->dim);
+                t->set_external_buffer(std::move(buf));
             }
         };
 

--- a/apps/hannk/interpreter/tensor.cpp
+++ b/apps/hannk/interpreter/tensor.cpp
@@ -6,7 +6,6 @@ namespace hannk {
 namespace {
 
 HalideBuffer<void> make_buffer(halide_type_t type, const Box &bounds) {
-    // TODO: Avoid this dynamic allocation. Halide's API requires std::vector here.
     TensorDimensions dims(bounds.size());
     int stride = 1;
     for (int i = 0; i < (int)bounds.size(); i++) {

--- a/apps/hannk/interpreter/tensor.cpp
+++ b/apps/hannk/interpreter/tensor.cpp
@@ -7,7 +7,7 @@ namespace {
 
 HalideBuffer<void> make_buffer(halide_type_t type, const Box &bounds) {
     // TODO: Avoid this dynamic allocation. Halide's API requires std::vector here.
-    SmallVector<halide_dimension_t, max_rank> dims(bounds.size());
+    TensorDimensions dims(bounds.size());
     int stride = 1;
     for (int i = 0; i < (int)bounds.size(); i++) {
         dims[i].min = bounds[i].min;
@@ -87,17 +87,23 @@ bool Tensor::is_allocated() const {
     return buffer_.data() != nullptr;
 }
 
-void Tensor::set_external_host(void *host) {
+void Tensor::set_external_buffer(HalideBuffer<void> external_buffer) {
+    assert(!is_dynamic());
+    assert(is_external());
+
     // No: it's ok to set this to different values over time,
     // so don't assert that host is currently null (or already equal to the new value)
     // assert(!is_allocated());
 
-    assert(is_external());
-    assert(!buffer_.owns_host_memory());
     // TODO: we don't allow aliasing of external tensors right now.
     // If we do, we need to maintain and update storage_ appropriately.
     assert(storage_ == nullptr);
-    buffer_.raw_buffer()->host = (uint8_t *)host;
+
+    for (int i = 0; i < buffer_.dimensions(); i++) {
+        assert(external_buffer.dim(i).min() == buffer_.dim(i).min());
+        assert(external_buffer.dim(i).extent() == buffer_.dim(i).extent());
+    }
+    buffer_ = std::move(external_buffer);
 }
 
 namespace {
@@ -142,7 +148,7 @@ void Tensor::resize(const Box &new_shape) {
     assert(is_dynamic());
     assert(!is_external());
 
-    SmallVector<halide_dimension_t, max_rank> new_dims;
+    TensorDimensions new_dims;
 
     const halide_dimension_t *old_dims = buffer_.raw_buffer()->dim;
 

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -40,6 +40,8 @@ class Op;
 
 class Tensor;
 using TensorPtr = std::shared_ptr<Tensor>;
+using TensorOffset = SmallVector<int, max_rank>;
+using TensorDimensions = SmallVector<halide_dimension_t, max_rank>;
 
 // Storage for a tensor. This can be shared among several tensors aliasing
 // the same memory. All aliases use the strides of the buffer in this storage
@@ -82,7 +84,8 @@ class Tensor {
     // (It may actually refer to read-only external memory, or it may simply be marked this may as
     // the result of a transform.)
     bool is_constant_ = false;
-    // If true, this Tensor's storage is externally owned and must not be freed.
+    // If true, this Tensor's buffer was externally created and must not be modified,
+    // (aside from allowing the buffer's dtor to run normally).
     bool is_external_ = false;
     // If true, this Tensor is 'dynamic' (i.e., it's an output whose size
     // is calculated during evaluation, rather than ahead of time).  It is an error
@@ -93,7 +96,7 @@ class Tensor {
     // Possibly shared storage for this tensor.
     std::shared_ptr<TensorStorage> storage_;
     // The offset of this tensor into the storage buffer.
-    SmallVector<int, max_rank> storage_offset_;
+    TensorOffset storage_offset_;
 
     // A list of ops that use this tensor as an output or an input, respectively.
     std::list<Op *> producers_;
@@ -169,7 +172,11 @@ public:
         is_external_ = external;
     }
 
-    void set_external_host(void *host);
+    // Requires that set_external() has already been called.
+    // external_buffer must have the same dimensions, mins, and extents
+    // as the current buffer (but the strides need not match).
+    // external_buffer must *not* have a null host pointer.
+    void set_external_buffer(HalideBuffer<void> external_buffer);
 
     bool is_dynamic() const {
         return is_dynamic_;
@@ -200,7 +207,7 @@ public:
     void resize(const Box &new_shape);
 
     bool is_alias() const;
-    void set_alias_of(const TensorPtr &t, const SmallVector<int, max_rank> &offset = {});
+    void set_alias_of(const TensorPtr &t, const TensorOffset &offset = {});
 
     void add_consumer(Op *op);
     void add_producer(Op *op);

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -93,7 +93,7 @@ class InPlace : public OpVisitor {
 
     // We can alias two tensors if the input is not used after the output is written,
     // and we meet a number of other requirements.
-    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, SmallVector<int, max_rank> offset = {}) const {
+    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, TensorOffset offset = {}) const {
         // If the input is used anywhere else, we should not alias it.
         // TODO: This is conservative, we could alias it if it is the *last* use.
         if (input->consumers().size() != 1) {
@@ -177,7 +177,7 @@ class InPlace : public OpVisitor {
 
     void visit(ConcatenationOp *op) {
         bool is_no_op = true;
-        SmallVector<int, max_rank> offset(op->axis() + 1);
+        TensorOffset offset(op->axis() + 1);
         for (int i = 0; i < op->input_count(); i++) {
             is_no_op = is_no_op && maybe_alias_tensors(op->input(i), op->output(), offset);
             is_no_op = is_no_op && op->input(i)->quantization() == op->output()->quantization();
@@ -191,7 +191,7 @@ class InPlace : public OpVisitor {
 
     void visit(SplitOp *op) {
         bool is_no_op = true;
-        SmallVector<int, max_rank> offset(op->axis() + 1);
+        TensorOffset offset(op->axis() + 1);
         for (int i = 0; i < op->output_count(); i++) {
             is_no_op = is_no_op && maybe_alias_tensors(op->input(), op->output(i), offset);
             is_no_op = is_no_op && op->output(i)->quantization() == op->input()->quantization();
@@ -211,7 +211,7 @@ class InPlace : public OpVisitor {
 
         auto padding = op->input(1)->buffer<const int32_t>();
 
-        SmallVector<int, max_rank> offset(padding.extent(1));
+        TensorOffset offset(padding.extent(1));
         for (int d = 0; d < padding.extent(1); d++) {
             offset[d] = padding(0, d);
         }


### PR DESCRIPTION
This is minor hygiene: instead of dancing on the host field, require the entire buffer to be 'external'; this will make it cleaner if we need to add usage of Buffers with non-host memory in the future, and is just generally less icky.

Also, drive-by addition of typedefs to Tensor for offsets and dimensions.

(Cherry-picked from #6097)
