### PR TITLE
Relax overzealous pruning rule

### DIFF
--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -1436,6 +1436,7 @@ vector<IntrusivePtr<const LoopNest>> LoopNest::compute_in_tiles(const FunctionDA
     vector<IntrusivePtr<const LoopNest>> result;
 
     // Some pruning to not waste time on terrible states
+    bool must_tile_to_vectorize = false;
     if (parent) {
         const auto &bounds_here = get_bounds(f);
         const auto &bounds_at_parent = parent->get_bounds(f);
@@ -1447,7 +1448,7 @@ vector<IntrusivePtr<const LoopNest>> LoopNest::compute_in_tiles(const FunctionDA
         int64_t e = p.extent();
         int64_t ep = p_parent.extent();
         if (ep >= f->vector_size && e < f->vector_size) {
-            return result;
+            must_tile_to_vectorize = true;
         }
 
         // Don't descend into loops if the bounds required don't
@@ -1477,7 +1478,8 @@ vector<IntrusivePtr<const LoopNest>> LoopNest::compute_in_tiles(const FunctionDA
     }
 
     // Place the computation directly inside this loop (provided it's not a SIMD loop)
-    if (!innermost &&
+    if (!must_tile_to_vectorize &&
+        !innermost &&
         (!in_realization ||
          size.empty() ||
          vector_dim == -1 ||


### PR DESCRIPTION
We don't allow schedules that fuse to the extent that we can no longer
vectorize. This was implemented incorrectly though. The check assumed
that something was going to be compute_at inside the innermost loop, and
neglected the possibility that we were about to tile that loop.