### PR TITLE
[Hexagon] Use LLVM masked stores.

### DIFF
--- a/apps/hannk/run_benchmark_on_hexagon_sim.sh
+++ b/apps/hannk/run_benchmark_on_hexagon_sim.sh
@@ -8,7 +8,7 @@ BIN=${BIN:-bin}
 
 echo "$HEXAGON_SDK_ROOT/rtos/qurt/computev65/debugger/lnx64/qurt_model.so" > $BIN/$HL_TARGET/osam.cfg
 echo "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/lib/iss/qtimer.so --csr_base=0xFC900000 --irq_p=1 --freq=19200000 --cnttid=1" > $BIN/$HL_TARGET/q6ss.cfg
-echo "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/lib/iss/l2vic.so 32 0xFC910000" >> $BIN)/$HL_TARGET/q6ss.cfg
+echo "$DEFAULT_HEXAGON_TOOLS_ROOT/Tools/lib/iss/l2vic.so 32 0xFC910000" >> $BIN/$HL_TARGET/q6ss.cfg
 
 $DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-sim \
     -mv65 \
@@ -20,4 +20,4 @@ $DEFAULT_HEXAGON_TOOLS_ROOT/Tools/bin/hexagon-sim \
     $HEXAGON_SDK_ROOT/rtos/qurt/computev65/sdksim_bin/runelf.pbn -- \
     $HEXAGON_SDK_ROOT/libs/run_main_on_hexagon/ship/hexagon_toolv84_v65/run_main_on_hexagon_sim \
     stack_size=0x400000 -- \
-    $PWD/$BIN/$HL_TARGET/$BENCHMARK_OUT --verbose $1;
+    $PWD/$BIN/$HL_TARGET/benchmark.so --verbose $1;

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -115,7 +115,7 @@ CXXFLAGS-host-opencl ?= $(CXXFLAGS)
 CXXFLAGS-host-cuda ?= $(CXXFLAGS)
 CXXFLAGS-host-metal ?= $(CXXFLAGS)
 CXXFLAGS-arm-64-android ?= $(CXXFLAGS)
-CXXFLAGS-hexagon-32-qurt-hvx ?= $(CXXFLAGS) -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev65/include/qurt -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev65/include/posix
+CXXFLAGS-hexagon-32-qurt-hvx ?= -mv65 $(CXXFLAGS) -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev65/include/qurt -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev65/include/posix
 CXXFLAGS-arm-32-android ?= $(CXXFLAGS)
 
 LDFLAGS-host ?= $(LDFLAGS)


### PR DESCRIPTION
Letting CodeGen_LLVM handle predicated stores for Hexagon allows us
to generate HVX predicated stores instead of scalar predicated stores.

The operators in hannk app should be able to test this patch.

@pranavb-ca @dsharletg 