### PR TITLE
Add IRMutator::mutate_exprs()

### DIFF
--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1047,8 +1047,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
                 std::string new_name = unique_name(op->name);
                 replacements[op->name] = new_name;
 
-                auto [new_extents, changed] = mutate_exprs(op->extents);
-                (void)changed;  // unused
+                auto new_extents = mutate(op->extents);
                 Stmt new_body = mutate(op->body);
                 Expr new_condition = mutate(op->condition);
                 Expr new_new_expr;

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1047,10 +1047,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
                 std::string new_name = unique_name(op->name);
                 replacements[op->name] = new_name;
 
-                std::vector<Expr> new_extents;
-                for (size_t i = 0; i < op->extents.size(); i++) {
-                    new_extents.push_back(mutate(op->extents[i]));
-                }
+                auto [new_extents, changed] = mutate_exprs(op->extents);
                 Stmt new_body = mutate(op->body);
                 Expr new_condition = mutate(op->condition);
                 Expr new_new_expr;

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1048,6 +1048,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
                 replacements[op->name] = new_name;
 
                 auto [new_extents, changed] = mutate_exprs(op->extents);
+                (void)changed;  // unused
                 Stmt new_body = mutate(op->body);
                 Expr new_condition = mutate(op->condition);
                 Expr new_new_expr;

