### PR TITLE
Substitute lets, simplify, then CSE for find_constant_bounds

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -19,6 +19,7 @@
 #include "PurifyIndexMath.h"
 #include "Simplify.h"
 #include "Solve.h"
+#include "Substitute.h"
 #include "Util.h"
 #include "Var.h"
 
@@ -66,7 +67,7 @@ Expr find_constant_bound(const Expr &e, Direction d, const Scope<Interval> &scop
 }
 
 Interval find_constant_bounds(const Expr &e, const Scope<Interval> &scope) {
-    Expr expr = simplify(remove_likelies(e));
+    Expr expr = common_subexpression_elimination(simplify(substitute_in_all_lets(remove_likelies(e))));
     Interval interval = bounds_of_expr_in_scope(expr, scope, FuncValueBounds(), true);
     interval.min = simplify(interval.min);
     interval.max = simplify(interval.max);


### PR DESCRIPTION
From the same logging mentioned in #6099, there are a bunch of cases of find_constant_bounds being called on expressions that need `substitute_in_all_lets` before simplification. One example from the logs is:

```
#include <iostream>
#include "Halide.h"

using namespace Halide;

int main(void) {
    Var x("x"), y("y"), z("z"), w("w");

    std::string var_name = "t58";
    Expr var = Internal::Variable::make(Int(32), var_name);
    Expr sub_expr = (var - min(min(select(0 < x, min(x*8, y), var), x*8), y + -8));
    Expr let_expr = Internal::Let::make(var_name, min(x*8, y + -8), sub_expr);
    Expr final_expr = (let_expr + 7) / 8;

    std::cout << final_expr << std::endl;

    Internal::Interval interval = Internal::find_constant_bounds(final_expr, Internal::Scope<Internal::Interval>::empty_scope());
    std::cout << "[ " << interval.min << ", " << interval.max << " ]" << std::endl;
    return 1;
}
```
Output (before change):
```
(((let t58 = min(x*8, y + -8) in (t58 - min(min(select(0 < x, min(x*8, y), t58), x*8), y + -8))) + 7)/8)
[ (void *)neg_inf, (void *)pos_inf ]
```
Output (after change):
```
(((let t58 = min(x*8, y + -8) in (t58 - min(min(select(0 < x, min(x*8, y), t58), x*8), y + -8))) + 7)/8)
[ 0, 0 ]
```

Such patterns appear to be somewhat common, and most seem to be from calls to `find_constant_bounds` in `BoundSmallAllocations`.