### PR TITLE
Use C++17 structured binding instead of std::tie

### DIFF
--- a/apps/fft/fft.cpp
+++ b/apps/fft/fft.cpp
@@ -501,8 +501,7 @@ ComplexFunc fft2d_c2c(ComplexFunc x,
     TwiddleFactorSet twiddle_cache;
 
     // transpose the input to the FFT.
-    ComplexFunc xT, x_tiled;
-    std::tie(xT, x_tiled) = tiled_transpose(x, N1, target, prefix);
+    auto [xT, x_tiled] = tiled_transpose(x, N1, target, prefix);
 
     // Compute the DFT of dimension 1 (originally dimension 0).
     ComplexFunc dft1T = fft_dim1(xT,
@@ -516,8 +515,7 @@ ComplexFunc fft2d_c2c(ComplexFunc x,
                                  &twiddle_cache);
 
     // transpose back.
-    ComplexFunc dft1, dft1_tiled;
-    std::tie(dft1, dft1_tiled) = tiled_transpose(dft1T, N0, target, prefix);
+    auto [dft1, dft1_tiled] = tiled_transpose(dft1T, N0, target, prefix);
 
     // Compute the DFT of dimension 1.
     ComplexFunc dft = fft_dim1(dft1,
@@ -783,8 +781,7 @@ ComplexFunc fft2d_r2c(Func r,
     int zipped_extent0 = std::min((N1 + 1) / 2, zip_width);
 
     // transpose so we can FFT dimension 0 (by making it dimension 1).
-    ComplexFunc unzippedT, unzippedT_tiled;
-    std::tie(unzippedT, unzippedT_tiled) = tiled_transpose(zipped_0, zipped_extent0, target, prefix);
+    auto [unzippedT, unzippedT_tiled] = tiled_transpose(zipped_0, zipped_extent0, target, prefix);
 
     // DFT down the columns again (the rows of the original).
     ComplexFunc dftT = fft_dim1(unzippedT,
@@ -949,8 +946,7 @@ Func fft2d_c2r(ComplexFunc c,
         }
 
         // transpose the input.
-        ComplexFunc cT, cT_tiled;
-        std::tie(cT, cT_tiled) =
+        auto [cT, cT_tiled] =
             tiled_transpose(c_zipped, zipped_extent0, target, prefix);
 
         // Take the inverse DFT of the columns (rows in the final result).
@@ -971,8 +967,7 @@ Func fft2d_c2r(ComplexFunc c,
         }
 
         // transpose so we can take the DFT of the columns again.
-        ComplexFunc dft0, dft0_tiled;
-        std::tie(dft0, dft0_tiled) = tiled_transpose(dft0T, zip_width, target, prefix, true);
+        auto [dft0, dft0_tiled] = tiled_transpose(dft0T, zip_width, target, prefix, true);
 
         // Unzip the DC and Nyquist DFTs.
         ComplexFunc dft0_unzipped("dft0_unzipped");

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -1385,9 +1385,7 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
 
         int variable_id = variable_ids[0];
         const string &variable = current_args[variable_id].name();
-        bool solved;
-        Expr result_rhs;
-        std::tie(solved, result_rhs) =
+        auto [solved, result_rhs] =
             solve_inverse(new_args[arg_id] == lhs[arg_id],
                           new_args[arg_id].name(),
                           variable);

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -92,13 +92,13 @@ map<string, Function> build_environment(const vector<Function> &funcs) {
 
 map<string, Function> find_transitive_calls(const Function &f) {
     map<string, Function> res;
-    populate_environment_helper(std::move(f), res, true, false);
+    populate_environment_helper(f, res, true, false);
     return res;
 }
 
 map<string, Function> find_direct_calls(const Function &f) {
     map<string, Function> res;
-    populate_environment_helper(std::move(f), res, false, false);
+    populate_environment_helper(f, res, false, false);
     return res;
 }
 

--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -10,6 +10,7 @@ namespace Internal {
 
 using std::map;
 using std::string;
+using std::vector;
 
 namespace {
 /* Find all the internal halide calls in an expr */
@@ -40,7 +41,7 @@ public:
     }
 };
 
-void populate_environment_helper(Function f, map<string, Function> &env,
+void populate_environment_helper(const Function &f, map<string, Function> &env,
                                  bool recursive = true, bool include_wrappers = false) {
     map<string, Function>::const_iterator iter = env.find(f.name());
     if (iter != env.end()) {
@@ -81,17 +82,21 @@ void populate_environment_helper(Function f, map<string, Function> &env,
 
 }  // namespace
 
-void populate_environment(Function f, map<string, Function> &env) {
-    populate_environment_helper(std::move(f), env, true, true);
+map<string, Function> build_environment(const vector<Function> &funcs) {
+    map<string, Function> env;
+    for (const Function &f : funcs) {
+        populate_environment_helper(f, env, true, true);
+    }
+    return env;
 }
 
-map<string, Function> find_transitive_calls(Function f) {
+map<string, Function> find_transitive_calls(const Function &f) {
     map<string, Function> res;
     populate_environment_helper(std::move(f), res, true, false);
     return res;
 }
 
-map<string, Function> find_direct_calls(Function f) {
+map<string, Function> find_direct_calls(const Function &f) {
     map<string, Function> res;
     populate_environment_helper(std::move(f), res, false, false);
     return res;

--- a/src/FindCalls.h
+++ b/src/FindCalls.h
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "Expr.h"
 
@@ -22,18 +23,18 @@ class Function;
  *  _does not_ include the Function f, unless it is called recursively by
  *  itself.
  */
-std::map<std::string, Function> find_direct_calls(Function f);
+std::map<std::string, Function> find_direct_calls(const Function &f);
 
 /** Construct a map from name to Function definition object for all Halide
  *  functions called directly in the definition of the Function f, or
  *  indirectly in those functions' definitions, recursively. This map always
  *  _includes_ the Function f.
  */
-std::map<std::string, Function> find_transitive_calls(Function f);
+std::map<std::string, Function> find_transitive_calls(const Function &f);
 
-/** Find all Functions transitively referenced by f in any way and add
- * them to the given map. */
-void populate_environment(Function f, std::map<std::string, Function> &env);
+/** Find all Functions transitively referenced by any Function in `funcs` and return
+ * a map of them. */
+std::map<std::string, Function> build_environment(const std::vector<Function> &funcs);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -211,14 +211,12 @@ int Func::dimensions() const {
 }
 
 FuncRef Func::operator()(vector<Var> args) const {
-    int placeholder_pos, count;
-    std::tie(placeholder_pos, count) = add_implicit_vars(args);
+    auto [placeholder_pos, count] = add_implicit_vars(args);
     return FuncRef(func, args, placeholder_pos, count);
 }
 
 FuncRef Func::operator()(vector<Expr> args) const {
-    int placeholder_pos, count;
-    std::tie(placeholder_pos, count) = add_implicit_vars(args);
+    auto [placeholder_pos, count] = add_implicit_vars(args);
     return FuncRef(func, args, placeholder_pos, count);
 }
 

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -251,11 +251,8 @@ Stmt IRMutator::visit(const Free *op) {
 }
 
 Stmt IRMutator::visit(const Realize *op) {
-    Region new_bounds;
-    bool bounds_changed;
-
     // Mutate the bounds
-    std::tie(new_bounds, bounds_changed) = mutate_region(this, op->bounds);
+    auto [new_bounds, bounds_changed] = mutate_region(this, op->bounds);
 
     Stmt body = mutate(op->body);
     Expr condition = mutate(op->condition);
@@ -272,11 +269,8 @@ Stmt IRMutator::visit(const Prefetch *op) {
     Stmt body = mutate(op->body);
     Expr condition = mutate(op->condition);
 
-    Region new_bounds;
-    bool bounds_changed;
-
     // Mutate the bounds
-    std::tie(new_bounds, bounds_changed) = mutate_region(this, op->bounds);
+    auto [new_bounds, bounds_changed] = mutate_region(this, op->bounds);
 
     if (!bounds_changed &&
         body.same_as(op->body) &&

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -76,7 +76,6 @@
 namespace Halide {
 namespace Internal {
 
-using std::map;
 using std::ostringstream;
 using std::string;
 using std::vector;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -109,15 +109,8 @@ void lower_impl(const vector<Function> &output_funcs,
                 Module &result_module) {
     auto time_start = std::chrono::high_resolution_clock::now();
 
-    // Compute an environment
-    map<string, Function> env;
-    for (const Function &f : output_funcs) {
-        populate_environment(f, env);
-    }
-
     // Create a deep-copy of the entire graph of Funcs.
-    vector<Function> outputs;
-    std::tie(outputs, env) = deep_copy(output_funcs, env);
+    auto [outputs, env] = deep_copy(output_funcs, build_environment(output_funcs));
 
     bool any_strict_float = strictify_float(env, t);
     result_module.set_any_strict_float(any_strict_float);
@@ -137,9 +130,7 @@ void lower_impl(const vector<Function> &output_funcs,
 
     // Compute a realization order and determine group of functions which loops
     // are to be fused together
-    vector<string> order;
-    vector<vector<string>> fused_groups;
-    std::tie(order, fused_groups) = realization_order(outputs, env);
+    auto [order, fused_groups] = realization_order(outputs, env);
 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -165,15 +165,8 @@ private:
 string print_loop_nest(const vector<Function> &output_funcs) {
     // Do the first part of lowering:
 
-    // Compute an environment
-    map<string, Function> env;
-    for (const Function &f : output_funcs) {
-        populate_environment(f, env);
-    }
-
     // Create a deep-copy of the entire graph of Funcs.
-    vector<Function> outputs;
-    std::tie(outputs, env) = deep_copy(output_funcs, env);
+    auto [outputs, env] = deep_copy(output_funcs, build_environment(output_funcs));
 
     // Output functions should all be computed and stored at root.
     for (const Function &f : outputs) {
@@ -190,9 +183,7 @@ string print_loop_nest(const vector<Function> &output_funcs) {
 
     // Compute a realization order and determine group of functions which loops
     // are to be fused together
-    vector<string> order;
-    vector<vector<string>> fused_groups;
-    std::tie(order, fused_groups) = realization_order(outputs, env);
+    auto [order, fused_groups] = realization_order(outputs, env);
 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -293,9 +293,7 @@ pair<vector<string>, vector<vector<string>>> realization_order(
     // Determine groups of functions which loops are to be fused together.
     // 'fused_groups' maps a fused group to its members.
     // 'group_name' maps a function to the name of the fused group it belongs to.
-    map<string, vector<string>> fused_groups;
-    map<string, string> group_name;
-    std::tie(fused_groups, group_name) = find_fused_groups(env, fuse_adjacency_list);
+    auto [fused_groups, group_name] = find_fused_groups(env, fuse_adjacency_list);
 
     // Compute the DAG representing the pipeline
     for (const pair<const string, Function> &caller : env) {

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -609,11 +609,8 @@ Stmt Simplify::visit(const Block *op) {
 }
 
 Stmt Simplify::visit(const Realize *op) {
-    Region new_bounds;
-    bool bounds_changed;
-
     // Mutate the bounds
-    std::tie(new_bounds, bounds_changed) = mutate_region(this, op->bounds, nullptr);
+    auto [new_bounds, bounds_changed] = mutate_region(this, op->bounds, nullptr);
 
     Stmt body = mutate(op->body);
     Expr condition = mutate(op->condition, nullptr);
@@ -635,11 +632,8 @@ Stmt Simplify::visit(const Prefetch *op) {
         return body;
     }
 
-    Region new_bounds;
-    bool bounds_changed;
-
     // Mutate the bounds
-    std::tie(new_bounds, bounds_changed) = mutate_region(this, op->bounds, nullptr);
+    auto [new_bounds, bounds_changed] = mutate_region(this, op->bounds, nullptr);
 
     if (!bounds_changed &&
         body.same_as(op->body) &&

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -569,10 +569,7 @@ bool depends_on_estimate(const Expr &expr) {
 }
 
 FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &params, const Target &target) {
-    map<string, Function> env;
-    for (const Function &o : outputs) {
-        populate_environment(o, env);
-    }
+    map<string, Function> env = build_environment(outputs);
 
     // A mutator to apply parameter estimates to the expressions
     // we encounter while constructing the graph.

--- a/test/generator/multitarget_aottest.cpp
+++ b/test/generator/multitarget_aottest.cpp
@@ -32,9 +32,7 @@ std::pair<std::string, bool> get_env_variable(char const *env_var_name) {
 }
 
 bool use_noboundsquery_feature() {
-    std::string value;
-    bool read;
-    std::tie(value, read) = get_env_variable("HL_MULTITARGET_TEST_USE_NOBOUNDSQUERY_FEATURE");
+    auto [value, read] = get_env_variable("HL_MULTITARGET_TEST_USE_NOBOUNDSQUERY_FEATURE");
     if (!read) {
         return false;
     }


### PR DESCRIPTION
Just a minor style thing, but IMHO using C++17 structured bindings is preferable in ~all cases to using std::tie(), so I'm proposing this change.

Also made a drive-by change to populate_environment (now build_environment) since literally every caller was calling it this way.