### PR TITLE
[hannk] Rewrite FC in terms of Conv2D

### DIFF
--- a/apps/hannk/README.md
+++ b/apps/hannk/README.md
@@ -10,7 +10,7 @@ All of the [TensorFlow hosted models](https://www.tensorflow.org/lite/guide/host
 are working and producing good performance.
 
 ### Benchmarks
-The comparison data below was produced with TensorFlow v.2.4.0 (the latest release as of this writing):
+The comparison data below was produced with TensorFlow v.2.5.0 (the latest release as of this writing):
 
 x86 OSX laptop w/ AVX2:
 

--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -691,7 +691,7 @@ private:
         auto output = GetTensorById(context, node->outputs->data[0]);
         const TfLiteFullyConnectedParams *params = (const TfLiteFullyConnectedParams *)(node->builtin_data);
         auto activation = ConvertTfLiteActivation(params->activation);
-        return make_op<FullyConnectedOp>(input, filter, bias, output, activation);
+        return lower_tflite_fullyconnected(input, filter, bias, output, activation);
     }
 
     OpPtr BuildPad(TfLiteContext *context, TfLiteNode *node) {

--- a/apps/hannk/interpreter/allocation_planner.cpp
+++ b/apps/hannk/interpreter/allocation_planner.cpp
@@ -58,7 +58,7 @@ void AllocationPlanner::commit() {
         next_offset += align_up(r.size_needed, alignment_);
     }
 
-#else   // HANNK_USE_TRIVIAL_ALLOCATION_PLANNER
+#else
 
     // Use a basic greedy algorithm to lay out the buffers;
     // the basic idea here is to start with the largest block,

--- a/apps/hannk/interpreter/lower.cpp
+++ b/apps/hannk/interpreter/lower.cpp
@@ -18,7 +18,7 @@ OpPtr lower_tflite_lstm(TensorPtr data_input, TensorPtr prev_activ_input, Tensor
 
     std::vector<TensorPtr> concat_inputs = {data_input, prev_activ_input};
     ops.push_back(make_op<ConcatenationOp>(concat_inputs, concat_temp, 0));
-    ops.push_back(make_op<FullyConnectedOp>(concat_temp, weights_input, biases_input, activ_temp, activation));
+    ops.push_back(lower_tflite_fullyconnected(concat_temp, weights_input, biases_input, activ_temp, activation));
 
     // Split activ_temp into the 4 ops we need.
     Box elementwise_bounds = activ_temp->bounds();
@@ -71,6 +71,114 @@ OpPtr lower_tflite_lstm(TensorPtr data_input, TensorPtr prev_activ_input, Tensor
 
     ops.push_back(make_op<ElementwiseProgramOp>(elementwise_inputs, elementwise_outputs, program_buf));
 
+    return make_op<OpGroup>(std::move(inputs), std::move(outputs), std::move(ops));
+}
+
+namespace {
+
+TensorPtr make_shape_tensor(const TensorPtr &t) {
+    const auto &b = t->buffer();
+    const int dims = b.dimensions();
+    HalideBuffer<int32_t> data(dims);
+    for (int d = 0; d < dims; d++) {
+        data.data()[d] = b.extent(dims - d - 1);
+    }
+    TensorPtr shape_tensor = std::make_shared<Tensor>(t->name() + ".shape_tensor", std::move(data));
+    shape_tensor->set_constant();
+    return shape_tensor;
+}
+
+struct TensorAndOp {
+    TensorPtr tensor;
+    OpPtr op;
+};
+
+TensorAndOp reshape_tensor(TensorPtr t, bool is_output = false) {
+    assert(t->is_dense());
+    assert(t->rank() == 2 || t->rank() == 4);
+
+    TensorPtr t_reshaped;
+    std::string name = t->name() + ".reshaped";
+    if (t->is_constant() && !t->is_external() && !t->is_dynamic() && !t->is_alias()) {
+        // We don't need to use the normal aliasing approach here: the source
+        // is a constant-external Tensor, so we can just make a new Tensor that uses the same buffer,
+        // and thus the same underlying data, but with extra dimensions inserted.
+        HalideBuffer<void> nb = t->buffer();
+        if (t->rank() == 2) {
+            nb.add_dimension();
+            nb.add_dimension();
+            nb.transpose(1, 3);
+        }
+
+        // Reshape (c, x, y, b) to (cxy, 1, 1, b)
+        auto *dim = nb.raw_buffer()->dim;
+        dim[0].extent *= dim[1].extent * dim[2].extent;
+        dim[1].extent = 1;
+        dim[2].extent = 1;
+
+        // Canonicalize the strides as dense.
+        int stride = 1;
+        for (int i = 0; i < 4; i++) {
+            dim[i].stride = stride;
+            stride *= dim[i].extent;
+        }
+
+        t_reshaped = std::make_shared<Tensor>(name, std::move(nb), t->quantization());
+    } else {
+        Box bounds = t->bounds();
+#ifndef NDEBUG
+        for (const auto &i : bounds) {
+            assert(i.min == 0);
+        }
+#endif
+        int c_extent = bounds.front().extent();
+        int b_extent = bounds.back().extent();
+        if (bounds.size() == 4) {
+            // Reshape (c, x, y, b) to (cxy, 1, 1, b)
+            c_extent = bounds[0].extent() * bounds[1].extent() * bounds[2].extent();
+        }
+        Box reshaped_bounds = {{0, c_extent - 1}, {0, 0}, {0, 0}, {0, b_extent - 1}};
+        t_reshaped = std::make_shared<Tensor>(name, t->type(), std::move(reshaped_bounds), t->quantization());
+    }
+    t_reshaped->set_constant(t->is_constant());
+
+    assert(t->buffer().number_of_elements() == t_reshaped->buffer().number_of_elements());
+    assert(t->buffer().size_in_bytes() == t_reshaped->buffer().size_in_bytes());
+
+    OpPtr op = is_output ?
+                   make_op<ReshapeOp>(t_reshaped, make_shape_tensor(t), t) :
+                   make_op<ReshapeOp>(t, make_shape_tensor(t_reshaped), t_reshaped);
+
+    return {t_reshaped, std::move(op)};
+};
+
+}  // namespace
+
+// Implement FullyConnected op using Hannk's Conv op.
+OpPtr lower_tflite_fullyconnected(const TensorPtr &input, const TensorPtr &filter, const TensorPtr &bias,
+                                  const TensorPtr &output, ActivationFunction activation) {
+    if (output->type() == halide_type_of<int16_t>()) {
+        // TODO: Conv2d doesn't support int16 output yet
+        return make_op<FullyConnectedOp>(input, filter, bias, output, activation);
+    }
+
+    auto input_reshaped = reshape_tensor(input);
+    auto filter_reshaped = reshape_tensor(filter);
+    auto output_reshaped = reshape_tensor(output, /*is_output*/ true);
+
+    const std::array<int, 2> stride = {{1, 1}};
+    const std::array<int, 2> dilation_factor = {{1, 1}};
+    OpPtr conv_op = make_op<Conv2DOp>(input_reshaped.tensor, filter_reshaped.tensor, bias, output_reshaped.tensor,
+                                      stride, dilation_factor, Padding::Same, activation);
+
+    std::vector<TensorPtr> inputs = {input, filter, bias};
+    std::vector<TensorPtr> outputs = {output};
+    // std::initializer_list doesn't work well with move-only types, alas
+    std::vector<OpPtr> ops(4);
+    ops[0] = std::move(input_reshaped.op);
+    ops[1] = std::move(filter_reshaped.op);
+    ops[2] = std::move(conv_op);
+    ops[3] = std::move(output_reshaped.op);
     return make_op<OpGroup>(std::move(inputs), std::move(outputs), std::move(ops));
 }
 

--- a/apps/hannk/interpreter/lower.cpp
+++ b/apps/hannk/interpreter/lower.cpp
@@ -140,7 +140,10 @@ TensorAndOp reshape_tensor(TensorPtr t, bool is_output = false) {
         Box reshaped_bounds = {{0, c_extent - 1}, {0, 0}, {0, 0}, {0, b_extent - 1}};
         t_reshaped = std::make_shared<Tensor>(name, t->type(), std::move(reshaped_bounds), t->quantization());
     }
-    t_reshaped->set_constant(t->is_constant());
+
+    // Don't do this here: Constant folding should do this for us.
+    // TODO: verify this is correct.
+    // t_reshaped->set_constant(t->is_constant());
 
     assert(t->buffer().number_of_elements() == t_reshaped->buffer().number_of_elements());
     assert(t->buffer().size_in_bytes() == t_reshaped->buffer().size_in_bytes());

--- a/apps/hannk/interpreter/lower.h
+++ b/apps/hannk/interpreter/lower.h
@@ -11,6 +11,10 @@ OpPtr lower_tflite_lstm(TensorPtr data_input, TensorPtr prev_activ_input, Tensor
                         TensorPtr activ_output, TensorPtr state_output, TensorPtr concat_temp, TensorPtr activ_temp,
                         ActivationFunction activation = ActivationFunction::None);
 
+// Implement the FullyConnected op.
+OpPtr lower_tflite_fullyconnected(const TensorPtr &input, const TensorPtr &filter, const TensorPtr &bias,
+                                  const TensorPtr &output, ActivationFunction activation = ActivationFunction::None);
+
 }  // namespace hannk
 
 #endif  // HANNK_LOWER_H_

--- a/apps/hannk/tflite/tflite_parser.cpp
+++ b/apps/hannk/tflite/tflite_parser.cpp
@@ -252,7 +252,7 @@ public:
         TensorPtr filter = tensors_[op->inputs()->Get(1)];
         TensorPtr bias = tensors_[op->inputs()->Get(2)];
         TensorPtr output = tensors_[op->outputs()->Get(0)];
-        return make_op<FullyConnectedOp>(input, filter, bias, output, activation);
+        return lower_tflite_fullyconnected(input, filter, bias, output, activation);
     }
 
     OpPtr parse_pad(const tflite::Operator *op) {

--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -245,7 +245,7 @@ int SeedTracker::seed_for_name(const std::string &name) {
         vsnprintf(buffer, sizeof(buffer), format, args_copy);
         va_end(args_copy);
 
-        *self->verbose_output_ << format;
+        *self->verbose_output_ << buffer;
     }
 }
 

