### PR TITLE
Use Variable nodes instead of StringImm ones to pass buffer names.

### DIFF
--- a/src/CodeGen_Xtensa.cpp
+++ b/src/CodeGen_Xtensa.cpp
@@ -1978,9 +1978,15 @@ string CodeGen_Xtensa::print_xtensa_call(const Call *op) {
     vector<string> args(op->args.size());
 
     if (op->name == "halide_xtensa_copy_1d") {
-        args[0] = print_name(op->args[0].as<StringImm>()->value);
+        internal_assert(op->args.size() >= 3);
+
+        const Variable *dest = op->args[0].as<Variable>();
+        internal_assert(dest != nullptr);
+        args[0] = print_name(dest->name);
         args[1] = print_expr(op->args[1]);
-        args[2] = print_name(op->args[2].as<StringImm>()->value);
+        const Variable *src = op->args[2].as<Variable>();
+        internal_assert(src != nullptr);
+        args[2] = print_name(src->name);
 
         for (size_t i = 3; i < op->args.size(); i++) {
             args[i] = print_expr(op->args[i]);
@@ -1991,7 +1997,9 @@ string CodeGen_Xtensa::print_xtensa_call(const Call *op) {
 
     if (op->name == "halide_xtensa_widening_load") {
         internal_assert(op->args.size() == 3);
-        args[0] = print_name(op->args[0].as<StringImm>()->value);
+        const Variable *src = op->args[0].as<Variable>();
+        internal_assert(src != nullptr);
+        args[0] = print_name(src->name);
         args[1] = print_expr(op->args[1]);
         // We are only using args[2] argument to get the type of the load.
 

--- a/src/InjectDmaTransfer.cpp
+++ b/src/InjectDmaTransfer.cpp
@@ -195,7 +195,10 @@ class InjectDmaTransferIntoProducer : public IRMutator {
                  << value_base << "\n>>>" << v.extent << "\n";
 
         // TODO(vksnk): is using Intrinsic here correct?
-        Expr copy_call = Call::make(Int(32), "halide_xtensa_copy_1d", {op->name, store_base, maybe_load->name, value_base, v.extent, op->value.type().bytes()}, Call::Intrinsic);
+        Expr copy_call = Call::make(Int(32), "halide_xtensa_copy_1d",
+                                    {Variable::make(type_of<void *>(), op->name), store_base,
+                                     Variable::make(type_of<void *>(), maybe_load->name), value_base,
+                                     v.extent, op->value.type().bytes()}, Call::Intrinsic);
         Expr wait_result = Call::make(Int(32), "halide_xtensa_wait_for_copy", {copy_call}, Call::Intrinsic);
         Stmt wait_is_done = AssertStmt::make(wait_result == 0, -1);
 

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -818,7 +818,7 @@ private:
             Expr dense_ramp_base = strided_ramp_base(load->index, 1);
             if (dense_ramp_base.defined() && is_const_one(load->predicate) && (op->type.is_int_or_uint()) && ((op->type.bits() == 16) || (op->type.bits() == 32)) && (load->type.is_int_or_uint()) && (2 * load->type.bits() == op->type.bits())) {
                 // The third argument is just to pass the type of load.
-                return Call::make(op->type, "halide_xtensa_widening_load", {load->name, dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern);
+                return Call::make(op->type, "halide_xtensa_widening_load", {Variable::make(type_of<void *>(), load->name), dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern);
             }
         }
 
@@ -830,7 +830,7 @@ private:
                         Expr dense_ramp_base = strided_ramp_base(load->index, 1);
                         if (dense_ramp_base.defined() && is_const_one(load->predicate) && (op->type.is_int_or_uint()) && ((op->type.bits() == 16) || (op->type.bits() == 32)) && (load->type.is_int_or_uint()) && (2 * load->type.bits() == op->type.bits())) {
                             // The third argument is just to pass the type of load.
-                            widened_loads.push_back(Call::make(op->type.with_lanes(v.type().lanes()), "halide_xtensa_widening_load", {load->name, dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern));
+                            widened_loads.push_back(Call::make(op->type.with_lanes(v.type().lanes()), "halide_xtensa_widening_load", {Variable::make(type_of<void *>(), load->name), dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern));
                         }
                     }
                 }
@@ -976,7 +976,7 @@ private:
                         // arg1 is an index and arg2 is a native vector size.
                         dense_ramp_base = dense_ramp_base + op->args[1] * op->args[2];
                         // The third argument is just to pass the type of load.
-                        return Call::make(op->type, "halide_xtensa_widening_load", {load->name, dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern);
+                        return Call::make(op->type, "halide_xtensa_widening_load", {Variable::make(type_of<void *>(), load->name), dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern);
                     }
                 }
             }


### PR DESCRIPTION
Avoid string names for Xtensa intrinsics as strings will not be captured by closure logic.