### PR TITLE
Fix unroll failures from adams2019 when the Expr depends on estimates

### DIFF
--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -691,7 +691,6 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
                 for (int j = 0; j < consumer.dimensions(); j++) {
                     const auto &req = node.region_required[j];
                     auto &comp = node.region_computed[j];
-                    // TODO: is this the right thing to do?
                     comp.depends_on_estimate = depends_on_estimate(comp.in.min) || depends_on_estimate(comp.in.max);
                     comp.in.min = simplify(apply_param_estimates.mutate(comp.in.min));
                     comp.in.max = simplify(apply_param_estimates.mutate(comp.in.max));

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -446,8 +446,8 @@ void FunctionDAG::Node::required_to_computed(const Span *required, Span *compute
     }
 }
 
-FunctionDAG::Edge::BoundInfo::BoundInfo(const Expr &e, const Node::Stage &consumer)
-    : expr(e) {
+FunctionDAG::Edge::BoundInfo::BoundInfo(const Expr &e, const Node::Stage &consumer, bool dependent)
+    : expr(e), depends_on_estimate(dependent) {
     // Do the analysis to detect if this is a simple case
     // that can be evaluated more cheaply. Currently this
     // acceleration recognises affine expressions. In the
@@ -524,6 +524,7 @@ void FunctionDAG::Edge::expand_footprint(const Span *consumer_loop, Span *produc
         // consumer.
         bool bounds_are_constant = true;
         auto eval_bound = [&](const BoundInfo &b) {
+            bounds_are_constant &= !b.depends_on_estimate;
             if (b.affine) {
                 // Common-case performance optimization
                 if (b.coeff == 0) {
@@ -547,6 +548,23 @@ void FunctionDAG::Edge::expand_footprint(const Span *consumer_loop, Span *produc
         int64_t b = eval_bound(bounds[i].second);
         producer_required[i].union_with(Span(a, b, bounds_are_constant));
     }
+}
+
+class DependsOnEstimate : public IRVisitor {
+public:
+    bool found_estimate = false;
+private:
+    using IRVisitor::visit;
+
+    void visit(const Variable *op) override {
+        found_estimate |= op->param.defined();
+    }
+};
+
+bool depends_on_estimate(const Expr &expr) {
+    DependsOnEstimate dependency_checker;
+    expr.accept(&dependency_checker);
+    return dependency_checker.found_estimate;
 }
 
 FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &params, const Target &target) {
@@ -672,6 +690,8 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
                 for (int j = 0; j < consumer.dimensions(); j++) {
                     const auto &req = node.region_required[j];
                     auto &comp = node.region_computed[j];
+                    // TODO: is this the right thing to do?
+                    comp.depends_on_estimate = depends_on_estimate(comp.in.min) || depends_on_estimate(comp.in.max);
                     comp.in.min = simplify(apply_param_estimates.mutate(comp.in.min));
                     comp.in.max = simplify(apply_param_estimates.mutate(comp.in.max));
                     if (equal(comp.in.min, req.min) && equal(comp.in.max, req.max)) {
@@ -891,11 +911,6 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
 
             exprs = apply_param_estimates.mutate(exprs);
 
-            for (auto &p : func_value_bounds) {
-                p.second.min = apply_param_estimates.mutate(p.second.min);
-                p.second.max = apply_param_estimates.mutate(p.second.max);
-            }
-
             // For this stage scope we want symbolic bounds for the rvars
 
             // Now create the edges that lead to this func
@@ -920,8 +935,12 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
                         internal_assert(in.is_bounded())
                             << "Unbounded producer->consumer relationship: "
                             << edge.producer->func.name() << " -> " << edge.consumer->name << "\n";
-                        Edge::BoundInfo min(simplify(in.min), *edge.consumer);
-                        Edge::BoundInfo max(simplify(in.max), *edge.consumer);
+                        bool min_dependent = depends_on_estimate(in.min);
+                        bool max_dependent = depends_on_estimate(in.max);
+                        Expr min_value = simplify(apply_param_estimates.mutate(in.min));
+                        Expr max_value = simplify(apply_param_estimates.mutate(in.max));
+                        Edge::BoundInfo min(min_value, *edge.consumer, min_dependent);
+                        Edge::BoundInfo max(max_value, *edge.consumer, max_dependent);
                         edge.bounds.emplace_back(std::move(min), std::move(max));
                         edge.all_bounds_affine &= edge.bounds.back().first.affine;
                         edge.all_bounds_affine &= edge.bounds.back().second.affine;

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -553,6 +553,7 @@ void FunctionDAG::Edge::expand_footprint(const Span *consumer_loop, Span *produc
 class DependsOnEstimate : public IRVisitor {
 public:
     bool found_estimate = false;
+
 private:
     using IRVisitor::visit;
 

--- a/src/autoschedulers/adams2019/FunctionDAG.h
+++ b/src/autoschedulers/adams2019/FunctionDAG.h
@@ -402,6 +402,7 @@ struct FunctionDAG {
             // The min and max in their full symbolic glory. We use
             // these in the general case.
             Interval in;
+            bool depends_on_estimate = false;
 
             // Analysis used to accelerate common cases
             bool equals_required = false, equals_union_of_required_with_constants = false;
@@ -530,9 +531,9 @@ struct FunctionDAG {
             // used to evaluate this bound more quickly.
             int64_t coeff, constant;
             int64_t consumer_dim;
-            bool affine, uses_max;
+            bool affine, uses_max, depends_on_estimate;
 
-            BoundInfo(const Expr &e, const Node::Stage &consumer);
+            BoundInfo(const Expr &e, const Node::Stage &consumer, bool dependent);
         };
 
         // Memory footprint on producer required by consumer.


### PR DESCRIPTION
Adams2019 often tries to unroll loops that are not constant-bounded due to substitution of estimates for input variables. This PR tracks which bounds depend on estimates (`BoundsInfo` now tracks `depend_on_estimate`), and removes the constant_bound tag if the calculation of a constant bound depends on an estimate.