### PR TITLE
[hannk] Add --keep_going flag to ModelRunner

### DIFF
--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -531,6 +531,10 @@ int ModelRunner::parse_flags(int argc, char **argv, std::vector<std::string> &fi
              this->external_delegate_path = value;
              return 0;
          }},
+        {"keep_going", [this](const std::string &value) {
+             this->keep_going = std::stoi(value) != 0;
+             return 0;
+         }},
         {"seed", [&seed](const std::string &value) {
              seed = std::stoi(value);
              return 0;
@@ -654,7 +658,9 @@ void ModelRunner::run(const std::string &filename) {
 
         if (!all_matched) {
             std::cerr << "Some runs exceeded the error threshold!\n";
-            exit(1);
+            if (!keep_going) {
+                exit(1);
+            }
         }
     }
 }

--- a/apps/hannk/util/model_runner.h
+++ b/apps/hannk/util/model_runner.h
@@ -101,6 +101,7 @@ struct ModelRunner {
     bool do_run[kNumRuns];  // no way to default-init everything to anything but zero, alas
     bool do_benchmark = true;
     bool do_compare_results = true;
+    bool keep_going = false;
     double tolerance;
     std::string external_delegate_path;
 


### PR DESCRIPTION
This allows you to run a compare operation against a bunch of graphs without exiting at the first one that is out-of-spec for comparison. (Useful when you want to verify that no *new* differences are introduced by a change.)