### PR TITLE
Prefetch cleanup

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2511,13 +2511,13 @@ void CodeGen_C::visit(const Call *op) {
                       " integer overflow for int32 and int64 is undefined behavior in"
                       " Halide.\n";
     } else if (op->is_intrinsic(Call::prefetch)) {
+        user_assert((op->args.size() == 4) && is_const_one(op->args[2]))
+            << "Only prefetch of 1 cache line is supported in C backend.\n";
+
         const Expr &base_address = op->args[0];
         const Expr &base_offset = op->args[1];
-        const Expr &extent0 = op->args[2];  // unused
+        // const Expr &extent0 = op->args[2];  // unused
         // const Expr &stride0 = op->args[3];  // unused
-
-        user_assert((op->args.size() == 4) && is_const_one(extent0))
-            << "Only prefetch of 1 cache line is supported in C backend.\n";
 
         const Variable *base = base_address.as<Variable>();
         internal_assert(base && base->type.is_handle());

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2511,13 +2511,19 @@ void CodeGen_C::visit(const Call *op) {
                       " integer overflow for int32 and int64 is undefined behavior in"
                       " Halide.\n";
     } else if (op->is_intrinsic(Call::prefetch)) {
-        user_assert((op->args.size() == 4) && is_const_one(op->args[2]))
+        const Expr &base_address = op->args[0];
+        const Expr &base_offset = op->args[1];
+        const Expr &extent0 = op->args[2];  // unused
+        // const Expr &stride0 = op->args[3];  // unused
+
+        user_assert((op->args.size() == 4) && is_const_one(extent0))
             << "Only prefetch of 1 cache line is supported in C backend.\n";
-        const Variable *base = op->args[0].as<Variable>();
+
+        const Variable *base = base_address.as<Variable>();
         internal_assert(base && base->type.is_handle());
         rhs << "__builtin_prefetch("
             << "((" << print_type(op->type) << " *)" << print_name(base->name)
-            << " + " << print_expr(op->args[1]) << "), 1)";
+            << " + " << print_expr(base_offset) << "), 1)";
     } else if (op->is_intrinsic(Call::size_of_halide_buffer_t)) {
         rhs << "(sizeof(halide_buffer_t))";
     } else if (op->is_intrinsic(Call::strict_float)) {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1914,23 +1914,31 @@ void CodeGen_Hexagon::visit(const Call *op) {
         internal_assert((op->args.size() == 4) || (op->args.size() == 6))
             << "Hexagon only supports 1D or 2D prefetch\n";
 
-        vector<llvm::Value *> args;
-        args.push_back(
-            codegen_buffer_pointer(codegen(op->args[0]), op->type, op->args[1]));
+        const int elem_size = op->type.bytes();
+        const Expr &base_address = op->args[0];
+        const Expr &base_offset = op->args[1];
+        const Expr &extent0 = op->args[2];
+        const Expr &stride0 = op->args[3];
 
-        Expr extent_0_bytes = op->args[2] * op->args[3] * op->type.bytes();
-        args.push_back(codegen(extent_0_bytes));
-
-        llvm::Function *prefetch_fn = nullptr;
-        if (op->args.size() ==
-            4) {  // 1D prefetch: {base, offset, extent0, stride0}
-            prefetch_fn = module->getFunction("_halide_prefetch_1d");
-        } else {  // 2D prefetch: {base, offset, extent0, stride0, extent1, stride1}
-            prefetch_fn = module->getFunction("_halide_prefetch_2d");
-            args.push_back(codegen(op->args[4]));
-            Expr stride_1_bytes = op->args[5] * op->type.bytes();
-            args.push_back(codegen(stride_1_bytes));
+        Expr width_bytes = extent0 * stride0 * elem_size;
+        Expr height, stride_bytes;
+        if (op->args.size() == 6) {
+            const Expr &extent1 = op->args[4];
+            const Expr &stride1 = op->args[5];
+            height = extent1;
+            stride_bytes = stride1 * elem_size;
+        } else {
+            height = 1;
+            stride_bytes = 1;
         }
+
+        vector<llvm::Value *> args;
+        args.push_back(codegen_buffer_pointer(codegen(base_address), op->type, base_offset));
+        args.push_back(codegen(width_bytes));
+        args.push_back(codegen(height));
+        args.push_back(codegen(stride_bytes));
+
+        llvm::Function *prefetch_fn = module->getFunction("_halide_prefetch_2d");
         internal_assert(prefetch_fn);
 
         // The first argument is a pointer, which has type i8*. We

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3167,12 +3167,13 @@ void CodeGen_LLVM::visit(const Call *op) {
         llvm::CallInst *call = builder->CreateCall(base_fn->getFunctionType(), phi, call_args);
         value = call;
     } else if (op->is_intrinsic(Call::prefetch)) {
+        user_assert((op->args.size() == 4) && is_const_one(op->args[2]))
+            << "Only prefetch of 1 cache line is supported.\n";
+
         const Expr &base_address = op->args[0];
         const Expr &base_offset = op->args[1];
-        const Expr &extent0 = op->args[2];
+        // const Expr &extent0 = op->args[2];  // unused
         // const Expr &stride0 = op->args[3];  // unused
-        user_assert((op->args.size() == 4) && is_const_one(extent0))
-            << "Only prefetch of 1 cache line is supported.\n";
 
         llvm::Function *prefetch_fn = module->getFunction("_halide_prefetch");
         internal_assert(prefetch_fn);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3167,14 +3167,18 @@ void CodeGen_LLVM::visit(const Call *op) {
         llvm::CallInst *call = builder->CreateCall(base_fn->getFunctionType(), phi, call_args);
         value = call;
     } else if (op->is_intrinsic(Call::prefetch)) {
-        user_assert((op->args.size() == 4) && is_const_one(op->args[2]))
+        const Expr &base_address = op->args[0];
+        const Expr &base_offset = op->args[1];
+        const Expr &extent0 = op->args[2];
+        // const Expr &stride0 = op->args[3];  // unused
+        user_assert((op->args.size() == 4) && is_const_one(extent0))
             << "Only prefetch of 1 cache line is supported.\n";
 
         llvm::Function *prefetch_fn = module->getFunction("_halide_prefetch");
         internal_assert(prefetch_fn);
 
         vector<llvm::Value *> args;
-        args.push_back(codegen_buffer_pointer(codegen(op->args[0]), op->type, op->args[1]));
+        args.push_back(codegen_buffer_pointer(codegen(base_address), op->type, base_offset));
         // The first argument is a pointer, which has type i8*. We
         // need to cast the argument, which might be a pointer to a
         // different type.
@@ -3182,7 +3186,6 @@ void CodeGen_LLVM::visit(const Call *op) {
         args[0] = builder->CreateBitCast(args[0], ptr_type);
 
         value = builder->CreateCall(prefetch_fn, args);
-
     } else if (op->is_intrinsic(Call::signed_integer_overflow)) {
         user_error << "Signed integer overflow occurred during constant-folding. Signed"
                       " integer overflow for int32 and int64 is undefined behavior in"

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -27,7 +27,7 @@ using std::vector;
  * here's the overall flow at the time this comment was written:
  *
  *  - When the .prefetch() schedule directive is used, a PrefetchDirective is
- *    added to the relevant Functiob
+ *    added to the relevant Function
  *  - At the start of lowering (schedule_functions()), a placeholder Prefetch IR nodes (w/ no region) are inserted
  *  - Various lowering passes mutate the placeholder Prefetch IR nodes as appropriate
  *  - After storage folding, the Prefetch IR nodes are updated with a proper region (via inject_prefetch())

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -479,7 +479,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         // Collapse the prefetched region into lower dimension whenever is possible.
         // TODO(psuriana): Deal with negative strides and overlaps.
 
-        internal_assert(op->args.size() % 2 == 0);  // Format: {base, offset, extent0, min0, ...}
+        internal_assert(op->args.size() % 2 == 0);  // Prefetch: {base, offset, extent0, stride0, ...}
 
         auto [args, changed] = mutate_with_changes(op->args, nullptr);
 

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -712,9 +712,9 @@ class SubstitutePrefetchVar : public IRMutator {
             if (op->prefetch.from == old_var) {
                 p.from = new_var;
             }
-            return Prefetch::make(op->name, op->types, op->bounds, p, op->condition, new_body);
+            return Prefetch::make(op->name, op->types, op->bounds, p, op->condition, std::move(new_body));
         } else if (!new_body.same_as(op->body)) {
-            return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, new_body);
+            return Prefetch::make(op->name, op->types, op->bounds, op->prefetch, op->condition, std::move(new_body));
         } else {
             return op;
         }

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -99,7 +99,7 @@ class SplitTuples : public IRMutator {
 
             for (const auto &idx : indices->second) {
                 internal_assert(idx < (int)op->types.size());
-                body = Prefetch::make(op->name + "." + std::to_string(idx), {op->types[(idx)]}, op->bounds, op->prefetch, op->condition, body);
+                body = Prefetch::make(op->name + "." + std::to_string(idx), {op->types[(idx)]}, op->bounds, op->prefetch, op->condition, std::move(body));
             }
             return body;
         } else {

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -339,8 +339,8 @@ private:
 
         auto iter = env.find(op->name);
         if (iter != env.end()) {
-            // Order the <min, extent> args based on the storage dims (i.e. innermost
-            // dimension should be first in args)
+            // Order the <min, extent> args based on the storage dims
+            // (i.e. innermost dimension should be first in args)
             vector<int> storage_permutation;
             {
                 Function f = iter->second.first;

--- a/src/runtime/qurt_hvx.cpp
+++ b/src/runtime/qurt_hvx.cpp
@@ -57,11 +57,6 @@ WEAK_INLINE int _halide_prefetch_2d(const void *ptr, int width_bytes, int height
     return 0;
 }
 
-WEAK_INLINE int _halide_prefetch_1d(const void *ptr, int size) {
-    _halide_prefetch_2d(ptr, size, 1, 1);
-    return 0;
-}
-
 struct hexagon_buffer_t_arg {
     uint64_t device;
     uint8_t *host;

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -2139,8 +2139,9 @@ int main(int argc, char **argv) {
     {
         // Check that contiguous prefetch call get collapsed
         Expr base = Variable::make(Handle(), "buf");
-        check(Call::make(Int(32), Call::prefetch, {base, x, 4, 1, 64, 4, min(x + y, 128), 256}, Call::Intrinsic),
-              Call::make(Int(32), Call::prefetch, {base, x, min(x + y, 128) * 256, 1}, Call::Intrinsic));
+        Expr offset = x;
+        check(Call::make(Int(32), Call::prefetch, {base, offset, 4, 1, 64, 4, min(x + y, 128), 256}, Call::Intrinsic),
+              Call::make(Int(32), Call::prefetch, {base, offset, min(x + y, 128) * 256, 1}, Call::Intrinsic));
     }
 
     // This expression is a good stress-test. It caused exponential


### PR DESCRIPTION
This is (mostly) a cleanup pass to make the flow of Prefetch injection & lowering more obvious to the reader of the code (via commenting and minor code restructuring).

Notable exception: the HVX backend processing of Call::prefetch (and relevant runtime code) was refactored to make it (IMHO) less janky.

(Also some drive-by insertions of std::move where appropriate)