### PR TITLE
Float16 support in CodeGen_ARM

### DIFF
--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -149,6 +149,7 @@ void define_enums(py::module &m) {
         .value("SVE", Target::Feature::SVE)
         .value("SVE2", Target::Feature::SVE2)
         .value("ARMDotProd", Target::Feature::ARMDotProd)
+        .value("ARMFp16", Target::Feature::ARMFp16)
         .value("LLVMLargeCodeModel", Target::Feature::LLVMLargeCodeModel)
         .value("RVV", Target::Feature::RVV)
         .value("ARMv81a", Target::Feature::ARMv81a)

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1,3 +1,4 @@
+#include <set>
 #include <sstream>
 
 #include "CSE.h"
@@ -56,6 +57,9 @@ protected:
     void visit(const LE *) override;
     void codegen_vector_reduce(const VectorReduce *, const Expr &) override;
     // @}
+    Type upgrade_type_for_arithmetic(const Type &t) const override;
+    Type upgrade_type_for_argument_passing(const Type &t) const override;
+    Type upgrade_type_for_storage(const Type &t) const override;
 
     /** Various patterns to peephole match against */
     struct Pattern {
@@ -77,6 +81,12 @@ protected:
     bool neon_intrinsics_disabled() {
         return target.has_feature(Target::NoNEON);
     }
+
+    bool isFloat16AndHasFeature(const Type &t) const {
+        // NOTE : t.is_float() returns true even in case of BFloat16. We don't include it for now.
+        return t.code() == Type::Float && t.bits() == 16 && target.has_feature(Target::ARMFp16);
+    }
+    bool supports_call_as_float16(const Call *op) const override;
 };
 
 CodeGen_ARM::CodeGen_ARM(const Target &target)
@@ -214,6 +224,7 @@ struct ArmIntrinsic {
         ScalarsAreVectors = 1 << 5,  // Some intrinsics have scalar arguments that are vector parameters :(
         SplitArg0 = 1 << 6,          // This intrinsic requires splitting the argument into the low and high halves.
         NoPrefix = 1 << 7,           // Don't prefix the intrinsic with llvm.*
+        RequireFp16 = 1 << 8,        // Available only if Target has ARMFp16 feature
     };
 };
 
@@ -223,8 +234,9 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vabs", "abs", UInt(16, 4), "abs", {Int(16, 4)}, ArmIntrinsic::HalfWidth},
     {"vabs", "abs", UInt(32, 2), "abs", {Int(32, 2)}, ArmIntrinsic::HalfWidth},
     {"llvm.fabs", "llvm.fabs", Float(32, 2), "abs", {Float(32, 2)}, ArmIntrinsic::HalfWidth},
+    {"llvm.fabs", "llvm.fabs", Float(16, 4), "abs", {Float(16, 4)}, ArmIntrinsic::HalfWidth | ArmIntrinsic::RequireFp16},
 
-    {"llvm.sqrt", "llvm.sqrt", Float(32, 4), "sqrt_f32", {Float(32, 4)}},
+    {"llvm.sqrt", "llvm.sqrt", Float(32, 2), "sqrt_f32", {Float(32, 2)}, ArmIntrinsic::HalfWidth},
     {"llvm.sqrt", "llvm.sqrt", Float(64, 2), "sqrt_f64", {Float(64, 2)}},
 
     // SABD, UABD - Absolute difference
@@ -301,6 +313,11 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vmins", "smin", Int(32, 2), "min", {Int(32, 2), Int(32, 2)}, ArmIntrinsic::HalfWidth},
     {"vminu", "umin", UInt(32, 2), "min", {UInt(32, 2), UInt(32, 2)}, ArmIntrinsic::HalfWidth},
     {"vmins", "fmin", Float(32, 2), "min", {Float(32, 2), Float(32, 2)}, ArmIntrinsic::HalfWidth},
+    {"vmins", "fmin", Float(16, 4), "min", {Float(16, 4), Float(16, 4)}, ArmIntrinsic::HalfWidth | ArmIntrinsic::RequireFp16},
+
+    // FCVTZS, FCVTZU
+    {nullptr, "fcvtzs", Int(16, 4), "fp_to_int", {Float(16, 4)}, ArmIntrinsic::HalfWidth | ArmIntrinsic::MangleRetArgs | ArmIntrinsic::RequireFp16},
+    {nullptr, "fcvtzu", UInt(16, 4), "fp_to_int", {Float(16, 4)}, ArmIntrinsic::HalfWidth | ArmIntrinsic::MangleRetArgs | ArmIntrinsic::RequireFp16},
 
     // SMAX, UMAX, FMAX - Max
     {"vmaxs", "smax", Int(8, 8), "max", {Int(8, 8), Int(8, 8)}, ArmIntrinsic::HalfWidth},
@@ -310,6 +327,7 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vmaxs", "smax", Int(32, 2), "max", {Int(32, 2), Int(32, 2)}, ArmIntrinsic::HalfWidth},
     {"vmaxu", "umax", UInt(32, 2), "max", {UInt(32, 2), UInt(32, 2)}, ArmIntrinsic::HalfWidth},
     {"vmaxs", "fmax", Float(32, 2), "max", {Float(32, 2), Float(32, 2)}, ArmIntrinsic::HalfWidth},
+    {"vmaxs", "fmax", Float(16, 4), "max", {Float(16, 4), Float(16, 4)}, ArmIntrinsic::HalfWidth | ArmIntrinsic::RequireFp16},
 
     // SQNEG, UQNEG - Saturating negation
     {"vqneg", "sqneg", Int(8, 8), "saturating_negate", {Int(8, 8)}, ArmIntrinsic::HalfWidth},
@@ -478,6 +496,7 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vpadd", nullptr, Int(32, 2), "pairwise_add", {Int(32, 4)}, ArmIntrinsic::SplitArg0},
     {"vpadd", nullptr, UInt(32, 2), "pairwise_add", {UInt(32, 4)}, ArmIntrinsic::SplitArg0},
     {"vpadd", nullptr, Float(32, 2), "pairwise_add", {Float(32, 4)}, ArmIntrinsic::SplitArg0},
