### PR TITLE
Fix wasm codegen for i32_to_double_s and i32_to_double_u

### DIFF
--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -94,11 +94,8 @@ const WasmIntrinsic intrinsic_defs[] = {
     {"llvm.wasm.extadd.pairwise.unsigned.v8i16", Int(16, 8), "pairwise_widening_add", {UInt(8, 16)}, Target::WasmSimd128},
     {"llvm.wasm.extadd.pairwise.unsigned.v4i32", Int(32, 4), "pairwise_widening_add", {UInt(16, 8)}, Target::WasmSimd128},
 
-    // TODO: these instructions are no longer available at LLVM top of tree,
-    // but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions;
-    // investigation needed.
-    // {"i32_to_double_s", Float(64, 4), "int_to_double", {Int(32, 4)}, Target::WasmSimd128},
-    // {"i32_to_double_u", Float(64, 4), "int_to_double", {UInt(32, 4)}, Target::WasmSimd128},
+    {"i32_to_double_s", Float(64, 4), "int_to_double", {Int(32, 4)}, Target::WasmSimd128},
+    {"i32_to_double_u", Float(64, 4), "int_to_double", {UInt(32, 4)}, Target::WasmSimd128},
 
     {"float_to_double", Float(64, 4), "float_to_double", {Float(32, 4)}, Target::WasmSimd128},
 

--- a/src/runtime/wasm_math.ll
+++ b/src/runtime/wasm_math.ll
@@ -164,13 +164,7 @@ define weak_odr <8 x i16> @saturating_narrow_i32x8_to_u16x8(<8 x i32> %x) nounwi
 ;   }
 
 ; single to double-precision floating point
-
-declare <2 x double> @llvm.wasm.promote.low(<4 x float>)
-
 define weak_odr <4 x double> @float_to_double(<4 x float> %x) nounwind alwaysinline {
-  %1 = shufflevector <4 x float> %x, <4 x float> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-  %2 = tail call <2 x double> @llvm.wasm.promote.low(<4 x float> %x)
-  %3 = tail call <2 x double> @llvm.wasm.promote.low(<4 x float> %1)
-  %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-  ret <4 x double> %4
+  %1 = fpext <4 x float> %x to <4 x double>
+  ret <4 x double> %1
 }

--- a/src/runtime/wasm_math.ll
+++ b/src/runtime/wasm_math.ll
@@ -140,28 +140,15 @@ define weak_odr <8 x i16> @saturating_narrow_i32x8_to_u16x8(<8 x i32> %x) nounwi
 }
 
 ; Integer to double-precision floating point
+define weak_odr <4 x double> @i32_to_double_s(<4 x i32> %x) nounwind alwaysinline {
+  %1 = sitofp <4 x i32> %x to <4 x double>
+  ret <4 x double> %1
+}
 
-; COMMENTED OUT AT TOP OF TREE; llvm.wasm.convert.low.[un]signed is no longer
-; available, but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions
-; that we'd expect, so investigation needs to be done.
-;   declare <2 x double> @llvm.wasm.convert.low.signed(<4 x i32>)
-;   declare <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32>)
-;
-;   define weak_odr <4 x double> @i32_to_double_s(<4 x i32> %x) nounwind alwaysinline {
-;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-;     %2 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %x)
-;     %3 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %1)
-;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-;     ret <4 x double> %4
-;   }
-;
-;   define weak_odr <4 x double> @i32_to_double_u(<4 x i32> %x) nounwind alwaysinline {
-;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-;     %2 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %x)
-;     %3 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %1)
-;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-;     ret <4 x double> %4
-;   }
+define weak_odr <4 x double> @i32_to_double_u(<4 x i32> %x) nounwind alwaysinline {
+  %1 = uitofp <4 x i32> %x to <4 x double>
+  ret <4 x double> %1
+}
 
 ; single to double-precision floating point
 define weak_odr <4 x double> @float_to_double(<4 x float> %x) nounwind alwaysinline {

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2183,11 +2183,8 @@ public:
 
                 // Integer to double-precision floating point
                 if (Halide::Internal::get_llvm_version() >= 130) {
-                    // TODO: we can't directly generate these instructions at LLVM top of tree,
-                    // but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions;
-                    // investigation needed.
-                    // check("f64x2.convert_low_i32x4_s", 2 * w, cast<double>(i32_1));
-                    // check("f64x2.convert_low_i32x4_u", 2 * w, cast<double>(u32_1));
+                    check("f64x2.convert_low_i32x4_s", 2 * w, cast<double>(i32_1));
+                    check("f64x2.convert_low_i32x4_u", 2 * w, cast<double>(u32_1));
                 }
 
                 // Single-precision floating point to integer with saturation


### PR DESCRIPTION
These were also easily fixed by using LLVM builtins.