### PR TITLE
Fix potential undefined behavior in `set_flag`

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1461,7 +1461,7 @@ typedef struct halide_buffer_t {
         if (value) {
             flags |= flag;
         } else {
-            flags &= ~flag;
+            flags &= ~uint64_t(flag);
         }
     }
 


### PR DESCRIPTION
Previously, the Clang UndefinedBehaviorSanitizer (UBSan) complained
about potential undefined behavior in `halide_buffer_t::set_flag`
because the enum `halide_buffer_flags` is interpreted as an int32_t
and implicitly converted to a uint64_t:

```
runtime error: implicit conversion from type 'int' of value -2 (32-bit, signed) to type 'unsigned long' changed the value to 18446744073709551614 (64-bit, unsigned)
```

On most compilers and hardware, this causes no issues,
since the conversion and implementation of `set_flag` together produce
the expected behavior still. However, it is better to be on the safe
side and make the explicit conversion to a uint64_t before doing the
bitwise negation.

This change makes sure the conversion from int32_t is made before the
bitwise negation, which fixes the potential undefined behavior and keeps
UBSan from complaining.