+    {"vpadd", nullptr, Float(16, 4), "pairwise_add", {Float(16, 8)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::RequireFp16},
 
     {nullptr, "addp", Int(8, 8), "pairwise_add", {Int(8, 16)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
     {nullptr, "addp", UInt(8, 8), "pairwise_add", {UInt(8, 16)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
@@ -487,6 +506,7 @@ const ArmIntrinsic intrinsic_defs[] = {
     {nullptr, "addp", UInt(32, 2), "pairwise_add", {UInt(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
     {nullptr, "faddp", Float(32, 2), "pairwise_add", {Float(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
     {nullptr, "faddp", Float(64, 2), "pairwise_add", {Float(64, 4)}, ArmIntrinsic::SplitArg0},
+    {nullptr, "faddp", Float(16, 4), "pairwise_add", {Float(16, 8)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth | ArmIntrinsic::RequireFp16},
 
     // SADDLP, UADDLP - Pairwise add long.
     {"vpaddls", "saddlp", Int(16, 4), "pairwise_widening_add", {Int(8, 8)}, ArmIntrinsic::HalfWidth | ArmIntrinsic::MangleRetArgs},
@@ -518,6 +538,7 @@ const ArmIntrinsic intrinsic_defs[] = {
     {nullptr, "smaxp", Int(32, 2), "pairwise_max", {Int(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
     {nullptr, "umaxp", UInt(32, 2), "pairwise_max", {UInt(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
     {nullptr, "fmaxp", Float(32, 2), "pairwise_max", {Float(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
+    {nullptr, "fmaxp", Float(16, 4), "pairwise_max", {Float(16, 8)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth | ArmIntrinsic::RequireFp16},
 
     // On arm32, we only have half-width versions of these.
     {"vpmaxs", nullptr, Int(8, 8), "pairwise_max", {Int(8, 16)}, ArmIntrinsic::SplitArg0},
@@ -527,6 +548,7 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vpmaxs", nullptr, Int(32, 2), "pairwise_max", {Int(32, 4)}, ArmIntrinsic::SplitArg0},
     {"vpmaxu", nullptr, UInt(32, 2), "pairwise_max", {UInt(32, 4)}, ArmIntrinsic::SplitArg0},
     {"vpmaxs", nullptr, Float(32, 2), "pairwise_max", {Float(32, 4)}, ArmIntrinsic::SplitArg0},
+    {"vpmaxs", nullptr, Float(16, 4), "pairwise_max", {Float(16, 8)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::RequireFp16},
 
     // SMINP, UMINP, FMINP - Pairwise min.
     {nullptr, "sminp", Int(8, 8), "pairwise_min", {Int(8, 16)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
@@ -536,6 +558,7 @@ const ArmIntrinsic intrinsic_defs[] = {
     {nullptr, "sminp", Int(32, 2), "pairwise_min", {Int(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
     {nullptr, "uminp", UInt(32, 2), "pairwise_min", {UInt(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
     {nullptr, "fminp", Float(32, 2), "pairwise_min", {Float(32, 4)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth},
+    {nullptr, "fminp", Float(16, 4), "pairwise_min", {Float(16, 8)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::HalfWidth | ArmIntrinsic::RequireFp16},
 
     // On arm32, we only have half-width versions of these.
     {"vpmins", nullptr, Int(8, 8), "pairwise_min", {Int(8, 16)}, ArmIntrinsic::SplitArg0},
@@ -545,6 +568,7 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vpmins", nullptr, Int(32, 2), "pairwise_min", {Int(32, 4)}, ArmIntrinsic::SplitArg0},
     {"vpminu", nullptr, UInt(32, 2), "pairwise_min", {UInt(32, 4)}, ArmIntrinsic::SplitArg0},
     {"vpmins", nullptr, Float(32, 2), "pairwise_min", {Float(32, 4)}, ArmIntrinsic::SplitArg0},
+    {"vpmins", nullptr, Float(16, 4), "pairwise_min", {Float(16, 8)}, ArmIntrinsic::SplitArg0 | ArmIntrinsic::RequireFp16},
 
     // SDOT, UDOT - Dot products.
     // Mangle this one manually, there aren't that many and it is a special case.
@@ -566,6 +590,43 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vabdl_i32x2", "vabdl_i32x2", Int(64, 2), "widening_absd", {Int(32, 2), Int(32, 2)}, ArmIntrinsic::NoMangle | ArmIntrinsic::NoPrefix},
     {"vabdl_i32x2", "vabdl_i32x2", UInt(64, 2), "widening_absd", {Int(32, 2), Int(32, 2)}, ArmIntrinsic::NoMangle | ArmIntrinsic::NoPrefix},
     {"vabdl_u32x2", "vabdl_u32x2", UInt(64, 2), "widening_absd", {UInt(32, 2), UInt(32, 2)}, ArmIntrinsic::NoMangle | ArmIntrinsic::NoPrefix},
+};
+
+// List of fp16 math functions which we can avoid "emulated" equivalent code generation.
+// Only possible if the target has ARMFp16 feature.
+
+// These can be vectorized as fp16 SIMD instruction
+const std::set<string> float16_native_funcs = {
+    "sqrt_f16",
+    "floor_f16",
+    "ceil_f16",
+    "round_f16",
+    "trunc_f16",
+    "is_nan_f16",
+    "is_inf_f16",
+    "is_finite_f16",
+};
+
+// These end up with fp32 math function call.
+// However, data type conversion of fp16 <-> fp32 is performed natively rather than emulation.
+// SIMD instruction is not available, so scalar based instruction is generated.
+const std::map<string, string> float16_transcendental_remapping = {
+    {"sin_f16", "sin_f32"},
+    {"asin_f16", "asin_f32"},
+    {"cos_f16", "cos_f32"},
+    {"acos_f16", "acos_f32"},
+    {"tan_f16", "tan_f32"},
+    {"atan_f16", "atan_f32"},
+    {"atan2_f16", "atan2_f32"},
+    {"sinh_f16", "sinh_f32"},
+    {"asinh_f16", "asinh_f32"},
+    {"cosh_f16", "cosh_f32"},
+    {"acosh_f16", "acosh_f32"},
+    {"tanh_f16", "tanh_f32"},
+    {"atanh_f16", "atanh_f32"},
+    {"exp_f16", "exp_f32"},
+    {"log_f16", "log_f32"},
+    {"pow_f16", "pow_f32"},
 };
 // clang-format on
 
@@ -615,6 +676,9 @@ void CodeGen_ARM::init_module() {
 
     string prefix = target.bits == 32 ? "llvm.arm.neon." : "llvm.aarch64.neon.";
     for (const ArmIntrinsic &intrin : intrinsic_defs) {
+        if (intrin.flags & ArmIntrinsic::RequireFp16 && !target.has_feature(Target::ARMFp16)) {
+            continue;
+        }
         // Get the name of the intrinsic with the appropriate prefix.
         const char *intrin_name = nullptr;
         if (target.bits == 32) {
@@ -765,6 +829,17 @@ void CodeGen_ARM::visit(const Cast *op) {
         }
     }
 
+    // LLVM fptoui generates fcvtzs if src is fp16 scalar else fcvtzu.
+    // To avoid that, we use neon intrinsic explicitly.
+    if (isFloat16AndHasFeature(op->value.type())) {
+        if (op->type.is_int_or_uint() && op->type.bits() == 16) {
+            value = call_overloaded_intrin(op->type, "fp_to_int", {op->value});
+            if (value) {
+                return;
+            }
+        }
+    }
+
     CodeGen_Posix::visit(op);
 }
 
@@ -786,10 +861,12 @@ void CodeGen_ARM::visit(const Sub *op) {
 
     // llvm will generate floating point negate instructions if we ask for (-0.0f)-x
     if (op->type.is_float() &&
-        op->type.bits() >= 32 &&
+        (op->type.bits() >= 32 || isFloat16AndHasFeature(op->type)) &&
         is_const_zero(op->a)) {
         Constant *a;
-        if (op->type.bits() == 32) {
+        if (op->type.bits() == 16) {
+            a = ConstantFP::getNegativeZero(f16_t);
+        } else if (op->type.bits() == 32) {
             a = ConstantFP::getNegativeZero(f32_t);
         } else if (op->type.bits() == 64) {
             a = ConstantFP::getNegativeZero(f64_t);
@@ -873,6 +950,7 @@ void CodeGen_ARM::visit(const Store *op) {
         Type elt = t.element_of();
         int vec_bits = t.bits() * t.lanes();
         if (elt == Float(32) ||
+            isFloat16AndHasFeature(elt) ||
             elt == Int(8) || elt == Int(16) || elt == Int(32) ||
             elt == UInt(8) || elt == UInt(16) || elt == UInt(32)) {
             if (vec_bits % 128 == 0) {
@@ -1097,6 +1175,24 @@ void CodeGen_ARM::visit(const Call *op) {
         }
     }
 
+    if (target.has_feature(Target::ARMFp16)) {
+        auto it = float16_transcendental_remapping.find(op->name);
+        if (it != float16_transcendental_remapping.end()) {
+            // This op doesn't have float16 native function.
+            // So we call float32 equivalent func with native type conversion between fp16 and fp32
+            // instead of emulated equivalent code as in EmulatedFloat16Math.cpp
+            std::vector<Expr> new_args(op->args.size());
+            for (size_t i = 0; i < op->args.size(); i++) {
+                new_args[i] = cast(Float(32, op->args[i].type().lanes()), op->args[i]);
+            }
+            auto &fp32_func_name = it->second;
+            Expr e = Call::make(Float(32, op->type.lanes()), fp32_func_name, new_args, op->call_type,
+                                op->func, op->value_index, op->image, op->param);
+            value = codegen(cast(Float(16, e.type().lanes()), e));
+            return;
+        }
+    }
+
     CodeGen_Posix::visit(op);
 }
 
@@ -1266,6 +1362,27 @@ void CodeGen_ARM::codegen_vector_reduce(const VectorReduce *op, const Expr &init
     CodeGen_Posix::codegen_vector_reduce(op, init);
 }
 
+Type CodeGen_ARM::upgrade_type_for_arithmetic(const Type &t) const {
+    if (isFloat16AndHasFeature(t)) {
+        return t;
+    }
+    return CodeGen_Posix::upgrade_type_for_arithmetic(t);
+}
+
+Type CodeGen_ARM::upgrade_type_for_argument_passing(const Type &t) const {
+    if (isFloat16AndHasFeature(t)) {
+        return t;
+    }
+    return CodeGen_Posix::upgrade_type_for_argument_passing(t);
+}
+
+Type CodeGen_ARM::upgrade_type_for_storage(const Type &t) const {
+    if (isFloat16AndHasFeature(t)) {
+        return t;
+    }
+    return CodeGen_Posix::upgrade_type_for_storage(t);
+}
+
 string CodeGen_ARM::mcpu() const {
     if (target.bits == 32) {
         if (target.has_feature(Target::ARMv7s)) {
@@ -1316,6 +1433,11 @@ string CodeGen_ARM::mattrs() const {
             separator = ",";
         }
 
+        if (target.has_feature(Target::ARMFp16)) {
+            arch_flags += separator + "+fullfp16";
+            separator = ",";
+        }
+
         if (target.os == Target::IOS || target.os == Target::OSX) {
             return arch_flags + separator + "+reserve-x18";
         } else {
@@ -1335,6 +1457,12 @@ bool CodeGen_ARM::use_soft_float_abi() const {
 
 int CodeGen_ARM::native_vector_bits() const {
     return 128;
+}
+
+bool CodeGen_ARM::supports_call_as_float16(const Call *op) const {
+    bool is_fp16_native = float16_native_funcs.find(op->name) != float16_native_funcs.end();
+    bool is_fp16_transcendental = float16_transcendental_remapping.find(op->name) != float16_transcendental_remapping.end();
+    return target.has_feature(Target::ARMFp16) && (is_fp16_native || is_fp16_transcendental);
 }
 
 }  // namespace

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3160,7 +3160,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         builder->setFastMathFlags(safe_flags);
         builder->setDefaultFPMathTag(strict_fp_math_md);
         value = codegen(op->args[0]);
-    } else if (is_float16_transcendental(op)) {
+    } else if (is_float16_transcendental(op) && !supports_call_as_float16(op)) {
         value = codegen(lower_float16_transcendental_to_float32_equivalent(op));
     } else if (op->is_intrinsic(Call::mux)) {
         value = codegen(lower_mux(op));
@@ -3196,7 +3196,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         Expr e = Internal::halide_exp(op->args[0]);
         e.accept(this);
     } else if (op->call_type == Call::PureExtern &&
-               (op->name == "is_nan_f32" || op->name == "is_nan_f64")) {
+               (op->name == "is_nan_f32" || op->name == "is_nan_f64" || op->name == "is_nan_f16")) {
         internal_assert(op->args.size() == 1);
         Value *a = codegen(op->args[0]);
 
@@ -3218,7 +3218,7 @@ void CodeGen_LLVM::visit(const Call *op) {
 
         value = builder->CreateFCmpUNO(a, a);
     } else if (op->call_type == Call::PureExtern &&
-               (op->name == "is_inf_f32" || op->name == "is_inf_f64")) {
+               (op->name == "is_inf_f32" || op->name == "is_inf_f64" || op->name == "is_inf_f16")) {
         internal_assert(op->args.size() == 1);
 
         IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter>::FastMathFlagGuard guard(*builder);
@@ -3233,7 +3233,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         Expr inf = e.type().max();
         codegen(abs(e) == inf);
     } else if (op->call_type == Call::PureExtern &&
-               (op->name == "is_finite_f32" || op->name == "is_finite_f64")) {
+               (op->name == "is_finite_f32" || op->name == "is_finite_f64" || op->name == "is_finite_f16")) {
         internal_assert(op->args.size() == 1);
         internal_assert(op->args[0].type().is_float());
 
@@ -4381,6 +4381,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
     const int output_lanes = op->type.lanes();
     const int native_lanes = native_vector_bits() / op->type.bits();
     const int factor = val.type().lanes() / output_lanes;
+    Type elt = op->type.element_of();
 
     Expr (*binop)(Expr, Expr) = nullptr;
     switch (op->op) {
@@ -4431,7 +4432,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
         return;
     }
 
-    if (op->type.element_of() == Float(16)) {
+    if (elt == Float(16) && upgrade_type_for_arithmetic(elt) != elt) {
         Expr equiv = cast(op->value.type().with_bits(32), op->value);
         equiv = VectorReduce::make(op->op, equiv, op->type.lanes());
         if (init.defined()) {
@@ -5102,6 +5103,10 @@ bool CodeGen_LLVM::use_pic() const {
 
 std::string CodeGen_LLVM::mabi() const {
     return "";
+}
+
+bool CodeGen_LLVM::supports_call_as_float16(const Call *op) const {
+    return false;
 }
 
 }  // namespace Internal

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -517,6 +517,10 @@ protected:
     /** Emit atomic store instructions? */
     bool emit_atomic_stores;
 
+    /** Can we call this operation with float16 type?
+        This is used to avoid "emulated" equivalent code-gen in case target has FP16 feature **/
+    virtual bool supports_call_as_float16(const Call *op) const;
+
 private:
     /** All the values in scope at the current code location during
      * codegen. Use sym_push and sym_pop to access. */

--- a/src/ConciseCasts.h
+++ b/src/ConciseCasts.h
@@ -25,6 +25,11 @@ inline Expr f32(Expr e) {
     return cast(t, std::move(e));
 }
 
+inline Expr f16(Expr e) {
+    Type t = Float(16, e.type().lanes());
+    return cast(t, std::move(e));
+}
+
 inline Expr bf16(Expr e) {
     Type t = BFloat(16, e.type().lanes());
     return cast(t, std::move(e));

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -2186,7 +2186,7 @@ Expr fast_inverse(Expr x) {
     } else if (t == Float(16)) {
         return Internal::Call::make(t, "fast_inverse_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        user_assert(0) << "fast_inverse only takes float arguments\n";
+        user_error << "fast_inverse only takes float16 or float32 arguments\n";
         return Expr();
     }
 }
@@ -2199,7 +2199,7 @@ Expr fast_inverse_sqrt(Expr x) {
     } else if (t == Float(16)) {
         return Internal::Call::make(t, "fast_inverse_sqrt_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        user_assert(0) << "fast_inverse_sqrt only takes float arguments\n";
+        user_error << "fast_inverse_sqrt only takes float16 or float32 arguments\n";
         return Expr();
     }
 }

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -2179,15 +2179,29 @@ Expr fast_pow(Expr x, Expr y) {
 }
 
 Expr fast_inverse(Expr x) {
-    user_assert(x.type() == Float(32)) << "fast_inverse only takes float arguments\n";
+    user_assert(x.defined()) << "fast_inverse of undefined Expr\n";
     Type t = x.type();
-    return Internal::Call::make(t, "fast_inverse_f32", {std::move(x)}, Internal::Call::PureExtern);
+    if (t == Float(32)) {
+        return Internal::Call::make(t, "fast_inverse_f32", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t == Float(16)) {
+        return Internal::Call::make(t, "fast_inverse_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        user_assert(0) << "fast_inverse only takes float arguments\n";
+        return Expr();
+    }
 }
 
 Expr fast_inverse_sqrt(Expr x) {
-    user_assert(x.type() == Float(32)) << "fast_inverse_sqrt only takes float arguments\n";
+    user_assert(x.defined()) << "fast_inverse_sqrt of undefined Expr\n";
     Type t = x.type();
-    return Internal::Call::make(t, "fast_inverse_sqrt_f32", {std::move(x)}, Internal::Call::PureExtern);
+    if (t == Float(32)) {
+        return Internal::Call::make(t, "fast_inverse_sqrt_f32", {std::move(x)}, Internal::Call::PureExtern);
+    } else if (t == Float(16)) {
+        return Internal::Call::make(t, "fast_inverse_sqrt_f16", {std::move(x)}, Internal::Call::PureExtern);
+    } else {
+        user_assert(0) << "fast_inverse_sqrt only takes float arguments\n";
+        return Expr();
+    }
 }
 
 Expr floor(Expr x) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -380,6 +380,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sve", Target::SVE},
     {"sve2", Target::SVE2},
     {"arm_dot_prod", Target::ARMDotProd},
+    {"arm_fp16", Target::ARMFp16},
     {"llvm_large_code_model", Target::LLVMLargeCodeModel},
     {"rvv", Target::RVV},
     {"armv81a", Target::ARMv81a},

--- a/src/Target.h
+++ b/src/Target.h
@@ -126,6 +126,7 @@ struct Target {
         SVE = halide_target_feature_sve,
         SVE2 = halide_target_feature_sve2,
         ARMDotProd = halide_target_feature_arm_dot_prod,
+        ARMFp16 = halide_target_feature_arm_fp16,
         LLVMLargeCodeModel = halide_llvm_large_code_model,
         RVV = halide_target_feature_rvv,
         ARMv81a = halide_target_feature_armv81a,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1334,6 +1334,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_sve2,                   ///< Enable ARM Scalable Vector Extensions v2
     halide_target_feature_egl,                    ///< Force use of EGL support.
     halide_target_feature_arm_dot_prod,           ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
+    halide_target_feature_arm_fp16,               ///< Enable ARMv8.2-a half-precision floating point data processing
     halide_llvm_large_code_model,                 ///< Use the LLVM large code model to compile
     halide_target_feature_rvv,                    ///< Enable RISCV "V" Vector Extension
     halide_target_feature_armv81a,                ///< Enable ARMv8.1-a instructions

--- a/src/runtime/aarch64.ll
+++ b/src/runtime/aarch64.ll
@@ -54,6 +54,14 @@ declare <4 x float> @llvm.aarch64.neon.frecps.v4f32(<4 x float> %x, <4 x float> 
 declare <2 x float> @llvm.aarch64.neon.frecps.v2f32(<2 x float> %x, <2 x float> %y) nounwind readnone;
 declare <4 x float> @llvm.aarch64.neon.frsqrts.v4f32(<4 x float> %x, <4 x float> %y) nounwind readnone;
 declare <2 x float> @llvm.aarch64.neon.frsqrts.v2f32(<2 x float> %x, <2 x float> %y) nounwind readnone;
+declare <8 x half> @llvm.aarch64.neon.frecpe.v8f16(<8 x half> %x) nounwind readnone;
+declare <4 x half> @llvm.aarch64.neon.frecpe.v4f16(<4 x half> %x) nounwind readnone;
+declare <8 x half> @llvm.aarch64.neon.frsqrte.v8f16(<8 x half> %x) nounwind readnone;
+declare <4 x half> @llvm.aarch64.neon.frsqrte.v4f16(<4 x half> %x) nounwind readnone;
+declare <8 x half> @llvm.aarch64.neon.frecps.v8f16(<8 x half> %x, <8 x half> %y) nounwind readnone;
+declare <4 x half> @llvm.aarch64.neon.frecps.v4f16(<4 x half> %x, <4 x half> %y) nounwind readnone;
+declare <8 x half> @llvm.aarch64.neon.frsqrts.v8f16(<8 x half> %x, <8 x half> %y) nounwind readnone;
+declare <4 x half> @llvm.aarch64.neon.frsqrts.v4f16(<4 x half> %x, <4 x half> %y) nounwind readnone;
 
 define weak_odr float @fast_inverse_f32(float %x) nounwind alwaysinline {
        %vec = insertelement <2 x float> undef, float %x, i32 0
@@ -74,6 +82,27 @@ define weak_odr <4 x float> @fast_inverse_f32x4(<4 x float> %x) nounwind alwaysi
        %correction = tail call <4 x float> @llvm.aarch64.neon.frecps.v4f32(<4 x float> %approx, <4 x float> %x)
        %result = fmul <4 x float> %approx, %correction
        ret <4 x float> %result
+}
+
+define weak_odr half @fast_inverse_f16(half %x) nounwind alwaysinline {
+       %vec = insertelement <4 x half> undef, half %x, i32 0
+       %approx = tail call <4 x half> @fast_inverse_f16x4(<4 x half> %vec)
+       %result = extractelement <4 x half> %approx, i32 0
+       ret half %result
+}
+
+define weak_odr <4 x half> @fast_inverse_f16x4(<4 x half> %x) nounwind alwaysinline {
+       %approx = tail call <4 x half> @llvm.aarch64.neon.frecpe.v4f16(<4 x half> %x)
+       %correction = tail call <4 x half> @llvm.aarch64.neon.frecps.v4f16(<4 x half> %approx, <4 x half> %x)
+       %result = fmul <4 x half> %approx, %correction
+       ret <4 x half> %result
+}
+
+define weak_odr <8 x half> @fast_inverse_f16x8(<8 x half> %x) nounwind alwaysinline {
+       %approx = tail call <8 x half> @llvm.aarch64.neon.frecpe.v8f16(<8 x half> %x)
+       %correction = tail call <8 x half> @llvm.aarch64.neon.frecps.v8f16(<8 x half> %approx, <8 x half> %x)
+       %result = fmul <8 x half> %approx, %correction
+       ret <8 x half> %result
 }
 
 define weak_odr float @fast_inverse_sqrt_f32(float %x) nounwind alwaysinline {
@@ -97,4 +126,27 @@ define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind al
        %correction = tail call <4 x float> @llvm.aarch64.neon.frsqrts.v4f32(<4 x float> %approx2, <4 x float> %x)
        %result = fmul <4 x float> %approx, %correction
        ret <4 x float> %result
+}
+
+define weak_odr half @fast_inverse_sqrt_f16(half %x) nounwind alwaysinline {
+       %vec = insertelement <4 x half> undef, half %x, i32 0
+       %approx = tail call <4 x half> @fast_inverse_sqrt_f16x4(<4 x half> %vec)
+       %result = extractelement <4 x half> %approx, i32 0
+       ret half %result
+}
+
+define weak_odr <4 x half> @fast_inverse_sqrt_f16x4(<4 x half> %x) nounwind alwaysinline {
+       %approx = tail call <4 x half> @llvm.aarch64.neon.frsqrte.v4f16(<4 x half> %x)
+       %approx2 = fmul <4 x half> %approx, %approx
+       %correction = tail call <4 x half> @llvm.aarch64.neon.frsqrts.v4f16(<4 x half> %approx2, <4 x half> %x)
+       %result = fmul <4 x half> %approx, %correction
+       ret <4 x half> %result
+}
+
+define weak_odr <8 x half> @fast_inverse_sqrt_f16x8(<8 x half> %x) nounwind alwaysinline {
+       %approx = tail call <8 x half> @llvm.aarch64.neon.frsqrte.v8f16(<8 x half> %x)
+       %approx2 = fmul <8 x half> %approx, %approx
+       %correction = tail call <8 x half> @llvm.aarch64.neon.frsqrts.v8f16(<8 x half> %approx2, <8 x half> %x)
+       %result = fmul <8 x half> %approx, %correction
+       ret <8 x half> %result
 }

--- a/src/runtime/arm_cpu_features.cpp
+++ b/src/runtime/arm_cpu_features.cpp
@@ -24,6 +24,7 @@ WEAK CpuFeatures halide_get_cpu_features() {
     // https://github.com/halide/Halide/issues/4727
 
     // TODO: add runtime detection for ARMFp16 extension
+    // https://github.com/halide/Halide/issues/6106
     return features;
 }
 

--- a/src/runtime/arm_cpu_features.cpp
+++ b/src/runtime/arm_cpu_features.cpp
@@ -22,6 +22,8 @@ WEAK CpuFeatures halide_get_cpu_features() {
 
     // TODO: add runtime detection for ARMDotProd extension
     // https://github.com/halide/Halide/issues/4727
+
+    // TODO: add runtime detection for ARMFp16 extension
     return features;
 }
 

--- a/src/runtime/posix_math.ll
+++ b/src/runtime/posix_math.ll
@@ -1,5 +1,6 @@
 declare float @llvm.sqrt.f32(float) nounwind readnone
 declare double @llvm.sqrt.f64(double) nounwind readnone
+declare half @llvm.sqrt.f16(half) nounwind readnone
 
 define weak_odr float @sqrt_f32(float %x) nounwind uwtable readnone alwaysinline {
        %y = tail call float @llvm.sqrt.f32(float %x) nounwind readnone
@@ -9,6 +10,11 @@ define weak_odr float @sqrt_f32(float %x) nounwind uwtable readnone alwaysinline
 define weak_odr double @sqrt_f64(double %x) nounwind uwtable readnone alwaysinline {
        %y = tail call double @llvm.sqrt.f64(double %x) nounwind readnone
        ret double %y
+}
+
+define weak_odr half @sqrt_f16(half %x) nounwind uwtable readnone alwaysinline {
+       %y = tail call half @llvm.sqrt.f16(half %x) nounwind readnone
+       ret half %y
 }
 
 declare float @llvm.sin.f32(float) nounwind readnone
@@ -78,6 +84,7 @@ define weak_odr double @abs_f64(double %x) nounwind uwtable readnone alwaysinlin
 
 declare float @llvm.floor.f32(float) nounwind readnone
 declare double @llvm.floor.f64(double) nounwind readnone
+declare half @llvm.floor.f16(half) nounwind readnone
 
 define weak_odr float @floor_f32(float %x) nounwind uwtable readnone alwaysinline {
        %y = tail call float @llvm.floor.f32(float %x) nounwind readnone
@@ -89,11 +96,17 @@ define weak_odr double @floor_f64(double %x) nounwind uwtable readnone alwaysinl
        ret double %y
 }
 
+define weak_odr half @floor_f16(half %x) nounwind uwtable readnone alwaysinline {
+       %y = tail call half @llvm.floor.f16(half %x) nounwind readnone
+       ret half %y
+}
+
 ; These are llvm 3.3 only
 ; declare float @llvm.ceil.f32(float) nounwind readnone
 ; declare double @llvm.ceil.f64(double) nounwind readnone
 declare float @ceilf(float) nounwind readnone
 declare double @ceil(double) nounwind readnone
+declare half @llvm.ceil.f16(half) nounwind readnone
 
 define weak_odr float @ceil_f32(float %x) nounwind uwtable readnone alwaysinline {
        %y = tail call float @ceilf(float %x) nounwind readnone
@@ -105,8 +118,14 @@ define weak_odr double @ceil_f64(double %x) nounwind uwtable readnone alwaysinli
        ret double %y
 }
 
+define weak_odr half @ceil_f16(half %x) nounwind uwtable readnone alwaysinline {
+       %y = tail call half @llvm.ceil.f16(half %x) nounwind readnone
+       ret half %y
+}
+
 declare float @llvm.nearbyint.f32(float) nounwind readnone
 declare double @llvm.nearbyint.f64(double) nounwind readnone
+declare half @llvm.nearbyint.f16(half) nounwind readnone
 
 define weak_odr float @round_f32(float %x) nounwind uwtable readnone alwaysinline {
        %y = tail call float @llvm.nearbyint.f32(float %x) nounwind readnone
@@ -118,8 +137,14 @@ define weak_odr double @round_f64(double %x) nounwind uwtable readnone alwaysinl
        ret double %y
 }
 
+define weak_odr half @round_f16(half %x) nounwind uwtable readnone alwaysinline {
+       %y = tail call half @llvm.nearbyint.f16(half %x) nounwind readnone
+       ret half %y
+}
+
 declare float @llvm.trunc.f32(float) nounwind readnone
 declare double @llvm.trunc.f64(double) nounwind readnone
+declare half @llvm.trunc.f16(half) nounwind readnone
 
 define weak_odr float @trunc_f32(float %x) nounwind uwtable readnone alwaysinline {
        %y = tail call float @llvm.trunc.f32(float %x) nounwind readnone
@@ -129,6 +154,11 @@ define weak_odr float @trunc_f32(float %x) nounwind uwtable readnone alwaysinlin
 define weak_odr double @trunc_f64(double %x) nounwind uwtable readnone alwaysinline {
        %y = tail call double @llvm.trunc.f64(double %x) nounwind readnone
        ret double %y
+}
+
+define weak_odr half @trunc_f16(half %x) nounwind uwtable readnone alwaysinline {
+       %y = tail call half @llvm.trunc.f16(half %x) nounwind readnone
+       ret half %y
 }
 
 declare float @llvm.pow.f32(float, float) nounwind readnone

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -104,6 +104,7 @@ tests(GROUPS correctness
       float16_t_comparison.cpp
       float16_t_constants.cpp
       float16_t_image_type.cpp
+      float16_t_neon_op_check.cpp
       for_each_element.cpp
       force_onto_stack.cpp
       func_clone.cpp

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -1,0 +1,136 @@
+#include "simd_op_check.h"
+#include "Halide.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+using namespace Halide;
+using namespace Halide::ConciseCasts;
+
+namespace {
+
+// This tests that we can correctly generate all the simd ops
+using std::string;
+using std::vector;
+
+constexpr int max_i8 = 127;
+constexpr int max_i16 = 32767;
+constexpr int max_i32 = 0x7fffffff;
+constexpr int max_u8 = 255;
+constexpr int max_u16 = 65535;
+const Expr max_u32 = UInt(32).max();
+
+class SimdOpCheck : public SimdOpCheckTest {
+public:
+    SimdOpCheck(Target t, int w = 768, int h = 128)
+        : SimdOpCheckTest(t, w, h) {}
+
+        void add_tests() override {
+            if (target.arch == Target::ARM) {
+                check_neon_all();
+            }
+        }
+
+        void check_neon_all() {
+            Expr f64_1  = in_f64(x), f64_2 = in_f64(x + 16), f64_3 = in_f64(x + 32);
+            Expr f32_1  = in_f32(x), f32_2 = in_f32(x + 16), f32_3 = in_f32(x + 32);
+            Expr f16_1  = in_f16(x), f16_2 = in_f16(x + 16), f16_3 = in_f16(x + 32);
+            Expr i8_1   = in_i8(x),  i8_2  = in_i8(x + 16),  i8_3  = in_i8(x + 32);
+            Expr u8_1   = in_u8(x),  u8_2  = in_u8(x + 16),  u8_3  = in_u8(x + 32);
+            Expr i16_1  = in_i16(x), i16_2 = in_i16(x + 16), i16_3 = in_i16(x + 32);
+            Expr u16_1  = in_u16(x), u16_2 = in_u16(x + 16), u16_3 = in_u16(x + 32);
+            Expr i32_1  = in_i32(x), i32_2 = in_i32(x + 16), i32_3 = in_i32(x + 32);
+            Expr u32_1  = in_u32(x), u32_2 = in_u32(x + 16), u32_3 = in_u32(x + 32);
+            Expr i64_1  = in_i64(x), i64_2 = in_i64(x + 16), i64_3 = in_i64(x + 32);
+            Expr u64_1  = in_u64(x), u64_2 = in_u64(x + 16), u64_3 = in_u64(x + 32);
+            Expr bool_1 = (f32_1 > 0.3f), bool_2 = (f32_1 < -0.3f), bool_3 = (f32_1 != -0.34f);
+
+            // Table copied from the Cortex-A9 TRM.
+
+            // In general neon ops have the 64-bit version, the 128-bit
+            // version (ending in q), and the widening version that takes
+            // 64-bit args and produces a 128-bit result (ending in l). We try
+            // to peephole match any with vector, so we just try 64-bits, 128
+            // bits, 192 bits, and 256 bits for everything.
+
+            bool arm32 = (target.bits == 32);
+
+            int vector_len = 8;
+            check(arm32 ? "vadd.f32" : "fadd", vector_len / 2, f32_1 + f32_2); 
+            check(arm32 ? "vadd.f16" : "fadd", vector_len, f16_1 + f16_2);
+
+            /*
+                // Eventually we'll test a variety of vector lengths 
+                for (int w = 1; w <= 4; w++) {
+
+                    // VADD     I, F    F, D    Add
+                    check(arm32 ? "vadd.f32" : "fadd", 2 * w, f32_1 + f32_2); 
+                    check(arm32 ? "vadd.f16" : "fadd", 2 * w, f16_1 + f16_2);
+                    // check(arm32 ? "vadd.i8" : "add", 8 * w, i8_1 + i8_2);
+                    // check(arm32 ? "vadd.i8" : "add", 8 * w, u8_1 + u8_2);
+                    // check(arm32 ? "vadd.i16" : "add", 4 * w, i16_1 + i16_2);
+                    // check(arm32 ? "vadd.i16" : "add", 4 * w, u16_1 + u16_2);
+                    // check(arm32 ? "vadd.i32" : "add", 2 * w, i32_1 + i32_2);
+                    // check(arm32 ? "vadd.i32" : "add", 2 * w, u32_1 + u32_2);
+                    // check(arm32 ? "vadd.i64" : "add", 2 * w, i64_1 + i64_2);
+                    // check(arm32 ? "vadd.i64" : "add", 2 * w, u64_1 + u64_2);
+                }
+            */
+        }
+private:
+    const Var x{"x"}, y{"y"};
+};
+}  // namespace
+
+int main(int argc, char **argv) {
+    Target host = get_host_target();
+    Target hl_target = Target("arm-64-android");
+    printf("host is:      %s\n", host.to_string().c_str());
+    printf("HL_TARGET is: %s\n", hl_target.to_string().c_str());
+
+    // Create Test Object 
+    SimdOpCheck test(hl_target);
+
+    if (argc > 1) {
+        test.filter = argv[1];
+        test.set_num_threads(1);
+    }
+
+    if (getenv("HL_SIMD_OP_CHECK_FILTER")) {
+        test.filter = getenv("HL_SIMD_OP_CHECK_FILTER");
+    }
+
+    // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;
+    // the fundamental issue is that we make one set of ImageParams to construct many
+    // Exprs, then realize those Exprs on arbitrary threads; it is known that sharing
+    // one Func across multiple threads is not guaranteed to be safe, and indeed, TSAN
+    // reports data races, of which some are likely 'benign' (e.g. Function.freeze) but others
+    // are highly suspect (e.g. Function.lock_loop_levels). Since multithreading here
+    // was added just to avoid having this test be the last to finish, the expedient 'fix'
+    // for now is to remove the multithreading. A proper fix could be made by restructuring this
+    // test so that every Expr constructed for testing was guaranteed to share no Funcs
+    // (Function.deep_copy() perhaps). Of course, it would also be desirable to allow Funcs, Exprs, etc
+    // to be usable across multiple threads, but that is a major undertaking that is
+    // definitely not worthwhile for present Halide usage patterns.
+    test.set_num_threads(1);
+
+    if (argc > 2) {
+        // Don't forget: if you want to run the standard tests to a specific output
+        // directory, you'll need to invoke with the first arg enclosed
+        // in quotes (to avoid it being wildcard-expanded by the shell):
+        //
+        //    correctness_simd_op_check "*" /path/to/output
+        //
+        test.output_directory = argv[2];
+    }
+
+    bool success = test.test_all();
+
+    if (!success) {
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -1,9 +1,8 @@
-#include "simd_op_check.h"
 #include "Halide.h"
+#include "simd_op_check.h"
 
-#include <stdarg.h>
 #include <stdio.h>
-#include <string.h>
+#include <string>
 
 using namespace Halide;
 using namespace Halide::ConciseCasts;
@@ -12,85 +11,327 @@ namespace {
 
 // This tests that we can correctly generate all the simd ops
 using std::string;
-using std::vector;
-
-constexpr int max_i8 = 127;
-constexpr int max_i16 = 32767;
-constexpr int max_i32 = 0x7fffffff;
-constexpr int max_u8 = 255;
-constexpr int max_u16 = 65535;
-const Expr max_u32 = UInt(32).max();
 
 class SimdOpCheck : public SimdOpCheckTest {
 public:
     SimdOpCheck(Target t, int w = 768, int h = 128)
-        : SimdOpCheckTest(t, w, h) {}
+        : SimdOpCheckTest(t, w, h) {
+    }
 
-        void add_tests() override {
-            if (target.arch == Target::ARM) {
-                check_neon_all();
+    bool can_run_code() const override {
+        // If we can (target matches host), run the error checking Halide::Func.
+
+        // TODO: Since features of Arm CPU cannot be obtained automatically from get_host_target(),
+        // it is necessary to set "arm_fp16" feature explicitly to HL_JIT_TARGET.
+        // Error is thrown if there is unacceptable mismatch between jit_target and host_target.
+        Target jit_target = get_jit_target_from_environment();
+        bool can_run_the_code =
+            (target.arch == jit_target.arch &&
+             target.bits == jit_target.bits &&
+             target.os == jit_target.os);
+        // A bunch of feature flags also need to match between the
+        // compiled code and the host in order to run the code.
+        for (Target::Feature f : {Target::ARMFp16, Target::NoNEON}) {
+            if (target.has_feature(f) != jit_target.has_feature(f)) {
+                can_run_the_code = false;
+            }
+        }
+        return can_run_the_code;
+    }
+
+    void add_tests() override {
+        check_neon_float16_all();
+    }
+
+    void check_neon_float16_all() {
+        Expr f64_1 = in_f64(x), f64_2 = in_f64(x + 16), f64_3 = in_f64(x + 32);
+        Expr f32_1 = in_f32(x), f32_2 = in_f32(x + 16), f32_3 = in_f32(x + 32);
+        Expr f16_1 = in_f16(x), f16_2 = in_f16(x + 16), f16_3 = in_f16(x + 32);
+        Expr i8_1 = in_i8(x), i8_2 = in_i8(x + 16), i8_3 = in_i8(x + 32);
+        Expr u8_1 = in_u8(x), u8_2 = in_u8(x + 16), u8_3 = in_u8(x + 32);
+        Expr i16_1 = in_i16(x), i16_2 = in_i16(x + 16), i16_3 = in_i16(x + 32);
+        Expr u16_1 = in_u16(x), u16_2 = in_u16(x + 16), u16_3 = in_u16(x + 32);
+        Expr i32_1 = in_i32(x), i32_2 = in_i32(x + 16), i32_3 = in_i32(x + 32);
+        Expr u32_1 = in_u32(x), u32_2 = in_u32(x + 16), u32_3 = in_u32(x + 32);
+        Expr i64_1 = in_i64(x), i64_2 = in_i64(x + 16), i64_3 = in_i64(x + 32);
+        Expr u64_1 = in_u64(x), u64_2 = in_u64(x + 16), u64_3 = in_u64(x + 32);
+        Expr bool_1 = (f32_1 > 0.3f), bool_2 = (f32_1 < -0.3f), bool_3 = (f32_1 != -0.34f);
+
+        // In general neon ops have the 64-bit version, the 128-bit
+        // version (ending in q), and the widening version that takes
+        // 64-bit args and produces a 128-bit result (ending in l). We try
+        // to peephole match any with vector, so we just try 64-bits, 128
+        // bits, 192 bits, and 256 bits for everything.
+        struct TestParams {
+            const int bits;
+            ImageParam in_f;
+            std::vector<std::pair<int, string>> vl_params;
+            Expr f_1, f_2, f_3, u_1, i_1;
+        };
+        // clang-format off
+        TestParams test_params[2] = {
+            {32, in_f32, {{1, "s"}, {2, ".2s"}, {4, ".4s"}, { 8, ".4s"}}, f32_1, f32_2, f32_3, u32_1, i32_1},
+            {16, in_f16, {{1, "h"}, {4, ".4h"}, {8, ".8h"}, {16, ".8h"}}, f16_1, f16_2, f16_3, u16_1, i16_1}
+        };
+        // clang-format on
+
+        for (auto &test_param : test_params) {  // outer loop for {fp32, fp16}
+            const int bits = test_param.bits;
+            ImageParam in_f = test_param.in_f;
+            Expr f_1 = test_param.f_1;
+            Expr f_2 = test_param.f_2;
+            Expr f_3 = test_param.f_3;
+            Expr u_1 = test_param.u_1;
+            Expr i_1 = test_param.i_1;
+
+            for (auto &vl_param : test_param.vl_params) {
+                const int vl = vl_param.first;
+                const string suffix = vl_param.second;
+                bool is_vector = vl > 1;
+
+                check_neon_suffix("fabs", suffix, vl, abs(f_1));
+                check_neon_suffix("fadd", suffix, vl, f_1 + f_2);
+                check_neon_suffix(is_vector ? "fcmeq" : "fcm", suffix, vl, select(f_1 == f_2, 1.0f, 2.0f));
+                check_neon_suffix(is_vector ? "fcmgt" : "fcm", suffix, vl, select(f_1 > f_2, 1.0f, 2.0f));
+                check_neon_suffix("ucvtf", suffix, vl, cast(Float(bits), u_1));
+                check_neon_suffix("scvtf", suffix, vl, cast(Float(bits), i_1));
+                check_neon_suffix("fcvtzu", suffix, vl, cast(UInt(bits), f_1));
+                check_neon_suffix("fcvtzs", suffix, vl, cast(Int(bits), f_1));
+                check_neon_suffix("fdiv", suffix, vl, f_1 / f_2);
+                check_neon_suffix("frinti", suffix, vl, round(f_1));
+                check_neon_suffix("frintm", suffix, vl, floor(f_1));
+                check_neon_suffix("frintp", suffix, vl, ceil(f_1));
+                if (is_vector) {
+                    check_neon_suffix("dup", suffix, vl, cast(Float(bits), y));
+                }
+                check_neon_suffix("ldr", "", vl, in_f(x));  // vector register is not used
+                if (is_vector) {
+                    check_neon_suffix("ld2", suffix, vl, in_f(x * 2) + in_f(x * 2 + 1));
+                    check_neon_suffix("ld3", suffix, vl, in_f(x * 3) + in_f(x * 3 + 1) + in_f(x * 3 + 2));
+                    check_neon_suffix("ld4", suffix, vl, in_f(x * 4) + in_f(x * 4 + 1) + in_f(x * 4 + 2) + in_f(x * 4 + 3));
+                }
+                check_neon_suffix("fmax", suffix, vl, max(f_1, f_2));
+                check_neon_suffix("fmin", suffix, vl, min(f_1, f_2));
+                check_neon_suffix(is_vector ? "fmla" : "fmadd", suffix, vl, f_1 + f_2 * f_3);
+                check_neon_suffix(is_vector ? "fmls" : "fmsub", suffix, vl, f_1 - f_2 * f_3);
+                check_neon_suffix("fmul", suffix, vl, f_1 * f_2);
+                check_neon_suffix("fneg", suffix, vl, -f_1);
+                check_neon_suffix("frecpe", suffix, vl, fast_inverse(f_1));
+                check_neon_suffix("frecps", suffix, vl, fast_inverse(f_1));
+                check_neon_suffix("frsqrte", suffix, vl, fast_inverse_sqrt(f_1));
+                check_neon_suffix("frsqrts", suffix, vl, fast_inverse_sqrt(f_1));
+                check_neon_suffix("fsqrt", suffix, vl, sqrt(f_1));
+                check_neon_suffix("fsub", suffix, vl, f_1 - f_2);
+                check_neon_suffix("st", "", vl, in_f(x));  // vector register is not used
+
+                if (bits == 16) {
+                    // Some of the math ops (exp,log,pow) for fp16 are converted into "xxx_fp32" call
+                    // and then lowered to Internal::halide_xxx() function.
+                    // In case the target has FP16 feature, native type conversion between fp16 and fp32 should be generated
+                    // instead of emulated equivalent code with other types.
+                    check_neon_suffix("fcvt", suffix, vl, exp(f_1));
+                    check_neon_suffix("fcvt", suffix, vl, log(f_1));
+                    check_neon_suffix("fcvt", suffix, vl, pow(f_1, f_2));
+                }
+
+                // No corresponding instructions exists for is_nan, is_inf, is_finite.
+                // The instructions expected to be generated depends on CodeGen_LLVM::visit(const Call *op)
+                check_neon_suffix(is_vector ? "fcmge" : "fcm", suffix, vl, is_nan(f_1));
+                check_neon_suffix(is_vector ? "fabs" : "fneg", suffix, vl, is_inf(f_1));
+                check_neon_suffix(is_vector ? "fcmlt" : "fcm", suffix, vl, is_finite(f_1));
+            }
+
+            for (int f : {2, 4}) {
+                RDom r(0, f);
+                const int vl = bits == 32 ? 4 : 8;
+                const string suffix = bits == 32 ? ".4s" : ".8h";
+                // A summation reduction that starts at something
+                // non-trivial, to avoid llvm simplifying accumulating
+                // widening summations into just widening summations.
+                auto sum_ = [&](Expr e) {
+                    Func f;
+                    f(x) = cast(e.type(), 123);
+                    f(x) += e;
+                    return f(x);
+                };
+                // VPADD    I, F    -       Pairwise Add
+                check_neon_suffix("faddp", suffix, vl, sum_(in_f(f * x + r)));
+                // VPMAX    I, F    -       Pairwise Maximum
+                check_neon_suffix("fmaxp", suffix, vl, maximum(in_f(f * x + r)));
+                // VPMIN    I, F    -       Pairwise Minimum
+                check_neon_suffix("fminp", suffix, vl, minimum(in_f(f * x + r)));
+            }
+
+            // VST2 X       -       Store two-element structures
+            for (int width = 128; width <= 128 * 4; width *= 2) {
+                const int vector_size = width / bits;
+                Func tmp1, tmp2;
+                tmp1(x) = cast(Float(bits), x);
+                tmp1.compute_root();
+                tmp2(x, y) = select(x % 2 == 0, tmp1(x / 2), tmp1(x / 2 + 16));
+                tmp2.compute_root().vectorize(x, vector_size);
+                auto suffix = suffix_of_st(2, bits, vector_size);
+                check_neon_suffix("st2", suffix, vector_size, tmp2(0, 0) + tmp2(0, 127));
+            }
+            // Also check when the two expressions interleaved have a common
+            // subexpression, which results in a vector var being lifted out.
+            for (int width = 128; width <= 128 * 4; width *= 2) {
+                const int vector_size = width / bits;
+                Func tmp1, tmp2;
+                tmp1(x) = cast(Float(bits), x);
+                tmp1.compute_root();
+                Expr e = (tmp1(x / 2) * 2 + 7) / 4;
+                tmp2(x, y) = select(x % 2 == 0, e * 3, e + 17);
+                tmp2.compute_root().vectorize(x, vector_size);
+                auto suffix = suffix_of_st(2, bits, vector_size);
+                check_neon_suffix("st2", suffix, vector_size, tmp2(0, 0) + tmp2(0, 127));
+            }
+
+            // VST3 X       -       Store three-element structures
+            for (int width = 192; width <= 192 * 4; width *= 2) {
+                const int vector_size = width / bits;
+                Func tmp1, tmp2;
+                tmp1(x) = cast(Float(bits), x);
+                tmp1.compute_root();
+                tmp2(x, y) = select(x % 3 == 0, tmp1(x / 3),
+                                    x % 3 == 1, tmp1(x / 3 + 16),
+                                    tmp1(x / 3 + 32));
+                tmp2.compute_root().vectorize(x, vector_size);
+                auto suffix = suffix_of_st(3, bits, vector_size);
+                check_neon_suffix("st3", suffix, vector_size, tmp2(0, 0) + tmp2(0, 127));
+            }
+
+            // VST4 X       -       Store four-element structures
+            for (int width = 256; width <= 256 * 4; width *= 2) {
+                const int vector_size = width / bits;
+                Func tmp1, tmp2;
+                tmp1(x) = cast(Float(bits), x);
+                tmp1.compute_root();
+                tmp2(x, y) = select(x % 4 == 0, tmp1(x / 4),
+                                    x % 4 == 1, tmp1(x / 4 + 16),
+                                    x % 4 == 2, tmp1(x / 4 + 32),
+                                    tmp1(x / 4 + 48));
+                tmp2.compute_root().vectorize(x, vector_size);
+                auto suffix = suffix_of_st(4, bits, vector_size);
+                check_neon_suffix("st4", suffix, vector_size, tmp2(0, 0) + tmp2(0, 127));
             }
         }
 
-        void check_neon_all() {
-            Expr f64_1  = in_f64(x), f64_2 = in_f64(x + 16), f64_3 = in_f64(x + 32);
-            Expr f32_1  = in_f32(x), f32_2 = in_f32(x + 16), f32_3 = in_f32(x + 32);
-            Expr f16_1  = in_f16(x), f16_2 = in_f16(x + 16), f16_3 = in_f16(x + 32);
-            Expr i8_1   = in_i8(x),  i8_2  = in_i8(x + 16),  i8_3  = in_i8(x + 32);
-            Expr u8_1   = in_u8(x),  u8_2  = in_u8(x + 16),  u8_3  = in_u8(x + 32);
-            Expr i16_1  = in_i16(x), i16_2 = in_i16(x + 16), i16_3 = in_i16(x + 32);
-            Expr u16_1  = in_u16(x), u16_2 = in_u16(x + 16), u16_3 = in_u16(x + 32);
-            Expr i32_1  = in_i32(x), i32_2 = in_i32(x + 16), i32_3 = in_i32(x + 32);
-            Expr u32_1  = in_u32(x), u32_2 = in_u32(x + 16), u32_3 = in_u32(x + 32);
-            Expr i64_1  = in_i64(x), i64_2 = in_i64(x + 16), i64_3 = in_i64(x + 32);
-            Expr u64_1  = in_u64(x), u64_2 = in_u64(x + 16), u64_3 = in_u64(x + 32);
-            Expr bool_1 = (f32_1 > 0.3f), bool_2 = (f32_1 < -0.3f), bool_3 = (f32_1 != -0.34f);
-
-            // Table copied from the Cortex-A9 TRM.
-
-            // In general neon ops have the 64-bit version, the 128-bit
-            // version (ending in q), and the widening version that takes
-            // 64-bit args and produces a 128-bit result (ending in l). We try
-            // to peephole match any with vector, so we just try 64-bits, 128
-            // bits, 192 bits, and 256 bits for everything.
-
-            bool arm32 = (target.bits == 32);
-
-            int vector_len = 8;
-            check(arm32 ? "vadd.f32" : "fadd", vector_len / 2, f32_1 + f32_2); 
-            check(arm32 ? "vadd.f16" : "fadd", vector_len, f16_1 + f16_2);
-
-            /*
-                // Eventually we'll test a variety of vector lengths 
-                for (int w = 1; w <= 4; w++) {
-
-                    // VADD     I, F    F, D    Add
-                    check(arm32 ? "vadd.f32" : "fadd", 2 * w, f32_1 + f32_2); 
-                    check(arm32 ? "vadd.f16" : "fadd", 2 * w, f16_1 + f16_2);
-                    // check(arm32 ? "vadd.i8" : "add", 8 * w, i8_1 + i8_2);
-                    // check(arm32 ? "vadd.i8" : "add", 8 * w, u8_1 + u8_2);
-                    // check(arm32 ? "vadd.i16" : "add", 4 * w, i16_1 + i16_2);
-                    // check(arm32 ? "vadd.i16" : "add", 4 * w, u16_1 + u16_2);
-                    // check(arm32 ? "vadd.i32" : "add", 2 * w, i32_1 + i32_2);
-                    // check(arm32 ? "vadd.i32" : "add", 2 * w, u32_1 + u32_2);
-                    // check(arm32 ? "vadd.i64" : "add", 2 * w, i64_1 + i64_2);
-                    // check(arm32 ? "vadd.i64" : "add", 2 * w, u64_1 + u64_2);
-                }
-            */
+        {
+            // Actually, the following ops are not vectorized because SIMD instruction is unavailable.
+            // The purpose of the test is just to confirm no error.
+            // In case the target has FP16 feature, native type conversion between fp16 and fp32 should be generated
+            // instead of emulated equivalent code with other types.
+            auto check_native_conv = [&](const string &op, Expr e) {
+                check_neon_suffix(op, "", 1, e);
+                check_neon_suffix("fcvt", "h", 1, e);
+            };
+            check_native_conv("sinf", sin(f16_1));
+            check_native_conv("asinf", asin(f16_1));
+            check_native_conv("cosf", cos(f16_1));
+            check_native_conv("acosf", acos(f16_1));
+            check_native_conv("tanf", tan(f16_1));
+            check_native_conv("atanf", atan(f16_1));
+            check_native_conv("atan2f", atan2(f16_1, f16_2));
+            check_native_conv("sinhf", sinh(f16_1));
+            check_native_conv("asinhf", asinh(f16_1));
+            check_native_conv("coshf", cosh(f16_1));
+            check_native_conv("acoshf", acosh(f16_1));
+            check_native_conv("tanhf", tanh(f16_1));
+            check_native_conv("atanhf", atanh(f16_1));
         }
+    }
+
 private:
+    void check_neon_suffix(string op, string suffix, int vector_width, Expr e) {
+        // Filter out the test case
+        if (!wildcard_match(filter, op)) return;
+
+        // Register to tasks
+        check(op, vector_width, e);
+
+        // Store the corresponding suffix
+        assert(tasks.size());
+        assert(tasks.back().op == op);
+        suffix_map.emplace(tasks.back().name, suffix);
+    }
+
+    void compile_and_check(Func error, const string &op, const string &name, int vector_width, std::ostringstream &error_msg) override {
+        std::string fn_name = "test_" + name;
+        std::string file_name = output_directory + fn_name;
+
+        auto ext = Internal::get_output_info(target);
+        std::map<Output, std::string> outputs = {
+            {Output::c_header, file_name + ext.at(Output::c_header).extension},
+            {Output::object, file_name + ext.at(Output::object).extension},
+            {Output::assembly, file_name + ".s"},
+        };
+        error.compile_to(outputs, arg_types, fn_name, target);
+
+        std::ifstream asm_file;
+        asm_file.open(file_name + ".s");
+
+        bool found_it = false;
+
+        string suffix = suffix_map[name];
+        std::ostringstream msg;
+        msg << op << " did not generate for target=" << target.to_string() << " suffix=" << suffix << " vector_width=" << vector_width << ". Instead we got:\n";
+
+        string line;
+        while (getline(asm_file, line)) {
+            msg << line << "\n";
+
+            // Check for the op in question. In addition, check if the expected suffix exists in the operand
+            found_it |= wildcard_search(op, line) && wildcard_search(suffix, line) && !wildcard_search("_" + op, line);
+        }
+
+        if (!found_it) {
+            error_msg << "Failed: " << msg.str() << "\n";
+        }
+
+        asm_file.close();
+    }
+
+    string suffix_of_st(int num_elements, int bits, int vector_size) {
+        assert(num_elements >= 2 && num_elements <= 4);
+        assert(vector_size % num_elements == 0);
+        const int num_lanes = vector_size / num_elements;
+        switch (bits) {
+        case 32:
+            return num_lanes == 2 ? ".2s" : ".4s";
+        case 16:
+            return num_lanes == 4 ? ".4h" : ".8h";
+        default:
+            assert(0);
+            return "unsupported_bits";
+        }
+    }
+
+    std::map<string, string> suffix_map;
     const Var x{"x"}, y{"y"};
 };
 }  // namespace
 
 int main(int argc, char **argv) {
     Target host = get_host_target();
-    Target hl_target = Target("arm-64-android");
+    Target hl_target = get_target_from_environment();
+    Target jit_target = get_jit_target_from_environment();
     printf("host is:      %s\n", host.to_string().c_str());
     printf("HL_TARGET is: %s\n", hl_target.to_string().c_str());
+    printf("HL_JIT_TARGET is: %s\n", jit_target.to_string().c_str());
 
-    // Create Test Object 
-    SimdOpCheck test(hl_target);
+    // Only for 64bit target with fp16 feature
+    if (!(hl_target.arch == Target::ARM && hl_target.bits == 64 && hl_target.has_feature(Target::ARMFp16))) {
+        printf("[SKIP] To run this test, set HL_TARGET=arm-64-<os>-arm_fp16. \n");
+        return 0;
+    }
+    // Create Test Object
+    // Use smaller dimension than default(768, 128) to avoid fp16 overflow in reduction test case
+    SimdOpCheck test(hl_target, 384, 32);
+
+    if (!test.can_run_code()) {
+        printf("[WARN] To run verification of realization, set HL_JIT_TARGET=arm-64-<os>-arm_fp16. \n");
+    }
 
     if (argc > 1) {
         test.filter = argv[1];

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1035,11 +1035,11 @@ public:
                     check(arm32 ? "vpadd.i16" : "addp", 8, sum_(in_u16(f * x + r)));
                     check(arm32 ? "vpadd.i32" : "addp", 4, sum_(in_i32(f * x + r)));
                     check(arm32 ? "vpadd.i32" : "addp", 4, sum_(in_u32(f * x + r)));
-                    check(arm32 ? "vpadd.f32" : "addp", 4, sum_(in_f32(f * x + r)));
+                    check(arm32 ? "vpadd.f32" : "faddp", 4, sum_(in_f32(f * x + r)));
                     // In 32-bit, we don't have a pairwise op for doubles,
                     // and expect to just get vadd instructions on d
                     // registers.
-                    check(arm32 ? "vadd.f64" : "addp", 4, sum_(in_f64(f * x + r)));
+                    check(arm32 ? "vadd.f64" : "faddp", 4, sum_(in_f64(f * x + r)));
 
                     if (f == 2) {
                         // VPADAL   I       -       Pairwise Add and Accumulate Long

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -30,6 +30,7 @@ public:
 
     ImageParam in_f32{Float(32), 1, "in_f32"};
     ImageParam in_f64{Float(64), 1, "in_f64"};
+    ImageParam in_f16{Float(16), 1, "in_f16"};
     ImageParam in_bf16{BFloat(16), 1, "in_bf16"};
     ImageParam in_i8{Int(8), 1, "in_i8"};
     ImageParam in_u8{UInt(8), 1, "in_u8"};
@@ -40,8 +41,8 @@ public:
     ImageParam in_i64{Int(64), 1, "in_i64"};
     ImageParam in_u64{UInt(64), 1, "in_u64"};
 
-    const std::vector<ImageParam> image_params{in_f32, in_f64, in_bf16, in_i8, in_u8, in_i16, in_u16, in_i32, in_u32, in_i64, in_u64};
-    const std::vector<Argument> arg_types{in_f32, in_f64, in_bf16, in_i8, in_u8, in_i16, in_u16, in_i32, in_u32, in_i64, in_u64};
+    const std::vector<ImageParam> image_params{in_f32, in_f64, in_f16, in_bf16, in_i8, in_u8, in_i16, in_u16, in_i32, in_u32, in_i64, in_u64};
+    const std::vector<Argument> arg_types{in_f32, in_f64, in_f16, in_bf16, in_i8, in_u8, in_i16, in_u16, in_i32, in_u32, in_i64, in_u64};
     int W;
     int H;
 

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -250,6 +250,8 @@ public:
                     buf.as<float>().for_each_value([&](float &f) { f = (rng() & 0xfff) / 8.0f - 0xff; });
                 } else if (t == Float(64)) {
                     buf.as<double>().for_each_value([&](double &f) { f = (rng() & 0xfff) / 8.0 - 0xff; });
+                } else if (t == Float(16)) {
+                    buf.as<float16_t>().for_each_value([&](float16_t &f) { f = float16_t((rng() & 0xff) / 8.0f - 0xf); });
                 } else {
                     // Random bits is fine
                     for (uint32_t *ptr = (uint32_t *)buf.data();


### PR DESCRIPTION
This PR is for #5449 .
Armv8-a extension of Half-precision floating point data processing is supported by CodeGen_ARM.

- The target needs to be set as 64-bit with "arm_fp16" feature.
- 32-bit is not supported in this commit.
- Upgrading fp16 to fp32 with emulated conversion is replaced with either
  - fp16 native instruction or
  - fp32 operation with native type conversion of fp16-fp32
- The dedicated unit test for NEON float16 is added.