### PR TITLE
Remove deprecated realize() variants from Func and PIpeline

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3091,21 +3091,6 @@ Realization Func::realize(std::vector<int32_t> sizes, const Target &target,
     return pipeline().realize(std::move(sizes), target, param_map);
 }
 
-Realization Func::realize(int x_size, int y_size, int z_size, int w_size, const Target &target,
-                          const ParamMap &param_map) {
-    return realize({x_size, y_size, z_size, w_size}, target, param_map);
-}
-
-Realization Func::realize(int x_size, int y_size, int z_size, const Target &target,
-                          const ParamMap &param_map) {
-    return realize({x_size, y_size, z_size}, target, param_map);
-}
-
-Realization Func::realize(int x_size, int y_size, const Target &target,
-                          const ParamMap &param_map) {
-    return realize({x_size, y_size}, target, param_map);
-}
-
 void Func::infer_input_bounds(const std::vector<int32_t> &sizes,
                               const Target &target,
                               const ParamMap &param_map) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -809,28 +809,8 @@ public:
      * instead.
      *
      */
-    // @{
     Realization realize(std::vector<int32_t> sizes = {}, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    Realization realize(int x_size, int y_size, int z_size, int w_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    Realization realize(int x_size, int y_size, int z_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    Realization realize(int x_size, int y_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-
-    // Making this a template function is a trick: `{intliteral}` is a valid scalar initializer
-    // in C++, but we want it to match the vector call, not the (deprecated) scalar one.
-    template<typename T, typename = typename std::enable_if<std::is_same<T, int>::value>::type>
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    HALIDE_ALWAYS_INLINE Realization realize(T x_size, const Target &target = Target(),
-                                             const ParamMap &param_map = ParamMap::empty_map()) {
-        return realize(std::vector<int32_t>{x_size}, target, param_map);
-    }
-    // @}
 
     /** Evaluate this function into an existing allocated buffer or
      * buffers. If the buffer is also one of the arguments to the

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -750,21 +750,6 @@ Realization Pipeline::realize(vector<int32_t> sizes, const Target &target,
     return r;
 }
 
-Realization Pipeline::realize(int x_size, int y_size, int z_size, int w_size, const Target &target,
-                              const ParamMap &param_map) {
-    return realize({x_size, y_size, z_size, w_size}, target, param_map);
-}
-
-Realization Pipeline::realize(int x_size, int y_size, int z_size, const Target &target,
-                              const ParamMap &param_map) {
-    return realize({x_size, y_size, z_size}, target, param_map);
-}
-
-Realization Pipeline::realize(int x_size, int y_size, const Target &target,
-                              const ParamMap &param_map) {
-    return realize({x_size, y_size}, target, param_map);
-}
-
 void Pipeline::add_requirement(const Expr &condition, std::vector<Expr> &error_args) {
     user_assert(defined()) << "Pipeline is undefined\n";
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -484,28 +484,8 @@ public:
     const std::vector<CustomLoweringPass> &custom_lowering_passes();
 
     /** See Func::realize */
-    // @{
     Realization realize(std::vector<int32_t> sizes = {}, const Target &target = Target(),
                         const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    Realization realize(int x_size, int y_size, int z_size, int w_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    Realization realize(int x_size, int y_size, int z_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    Realization realize(int x_size, int y_size, const Target &target = Target(),
-                        const ParamMap &param_map = ParamMap::empty_map());
-
-    // Making this a template function is a trick: `{intliteral}` is a valid scalar initializer
-    // in C++, but we want it to match the vector call, not the (deprecated) scalar one.
-    template<typename T, typename = typename std::enable_if<std::is_same<T, int>::value>::type>
-    HALIDE_ATTRIBUTE_DEPRECATED("Call realize() with a vector<int> instead")
-    HALIDE_ALWAYS_INLINE Realization realize(T x_size, const Target &target = Target(),
-                                             const ParamMap &param_map = ParamMap::empty_map()) {
-        return realize(std::vector<int32_t>{x_size}, target, param_map);
-    }
-    // @}
 
     /** Evaluate this Pipeline into an existing allocated buffer or
      * buffers. If the buffer is also one of the arguments to the


### PR DESCRIPTION
These were deprecated in Halide 12. Let's remove them for Halide 13.