### PR TITLE
[Hexagon] Do not pattern match inside if_then_else block

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -914,6 +914,9 @@ private:
     }
 
     Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::if_then_else)) {
+            return op;
+        }
         if (op->is_intrinsic(Call::widening_add)) {
             Expr mpyadds = find_mpyadds(Add::make(cast(op->type, op->args[0]), cast(op->type, op->args[1])));
             if (mpyadds.defined()) {
@@ -1071,6 +1074,13 @@ class VectorReducePatterns : public IRMutator {
             return true;
         }
         return false;
+    }
+
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::if_then_else)) {
+            return op;
+        }
+        return IRMutator::visit(op);
     }
 
     Expr visit(const VectorReduce *op) override {
@@ -1950,6 +1960,13 @@ class OptimizeShuffles : public IRMutator {
 
     using IRMutator::visit;
 
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::if_then_else)) {
+            return op;
+        }
+        return IRMutator::visit(op);
+    }
+
     template<typename NodeType, typename T>
     NodeType visit_let(const T *op) {
         // We only care about vector lets.
@@ -2173,6 +2190,13 @@ class ScatterGatherGenerator : public IRMutator {
     std::unordered_map<string, const Allocate *> allocations;
 
     using IRMutator::visit;
+
+    Expr visit(const Call *op) override {
+        if (op->is_intrinsic(Call::if_then_else)) {
+            return op;
+        }
+        return IRMutator::visit(op);
+    }
 
     template<typename NodeType, typename T>
     NodeType visit_let(const T *op) {

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -914,7 +914,7 @@ private:
     }
 
     Expr visit(const Call *op) override {
-        if (op->is_intrinsic(Call::if_then_else)) {
+        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
             return op;
         }
         if (op->is_intrinsic(Call::widening_add)) {
@@ -1077,7 +1077,7 @@ class VectorReducePatterns : public IRMutator {
     }
 
     Expr visit(const Call *op) override {
-        if (op->is_intrinsic(Call::if_then_else)) {
+        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
             return op;
         }
         return IRMutator::visit(op);
@@ -1961,7 +1961,7 @@ class OptimizeShuffles : public IRMutator {
     using IRMutator::visit;
 
     Expr visit(const Call *op) override {
-        if (op->is_intrinsic(Call::if_then_else)) {
+        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
             return op;
         }
         return IRMutator::visit(op);
@@ -2192,7 +2192,7 @@ class ScatterGatherGenerator : public IRMutator {
     using IRMutator::visit;
 
     Expr visit(const Call *op) override {
-        if (op->is_intrinsic(Call::if_then_else)) {
+        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
             return op;
         }
         return IRMutator::visit(op);

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -914,8 +914,11 @@ private:
     }
 
     Expr visit(const Call *op) override {
-        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
-            return op;
+        if (op->is_intrinsic(Call::if_then_else) && op->args[0].type().is_vector()) {
+            const Broadcast *b = op->args[0].as<Broadcast>();
+            if (!b || b->value.type().is_vector()) {
+                return op;
+            }
         }
         if (op->is_intrinsic(Call::widening_add)) {
             Expr mpyadds = find_mpyadds(Add::make(cast(op->type, op->args[0]), cast(op->type, op->args[1])));
@@ -1077,8 +1080,11 @@ class VectorReducePatterns : public IRMutator {
     }
 
     Expr visit(const Call *op) override {
-        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
-            return op;
+        if (op->is_intrinsic(Call::if_then_else) && op->args[0].type().is_vector()) {
+            const Broadcast *b = op->args[0].as<Broadcast>();
+            if (!b || b->value.type().is_vector()) {
+                return op;
+            }
         }
         return IRMutator::visit(op);
     }
@@ -1961,8 +1967,11 @@ class OptimizeShuffles : public IRMutator {
     using IRMutator::visit;
 
     Expr visit(const Call *op) override {
-        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
-            return op;
+        if (op->is_intrinsic(Call::if_then_else) && op->args[0].type().is_vector()) {
+            const Broadcast *b = op->args[0].as<Broadcast>();
+            if (!b || b->value.type().is_vector()) {
+                return op;
+            }
         }
         return IRMutator::visit(op);
     }
@@ -2192,8 +2201,11 @@ class ScatterGatherGenerator : public IRMutator {
     using IRMutator::visit;
 
     Expr visit(const Call *op) override {
-        if (op->type.is_vector() && op->is_intrinsic(Call::if_then_else)) {
-            return op;
+        if (op->is_intrinsic(Call::if_then_else) && op->args[0].type().is_vector()) {
+            const Broadcast *b = op->args[0].as<Broadcast>();
+            if (!b || b->value.type().is_vector()) {
+                return op;
+            }
         }
         return IRMutator::visit(op);
     }


### PR DESCRIPTION
Resolves the compilation below compilation error while generating
hannk::upsample_channels_uint8 from hannk/depthwise_conv.generator
for HVX:

Unknown intrinsic dynamic_shuffle

The problem occurs when we pattern match hvx instrinsics inside
if_then_else nodes and try to scalarize them later. In the patch we
prevent matching these intrinsics inside if_then_else blocks.

@dsharletg @pranavb-ca PTAL 