### PR TITLE
Add various bounds-related simplifier rules

### DIFF
--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -74,7 +74,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite(select(x, y, z) + (w + select(x, u, v)), select(x, y + u, z + v) + w) ||
              rewrite(select(x, y, z) + (select(x, u, v) - w), select(x, y + u, z + v) - w) ||
              rewrite(select(x, y, z) + (w - select(x, u, v)), select(x, y - u, z - v) + w) ||
-             rewrite(select(x, c0 - y, c1) + c2, select(x, fold(c0 + c2) - y, fold(c1 + c2)), !overflows(c0 + c2) && !overflows(c1 + c2)) ||
+             rewrite(select(x, c0 - y, c1) + c2, select(x, fold(c0 + c2) - y, fold(c1 + c2))) ||
 
              rewrite(x + y*(-1), x - y) ||
              rewrite(x*(-1) + y, y - x) ||
@@ -150,7 +150,6 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
                rewrite(max(y + c0, x) + c1, max(y, x + c1), c0 + c1 == 0) ||
                rewrite(max(x, y) + min(x, y), x + y) ||
                rewrite(max(x, y) + min(y, x), x + y) ||
-               rewrite(max(x, y*c0 + z) + (u - y)*c0, max(x - y*c0, z) + u*c0) ||
 
                rewrite(min(x, y + (z*c0)) + (z*c1), min(x + (z*c1), y), (c0 + c1) == 0) ||
                rewrite(min(x, (y*c0) + z) + (y*c1), min(x + (y*c1), z), (c0 + c1) == 0) ||

--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -74,6 +74,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite(select(x, y, z) + (w + select(x, u, v)), select(x, y + u, z + v) + w) ||
              rewrite(select(x, y, z) + (select(x, u, v) - w), select(x, y + u, z + v) - w) ||
              rewrite(select(x, y, z) + (w - select(x, u, v)), select(x, y - u, z - v) + w) ||
+             rewrite(select(x, c0 - y, c1) + c2, select(x, fold(c0 + c2) - y, fold(c1 + c2)), !overflows(c0 + c2) && !overflows(c1 + c2)) ||
 
              rewrite(x + y*(-1), x - y) ||
              rewrite(x*(-1) + y, y - x) ||
@@ -83,6 +84,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
              rewrite(x + (y + c0), (x + y) + c0) ||
              rewrite((c0 - x) + c1, fold(c0 + c1) - x) ||
              rewrite((c0 - x) + y, (y - x) + c0) ||
+             rewrite(max(x, y*c0 + z) + (u - y)*c0, max(x - y*c0, z) + u*c0) ||
 
              rewrite((x - y) + y, x) ||
              rewrite(x + (y - x), y) ||
@@ -148,6 +150,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
                rewrite(max(y + c0, x) + c1, max(y, x + c1), c0 + c1 == 0) ||
                rewrite(max(x, y) + min(x, y), x + y) ||
                rewrite(max(x, y) + min(y, x), x + y) ||
+               rewrite(max(x, y*c0 + z) + (u - y)*c0, max(x - y*c0, z) + u*c0) ||
 
                rewrite(min(x, y + (z*c0)) + (z*c1), min(x + (z*c1), y), (c0 + c1) == 0) ||
                rewrite(min(x, (y*c0) + z) + (y*c1), min(x + (y*c1), z), (c0 + c1) == 0) ||

