### PR TITLE
[hannk] Allow aliasing of Reshape tensors

### DIFF
--- a/apps/hannk/interpreter/lower.cpp
+++ b/apps/hannk/interpreter/lower.cpp
@@ -23,14 +23,15 @@ OpPtr lower_tflite_lstm(TensorPtr data_input, TensorPtr prev_activ_input, Tensor
     // Split activ_temp into the 4 ops we need.
     Box elementwise_bounds = activ_temp->bounds();
     elementwise_bounds[0].set_extent(elementwise_bounds[0].extent() / 4);
+    // Tensor names don't have to be unique, but basing these on activ_temp's name makes debugging a little easier.
     TensorPtr input_gate_buf =
-        std::make_shared<Tensor>("input_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
+        std::make_shared<Tensor>(activ_temp->name() + ".input_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
     TensorPtr input_modulation_gate_buf =
-        std::make_shared<Tensor>("input_modulation_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
+        std::make_shared<Tensor>(activ_temp->name() + ".input_modulation_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
     TensorPtr forget_gate_buf =
-        std::make_shared<Tensor>("forget_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
+        std::make_shared<Tensor>(activ_temp->name() + ".forget_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
     TensorPtr output_gate_buf =
-        std::make_shared<Tensor>("output_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
+        std::make_shared<Tensor>(activ_temp->name() + ".output_gate", activ_temp->type(), elementwise_bounds, activ_temp->quantization());
     std::vector<TensorPtr> split_outputs = {input_gate_buf, input_modulation_gate_buf, forget_gate_buf, output_gate_buf};
     ops.push_back(make_op<SplitOp>(activ_temp, split_outputs, 0));
 

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -1400,9 +1400,10 @@ void ReshapeOp::execute() {
         assert(new_shape.at(d) == output_buf.dim(d).extent());
     }
 
-    // NOTE: HCHECK, not assert, to ensure a runtime failure to match TFLite
-    // TODO: return error code
-    HCHECK(input_buf.number_of_elements() == output_buf.number_of_elements());
+    // TODO: we must verify these match (and fail at runtime if not).
+    // That said, we should be able to predict this at parse time
+    // (for non-dynamic tensors) and skip the runtime check most of the time.
+    assert(input_buf.number_of_elements() == output_buf.number_of_elements());
 
     assert(in->is_dense());
     assert(out->is_dense());

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -1400,12 +1400,16 @@ void ReshapeOp::execute() {
         assert(new_shape.at(d) == output_buf.dim(d).extent());
     }
 
-    assert(input_buf.number_of_elements() == output_buf.number_of_elements());
+    // NOTE: HCHECK, not assert, to ensure a runtime failure to match TFLite
+    // TODO: return error code
+    HCHECK(input_buf.number_of_elements() == output_buf.number_of_elements());
+
+    assert(in->is_dense());
+    assert(out->is_dense());
     if (is_alias(input_buf.raw_buffer(), output_buf.raw_buffer())) {
         assert(input_buf.begin() == output_buf.begin());
         assert(input_buf.end() == output_buf.end());
     } else {
-        // TODO: This should also check the strides are dense.
         size_t output_size = output_buf.number_of_elements() * out->type().bytes();
         memcpy(output_buf.data(), input_buf.data(), output_size);
     }

--- a/apps/hannk/interpreter/tensor.cpp
+++ b/apps/hannk/interpreter/tensor.cpp
@@ -284,9 +284,9 @@ void Tensor::dump(std::ostream &os) const {
         os << " sparse";
     }
 
-    os << " storage:@" << (void*)storage_.get();
+    os << " storage:@" << (void *)storage_.get();
 
-    os << " " << name() << " this:@" << (void*)this << std::endl;
+    os << " " << name() << " this:@" << (void *)this << std::endl;
 }
 
 }  // namespace hannk

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -80,11 +80,15 @@ class Tensor {
     bool is_dynamic_ = false;
     // If true, this Tensor shares its TensorStorage with at least one other Tensor.
     bool is_alias_ = false;
+    // If true, this Tensor is aliased to another via reshape (rather than cropping),
+    // and may have a different rank from the underlying storage.
+    // Only used if is_alias_ = true.
+    bool is_reshape_alias_ = false;
 
     // Possibly shared storage for this tensor.
     TensorStoragePtr storage_;
     // The offset of this tensor into the storage buffer.
-    // Only used if is_alias_ = true.
+    // Only used if is_alias_ = true and is_reshape_alias_ = false.
     // If storage_offset_.size() < rank(), remaining offset entries are implicitly zero.
     TensorOffset storage_offset_;
 
@@ -206,7 +210,7 @@ public:
     bool is_alias() const {
         return is_alias_;
     }
-    void set_alias_of(const TensorPtr &t, const TensorOffset &offset = {});
+    void set_alias_of(const TensorPtr &t, const TensorOffset &offset = {}, bool is_reshape = false);
 
     bool is_dense() const;
 

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -208,6 +208,8 @@ public:
     }
     void set_alias_of(const TensorPtr &t, const TensorOffset &offset = {});
 
+    bool is_dense() const;
+
     void add_consumer(Op *op);
     void add_producer(Op *op);
     void remove_consumer(Op *op);

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -91,9 +91,7 @@ bool has_storage(const TensorPtr &t) {
 class InPlace : public OpVisitor {
     using OpVisitor::visit;
 
-    // We can alias two tensors if the input is not used after the output is written,
-    // and we meet a number of other requirements.
-    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, TensorOffset offset = {}) const {
+    bool is_alias_possible(TensorPtr input, TensorPtr output) const {
         // If the input is used anywhere else, we should not alias it.
         // TODO: This is conservative, we could alias it if it is the *last* use.
         if (input->consumers().size() != 1) {
@@ -111,11 +109,6 @@ class InPlace : public OpVisitor {
             return false;
         }
 
-        if (input->rank() != output->rank()) {
-            // TODO: We should be able to alias reshapes.
-            return false;
-        }
-
         if (input->type().bytes() != output->type().bytes()) {
             // We can't alias tensors with types of different size.
             return false;
@@ -124,6 +117,21 @@ class InPlace : public OpVisitor {
         // We can't alias an input that is an input or output of the root graph.
         // TODO: We could, if we don't change the shape.
         if (is_root_input_or_output(input)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    // We can alias two tensors if the input is not used after the output is written,
+    // and we meet a number of other requirements.
+    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, TensorOffset offset = {}) const {
+        if (!is_alias_possible(input, output)) {
+            return false;
+        }
+
+        // rank has to match for most aliasing (note that Reshape is an exception to this)
+        if (input->rank() != output->rank()) {
             return false;
         }
 
@@ -220,7 +228,26 @@ class InPlace : public OpVisitor {
     }
 
     void visit(ReshapeOp *op) {
-        maybe_alias_tensors(op->input(), op->output());
+        const TensorPtr &input = op->input();
+        const TensorPtr &output = op->output();
+
+        // Reshape is unusual in that it's OK to alias Reshapes with mismatched rank
+        // (indeed, this is basically always the case), so we handle everything here
+        // instead of calling maybe_alias_tensors().
+        if (!is_alias_possible(input, output)) {
+            return;
+        }
+
+        if (!input->is_dense() || !output->is_dense()) {
+            // Can't alias a Reshape unless both Tensors have dense strides.
+            return;
+        }
+
+        if (!has_storage(input)) {
+            input->set_alias_of(output);
+        } else if (!has_storage(output)) {
+            output->set_alias_of(input);
+        }
     }
 
     void visit(OpGroup *op) {

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -232,7 +232,7 @@ class InPlace : public OpVisitor {
         const TensorPtr &output = op->output();
 
         // Reshape is unusual in that it's OK to alias Reshapes with mismatched rank
-        // (indeed, this is basically always the case), so we handle everything here
+        // (indeed, this is almost always the case), so we handle everything here
         // instead of calling maybe_alias_tensors().
         if (!is_alias_possible(input, output)) {
             return;
@@ -243,10 +243,11 @@ class InPlace : public OpVisitor {
             return;
         }
 
+        constexpr bool is_reshape = true;
         if (!has_storage(input)) {
-            input->set_alias_of(output);
+            input->set_alias_of(output, {}, is_reshape);
         } else if (!has_storage(output)) {
-            output->set_alias_of(input);
+            output->set_alias_of(input, {}, is_reshape);
         }
     }
 


### PR DESCRIPTION
Previously we didn't allow this because aliased tensors had to have the same rank, which is ~never the case for Reshape. Aliasing for Reshape is a huge win because it essentially becomes a no-op rather than a memcpy. Running against standard set of models shows no regression in differences vs. tflite.