### PR TITLE
Remove deprecated realize() Python wrapprs

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -136,46 +136,6 @@ void define_func(py::module &m) {
                 },
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
 
-            .def(
-                "realize",
-                [](Func &f, int x_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(f.realize(std::vector<int32_t>{x_size}, target));
-                },
-                py::arg("x_size"), py::arg("target") = Target())
-
-            .def(
-                "realize",
-                [](Func &f, int x_size, int y_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(f.realize({x_size, y_size}, target));
-                },
-                py::arg("x_size"), py::arg("y_size"), py::arg("target") = Target())
-
-            .def(
-                "realize",
-                [](Func &f, int x_size, int y_size, int z_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(f.realize({x_size, y_size, z_size}, target));
-                },
-                py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("target") = Target())
-
-            .def(
-                "realize",
-                [](Func &f, int x_size, int y_size, int z_size, int w_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(f.realize({x_size, y_size, z_size, w_size}, target));
-                },
-                py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target())
-
             .def("defined", &Func::defined)
             .def("name", &Func::name)
             .def("dimensions", &Func::dimensions)

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -114,42 +114,6 @@ void define_pipeline(py::module &m) {
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
 
             .def(
-                "realize", [](Pipeline &p, int x_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(p.realize(std::vector<int32_t>{x_size}, target));
-                },
-                py::arg("x_size"), py::arg("target") = Target())
-
-            .def(
-                "realize", [](Pipeline &p, int x_size, int y_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(p.realize({x_size, y_size}, target));
-                },
-                py::arg("x_size"), py::arg("y_size"), py::arg("target") = Target())
-
-            .def(
-                "realize", [](Pipeline &p, int x_size, int y_size, int z_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(p.realize({x_size, y_size, z_size}, target));
-                },
-                py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("target") = Target())
-
-            .def(
-                "realize", [](Pipeline &p, int x_size, int y_size, int z_size, int w_size, const Target &target) -> py::object {
-                    PyErr_WarnEx(PyExc_DeprecationWarning,
-                                 "Call realize() with an explicit list of ints instead.",
-                                 1);
-                    return realization_to_object(p.realize({x_size, y_size, z_size, w_size}, target));
-                },
-                py::arg("x_size"), py::arg("y_size"), py::arg("z_size"), py::arg("w_size"), py::arg("target") = Target())
-
-            .def(
                 "infer_input_bounds", [](Pipeline &p, const py::object &dst, const Target &target) -> void {
                     // dst could be Buffer<>, vector<Buffer>, or vector<int>
                     try {


### PR DESCRIPTION
The C++ versions were removed in #6122, but the Python equivalents were overlooked.