--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -143,6 +143,8 @@ Expr Simplify::visit(const Div *op, ExprInfo *bounds) {
                rewrite((x * c0) / c1, x / fold(c1 / c0),                          c1 % c0 == 0 && c0 > 0 && c1 / c0 != 0) ||
                // Pull out terms that are a multiple of the denominator
                rewrite((x * c0) / c1, x * fold(c0 / c1),                          c0 % c1 == 0 && c1 > 0) ||
+               rewrite(min((x * c0), c1) / c2, min(x * fold(c0 / c2), fold(c1 / c2)), c0 % c2 == 0 && c2 > 0) ||
+               rewrite(max((x * c0), c1) / c2, max(x * fold(c0 / c2), fold(c1 / c2)), c0 % c2 == 0 && c2 > 0) ||
 
                rewrite((x * c0 + y) / c1, y / c1 + x * fold(c0 / c1),             c0 % c1 == 0 && c1 > 0) ||
                rewrite((x * c0 - y) / c0, x + (0 - y) / c0) ||

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -97,6 +97,10 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
              rewrite(max(max(x, y), min(z, x)), a) ||
              rewrite(max(max(x, y), min(z, y)), a) ||
 
+             rewrite(max(select(x, max(z, y), w), z), max(select(x, y, w), z)) ||
+             rewrite(max(select(x, max(z, y), w), y), max(select(x, z, w), y)) ||
+             rewrite(max(min(x*c0, y + c1) - min(select(0 < x, y, min(x*c0, y + c1)), x*c0), 0), 0, c1 < 0) ||
+
              rewrite(max(intrin(Call::likely, x), x), b) ||
              rewrite(max(x, intrin(Call::likely, x)), a) ||
              rewrite(max(intrin(Call::likely_if_innermost, x), x), b) ||

--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -99,7 +99,8 @@ Expr Simplify::visit(const Max *op, ExprInfo *bounds) {
 
              rewrite(max(select(x, max(z, y), w), z), max(select(x, y, w), z)) ||
              rewrite(max(select(x, max(z, y), w), y), max(select(x, z, w), y)) ||
-             rewrite(max(min(x*c0, y + c1) - min(select(0 < x, y, min(x*c0, y + c1)), x*c0), 0), 0, c1 < 0) ||
+             rewrite(max(select(x, w, max(z, y)), z), max(select(x, w, y), z)) ||
+             rewrite(max(select(x, w, max(z, y)), y), max(select(x, w, z), y)) ||
 
              rewrite(max(intrin(Call::likely, x), x), b) ||
              rewrite(max(x, intrin(Call::likely, x)), a) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -100,6 +100,8 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(max(x, y + c0), y), y, c0 > 0) ||
              rewrite(min(select(x, min(z, y), w), y), min(select(x, z, w), y)) ||
              rewrite(min(select(x, min(z, y), w), z), min(select(x, y, w), z)) ||
+             rewrite(min(select(x, w, min(z, y)), y), min(select(x, w, z), y)) ||
+             rewrite(min(select(x, w, min(z, y)), z), min(select(x, w, y), z)) ||
 
              rewrite(min(intrin(Call::likely, x), x), b) ||
              rewrite(min(x, intrin(Call::likely, x)), a) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -97,6 +97,10 @@ Expr Simplify::visit(const Min *op, ExprInfo *bounds) {
              rewrite(min(max(x, y), min(z, x)), b) ||
              rewrite(min(max(x, y), min(z, y)), b) ||
 
+             rewrite(min(max(x, y + c0), y), y, c0 > 0) ||
+             rewrite(min(select(x, min(z, y), w), y), min(select(x, z, w), y)) ||
+             rewrite(min(select(x, min(z, y), w), z), min(select(x, y, w), z)) ||
+
              rewrite(min(intrin(Call::likely, x), x), b) ||
              rewrite(min(x, intrin(Call::likely, x)), a) ||
              rewrite(min(intrin(Call::likely_if_innermost, x), x), b) ||

--- a/src/Simplify_Mul.cpp
+++ b/src/Simplify_Mul.cpp
@@ -80,10 +80,10 @@ Expr Simplify::visit(const Mul *op, ExprInfo *bounds) {
             rewrite(max(x, y) * min(x, y), x * y) ||
             rewrite(max(x, y) * min(y, x), y * x) ||
 
-            rewrite(min(x*c0, c1)*c2, min(x*fold(c0*c2), fold(c1*c2)), c2 > 0) ||
-            rewrite(min(x*c0, c1)*c2, max(x*fold(c0*c2), fold(c1*c2)), c2 < 0) ||
-            rewrite(max(x*c0, c1)*c2, max(x*fold(c0*c2), fold(c1*c2)), c2 > 0) ||
-            rewrite(max(x*c0, c1)*c2, min(x*fold(c0*c2), fold(c1*c2)), c2 < 0) ||
+            rewrite(min(x * c0, c1) * c2, min(x * fold(c0 * c2), fold(c1 * c2)), c2 > 0) ||
+            rewrite(min(x * c0, c1) * c2, max(x * fold(c0 * c2), fold(c1 * c2)), c2 < 0) ||
+            rewrite(max(x * c0, c1) * c2, max(x * fold(c0 * c2), fold(c1 * c2)), c2 > 0) ||
+            rewrite(max(x * c0, c1) * c2, min(x * fold(c0 * c2), fold(c1 * c2)), c2 < 0) ||
 
             rewrite(broadcast(x, c0) * broadcast(y, c0), broadcast(x * y, c0)) ||
             rewrite(broadcast(x, c0) * broadcast(y, c1), broadcast(x * broadcast(y, fold(c1 / c0)), c0), c1 % c0 == 0) ||

--- a/src/Simplify_Mul.cpp
+++ b/src/Simplify_Mul.cpp
@@ -79,6 +79,12 @@ Expr Simplify::visit(const Mul *op, ExprInfo *bounds) {
             rewrite(x * (y * c0), (x * y) * c0) ||
             rewrite(max(x, y) * min(x, y), x * y) ||
             rewrite(max(x, y) * min(y, x), y * x) ||
+
+            rewrite(min(x*c0, c1)*c2, min(x*fold(c0*c2), fold(c1*c2)), c2 > 0) ||
+            rewrite(min(x*c0, c1)*c2, max(x*fold(c0*c2), fold(c1*c2)), c2 < 0) ||
+            rewrite(max(x*c0, c1)*c2, max(x*fold(c0*c2), fold(c1*c2)), c2 > 0) ||
+            rewrite(max(x*c0, c1)*c2, min(x*fold(c0*c2), fold(c1*c2)), c2 < 0) ||
+
             rewrite(broadcast(x, c0) * broadcast(y, c0), broadcast(x * y, c0)) ||
             rewrite(broadcast(x, c0) * broadcast(y, c1), broadcast(x * broadcast(y, fold(c1 / c0)), c0), c1 % c0 == 0) ||
             rewrite(broadcast(y, c1) * broadcast(x, c0), broadcast(broadcast(y, fold(c1 / c0)) * x, c0), c1 % c0 == 0) ||

--- a/src/Simplify_Mul.cpp
+++ b/src/Simplify_Mul.cpp
@@ -80,11 +80,6 @@ Expr Simplify::visit(const Mul *op, ExprInfo *bounds) {
             rewrite(max(x, y) * min(x, y), x * y) ||
             rewrite(max(x, y) * min(y, x), y * x) ||
 
-            rewrite(min(x * c0, c1) * c2, min(x * fold(c0 * c2), fold(c1 * c2)), c2 > 0) ||
-            rewrite(min(x * c0, c1) * c2, max(x * fold(c0 * c2), fold(c1 * c2)), c2 < 0) ||
-            rewrite(max(x * c0, c1) * c2, max(x * fold(c0 * c2), fold(c1 * c2)), c2 > 0) ||
-            rewrite(max(x * c0, c1) * c2, min(x * fold(c0 * c2), fold(c1 * c2)), c2 < 0) ||
-
             rewrite(broadcast(x, c0) * broadcast(y, c0), broadcast(x * y, c0)) ||
             rewrite(broadcast(x, c0) * broadcast(y, c1), broadcast(x * broadcast(y, fold(c1 / c0)), c0), c1 % c0 == 0) ||
             rewrite(broadcast(y, c1) * broadcast(x, c0), broadcast(broadcast(y, fold(c1 / c0)) * x, c0), c1 % c0 == 0) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -140,6 +140,10 @@ Expr Simplify::visit(const Select *op, ExprInfo *bounds) {
              rewrite(select(x, max(w, y), max(z, w)), max(w, select(x, y, z))) ||
              rewrite(select(x, max(w, y), max(w, z)), max(w, select(x, y, z))) ||
 
+             rewrite(select(0 < x, min(x*c0, c1), x*c0), min(x*c0, c1), c1 >= 0 && c0 >= 0) ||
+             rewrite(select(x < c0, 0, min(x, c0) + c1), 0, c0 == -c1) ||
+             rewrite(select(0 < x, ((x*c0) + c1) / x, y), select(0 < x, c0 - 1, y), c1 == -1) ||
+
              rewrite(select(x, select(y, z, min(w, z)), min(u, z)), min(select(x, select(y, z, w), u), z)) ||
              rewrite(select(x, select(y, min(w, z), z), min(u, z)), min(select(x, select(y, w, z), u), z)) ||
              rewrite(select(x, min(u, z), select(y, z, min(w, z))), min(select(x, u, select(y, z, w)), z)) ||

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -173,6 +173,7 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite(((x - y) - z) - x, 0 - (y + z)) ||
 
              rewrite(x - x%c0, (x/c0)*c0) ||
+             rewrite(x - ((x + c0)/c1)*c1, (x + c0)%c1 - c0, c1 > 0) ||
 
              (no_overflow(op->type) &&
               (rewrite(max(x, y) - x, max(y - x, 0)) ||
@@ -243,6 +244,7 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
                rewrite(min(x, y) - min(y, x), 0) ||
                rewrite(min(x, y) - min(z, w), y - w, can_prove(x - y == z - w, this)) ||
                rewrite(min(x, y) - min(w, z), y - w, can_prove(x - y == z - w, this)) ||
+               rewrite(min(x*c0, c1) - min(x, c2)*c0, min(c1 - min(x, c2)*c0, 0), c0 > 0 && c1 <= c2*c0) ||
 
                rewrite((x - max(z, (x + y))), (0 - max(z - x, y)), !is_const(x)) ||
                rewrite((x - max(z, (y + x))), (0 - max(z - x, y)), !is_const(x)) ||


### PR DESCRIPTION
All of these simplifier rules came from `find_constant_bounds` failures. Some are oddly specific and I can be convinced to remove them (i.e. in Simplify_Max.cpp and Simplify_Select.cpp), but many of them are useful for `find_constant_bounds`.