### PR TITLE
Add optimization for corner case in conv

### DIFF
--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -137,12 +137,6 @@ void fuse(int d0, int d1, FuseType type, halide_buffer_t *a, Bufs *...rest) {
     fuse(d0, d1, type, rest...);
 }
 
-void swap_dims(int d0, int d1, halide_buffer_t *buf) {
-    std::swap(buf->dim[d0].min, buf->dim[d1].min);
-    std::swap(buf->dim[d0].extent, buf->dim[d1].extent);
-    std::swap(buf->dim[d0].stride, buf->dim[d1].stride);
-}
-
 // Embed extent 1 dimensions until buf has the given rank.
 template<typename T>
 void pad_to_rank(int rank, HalideBuffer<T> &buf) {
@@ -808,8 +802,8 @@ void Conv2DOp::execute() {
                 // Some networks have shapes with very small x and large y that we can't fuse.
                 // This case is bad for us because we tile the x dimension. It would be better
                 // if we tiled y instead. We can do this by just swapping the x and y dimensions.
-                swap_dims(1, 2, input_buf);
-                swap_dims(1, 2, output_buf);
+                input_buf.transpose(1, 2);
+                output_buf.transpose(1, 2);
             }
         }
 

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -137,6 +137,12 @@ void fuse(int d0, int d1, FuseType type, halide_buffer_t *a, Bufs *...rest) {
     fuse(d0, d1, type, rest...);
 }
 
+void swap_dims(int d0, int d1, halide_buffer_t *buf) {
+    std::swap(buf->dim[d0].min, buf->dim[d1].min);
+    std::swap(buf->dim[d0].extent, buf->dim[d1].extent);
+    std::swap(buf->dim[d0].stride, buf->dim[d1].stride);
+}
+
 // Embed extent 1 dimensions until buf has the given rank.
 template<typename T>
 void pad_to_rank(int rank, HalideBuffer<T> &buf) {
@@ -796,6 +802,14 @@ void Conv2DOp::execute() {
                    input_buf.dim(1).extent() == output_buf.dim(1).extent()) {
                 fuse_xy(FuseType::Pad, input_buf);
                 fuse_xy(FuseType::Pad, output_buf);
+            }
+
+            if (output_buf.dim(1).extent() < output_buf.dim(2).extent()) {
+                // Some networks have shapes with very small x and large y that we can't fuse.
+                // This case is bad for us because we tile the x dimension. It would be better
+                // if we tiled y instead. We can do this by just swapping the x and y dimensions.
+                swap_dims(1, 2, input_buf);
+                swap_dims(1, 2, output_buf);
             }
         }
 


### PR DESCRIPTION
Some pipelines have conv layers with really weird shapes, e.g. 6 x 28. Since we tile the x dimension by things like 4 (x86) or 5 (ARM), we do a lot of redundant compute (the split in x is ShiftInwards).

Trying to optimize the tile sizes is a difficult game of whack a mole. We can avoid all of this by simply swapping the x and y dimensions, so we split 28 instead of 6 instead, making the overlapping compute much less significant.

This is probably only relevant for a very small number of corner cases, but it is also a very small amount of safe code, so it seems worth doing.