### PR TITLE
De-predicate loads and stores in Metal/OpenCL/D3D12 backend

### DIFF
--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -972,6 +972,13 @@ void CodeGen_D3D12Compute_Dev::add_kernel(Stmt s,
                                           const vector<DeviceArgument> &args) {
     debug(2) << "CodeGen_D3D12Compute_Dev::compile " << name << "\n";
 
+    // We need to scalarize/de-predicate any loads/stores, since HLSL does not
+    // support predication.
+    s = scalarize_predicated_loads_stores(s);
+
+    debug(2) << "CodeGen_D3D12Compute_Dev: after removing predication: \n"
+             << s;
+
     // TODO: do we have to uniquify these names, or can we trust that they are safe?
     cur_kernel_name = name;
     d3d12compute_c.add_kernel(s, name, args);

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -115,7 +115,7 @@ protected:
                                 mutate(extract_lane(s->value, ln)),
                                 mutate(extract_lane(s->index, ln)),
                                 s->param,
-                                make_bool(true),
+                                const_true(),
                                 // TODO: alignment needs to be changed
                                 s->alignment)));
             }

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -102,9 +102,10 @@ namespace {
 class ScalarizePredicatedLoadStore : public IRMutator {
 public:
     using IRMutator::mutate;
+    using IRMutator::visit;
 
 protected:
-    Stmt visit(const Store *s) {
+    Stmt visit(const Store *s) override {
         if (!is_const_one(s->predicate)) {
             std::vector<Stmt> scalar_stmts;
             for (int ln = 0; ln < s->value.type().lanes(); ln++) {
@@ -124,7 +125,7 @@ protected:
         }
     }
 
-    Expr visit(const Load *op) {
+    Expr visit(const Load *op) override {
         if (!is_const_one(op->predicate)) {
             Expr load_expr = Load::make(op->type, op->name, op->index, op->image, 
                                         op->param, const_true(op->type.lanes()), op->alignment);

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -1,5 +1,8 @@
 #include "CodeGen_GPU_Dev.h"
+#include "Deinterleave.h"
 #include "Bounds.h"
+#include "IRMutator.h"
+#include "IROperator.h"
 #include "IRVisitor.h"
 
 namespace Halide {
@@ -92,6 +95,55 @@ bool CodeGen_GPU_Dev::is_buffer_constant(const Stmt &kernel,
     IsBufferConstant v(buffer);
     kernel.accept(&v);
     return v.result;
+}
+
+namespace {
+
+class ScalarizePredicatedLoadStore : public IRMutator {
+public:
+    using IRMutator::mutate;
+
+protected:
+    Stmt visit(const Store *s) {
+        if (!is_const_one(s->predicate)) {
+            std::vector<Stmt> scalar_stmts;
+            for (int ln = 0; ln < s->value.type().lanes(); ln++) {
+                scalar_stmts.push_back(IfThenElse::make(
+                                           extract_lane(s->predicate, ln),
+                                           Store::make(s->name,
+                                                       mutate(extract_lane(s->value, ln)),
+                                                       mutate(extract_lane(s->index, ln)),
+                                                       s->param,
+                                                       make_bool(true),
+                                                       // TODO: alignment needs to be changed
+                                                       s->alignment)));
+            }
+            return Block::make(scalar_stmts);
+        } else {
+            return s;
+        }
+    }
+
+    Expr visit(const Load *op) {
+        if (!is_const_one(op->predicate)) {
+            Expr load_expr = Load::make(op->type, op->name, op->index, op->image, 
+                                        op->param, const_true(op->type.lanes()), op->alignment);
+            Expr pred_load = Call::make(load_expr.type(),
+                                        Call::if_then_else,
+                                        {op->predicate, load_expr},
+                                        Internal::Call::PureIntrinsic);
+            return pred_load;
+        } else {
+            return op;
+        }
+    }
+};
+
+} // namespace
+
+Stmt CodeGen_GPU_Dev::scalarize_predicated_loads_stores(Stmt &s) {
+    ScalarizePredicatedLoadStore sps;
+    return sps.mutate(s);
 }
 
 }  // namespace Internal

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -1,6 +1,6 @@
 #include "CodeGen_GPU_Dev.h"
-#include "Deinterleave.h"
 #include "Bounds.h"
+#include "Deinterleave.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "IRVisitor.h"
@@ -110,14 +110,14 @@ protected:
             std::vector<Stmt> scalar_stmts;
             for (int ln = 0; ln < s->value.type().lanes(); ln++) {
                 scalar_stmts.push_back(IfThenElse::make(
-                                           extract_lane(s->predicate, ln),
-                                           Store::make(s->name,
-                                                       mutate(extract_lane(s->value, ln)),
-                                                       mutate(extract_lane(s->index, ln)),
-                                                       s->param,
-                                                       make_bool(true),
-                                                       // TODO: alignment needs to be changed
-                                                       s->alignment)));
+                    extract_lane(s->predicate, ln),
+                    Store::make(s->name,
+                                mutate(extract_lane(s->value, ln)),
+                                mutate(extract_lane(s->index, ln)),
+                                s->param,
+                                make_bool(true),
+                                // TODO: alignment needs to be changed
+                                s->alignment)));
             }
             return Block::make(scalar_stmts);
         } else {
@@ -127,7 +127,7 @@ protected:
 
     Expr visit(const Load *op) override {
         if (!is_const_one(op->predicate)) {
-            Expr load_expr = Load::make(op->type, op->name, op->index, op->image, 
+            Expr load_expr = Load::make(op->type, op->name, op->index, op->image,
                                         op->param, const_true(op->type.lanes()), op->alignment);
             Expr pred_load = Call::make(load_expr.type(),
                                         Call::if_then_else,
@@ -140,7 +140,7 @@ protected:
     }
 };
 
-} // namespace
+}  // namespace
 
 Stmt CodeGen_GPU_Dev::scalarize_predicated_loads_stores(Stmt &s) {
     ScalarizePredicatedLoadStore sps;

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -68,6 +68,10 @@ struct CodeGen_GPU_Dev {
      * uniform within the workgroup. */
     static bool is_buffer_constant(const Stmt &kernel, const std::string &buffer);
 
+    /** Modifies predicated loads and stores to be non-predicated, since most
+     * GPU backends do not support predication. */
+    static Stmt scalarize_predicated_loads_stores(Stmt &s);
+
     /** An mask describing which type of memory fence to use for the gpu_thread_barrier()
     * intrinsic.  Not all GPUs APIs support all types.
     */

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -551,7 +551,7 @@ void CodeGen_Metal_Dev::add_kernel(Stmt s,
 
     // We need to scalarize/de-predicate any loads/stores, since Metal does not
     // support predication.
-    s = scalarize_predicated_loads_store(s);
+    s = scalarize_predicated_loads_stores(s);
 
     debug(2) << "CodeGen_Metal_Dev: after removing predication: \n" << s;
 

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -549,6 +549,12 @@ void CodeGen_Metal_Dev::add_kernel(Stmt s,
                                    const vector<DeviceArgument> &args) {
     debug(2) << "CodeGen_Metal_Dev::compile " << name << "\n";
 
+    // We need to scalarize/de-predicate any loads/stores, since Metal does not
+    // support predication.
+    s = scalarize_predicated_loads_store(s);
+
+    debug(2) << "CodeGen_Metal_Dev: after removing predication: \n" << s;
+
     // TODO: do we have to uniquify these names, or can we trust that they are safe?
     cur_kernel_name = name;
     metal_c.add_kernel(s, name, args);
@@ -575,6 +581,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
                                                     const vector<DeviceArgument> &args) {
 
     debug(2) << "Adding Metal kernel " << name << "\n";
+
 
     // Figure out which arguments should be passed in constant.
     // Such arguments should be:

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -553,7 +553,8 @@ void CodeGen_Metal_Dev::add_kernel(Stmt s,
     // support predication.
     s = scalarize_predicated_loads_stores(s);
 
-    debug(2) << "CodeGen_Metal_Dev: after removing predication: \n" << s;
+    debug(2) << "CodeGen_Metal_Dev: after removing predication: \n"
+             << s;
 
     // TODO: do we have to uniquify these names, or can we trust that they are safe?
     cur_kernel_name = name;
@@ -581,7 +582,6 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
                                                     const vector<DeviceArgument> &args) {
 
     debug(2) << "Adding Metal kernel " << name << "\n";
-
 
     // Figure out which arguments should be passed in constant.
     // Such arguments should be:

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -887,6 +887,13 @@ void CodeGen_OpenCL_Dev::add_kernel(Stmt s,
                                     const vector<DeviceArgument> &args) {
     debug(2) << "CodeGen_OpenCL_Dev::compile " << name << "\n";
 
+    // We need to scalarize/de-predicate any loads/stores, since OpenCL does not
+    // support predication.
+    s = scalarize_predicated_loads_stores(s);
+
+    debug(2) << "CodeGen_OpenCL_Dev: after removing predication: \n"
+             << s;
+
     // TODO: do we have to uniquify these names, or can we trust that they are safe?
     cur_kernel_name = name;
     clc.add_kernel(s, name, args);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -150,6 +150,7 @@ tests(GROUPS correctness
       gpu_texture.cpp
       gpu_thread_barrier.cpp
       gpu_transpose.cpp
+      gpu_vectorize.cpp
       gpu_vectorized_shared_memory.cpp
       half_native_interleave.cpp
       halide_buffer.cpp

--- a/test/correctness/gpu_vectorize.cpp
+++ b/test/correctness/gpu_vectorize.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
         }
 
         printf("Realizing function...\n");
-        Buffer<float_t> input_img(32, 32);
+        Buffer<float> input_img(32, 32);
         for (int i=0; i<32; i++) {
             for (int j=0; j<32; j++) {
                 input_img(i, j) = i + j;

--- a/test/correctness/gpu_vectorize.cpp
+++ b/test/correctness/gpu_vectorize.cpp
@@ -50,8 +50,8 @@ int main(int argc, char **argv) {
 
         printf("Realizing function...\n");
         Buffer<float> input_img(32, 32);
-        for (int i=0; i<32; i++) {
-            for (int j=0; j<32; j++) {
+        for (int i = 0; i < 32; i++) {
+            for (int j = 0; j < 32; j++) {
                 input_img(i, j) = i + j;
             }
         }

--- a/test/correctness/gpu_vectorize.cpp
+++ b/test/correctness/gpu_vectorize.cpp
@@ -1,0 +1,76 @@
+#include "Halide.h"
+#include <iostream>
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+
+    {
+        Var x("x"), y("y"), xi("xi"), yi("yi");
+        Func f("f");
+
+        printf("Defining function...\n");
+
+        f(x, y) = x * y + 2.4f;
+
+        Target target = get_jit_target_from_environment();
+        if (target.has_gpu_feature()) {
+            f.gpu_tile(x, y, xi, yi, 8, 8, TailStrategy::GuardWithIf).vectorize(xi, 4, TailStrategy::GuardWithIf);
+        }
+
+        printf("Realizing function...\n");
+
+        Buffer<float> imf = f.realize({32, 32}, target);
+
+        // Check the result was what we expected
+        for (int i = 0; i < 32; i++) {
+            for (int j = 0; j < 32; j++) {
+                float correct = i * j + 2.4f;
+                if (fabs(imf(i, j) - correct) > 0.001f) {
+                    printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
+                    return -1;
+                }
+            }
+        }
+    }
+    {
+        Var x("x"), y("y"), xi("xi"), yi("yi");
+        Func f("f");
+        ImageParam im(Float(32), 2);
+
+        printf("Defining function...\n");
+
+        f(x, y) = x * y + 2.4f + im(x, y);
+
+        Target target = get_jit_target_from_environment();
+        if (target.has_gpu_feature()) {
+            f.gpu_tile(x, y, xi, yi, 8, 8, TailStrategy::GuardWithIf).vectorize(xi, 4, TailStrategy::GuardWithIf);
+        }
+
+        printf("Realizing function...\n");
+        Buffer<float_t> input_img(32, 32);
+        for (int i=0; i<32; i++) {
+            for (int j=0; j<32; j++) {
+                input_img(i, j) = i + j;
+            }
+        }
+        im.set(input_img);
+
+        Buffer<float> imf = f.realize({32, 32}, target);
+
+        // Check the result was what we expected
+        for (int i = 0; i < 32; i++) {
+            for (int j = 0; j < 32; j++) {
+                float correct = i * j + 2.4f + i + j;
+                if (fabs(imf(i, j) - correct) > 0.001f) {
+                    printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
+                    return -1;
+                }
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Because GPU backends do not support predication, this adds a mutator that de-predicates them, and a test to exercise this.  Should fix #6157.