--- a/src/CompilerLogger.cpp
+++ b/src/CompilerLogger.cpp
@@ -25,7 +25,8 @@ class ObfuscateNames : public IRMutator {
     std::map<std::string, std::string> remapping;
 
     Expr visit(const Call *op) override {
-        auto [args, changed_args] = mutate_exprs(op->args);
+        auto [args, changed] = mutate_exprs(op->args);
+        (void)changed;  // unused
         std::string name = op->name;
         if (op->call_type == Call::Extern ||
             op->call_type == Call::ExternCPlusPlus ||

--- a/src/CompilerLogger.cpp
+++ b/src/CompilerLogger.cpp
@@ -25,11 +25,7 @@ class ObfuscateNames : public IRMutator {
     std::map<std::string, std::string> remapping;
 
     Expr visit(const Call *op) override {
-        std::vector<Expr> args;
-        for (const Expr &e : op->args) {
-            args.emplace_back(mutate(e));
-        }
-
+        auto [args, changed_args] = mutate_exprs(op->args);
         std::string name = op->name;
         if (op->call_type == Call::Extern ||
             op->call_type == Call::ExternCPlusPlus ||

--- a/src/CompilerLogger.cpp
+++ b/src/CompilerLogger.cpp
@@ -25,8 +25,7 @@ class ObfuscateNames : public IRMutator {
     std::map<std::string, std::string> remapping;
 
     Expr visit(const Call *op) override {
-        auto [args, changed] = mutate_exprs(op->args);
-        (void)changed;  // unused
+        auto args = mutate(op->args);
         std::string name = op->name;
         if (op->call_type == Call::Extern ||
             op->call_type == Call::ExternCPlusPlus ||

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -335,6 +335,7 @@ private:
 
             // Beware of intrinsics for which this is not true!
             auto [args, changed] = mutate_exprs(op->args);
+            (void)changed;  // unused
             return Call::make(t, op->name, args, op->call_type,
                               op->func, op->value_index, op->image, op->param);
         }

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -334,11 +334,7 @@ private:
             // can just deinterleave the args.
 
             // Beware of intrinsics for which this is not true!
-            std::vector<Expr> args(op->args.size());
-            for (size_t i = 0; i < args.size(); i++) {
-                args[i] = mutate(op->args[i]);
-            }
-
+            auto [args, changed] = mutate_exprs(op->args);
             return Call::make(t, op->name, args, op->call_type,
                               op->func, op->value_index, op->image, op->param);
         }

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -334,8 +334,7 @@ private:
             // can just deinterleave the args.
 
             // Beware of intrinsics for which this is not true!
-            auto [args, changed] = mutate_exprs(op->args);
-            (void)changed;  // unused
+            auto args = mutate(op->args);
             return Call::make(t, op->name, args, op->call_type,
                               op->func, op->value_index, op->image, op->param);
         }

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -146,7 +146,7 @@ Expr IRMutator::visit(const Broadcast *op) {
 }
 
 Expr IRMutator::visit(const Call *op) {
-    auto [new_args, changed] = mutate_exprs(op->args);
+    auto [new_args, changed] = mutate_with_changes(op->args);
     if (!changed) {
         return op;
     }
@@ -217,8 +217,8 @@ Stmt IRMutator::visit(const Store *op) {
 
 Stmt IRMutator::visit(const Provide *op) {
     // Mutate the args
-    auto [new_args, changed_args] = mutate_exprs(op->args);
-    auto [new_values, changed_values] = mutate_exprs(op->values);
+    auto [new_args, changed_args] = mutate_with_changes(op->args);
+    auto [new_values, changed_values] = mutate_with_changes(op->values);
     Expr new_predicate = mutate(op->predicate);
 
     if (!(changed_args || changed_values) && new_predicate.same_as(op->predicate)) {
@@ -228,7 +228,7 @@ Stmt IRMutator::visit(const Provide *op) {
 }
 
 Stmt IRMutator::visit(const Allocate *op) {
-    auto [new_extents, changed] = mutate_exprs(op->extents);
+    auto [new_extents, changed] = mutate_with_changes(op->extents);
     Stmt body = mutate(op->body);
     Expr condition = mutate(op->condition);
     Expr new_expr;
@@ -318,7 +318,7 @@ Stmt IRMutator::visit(const Evaluate *op) {
 }
 
 Expr IRMutator::visit(const Shuffle *op) {
-    auto [new_vectors, changed] = mutate_exprs(op->vectors);
+    auto [new_vectors, changed] = mutate_with_changes(op->vectors);
     if (!changed) {
         return op;
     }
@@ -386,7 +386,7 @@ Expr IRGraphMutator::mutate(const Expr &e) {
     return p.first->second;
 }
 
-std::pair<std::vector<Expr>, bool> IRMutator::mutate_exprs(const std::vector<Expr> &old_exprs) {
+std::pair<std::vector<Expr>, bool> IRMutator::mutate_with_changes(const std::vector<Expr> &old_exprs) {
     vector<Expr> new_exprs(old_exprs.size());
     bool changed = false;
 

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -146,19 +146,7 @@ Expr IRMutator::visit(const Broadcast *op) {
 }
 
 Expr IRMutator::visit(const Call *op) {
-    vector<Expr> new_args(op->args.size());
-    bool changed = false;
-
-    // Mutate the args
-    for (size_t i = 0; i < op->args.size(); i++) {
-        const Expr &old_arg = op->args[i];
-        Expr new_arg = mutate(old_arg);
-        if (!new_arg.same_as(old_arg)) {
-            changed = true;
-        }
-        new_args[i] = std::move(new_arg);
-    }
-
+    auto [new_args, changed] = mutate_exprs(op->args);
     if (!changed) {
         return op;
     }
@@ -228,50 +216,26 @@ Stmt IRMutator::visit(const Store *op) {
 }
 
 Stmt IRMutator::visit(const Provide *op) {
-    vector<Expr> new_args(op->args.size());
-    vector<Expr> new_values(op->values.size());
-    bool changed = false;
-
     // Mutate the args
-    for (size_t i = 0; i < op->args.size(); i++) {
-        const Expr &old_arg = op->args[i];
-        Expr new_arg = mutate(old_arg);
-        if (!new_arg.same_as(old_arg)) {
-            changed = true;
-        }
-        new_args[i] = new_arg;
-    }
-
-    for (size_t i = 0; i < op->values.size(); i++) {
-        const Expr &old_value = op->values[i];
-        Expr new_value = mutate(old_value);
-        if (!new_value.same_as(old_value)) {
-            changed = true;
-        }
-        new_values[i] = new_value;
-    }
+    auto [new_args, changed_args] = mutate_exprs(op->args);
+    auto [new_values, changed_values] = mutate_exprs(op->values);
     Expr new_predicate = mutate(op->predicate);
 
-    if (!changed && new_predicate.same_as(op->predicate)) {
+    if (!(changed_args || changed_values) && new_predicate.same_as(op->predicate)) {
         return op;
     }
     return Provide::make(op->name, new_values, new_args, new_predicate);
 }
 
 Stmt IRMutator::visit(const Allocate *op) {
-    std::vector<Expr> new_extents;
-    bool all_extents_unmodified = true;
-    for (size_t i = 0; i < op->extents.size(); i++) {
-        new_extents.push_back(mutate(op->extents[i]));
-        all_extents_unmodified &= new_extents[i].same_as(op->extents[i]);
-    }
+    auto [new_extents, changed] = mutate_exprs(op->extents);
     Stmt body = mutate(op->body);
     Expr condition = mutate(op->condition);
     Expr new_expr;
     if (op->new_expr.defined()) {
         new_expr = mutate(op->new_expr);
     }
-    if (all_extents_unmodified &&
+    if (!changed &&
         body.same_as(op->body) &&
         condition.same_as(op->condition) &&
         new_expr.same_as(op->new_expr)) {
@@ -354,18 +318,7 @@ Stmt IRMutator::visit(const Evaluate *op) {
 }
 
 Expr IRMutator::visit(const Shuffle *op) {
-    vector<Expr> new_vectors(op->vectors.size());
-    bool changed = false;
-
-    for (size_t i = 0; i < op->vectors.size(); i++) {
-        Expr old_vector = op->vectors[i];
-        Expr new_vector = mutate(old_vector);
-        if (!new_vector.same_as(old_vector)) {
-            changed = true;
-        }
-        new_vectors[i] = new_vector;
-    }
-
+    auto [new_vectors, changed] = mutate_exprs(op->vectors);
     if (!changed) {
         return op;
     }
@@ -431,6 +384,23 @@ Expr IRGraphMutator::mutate(const Expr &e) {
         p.first->second = IRMutator::mutate(e);
     }
     return p.first->second;
+}
+
+std::pair<std::vector<Expr>, bool> IRMutator::mutate_exprs(const std::vector<Expr> &old_exprs) {
+    vector<Expr> new_exprs(old_exprs.size());
+    bool changed = false;
+
+    // Mutate the args
+    for (size_t i = 0; i < old_exprs.size(); i++) {
+        const Expr &old_e = old_exprs[i];
+        Expr new_e = mutate(old_e);
+        if (!new_e.same_as(old_e)) {
+            changed = true;
+        }
+        new_exprs[i] = std::move(new_e);
+    }
+
+    return {std::move(new_exprs), changed};
 }
 
 }  // namespace Internal

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -35,6 +35,10 @@ public:
     virtual Expr mutate(const Expr &expr);
     virtual Stmt mutate(const Stmt &stmt);
 
+    // Mutate all the Exprs and return the new list.
+    // pair.second is true iff at least one item in the list changed.
+    std::pair<std::vector<Expr>, bool> mutate_exprs(const std::vector<Expr> &);
+
 protected:
     // ExprNode<> and StmtNode<> are allowed to call visit (to implement mutate_expr/mutate_stmt())
     template<typename T>

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -35,9 +35,14 @@ public:
     virtual Expr mutate(const Expr &expr);
     virtual Stmt mutate(const Stmt &stmt);
 
-    // Mutate all the Exprs and return the new list.
-    // pair.second is true iff at least one item in the list changed.
-    std::pair<std::vector<Expr>, bool> mutate_exprs(const std::vector<Expr> &);
+    // Mutate all the Exprs and return the new list in ret, along with
+    // a flag that is true iff at least one item in the list changed.
+    std::pair<std::vector<Expr>, bool> mutate_with_changes(const std::vector<Expr> &);
+
+    // Like mutate_with_changes, but discard the changes flag.
+    std::vector<Expr> mutate(const std::vector<Expr> &exprs) {
+        return mutate_with_changes(exprs).first;
+    }
 
 protected:
     // ExprNode<> and StmtNode<> are allowed to call visit (to implement mutate_expr/mutate_stmt())
@@ -106,6 +111,10 @@ protected:
 public:
     Stmt mutate(const Stmt &s) override;
     Expr mutate(const Expr &e) override;
+
+    std::vector<Expr> mutate(const std::vector<Expr> &exprs) {
+        return IRMutator::mutate(exprs);
+    }
 };
 
 /** A helper function for mutator-like things to mutate regions */

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -102,8 +102,7 @@ class Inliner : public IRMutator {
         if (op->name == func.name()) {
 
             // Mutate the args
-            auto [args, changed_args] = mutate_exprs(op->args);
-            (void)changed_args;  // unused
+            auto args = mutate(op->args);
 
             // Grab the body
             Expr body = qualify(func.name() + ".", func.values()[op->value_index]);

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -102,10 +102,8 @@ class Inliner : public IRMutator {
         if (op->name == func.name()) {
 
             // Mutate the args
-            vector<Expr> args(op->args.size());
-            for (size_t i = 0; i < args.size(); i++) {
-                args[i] = mutate(op->args[i]);
-            }
+            auto [args, changed_args] = mutate_exprs(op->args);
+
             // Grab the body
             Expr body = qualify(func.name() + ".", func.values()[op->value_index]);
 

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -103,6 +103,7 @@ class Inliner : public IRMutator {
 
             // Mutate the args
             auto [args, changed_args] = mutate_exprs(op->args);
+            (void)changed_args;  // unused
 
             // Grab the body
             Expr body = qualify(func.name() + ".", func.values()[op->value_index]);

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -104,10 +104,7 @@ bool can_parallelize_rvar(const string &v,
 
     // Make an expr representing the store done by a different thread.
     RenameFreeVars renamer;
-    vector<Expr> other_store(args.size());
-    for (size_t i = 0; i < args.size(); i++) {
-        other_store[i] = renamer.mutate(args[i]);
-    }
+    auto [other_store, changed] = renamer.mutate_exprs(args);
 
     // Construct an expression which is true when the two threads are
     // in fact two different threads. We'll use this liberally in the

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -104,8 +104,7 @@ bool can_parallelize_rvar(const string &v,
 
     // Make an expr representing the store done by a different thread.
     RenameFreeVars renamer;
-    auto [other_store, changed] = renamer.mutate_exprs(args);
-    (void)changed;  // unused
+    auto other_store = renamer.mutate(args);
 
     // Construct an expression which is true when the two threads are
     // in fact two different threads. We'll use this liberally in the

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -105,6 +105,7 @@ bool can_parallelize_rvar(const string &v,
     // Make an expr representing the store done by a different thread.
     RenameFreeVars renamer;
     auto [other_store, changed] = renamer.mutate_exprs(args);
+    (void)changed;  // unused
 
     // Construct an expression which is true when the two threads are
     // in fact two different threads. We'll use this liberally in the

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -125,12 +125,7 @@ private:
     Stmt visit(const Allocate *op) override {
         int idx = get_func_id(op->name);
 
-        vector<Expr> new_extents;
-        bool all_extents_unmodified = true;
-        for (size_t i = 0; i < op->extents.size(); i++) {
-            new_extents.push_back(mutate(op->extents[i]));
-            all_extents_unmodified &= new_extents[i].same_as(op->extents[i]);
-        }
+        auto [new_extents, changed] = mutate_exprs(op->extents);
         Expr condition = mutate(op->condition);
 
         bool on_stack;
@@ -158,7 +153,7 @@ private:
         if (op->new_expr.defined()) {
             new_expr = mutate(op->new_expr);
         }
-        if (all_extents_unmodified &&
+        if (!changed &&
             body.same_as(op->body) &&
             condition.same_as(op->condition) &&
             new_expr.same_as(op->new_expr)) {

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -125,7 +125,7 @@ private:
     Stmt visit(const Allocate *op) override {
         int idx = get_func_id(op->name);
 
-        auto [new_extents, changed] = mutate_exprs(op->extents);
+        auto [new_extents, changed] = mutate_with_changes(op->extents);
         Expr condition = mutate(op->condition);
 
         bool on_stack;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -133,21 +133,12 @@ class AddPredicates : public IRGraphMutator {
     using IRMutator::visit;
 
     Stmt visit(const Provide *p) override {
-        vector<Expr> values;
-        vector<Expr> args;
-        bool changed = false;
-        for (const Expr &i : p->args) {
-            args.push_back(mutate(i));
-            changed = changed || !args.back().same_as(i);
-        }
-        for (const Expr &i : p->values) {
-            values.push_back(mutate(i));
-            changed = changed || !args.back().same_as(i);
-        }
+        auto [args, changed_args] = mutate_exprs(p->args);
+        auto [values, changed_values] = mutate_exprs(p->values);
         Expr predicate = mutate(p->predicate);
         if (provides) {
             return Provide::make(p->name, values, args, predicate && cond);
-        } else if (changed || !predicate.same_as(p->predicate)) {
+        } else if (changed_args || changed_values || !predicate.same_as(p->predicate)) {
             return Provide::make(p->name, values, args, predicate);
         } else {
             return p;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -133,8 +133,8 @@ class AddPredicates : public IRGraphMutator {
     using IRMutator::visit;
 
     Stmt visit(const Provide *p) override {
-        auto [args, changed_args] = mutate_exprs(p->args);
-        auto [values, changed_values] = mutate_exprs(p->values);
+        auto [args, changed_args] = mutate_with_changes(p->args);
+        auto [values, changed_values] = mutate_with_changes(p->values);
         Expr predicate = mutate(p->predicate);
         if (provides) {
             return Provide::make(p->name, values, args, predicate && cond);

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -54,7 +54,7 @@ Simplify::Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemaind
     }
 }
 
-std::pair<std::vector<Expr>, bool> Simplify::mutate_exprs(const std::vector<Expr> &old_exprs, ExprInfo *bounds) {
+std::pair<std::vector<Expr>, bool> Simplify::mutate_with_changes(const std::vector<Expr> &old_exprs, ExprInfo *bounds) {
     vector<Expr> new_exprs(old_exprs.size());
     bool changed = false;
 

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -54,6 +54,23 @@ Simplify::Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemaind
     }
 }
 
+std::pair<std::vector<Expr>, bool> Simplify::mutate_exprs(const std::vector<Expr> &old_exprs, ExprInfo *bounds) {
+    vector<Expr> new_exprs(old_exprs.size());
+    bool changed = false;
+
+    // Mutate the args
+    for (size_t i = 0; i < old_exprs.size(); i++) {
+        const Expr &old_e = old_exprs[i];
+        Expr new_e = mutate(old_e, bounds);
+        if (!new_e.same_as(old_e)) {
+            changed = true;
+        }
+        new_exprs[i] = std::move(new_e);
+    }
+
+    return {std::move(new_exprs), changed};
+}
+
 void Simplify::found_buffer_reference(const string &name, size_t dimensions) {
     for (size_t i = 0; i < dimensions; i++) {
         string stride = name + ".stride." + std::to_string(i);

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -481,14 +481,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
         internal_assert(op->args.size() % 2 == 0);  // Format: {base, offset, extent0, min0, ...}
 
-        vector<Expr> args(op->args);
-        bool changed = false;
-        for (size_t i = 0; i < op->args.size(); ++i) {
-            args[i] = mutate(op->args[i], nullptr);
-            if (!args[i].same_as(op->args[i])) {
-                changed = true;
-            }
-        }
+        auto [args, changed] = mutate_exprs(op->args, nullptr);
 
         // The {extent, stride} args in the prefetch call are sorted
         // based on the storage dimension in ascending order (i.e. innermost
@@ -845,19 +838,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
     // No else: we want to fall thru from the PureExtern clause.
     {
-        vector<Expr> new_args(op->args.size());
-        bool changed = false;
-
-        // Mutate the args
-        for (size_t i = 0; i < op->args.size(); i++) {
-            const Expr &old_arg = op->args[i];
-            Expr new_arg = mutate(old_arg, nullptr);
-            if (!new_arg.same_as(old_arg)) {
-                changed = true;
-            }
-            new_args[i] = std::move(new_arg);
-        }
-
+        auto [new_args, changed] = mutate_exprs(op->args, nullptr);
         if (!changed) {
             return op;
         } else {

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -481,7 +481,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
         internal_assert(op->args.size() % 2 == 0);  // Format: {base, offset, extent0, min0, ...}
 
-        auto [args, changed] = mutate_exprs(op->args, nullptr);
+        auto [args, changed] = mutate_with_changes(op->args, nullptr);
 
         // The {extent, stride} args in the prefetch call are sorted
         // based on the storage dimension in ascending order (i.e. innermost
@@ -838,7 +838,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
 
     // No else: we want to fall thru from the PureExtern clause.
     {
-        auto [new_args, changed] = mutate_exprs(op->args, nullptr);
+        auto [new_args, changed] = mutate_with_changes(op->args, nullptr);
         if (!changed) {
             return op;
         } else {

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -350,7 +350,7 @@ public:
     Stmt visit(const Fork *op);
     Stmt visit(const Atomic *op);
 
-    std::pair<std::vector<Expr>, bool> mutate_exprs(const std::vector<Expr> &old_exprs, ExprInfo *bounds);
+    std::pair<std::vector<Expr>, bool> mutate_with_changes(const std::vector<Expr> &old_exprs, ExprInfo *bounds);
 };
 
 }  // namespace Internal

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -349,6 +349,8 @@ public:
     Stmt visit(const Acquire *op);
     Stmt visit(const Fork *op);
     Stmt visit(const Atomic *op);
+
+    std::pair<std::vector<Expr>, bool> mutate_exprs(const std::vector<Expr> &old_exprs, ExprInfo *bounds);
 };
 
 }  // namespace Internal

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -275,32 +275,12 @@ Stmt Simplify::visit(const For *op) {
 Stmt Simplify::visit(const Provide *op) {
     found_buffer_reference(op->name, op->args.size());
 
-    vector<Expr> new_args(op->args.size());
-    vector<Expr> new_values(op->values.size());
-    bool changed = false;
-
     // Mutate the args
-    for (size_t i = 0; i < op->args.size(); i++) {
-        const Expr &old_arg = op->args[i];
-        Expr new_arg = mutate(old_arg, nullptr);
-        if (!new_arg.same_as(old_arg)) {
-            changed = true;
-        }
-        new_args[i] = new_arg;
-    }
-
-    for (size_t i = 0; i < op->values.size(); i++) {
-        const Expr &old_value = op->values[i];
-        Expr new_value = mutate(old_value, nullptr);
-        if (!new_value.same_as(old_value)) {
-            changed = true;
-        }
-        new_values[i] = new_value;
-    }
-
+    auto [new_args, changed_args] = mutate_exprs(op->args, nullptr);
+    auto [new_values, changed_values] = mutate_exprs(op->values, nullptr);
     Expr new_predicate = mutate(op->predicate, nullptr);
 
-    if (!changed && new_predicate.same_as(op->predicate)) {
+    if (!(changed_args || changed_values) && new_predicate.same_as(op->predicate)) {
         return op;
     } else {
         return Provide::make(op->name, new_values, new_args, new_predicate);

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -276,8 +276,8 @@ Stmt Simplify::visit(const Provide *op) {
     found_buffer_reference(op->name, op->args.size());
 
     // Mutate the args
-    auto [new_args, changed_args] = mutate_exprs(op->args, nullptr);
-    auto [new_values, changed_values] = mutate_exprs(op->values, nullptr);
+    auto [new_args, changed_args] = mutate_with_changes(op->args, nullptr);
+    auto [new_values, changed_values] = mutate_with_changes(op->values, nullptr);
     Expr new_predicate = mutate(op->predicate, nullptr);
 
     if (!(changed_args || changed_values) && new_predicate.same_as(op->predicate)) {

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -118,7 +118,7 @@ class SplitTuples : public IRMutator {
                 name += "." + std::to_string(op->value_index);
                 changed_name = true;
             }
-            auto [args, changed_args] = mutate_exprs(op->args);
+            auto [args, changed_args] = mutate_with_changes(op->args);
             // It's safe to hook up the pointer to the function
             // unconditionally. This expr never gets held by a
             // Function, so there can't be a cycle. We do this even
@@ -144,8 +144,7 @@ class SplitTuples : public IRMutator {
         }
 
         // Mutate the args
-        auto [args, changed] = mutate_exprs(op->args);
-        (void)changed;  // unused
+        auto args = mutate(op->args);
 
         // Get the Function
         auto it = env.find(op->name);

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -145,6 +145,7 @@ class SplitTuples : public IRMutator {
 
         // Mutate the args
         auto [args, changed] = mutate_exprs(op->args);
+        (void)changed;  // unused
 
         // Get the Function
         auto it = env.find(op->name);

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -117,10 +117,9 @@ private:
         Stmt body = mutate(op->body);
 
         // Compute the size
-        vector<Expr> extents;
+        vector<Expr> extents(op->bounds.size());
         for (size_t i = 0; i < op->bounds.size(); i++) {
-            extents.push_back(op->bounds[i].extent);
-            extents[i] = mutate(extents[i]);
+            extents[i] = mutate(op->bounds[i].extent);
         }
         Expr condition = mutate(op->condition);
 
@@ -424,10 +423,7 @@ class PromoteToMemoryType : public IRMutator {
     Stmt visit(const Allocate *op) override {
         Type t = upgrade(op->type);
         if (t != op->type) {
-            vector<Expr> extents;
-            for (const Expr &e : op->extents) {
-                extents.push_back(mutate(e));
-            }
+            auto [extents, changed] = mutate_exprs(op->extents);
             return Allocate::make(op->name, t, op->memory_type, extents,
                                   mutate(op->condition), mutate(op->body),
                                   mutate(op->new_expr), op->free_function);

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -423,9 +423,7 @@ class PromoteToMemoryType : public IRMutator {
     Stmt visit(const Allocate *op) override {
         Type t = upgrade(op->type);
         if (t != op->type) {
-            auto [extents, changed] = mutate_exprs(op->extents);
-            (void)changed;  // unused
-            return Allocate::make(op->name, t, op->memory_type, extents,
+            return Allocate::make(op->name, t, op->memory_type, mutate(op->extents),
                                   mutate(op->condition), mutate(op->body),
                                   mutate(op->new_expr), op->free_function);
         } else {

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -424,6 +424,7 @@ class PromoteToMemoryType : public IRMutator {
         Type t = upgrade(op->type);
         if (t != op->type) {
             auto [extents, changed] = mutate_exprs(op->extents);
+            (void)changed;  // unused
             return Allocate::make(op->name, t, op->memory_type, extents,
                                   mutate(op->condition), mutate(op->body),
                                   mutate(op->new_expr), op->free_function);

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -635,7 +635,7 @@ class VectorSubs : public IRMutator {
         // arguments and its return type
 
         // Mutate the args
-        auto [new_args, changed] = mutate_exprs(op->args);
+        auto [new_args, changed] = mutate_with_changes(op->args);
         int max_lanes = 0;
         for (const auto &new_arg : new_args) {
             max_lanes = std::max(new_arg.type().lanes(), max_lanes);

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -633,18 +633,11 @@ class VectorSubs : public IRMutator {
     Expr visit(const Call *op) override {
         // Widen the call by changing the lanes of all of its
         // arguments and its return type
-        vector<Expr> new_args(op->args.size());
-        bool changed = false;
 
         // Mutate the args
+        auto [new_args, changed] = mutate_exprs(op->args);
         int max_lanes = 0;
-        for (size_t i = 0; i < op->args.size(); i++) {
-            Expr old_arg = op->args[i];
-            Expr new_arg = mutate(old_arg);
-            if (!new_arg.same_as(old_arg)) {
-                changed = true;
-            }
-            new_args[i] = new_arg;
+        for (const auto &new_arg : new_args) {
             max_lanes = std::max(new_arg.type().lanes(), max_lanes);
         }
 


### PR DESCRIPTION
There's a common pattern in many IRMutators that is "mutate a vector<Expr> and optionally let me know if anything is different".

(Note, this uses C++17 structured-binding syntax, which we previously weren't using in Halide. Objections?)

This adds a shared utility method (well, two, thanks to VariadicVisitor) and plus in the usage in all the places that seemed obvious.

I doubt this moves the needle on speed in either direction, but makes for smaller code.