--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -571,7 +571,7 @@ int ModelRunner::parse_flags(int argc, char **argv, std::vector<std::string> &fi
 }
 
 void ModelRunner::run(const std::string &filename) {
-    std::cout << "\nProcessing " << filename << " ...\n";
+    std::cout << "Processing " << filename << " ...\n";
 
     const std::vector<char> buffer = read_entire_file(filename);
 

--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -621,7 +621,7 @@ void ModelRunner::run(const std::string &filename) {
             std::cout << RunNames[i] << " Time: " << t << " us";
             if (i != kTfLite) {
                 const auto t_ref = std::chrono::duration_cast<std::chrono::microseconds>(results[kTfLite].time).count();
-                std::cout << " (Speedup: " << std::fixed << std::setprecision(2) << (double) t_ref / (double) t << ")";
+                std::cout << " (Speedup: " << std::fixed << std::setprecision(2) << (double)t_ref / (double)t << ")";
             }
             std::cout << "\n";
         }

--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -617,13 +617,7 @@ void ModelRunner::run(const std::string &filename) {
     // ----- Log benchmark times
     if (do_benchmark) {
         for (WhichRun i : active_runs) {
-            const auto t = std::chrono::duration_cast<std::chrono::microseconds>(results[i].time).count();
-            std::cout << RunNames[i] << " Time: " << t << " us";
-            if (i != kTfLite) {
-                const auto t_ref = std::chrono::duration_cast<std::chrono::microseconds>(results[kTfLite].time).count();
-                std::cout << " (Speedup: " << std::fixed << std::setprecision(2) << (double)t_ref / (double)t << ")";
-            }
-            std::cout << "\n";
+            std::cout << RunNames[i] << " Time: " << std::chrono::duration_cast<std::chrono::microseconds>(results[i].time).count() << " us\n";
         }
     }
 

--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -571,7 +571,7 @@ int ModelRunner::parse_flags(int argc, char **argv, std::vector<std::string> &fi
 }
 
 void ModelRunner::run(const std::string &filename) {
-    std::cout << "Processing " << filename << " ...\n";
+    std::cout << "\nProcessing " << filename << " ...\n";
 
     const std::vector<char> buffer = read_entire_file(filename);
 
@@ -617,7 +617,13 @@ void ModelRunner::run(const std::string &filename) {
     // ----- Log benchmark times
     if (do_benchmark) {
         for (WhichRun i : active_runs) {
-            std::cout << RunNames[i] << " Time: " << std::chrono::duration_cast<std::chrono::microseconds>(results[i].time).count() << " us\n";
+            const auto t = std::chrono::duration_cast<std::chrono::microseconds>(results[i].time).count();
+            std::cout << RunNames[i] << " Time: " << t << " us";
+            if (i != kTfLite) {
+                const auto t_ref = std::chrono::duration_cast<std::chrono::microseconds>(results[kTfLite].time).count();
+                std::cout << " (Speedup: " << std::fixed << std::setprecision(2) << (double) t_ref / (double) t << ")";
+            }
+            std::cout << "\n";
         }
     }
 

--- a/apps/hannk/util/small_vector.h
+++ b/apps/hannk/util/small_vector.h
@@ -148,6 +148,15 @@ public:
     const T &operator[](size_t i) const {
         return data()[i];
     }
+
+    const T &front() const {
+        return at(0);
+    }
+
+    const T &back() const {
+        assert(size_ > 0);
+        return at(size_ - 1);
+    }
 };
 
 template<typename T, size_t Capacity>

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -106,6 +106,7 @@ CXX-host-metal ?= $(CXX)
 CXX-host-hvx ?= $(CXX)
 CXX-hexagon-32-qurt-hvx ?= hexagon-clang++
 CXX-arm-64-android ?= ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_PLATFORM}-x86_64/bin/aarch64-linux-android${ANDROID_API_VERSION}-clang++
+CXX-arm-64-android-arm_dot_prod ?= $(CXX-arm-64-android)
 CXX-arm-32-android ?= ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_PLATFORM}-x86_64/bin/armv7a-linux-androideabi${ANDROID_API_VERSION}-clang++
 CXX-arm-64-profile-android ?= $(CXX-arm-64-android)
 CXX-arm-32-profile-android ?= $(CXX-arm-32-android)
@@ -115,6 +116,7 @@ CXXFLAGS-host-opencl ?= $(CXXFLAGS)
 CXXFLAGS-host-cuda ?= $(CXXFLAGS)
 CXXFLAGS-host-metal ?= $(CXXFLAGS)
 CXXFLAGS-arm-64-android ?= $(CXXFLAGS)
+CXXFLAGS-arm-64-android-arm_dot_prod ?= $(CXXFLAGS-arm-64-android)
 CXXFLAGS-hexagon-32-qurt-hvx ?= -mv65 $(CXXFLAGS) -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev65/include/qurt -I$(HEXAGON_SDK_ROOT)/rtos/qurt/computev65/include/posix
 CXXFLAGS-arm-32-android ?= $(CXXFLAGS)
 
@@ -127,6 +129,7 @@ LDFLAGS-hexagon-32-qurt-hvx =
 # Use the statically-linked version of libc++ on Android by default, for simplicity
 # of deployment. (Despite the name, this applies to libc++, not libstdc++)
 LDFLAGS-arm-64-android ?= -llog -fPIE -pie -static-libstdc++
+LDFLAGS-arm-64-android-arm_dot_prod ?= $(LDFLAGS-arm-64-android)
 LDFLAGS-arm-32-android ?= -llog -fPIE -pie -static-libstdc++
 
 # Put HL_TARGET variants of all of these last, to avoid conflict with the android variants


### PR DESCRIPTION
FullyConnected is very similar to Conv2D, so rather than maintaining multiple similar implementations, let's translate a FullyConnected node into a Conv2D node (with some Reshape nodes as necessary). Benchmarking before-and-after shows performance to be more or less a wash on x86 OSX laptop and Pixel 4a.

Note that we keep the old FC logic for int16 outputs, as Conv2D doesn't support those yet; if this PR is landed, a followup PR will add that ability to Conv2D, and the existing FC support will be removed entirely.

Also a handful of drive-by fixes.