### PR TITLE
[hannk] Proposal for better error handling

### DIFF
--- a/apps/hannk/benchmark.cpp
+++ b/apps/hannk/benchmark.cpp
@@ -18,7 +18,8 @@ void run_benchmark(const std::string &filename, const InterpreterOptions &option
         std::cout << filename;
     }
 
-    std::vector<char> buffer = read_entire_file(filename);
+    std::vector<char> buffer;
+    read_entire_file(filename, &buffer).check();
     std::unique_ptr<OpGroup> model = parse_tflite_model_from_buffer(buffer.data());
 
     if (options.verbose) {

--- a/apps/hannk/compare_vs_tflite.cpp
+++ b/apps/hannk/compare_vs_tflite.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
     runner.status();
 
     for (auto f : files_to_process) {
-        runner.run(f);
+        runner.run(f).check();
         halide_profiler_report(nullptr);
         halide_profiler_reset();
         std::cout << "\n";

--- a/apps/hannk/util/CMakeLists.txt
+++ b/apps/hannk/util/CMakeLists.txt
@@ -32,6 +32,10 @@ add_library(hannk_log_hdr INTERFACE)
 target_include_directories(hannk_log_hdr INTERFACE
                            $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
 
+add_library(status INTERFACE)
+target_include_directories(status INTERFACE
+                           $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
+
 add_library(model_runner STATIC
             model_runner.cpp)
 target_include_directories(model_runner PUBLIC

--- a/apps/hannk/util/file_util.h
+++ b/apps/hannk/util/file_util.h
@@ -5,24 +5,26 @@
 #include <memory>
 #include <vector>
 
-#include "util/error_util.h"
+#include "util/status.h"
 
 namespace hannk {
 
-inline std::vector<char> read_entire_file(const std::string &filename) {
+inline Status read_entire_file(const std::string &filename, std::vector<char> *result) {
     std::ifstream f(filename, std::ios::in | std::ios::binary);
-    HCHECK(f.is_open()) << "Unable to open file: " << filename;
-
-    std::vector<char> result;
+    if (!f.is_open()) {
+        return Status::Error;
+    }
 
     f.seekg(0, std::ifstream::end);
     size_t size = f.tellg();
-    result.resize(size);
+    result->resize(size);
     f.seekg(0, std::ifstream::beg);
-    f.read(result.data(), result.size());
-    HCHECK(f.good()) << "Unable to read file: " << filename;
+    f.read(result->data(), result->size());
+    if (!f.good()) {
+        return Status::Error;
+    }
     f.close();
-    return result;
+    return Status::OK;
 }
 
 }  // namespace hannk

--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -575,10 +575,14 @@ int ModelRunner::parse_flags(int argc, char **argv, std::vector<std::string> &fi
     return 0;
 }
 
-void ModelRunner::run(const std::string &filename) {
+Status ModelRunner::run(const std::string &filename) {
     std::cout << "Processing " << filename << " ...\n";
 
-    const std::vector<char> buffer = read_entire_file(filename);
+    std::vector<char> buffer;
+    auto status = read_entire_file(filename, &buffer);
+    if (!status.ok()) {
+        return status;
+    }
 
     std::map<WhichRun, RunResult> results;
 
@@ -663,10 +667,12 @@ void ModelRunner::run(const std::string &filename) {
         if (!all_matched) {
             std::cerr << "Some runs exceeded the error threshold!\n";
             if (!keep_going) {
-                exit(1);
+                return Status::Error;
             }
         }
     }
+
+    return Status::OK;
 }
 
 }  // namespace hannk

--- a/apps/hannk/util/model_runner.h
+++ b/apps/hannk/util/model_runner.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "util/buffer_util.h"
+#include "util/status.h"
 
 struct TfLiteDelegate;
 struct TfLiteInterpreter;
@@ -111,7 +112,7 @@ struct ModelRunner {
 
     void set_seed(int seed);
     void status();
-    void run(const std::string &filename);
+    Status run(const std::string &filename);
 
     // Movable but not copyable.
     ModelRunner(const ModelRunner &) = delete;

--- a/apps/hannk/util/status.h
+++ b/apps/hannk/util/status.h
@@ -1,0 +1,115 @@
+#ifndef HANNK_STATUS_H
+#define HANNK_STATUS_H
+
+#include <cstring>
+#include <iostream>
+
+#include "util/error_util.h"
+
+#ifndef HANNK_STATUS_SOURCE_LOCATION
+#ifndef NDEBUG
+#ifdef __is_identifier
+#if !__is_identifier(__builtin_LINE) && !__is_identifier(__builtin_FILE) && !__is_identifier(__builtin_FUNCTION)
+#define HANNK_STATUS_SOURCE_LOCATION 1
+#endif
+#elif __GNUC__ >= 5
+#define HANNK_STATUS_SOURCE_LOCATION 1
+#endif
+#endif
+#endif
+
+#ifndef HANNK_STATUS_SOURCE_LOCATION
+#define HANNK_STATUS_SOURCE_LOCATION 0
+#endif
+
+namespace hannk {
+
+namespace internal {
+
+#if HANNK_STATUS_SOURCE_LOCATION
+struct SourceLocation final {
+    // These aren't 'standard' yet but widely supported in modern GCC and Clang compilers
+    const char *function = __builtin_FUNCTION();
+    const char *file = __builtin_FILE();
+    unsigned line = __builtin_LINE();
+};
+#endif  // HANNK_STATUS_SOURCE_LOCATION
+
+}  // namespace internal
+
+// [[nodiscard]] is the C++17 way of specifying MUST_USE_RESULT
+class [[nodiscard]] Status final {
+public:
+    enum Code {
+        OK = 0,
+        Error = 1,
+        // Add more as needed, but only as *needed*; very little of our code
+        // cares much about why things fail, only whether they fail or not.
+    };
+
+#if HANNK_STATUS_SOURCE_LOCATION
+    /*not-explicit*/ constexpr Status(Code code = OK, internal::SourceLocation location = {})
+        : code_(code), location_(std::move(location)) {
+    }
+#else
+    /*not-explicit*/ constexpr Status(Code code = OK)
+        : code_(code) {
+    }
+#endif
+
+    [[nodiscard]] bool ok() const {
+        return code_ == OK;
+    }
+
+    [[nodiscard]] Code code() const {
+        return code_;
+    }
+
+    [[nodiscard]] std::string to_string() const {
+        const char *result = ok() ? "OK" : "Error";
+#if HANNK_STATUS_SOURCE_LOCATION
+        std::ostringstream oss;
+        oss << "Status::" << result << " in " << location_.function << "() (" << location_.file << ":" << std::to_string(location_.line) << ")";
+        return oss.str();
+#else
+        return result;
+#endif
+    }
+
+    friend std::ostream &operator<<(std::ostream &stream, const Status &status) {
+        stream << status.to_string();
+        return stream;
+    }
+
+    // Generally, this should only be called by top-level code (i.e., something with a main());
+    // otherwise, return the result to the caller and force them to deal with it.
+    void check() const {
+        if (!ok()) {
+            HLOG(FATAL) << to_string();
+        }
+    }
+
+    friend bool operator==(const Status &a, const Status &b) {
+        return a.code_ == b.code_;
+    }
+
+    friend bool operator!=(const Status &a, const Status &b) {
+        return a.code_ != b.code_;
+    }
+
+    // Movable + Copyable
+    Status(const Status &) = default;
+    Status &operator=(const Status &) = default;
+    Status(Status &&) = default;
+    Status &operator=(Status &&) = default;
+
+private:
+    Code code_;
+#if HANNK_STATUS_SOURCE_LOCATION
+    internal::SourceLocation location_;
+#endif
+};
+
+}  // namespace hannk
+
+#endif  // HANNK_STATUS_H


### PR DESCRIPTION
Currently, hannk deals with most errors by crashing (either via HCHECK or assert).

This proposes a Status return code approach:
- In opt builds, is just an int-sized class, marked with [[nodiscard]] so that it can't be accidentally ignored

- in non-opt builds, we also gather the function/file/line from the point of instantiation, so that we can eventually report that to aid with debugging.

- Made some initial changes in file_util.h and model_runner to use it.

The astute observer will note that this is not unlike a very very cut-down version of absl::Status, which is not an accident... except that this is intended to stay extremely minimal. (In point of fact, I was going to propose just using an enum marked with [[nodiscard]], but being able to optionally preserve source location, etc for debugging purposes seems like a worthwhile bonus at what should be negligible code cost in opt builds.)

If we like this approach, I'll likely implement it in a few PRs, adding Status results to the API surfaces that need it, changing callers as needed.

(I debated over whether an equivalent of absl::StatusOr would be useful or overkill, and ended up leaving it out. Thoughts?)