### PR TITLE
Use generic build command instead of make in run-clang-tidy.sh

### DIFF
--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -47,7 +47,7 @@ cmake -DCMAKE_BUILD_TYPE=Debug \
 [ -a ${CLANG_TIDY_BUILD_DIR}/compile_commands.json ]
 
 # We must populate the includes directory to check things outside of src/
-cd ${CLANG_TIDY_BUILD_DIR} && make HalideIncludes
+cmake --build ${CLANG_TIDY_BUILD_DIR} --target HalideIncludes
 
 RUN_CLANG_TIDY=${CLANG_TIDY_LLVM_INSTALL_DIR}/share/clang/run-clang-tidy.py
 


### PR DESCRIPTION
Script had previously assumed CMake would generate makefiles. If Ninja is selected via the `CMAKE_GENERATOR` environment variable, the script would fail.

Fixes #6163