### PR TITLE
Fix performance regression in is_monotonic

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1030,6 +1030,21 @@ struct RemoveLikelies : public IRMutator {
     }
 };
 
+// TODO: There could just be one IRMutator that can remove
+// calls from a list. If we need more of these, it might be worth
+// doing that refactor.
+struct RemovePromises : public IRMutator {
+    using IRMutator::visit;
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::promise_clamped) ||
+            op->is_intrinsic(Call::unsafe_promise_clamped)) {
+            return mutate(op->args[0]);
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+};
+
 }  // namespace
 
 Expr remove_likelies(const Expr &e) {
@@ -1038,6 +1053,14 @@ Expr remove_likelies(const Expr &e) {
 
 Stmt remove_likelies(const Stmt &s) {
     return RemoveLikelies().mutate(s);
+}
+
+Expr remove_promises(const Expr &e) {
+    return RemovePromises().mutate(e);
+}
+
+Stmt remove_promises(const Stmt &s) {
+    return RemovePromises().mutate(s);
 }
 
 Expr unwrap_tags(const Expr &e) {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -310,6 +310,14 @@ Expr remove_likelies(const Expr &e);
  * all calls to likely() and likely_if_innermost() removed. */
 Stmt remove_likelies(const Stmt &s);
 
+/** Return an Expr that is identical to the input Expr, but with
+ * all calls to promise_clamped() and unsafe_promise_clamped() removed. */
+Expr remove_promises(const Expr &e);
+
+/** Return a Stmt that is identical to the input Stmt, but with
+ * all calls to promise_clamped() and unsafe_promise_clamped() removed. */
+Stmt remove_promises(const Stmt &s);
+
 /** If the expression is a tag helper call, remove it and return
  * the tagged expression. If not, returns the expression. */
 Expr unwrap_tags(const Expr &e);

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -631,7 +631,7 @@ ConstantInterval derivative_bounds(const Expr &e, const std::string &var, const 
         return ConstantInterval::everything();
     }
     DerivativeBounds m(var, scope);
-    e.accept(&m);
+    remove_likelies(remove_promises(e)).accept(&m);
     return m.result;
 }
 
@@ -725,6 +725,8 @@ void is_monotonic_test() {
     check_unknown(select(x > 2, x - 5, x));
 
     check_unknown(select(x > 0, y, z));
+
+    check_increasing(select(0 < x, promise_clamped(x - 1, x - 1, z) + 1, promise_clamped(x, x, z)));
 
     check_constant(y);
 


### PR DESCRIPTION
#6083 introduced a performance regression. The old logic worked in the presence of likely and promise_clamped, but the new logic does not. This PR fixes this performance regression.