### PR TITLE
Remove floats from extern_producer

### DIFF
--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -27,7 +27,8 @@ int round_down(int x, int m) {
     }
 }
 
-// Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using sinf.
+// Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using a
+// periodic integer function.
 extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
     static int desired_row_extent = 0;
     if (out->is_bounds_query()) {
@@ -48,7 +49,7 @@ extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
         return 0;
     }
     assert(out->host);
-    assert(out->type == halide_type_of<float>());
+    assert(out->type == halide_type_of<int>());
     assert(out->dimensions == 2);
     assert(out->dim[0].stride == 1);
     // Check that the row stride is 128B/32-element aligned.
@@ -59,25 +60,26 @@ extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
            out->dim[0].min, out->dim[0].min + out->dim[0].extent,
            out->dim[1].min, out->dim[1].min + out->dim[1].extent);
     for (int y = 0; y < out->dim[1].extent; y++) {
-        float *dst = (float *)out->host + y * out->dim[1].stride;
+        int *dst = (int *)out->host + y * out->dim[1].stride;
         for (int x = 0; x < out->dim[0].extent; x++) {
             int x_coord = x + out->dim[0].min;
             int y_coord = y + out->dim[1].min;
-            dst[x] = sinf(x_coord + y_coord);
+            dst[x] = (x_coord + y_coord) % 64;
         }
     }
     return 0;
 }
 
-// Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using sinf.
+// Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using a
+// periodic integer function.
 extern "C" DLLEXPORT int make_data_multi(halide_buffer_t *out1, halide_buffer_t *out2) {
     if (!out1->host || !out2->host) {
         // Bounds query mode. We're ok with any requested output size (Halide guarantees they match).
         return 0;
     }
     assert(out1->dimensions == 2 && out2->dimensions == 2);
-    assert(out1->host && out1->type == halide_type_of<float>() && out1->dim[0].stride == 1);
-    assert(out2->host && out2->type == halide_type_of<float>() && out2->dim[0].stride == 1);
+    assert(out1->host && out1->type == halide_type_of<int>() && out1->dim[0].stride == 1);
+    assert(out2->host && out2->type == halide_type_of<int>() && out2->dim[0].stride == 1);
     assert(out1->dim[0].min == out2->dim[0].min &&
            out1->dim[1].min == out2->dim[1].min &&
            out1->dim[0].extent == out2->dim[0].extent &&
@@ -86,13 +88,13 @@ extern "C" DLLEXPORT int make_data_multi(halide_buffer_t *out1, halide_buffer_t 
            out1->dim[0].min, out1->dim[0].min + out1->dim[0].extent,
            out1->dim[1].min, out1->dim[1].min + out1->dim[1].extent);
     for (int y = 0; y < out1->dim[1].extent; y++) {
-        float *dst1 = (float *)out1->host + y * out1->dim[1].stride;
-        float *dst2 = (float *)out2->host + y * out2->dim[1].stride;
+        int *dst1 = (int *)out1->host + y * out1->dim[1].stride;
+        int *dst2 = (int *)out2->host + y * out2->dim[1].stride;
         for (int x = 0; x < out1->dim[0].extent; x++) {
             int x_coord = x + out1->dim[0].min;
             int y_coord = y + out1->dim[1].min;
-            dst1[x] = sinf(x_coord + y_coord);
-            dst2[x] = cosf(x_coord + y_coord);
+            dst1[x] = (x_coord + y_coord) % 64;
+            dst2[x] = (x_coord + y_coord + 16) % 64;
         }
     }
     return 0;
@@ -105,22 +107,22 @@ int main(int argc, char **argv) {
         Func source;
         source.define_extern("make_data",
                              std::vector<ExternFuncArgument>(),
-                             Float(32), {x, y});
+                             Int(32), {x, y});
         // Row stride should be 128B/32-element aligned.
         source.align_storage(x, 32);
         Func sink;
-        sink(x, y) = source(x, y) - sin(x + y);
+        sink(x, y) = source(x, y) - (x + y) % 64;
 
         sink.tile(x, y, xi, yi, 32, 32);
 
         // Compute the source per tile of sink
         source.compute_at(sink, x);
 
-        Buffer<float> output = sink.realize({100, 100});
+        Buffer<int> output = sink.realize({100, 100});
 
         // Should be all zeroes.
         RDom r(output);
-        float error = evaluate_may_gpu<float>(sum(abs(output(r.x, r.y))));
+        unsigned int error = evaluate_may_gpu<unsigned int>(sum(abs(output(r.x, r.y))));
         if (error != 0) {
             printf("Something went wrong\n");
             return -1;
@@ -130,25 +132,25 @@ int main(int argc, char **argv) {
     {
         Func multi;
         std::vector<Type> types;
-        types.push_back(Float(32));
-        types.push_back(Float(32));
+        types.push_back(Int(32));
+        types.push_back(Int(32));
         multi.define_extern("make_data_multi",
                             std::vector<ExternFuncArgument>(),
                             types, {x, y});
         Func sink_multi;
-        sink_multi(x, y) = multi(x, y)[0] - sin(x + y) +
-                           multi(x, y)[1] - cos(x + y);
+        sink_multi(x, y) = multi(x, y)[0] - (x + y) % 64 +
+                           multi(x, y)[1] - (x + y + 16) % 64;
 
         sink_multi.tile(x, y, xi, yi, 32, 32);
 
         // Compute the source per tile of sink
         multi.compute_at(sink_multi, x);
 
-        Buffer<float> output_multi = sink_multi.realize({100, 100});
+        Buffer<int> output_multi = sink_multi.realize({100, 100});
 
         // Should be all zeroes.
         RDom r(output_multi);
-        float error_multi = evaluate<float>(sum(abs(output_multi(r.x, r.y))));
+        unsigned int error_multi = evaluate<unsigned int>(sum(abs(output_multi(r.x, r.y))));
         if (error_multi != 0) {
             printf("Something went wrong in multi case\n");
             return -1;

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -64,7 +64,7 @@ extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
         for (int x = 0; x < out->dim[0].extent; x++) {
             int x_coord = x + out->dim[0].min;
             int y_coord = y + out->dim[1].min;
-            dst[x] = (x_coord + y_coord) % 64;
+            dst[x] = (x_coord + y_coord) % 61;
         }
     }
     return 0;
@@ -93,8 +93,8 @@ extern "C" DLLEXPORT int make_data_multi(halide_buffer_t *out1, halide_buffer_t 
         for (int x = 0; x < out1->dim[0].extent; x++) {
             int x_coord = x + out1->dim[0].min;
             int y_coord = y + out1->dim[1].min;
-            dst1[x] = (x_coord + y_coord) % 64;
-            dst2[x] = (x_coord + y_coord + 16) % 64;
+            dst1[x] = (x_coord + y_coord) % 61;
+            dst2[x] = (x_coord + y_coord + 15) % 61;
         }
     }
     return 0;
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
         // Row stride should be 128B/32-element aligned.
         source.align_storage(x, 32);
         Func sink;
-        sink(x, y) = source(x, y) - (x + y) % 64;
+        sink(x, y) = source(x, y) - (x + y) % 61;
 
         sink.tile(x, y, xi, yi, 32, 32);
 
@@ -138,8 +138,8 @@ int main(int argc, char **argv) {
                             std::vector<ExternFuncArgument>(),
                             types, {x, y});
         Func sink_multi;
-        sink_multi(x, y) = multi(x, y)[0] - (x + y) % 64 +
-                           multi(x, y)[1] - (x + y + 16) % 64;
+        sink_multi(x, y) = multi(x, y)[0] - (x + y) % 61 +
+                           multi(x, y)[1] - (x + y + 15) % 61;
 
         sink_multi.tile(x, y, xi, yi, 32, 32);
 


### PR DESCRIPTION
Small changes to sinf/cosf in libc has caused this test to start failing for us. This PR changes the test to use integers instead. Addresses the immediate issue in #6108, but leaving that open because I think we should remove unnecessary float usage in the rest of the tests as well.