### PR TITLE
Refactor mutate-vector-of-Expr code

### DIFF
--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1047,10 +1047,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
                 std::string new_name = unique_name(op->name);
                 replacements[op->name] = new_name;
 
-                std::vector<Expr> new_extents;
-                for (size_t i = 0; i < op->extents.size(); i++) {
-                    new_extents.push_back(mutate(op->extents[i]));
-                }
+                auto new_extents = mutate(op->extents);
                 Stmt new_body = mutate(op->body);
                 Expr new_condition = mutate(op->condition);
                 Expr new_new_expr;

--- a/src/CompilerLogger.cpp
+++ b/src/CompilerLogger.cpp
@@ -25,11 +25,7 @@ class ObfuscateNames : public IRMutator {
     std::map<std::string, std::string> remapping;
 
     Expr visit(const Call *op) override {
-        std::vector<Expr> args;
-        for (const Expr &e : op->args) {
-            args.emplace_back(mutate(e));
-        }
-
+        auto args = mutate(op->args);
         std::string name = op->name;
         if (op->call_type == Call::Extern ||
             op->call_type == Call::ExternCPlusPlus ||

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -334,11 +334,7 @@ private:
             // can just deinterleave the args.
 
             // Beware of intrinsics for which this is not true!
-            std::vector<Expr> args(op->args.size());
-            for (size_t i = 0; i < args.size(); i++) {
-                args[i] = mutate(op->args[i]);
-            }
-
+            auto args = mutate(op->args);
             return Call::make(t, op->name, args, op->call_type,
                               op->func, op->value_index, op->image, op->param);
         }

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -431,6 +431,24 @@ struct Stmt : public IRHandle {
     };
 };
 
+/** Return true iff:
+ * - both vectors are the same length
+ * - T::same_as() returns true for each corresponding entry pair. */
+template<typename T>
+bool same_as(const std::vector<T> &a, const std::vector<T> &b) {
+    if (a.size() != b.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.size(); i++) {
+        if (!a[i].same_as(b[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -146,20 +146,8 @@ Expr IRMutator::visit(const Broadcast *op) {
 }
 
 Expr IRMutator::visit(const Call *op) {
-    vector<Expr> new_args(op->args.size());
-    bool changed = false;
-
-    // Mutate the args
-    for (size_t i = 0; i < op->args.size(); i++) {
-        const Expr &old_arg = op->args[i];
-        Expr new_arg = mutate(old_arg);
-        if (!new_arg.same_as(old_arg)) {
-            changed = true;
-        }
-        new_args[i] = std::move(new_arg);
-    }
-
-    if (!changed) {
+    auto new_args = mutate(op->args);
+    if (!same_as(new_args, op->args)) {
         return op;
     }
     return Call::make(op->type, op->name, new_args, op->call_type,
@@ -228,50 +216,26 @@ Stmt IRMutator::visit(const Store *op) {
 }
 
 Stmt IRMutator::visit(const Provide *op) {
-    vector<Expr> new_args(op->args.size());
-    vector<Expr> new_values(op->values.size());
-    bool changed = false;
-
     // Mutate the args
-    for (size_t i = 0; i < op->args.size(); i++) {
-        const Expr &old_arg = op->args[i];
-        Expr new_arg = mutate(old_arg);
-        if (!new_arg.same_as(old_arg)) {
-            changed = true;
-        }
-        new_args[i] = new_arg;
-    }
-
-    for (size_t i = 0; i < op->values.size(); i++) {
-        const Expr &old_value = op->values[i];
-        Expr new_value = mutate(old_value);
-        if (!new_value.same_as(old_value)) {
-            changed = true;
-        }
-        new_values[i] = new_value;
-    }
+    auto new_args = mutate(op->args);
+    auto new_values = mutate(op->values);
     Expr new_predicate = mutate(op->predicate);
 
-    if (!changed && new_predicate.same_as(op->predicate)) {
+    if (same_as(new_args, op->args) && same_as(new_values, op->values) && new_predicate.same_as(op->predicate)) {
         return op;
     }
     return Provide::make(op->name, new_values, new_args, new_predicate);
 }
 
 Stmt IRMutator::visit(const Allocate *op) {
-    std::vector<Expr> new_extents;
-    bool all_extents_unmodified = true;
-    for (size_t i = 0; i < op->extents.size(); i++) {
-        new_extents.push_back(mutate(op->extents[i]));
-        all_extents_unmodified &= new_extents[i].same_as(op->extents[i]);
-    }
+    auto new_extents = mutate(op->extents);
     Stmt body = mutate(op->body);
     Expr condition = mutate(op->condition);
     Expr new_expr;
     if (op->new_expr.defined()) {
         new_expr = mutate(op->new_expr);
     }
-    if (all_extents_unmodified &&
+    if (same_as(new_extents, op->extents) &&
         body.same_as(op->body) &&
         condition.same_as(op->condition) &&
         new_expr.same_as(op->new_expr)) {
@@ -354,19 +318,8 @@ Stmt IRMutator::visit(const Evaluate *op) {
 }
 
 Expr IRMutator::visit(const Shuffle *op) {
-    vector<Expr> new_vectors(op->vectors.size());
-    bool changed = false;
-
-    for (size_t i = 0; i < op->vectors.size(); i++) {
-        Expr old_vector = op->vectors[i];
-        Expr new_vector = mutate(old_vector);
-        if (!new_vector.same_as(old_vector)) {
-            changed = true;
-        }
-        new_vectors[i] = new_vector;
-    }
-
-    if (!changed) {
+    auto new_vectors = mutate(op->vectors);
+    if (same_as(new_vectors, op->vectors)) {
         return op;
     }
     return Shuffle::make(new_vectors, op->indices);
@@ -431,6 +384,17 @@ Expr IRGraphMutator::mutate(const Expr &e) {
         p.first->second = IRMutator::mutate(e);
     }
     return p.first->second;
+}
+
+std::vector<Expr> IRMutator::mutate(const std::vector<Expr> &old_exprs) {
+    vector<Expr> new_exprs(old_exprs.size());
+
+    // Mutate the args
+    for (size_t i = 0; i < old_exprs.size(); i++) {
+        new_exprs[i] = mutate(old_exprs[i]);
+    }
+
+    return new_exprs;
 }
 
 }  // namespace Internal

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -147,7 +147,7 @@ Expr IRMutator::visit(const Broadcast *op) {
 
 Expr IRMutator::visit(const Call *op) {
     auto new_args = mutate(op->args);
-    if (!same_as(new_args, op->args)) {
+    if (same_as(new_args, op->args)) {
         return op;
     }
     return Call::make(op->type, op->name, new_args, op->call_type,

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -35,6 +35,9 @@ public:
     virtual Expr mutate(const Expr &expr);
     virtual Stmt mutate(const Stmt &stmt);
 
+    // Mutate all the Exprs and return the new list.
+    std::vector<Expr> mutate(const std::vector<Expr> &exprs);
+
 protected:
     // ExprNode<> and StmtNode<> are allowed to call visit (to implement mutate_expr/mutate_stmt())
     template<typename T>
@@ -102,6 +105,11 @@ protected:
 public:
     Stmt mutate(const Stmt &s) override;
     Expr mutate(const Expr &e) override;
+
+    // Mutate all the Exprs and return the new list.
+    std::vector<Expr> mutate(const std::vector<Expr> &exprs) {
+        return IRMutator::mutate(exprs);
+    }
 };
 
 /** A helper function for mutator-like things to mutate regions */

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -102,10 +102,8 @@ class Inliner : public IRMutator {
         if (op->name == func.name()) {
 
             // Mutate the args
-            vector<Expr> args(op->args.size());
-            for (size_t i = 0; i < args.size(); i++) {
-                args[i] = mutate(op->args[i]);
-            }
+            auto args = mutate(op->args);
+
             // Grab the body
             Expr body = qualify(func.name() + ".", func.values()[op->value_index]);
 

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -104,10 +104,7 @@ bool can_parallelize_rvar(const string &v,
 
     // Make an expr representing the store done by a different thread.
     RenameFreeVars renamer;
-    vector<Expr> other_store(args.size());
-    for (size_t i = 0; i < args.size(); i++) {
-        other_store[i] = renamer.mutate(args[i]);
-    }
+    auto other_store = renamer.mutate(args);
 
     // Construct an expression which is true when the two threads are
     // in fact two different threads. We'll use this liberally in the

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -125,12 +125,7 @@ private:
     Stmt visit(const Allocate *op) override {
         int idx = get_func_id(op->name);
 
-        vector<Expr> new_extents;
-        bool all_extents_unmodified = true;
-        for (size_t i = 0; i < op->extents.size(); i++) {
-            new_extents.push_back(mutate(op->extents[i]));
-            all_extents_unmodified &= new_extents[i].same_as(op->extents[i]);
-        }
+        auto new_extents = mutate(op->extents);
         Expr condition = mutate(op->condition);
 
         bool on_stack;
@@ -158,7 +153,7 @@ private:
         if (op->new_expr.defined()) {
             new_expr = mutate(op->new_expr);
         }
-        if (all_extents_unmodified &&
+        if (same_as(new_extents, op->extents) &&
             body.same_as(op->body) &&
             condition.same_as(op->condition) &&
             new_expr.same_as(op->new_expr)) {

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -133,21 +133,12 @@ class AddPredicates : public IRGraphMutator {
     using IRMutator::visit;
 
     Stmt visit(const Provide *p) override {
-        vector<Expr> values;
-        vector<Expr> args;
-        bool changed = false;
-        for (const Expr &i : p->args) {
-            args.push_back(mutate(i));
-            changed = changed || !args.back().same_as(i);
-        }
-        for (const Expr &i : p->values) {
-            values.push_back(mutate(i));
-            changed = changed || !args.back().same_as(i);
-        }
+        auto args = mutate(p->args);
+        auto values = mutate(p->values);
         Expr predicate = mutate(p->predicate);
         if (provides) {
             return Provide::make(p->name, values, args, predicate && cond);
-        } else if (changed || !predicate.same_as(p->predicate)) {
+        } else if (!same_as(args, p->args) || !same_as(values, p->values) || !predicate.same_as(p->predicate)) {
             return Provide::make(p->name, values, args, predicate);
         } else {
             return p;

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -54,6 +54,14 @@ Simplify::Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemaind
     }
 }
 
+std::vector<Expr> Simplify::mutate(const std::vector<Expr> &old_exprs, ExprInfo *bounds) {
+    vector<Expr> new_exprs(old_exprs.size());
+    for (size_t i = 0; i < old_exprs.size(); i++) {
+        new_exprs[i] = mutate(old_exprs[i], bounds);
+    }
+    return new_exprs;
+}
+
 void Simplify::found_buffer_reference(const string &name, size_t dimensions) {
     for (size_t i = 0; i < dimensions; i++) {
         string stride = name + ".stride." + std::to_string(i);

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -349,6 +349,8 @@ public:
     Stmt visit(const Acquire *op);
     Stmt visit(const Fork *op);
     Stmt visit(const Atomic *op);
+
+    std::vector<Expr> mutate(const std::vector<Expr> &old_exprs, ExprInfo *bounds);
 };
 
 }  // namespace Internal

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -275,32 +275,12 @@ Stmt Simplify::visit(const For *op) {
 Stmt Simplify::visit(const Provide *op) {
     found_buffer_reference(op->name, op->args.size());
 
-    vector<Expr> new_args(op->args.size());
-    vector<Expr> new_values(op->values.size());
-    bool changed = false;
-
     // Mutate the args
-    for (size_t i = 0; i < op->args.size(); i++) {
-        const Expr &old_arg = op->args[i];
-        Expr new_arg = mutate(old_arg, nullptr);
-        if (!new_arg.same_as(old_arg)) {
-            changed = true;
-        }
-        new_args[i] = new_arg;
-    }
-
-    for (size_t i = 0; i < op->values.size(); i++) {
-        const Expr &old_value = op->values[i];
-        Expr new_value = mutate(old_value, nullptr);
-        if (!new_value.same_as(old_value)) {
-            changed = true;
-        }
-        new_values[i] = new_value;
-    }
-
+    auto new_args = mutate(op->args, nullptr);
+    auto new_values = mutate(op->values, nullptr);
     Expr new_predicate = mutate(op->predicate, nullptr);
 
-    if (!changed && new_predicate.same_as(op->predicate)) {
+    if (same_as(new_args, op->args) && same_as(new_values, op->values) && new_predicate.same_as(op->predicate)) {
         return op;
     } else {
         return Provide::make(op->name, new_values, new_args, new_predicate);

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -118,16 +118,12 @@ class SplitTuples : public IRMutator {
                 name += "." + std::to_string(op->value_index);
                 changed = true;
             }
-            vector<Expr> args;
-            for (const Expr &e : op->args) {
-                args.push_back(mutate(e));
-                changed = changed || !args.back().same_as(e);
-            }
+            auto args = mutate(op->args);
             // It's safe to hook up the pointer to the function
             // unconditionally. This expr never gets held by a
             // Function, so there can't be a cycle. We do this even
             // for scalar provides.
-            if (changed) {
+            if (changed || !same_as(args, op->args)) {
                 return Call::make(op->type, name, args, op->call_type, f.get_contents());
             } else {
                 return op;
@@ -148,10 +144,7 @@ class SplitTuples : public IRMutator {
         }
 
         // Mutate the args
-        vector<Expr> args;
-        for (const Expr &e : op->args) {
-            args.push_back(mutate(e));
-        }
+        auto args = mutate(op->args);
 
         // Get the Function
         auto it = env.find(op->name);

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -117,10 +117,9 @@ private:
         Stmt body = mutate(op->body);
 
         // Compute the size
-        vector<Expr> extents;
+        vector<Expr> extents(op->bounds.size());
         for (size_t i = 0; i < op->bounds.size(); i++) {
-            extents.push_back(op->bounds[i].extent);
-            extents[i] = mutate(extents[i]);
+            extents[i] = mutate(op->bounds[i].extent);
         }
         Expr condition = mutate(op->condition);
 
@@ -424,11 +423,7 @@ class PromoteToMemoryType : public IRMutator {
     Stmt visit(const Allocate *op) override {
         Type t = upgrade(op->type);
         if (t != op->type) {
-            vector<Expr> extents;
-            for (const Expr &e : op->extents) {
-                extents.push_back(mutate(e));
-            }
-            return Allocate::make(op->name, t, op->memory_type, extents,
+            return Allocate::make(op->name, t, op->memory_type, mutate(op->extents),
                                   mutate(op->condition), mutate(op->body),
                                   mutate(op->new_expr), op->free_function);
         } else {

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -633,22 +633,15 @@ class VectorSubs : public IRMutator {
     Expr visit(const Call *op) override {
         // Widen the call by changing the lanes of all of its
         // arguments and its return type
-        vector<Expr> new_args(op->args.size());
-        bool changed = false;
 
         // Mutate the args
+        auto new_args = mutate(op->args);
         int max_lanes = 0;
-        for (size_t i = 0; i < op->args.size(); i++) {
-            Expr old_arg = op->args[i];
-            Expr new_arg = mutate(old_arg);
-            if (!new_arg.same_as(old_arg)) {
-                changed = true;
-            }
-            new_args[i] = new_arg;
+        for (const auto &new_arg : new_args) {
             max_lanes = std::max(new_arg.type().lanes(), max_lanes);
         }
 
-        if (!changed) {
+        if (same_as(new_args, op->args)) {
             return op;
         } else if (op->name == Call::trace) {
             const int64_t *event = as_const_int(op->args[6]);


### PR DESCRIPTION
There's a common pattern in many IRMutators that is "mutate a vector<Expr> and optionally let me know if anything is different".

This just adds `mutate()` and `same_as()` for `vector<Expr>` (and refactors some obvious places to use them).

I doubt this moves the needle in terms of performance, but IMHO it's cleaner code.

(Replaces https://github.com/halide/Halide/pull/6203)