### PR TITLE
fix _halide_buffer_crop bug

### DIFF
--- a/src/runtime/halide_buffer_t.cpp
+++ b/src/runtime/halide_buffer_t.cpp
@@ -151,7 +151,7 @@ halide_buffer_t *_halide_buffer_crop(void *user_context,
         offset += (min[i] - src->dim[i].min) * (int64_t)src->dim[i].stride;
     }
     if (dst->host) {
-        dst->host += offset * src->type.bytes();
+        dst->host += offset * src->type.bytes() * src->type.lanes;
     }
     dst->device_interface = nullptr;
     dst->device = 0;


### PR DESCRIPTION
src/runtime/halide_buffer_t.cpp
has a bug in function "_halide_buffer_crop".
It does not consider the situation when src->type.lanes != 1