### PR TITLE
Add modernize-loop-convert to .clang-tidy and fix all warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,7 @@ Checks: >
     -misc-unconventional-assign-operator,
     -misc-unused-parameters,
     modernize-deprecated-headers,
+    modernize-loop-convert,
     modernize-redundant-void-arg,
     modernize-use-bool-literals,
     modernize-use-default-member-init,

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -267,25 +267,24 @@ Stmt add_image_checks_inner(Stmt s,
         if (param.defined()) {
             // Find the extern users.
             vector<string> extern_users;
-            for (size_t i = 0; i < order.size(); i++) {
-                Function f = env.find(order[i])->second;
+            for (const auto &i : order) {
+                Function f = env.find(i)->second;
                 if (f.has_extern_definition() &&
                     !f.extern_definition_proxy_expr().defined()) {
                     const vector<ExternFuncArgument> &args = f.extern_arguments();
-                    for (size_t j = 0; j < args.size(); j++) {
-                        if ((args[j].image_param.defined() &&
-                             args[j].image_param.name() == param.name()) ||
-                            (args[j].buffer.defined() &&
-                             args[j].buffer.name() == param.name())) {
-                            extern_users.push_back(order[i]);
+                    for (const auto &arg : args) {
+                        if ((arg.image_param.defined() &&
+                             arg.image_param.name() == param.name()) ||
+                            (arg.buffer.defined() &&
+                             arg.buffer.name() == param.name())) {
+                            extern_users.push_back(i);
                         }
                     }
                 }
             }
 
             // Expand the box by the result of the bounds query from each.
-            for (size_t i = 0; i < extern_users.size(); i++) {
-                const string &extern_user = extern_users[i];
+            for (auto &extern_user : extern_users) {
                 Box query_box;
                 Expr query_buf = Variable::make(type_of<struct halide_buffer_t *>(),
                                                 param.name() + ".bounds_query." + extern_user);
@@ -592,20 +591,20 @@ Stmt add_image_checks_inner(Stmt s,
         }
 
         // Assert all the conditions, and set the new values
-        for (size_t i = 0; i < constraints.size(); i++) {
-            Expr var = constraints[i].first;
+        for (auto &constraint : constraints) {
+            Expr var = constraint.first;
             const string &name = var.as<Variable>()->name;
             Expr constrained_var = Variable::make(Int(32), name + ".constrained");
 
             std::ostringstream ss;
-            ss << constraints[i].second;
+            ss << constraint.second;
             string constrained_var_str = ss.str();
 
-            lets_constrained.emplace_back(name + ".constrained", constraints[i].second);
+            lets_constrained.emplace_back(name + ".constrained", constraint.second);
 
             // Substituting in complex expressions is not typically a good idea
-            if (constraints[i].second.as<Variable>() ||
-                is_const(constraints[i].second)) {
+            if (constraint.second.as<Variable>() ||
+                is_const(constraint.second)) {
                 replace_with_constrained[name] = constrained_var;
             }
 

--- a/src/AddParameterChecks.cpp
+++ b/src/AddParameterChecks.cpp
@@ -89,13 +89,12 @@ Stmt add_parameter_checks(const vector<Stmt> &preconditions, Stmt s, const Targe
     s = substitute(replace_with_constrained, s);
 
     // Inject the let statements
-    for (size_t i = 0; i < lets.size(); i++) {
-        s = LetStmt::make(lets[i].first, lets[i].second, s);
+    for (auto &let : lets) {
+        s = LetStmt::make(let.first, let.second, s);
     }
 
     // Inject the assert statements
-    for (size_t i = 0; i < asserts.size(); i++) {
-        ParamAssert p = asserts[i];
+    for (auto p : asserts) {
         // Upgrade the types to 64-bit versions for the error call
         Type wider = p.value.type().with_bits(64);
         p.limit_value = cast(wider, p.limit_value);

--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -57,8 +57,7 @@ class AllocationInference : public IRMutator {
         for (size_t i = 0; i < b.size(); i++) {
             // Get any applicable bound on this dimension
             Bound bound;
-            for (size_t j = 0; j < f.schedule().bounds().size(); j++) {
-                Bound b = f.schedule().bounds()[j];
+            for (const auto &b : f.schedule().bounds()) {
                 if (f_args[i] == b.var) {
                     bound = b;
                 }
@@ -132,13 +131,11 @@ public:
     AllocationInference(const map<string, Function> &e, const FuncValueBounds &fb)
         : env(e), func_bounds(fb) {
         // Figure out which buffers are touched by extern stages
-        for (map<string, Function>::const_iterator iter = e.begin();
-             iter != e.end(); ++iter) {
-            Function f = iter->second;
+        for (const auto &iter : e) {
+            Function f = iter.second;
             if (f.has_extern_definition()) {
                 touched_by_extern.insert(f.name());
-                for (size_t i = 0; i < f.extern_arguments().size(); i++) {
-                    ExternFuncArgument arg = f.extern_arguments()[i];
+                for (const auto &arg : f.extern_arguments()) {
                     if (!arg.is_func()) {
                         continue;
                     }

--- a/src/AutoScheduleUtils.h
+++ b/src/AutoScheduleUtils.h
@@ -31,8 +31,8 @@ class FindAllCalls : public IRVisitor {
             funcs_called.insert(call->name);
             call_args.emplace_back(call->name, call->args);
         }
-        for (size_t i = 0; i < call->args.size(); i++) {
-            call->args[i].accept(this);
+        for (const auto &arg : call->args) {
+            arg.accept(this);
         }
     }
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2842,11 +2842,11 @@ private:
         }
 
         if (consider_calls) {
-            for (size_t i = 0; i < op->args.size(); i++) {
-                op->args[i].accept(this);
+            for (const auto &arg : op->args) {
+                arg.accept(this);
             }
-            for (size_t i = 0; i < op->values.size(); i++) {
-                op->values[i].accept(this);
+            for (const auto &value : op->values) {
+                value.accept(this);
             }
         }
     }
@@ -3086,8 +3086,8 @@ FuncValueBounds compute_function_value_bounds(const vector<string> &order,
                                               const map<string, Function> &env) {
     FuncValueBounds fb;
 
-    for (size_t i = 0; i < order.size(); i++) {
-        Function f = env.find(order[i])->second;
+    for (const auto &i : order) {
+        Function f = env.find(i)->second;
         const vector<string> f_args = f.args();
         for (int j = 0; j < f.outputs(); j++) {
             pair<string, int> key = {f.name(), j};
@@ -3129,7 +3129,7 @@ FuncValueBounds compute_function_value_bounds(const vector<string> &order,
             }
 
             debug(2) << "Bounds on value " << j
-                     << " for func " << order[i]
+                     << " for func " << i
                      << " are: " << result.min << ", " << result.max << "\n";
         }
     }

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -547,8 +547,7 @@ public:
                 LoopLevel compute_at = func.schedule().compute_level();
                 LoopLevel store_at = func.schedule().store_level();
 
-                for (size_t i = 0; i < func.schedule().bounds().size(); i++) {
-                    Bound bound = func.schedule().bounds()[i];
+                for (auto bound : func.schedule().bounds()) {
                     string min_var = prefix + bound.var + ".min";
                     string max_var = prefix + bound.var + ".max";
                     Expr min_required = Variable::make(Int(32), min_var);
@@ -656,11 +655,11 @@ public:
             Expr null_handle = make_zero(Handle());
 
             vector<pair<Expr, int>> buffers_to_annotate;
-            for (size_t j = 0; j < args.size(); j++) {
-                if (args[j].is_expr()) {
-                    bounds_inference_args.push_back(args[j].expr);
-                } else if (args[j].is_func()) {
-                    Function input(args[j].func);
+            for (const auto &arg : args) {
+                if (arg.is_expr()) {
+                    bounds_inference_args.push_back(arg.expr);
+                } else if (arg.is_func()) {
+                    Function input(arg.func);
                     for (int k = 0; k < input.outputs(); k++) {
                         string name = input.name() + ".o" + std::to_string(k) + ".bounds_query." + func.name();
 
@@ -673,11 +672,11 @@ public:
                         bounds_inference_args.push_back(Variable::make(type_of<struct halide_buffer_t *>(), name));
                         buffers_to_annotate.emplace_back(bounds_inference_args.back(), input.dimensions());
                     }
-                } else if (args[j].is_image_param() || args[j].is_buffer()) {
-                    Parameter p = args[j].image_param;
-                    Buffer<> b = args[j].buffer;
-                    string name = args[j].is_image_param() ? p.name() : b.name();
-                    int dims = args[j].is_image_param() ? p.dimensions() : b.dimensions();
+                } else if (arg.is_image_param() || arg.is_buffer()) {
+                    Parameter p = arg.image_param;
+                    Buffer<> b = arg.buffer;
+                    string name = arg.is_image_param() ? p.name() : b.name();
+                    int dims = arg.is_image_param() ? p.dimensions() : b.dimensions();
 
                     Expr in_buf = Variable::make(type_of<struct halide_buffer_t *>(), name + ".buffer");
 
@@ -776,8 +775,8 @@ public:
             s = Block::make(check, s);
 
             // Wrap in let stmts defining the args
-            for (size_t i = 0; i < lets.size(); i++) {
-                s = LetStmt::make(lets[i].first, lets[i].second, s);
+            for (auto &let : lets) {
+                s = LetStmt::make(let.first, let.second, s);
             }
 
             return s;
@@ -863,10 +862,8 @@ public:
         for (size_t i = f.size(); i > 0; i--) {
             Function func = f[i - 1];
             if (inlined[i - 1]) {
-                for (size_t j = 0; j < stages.size(); j++) {
-                    Stage &s = stages[j];
-                    for (size_t k = 0; k < s.exprs.size(); k++) {
-                        CondValue &cond_val = s.exprs[k];
+                for (auto &s : stages) {
+                    for (auto &cond_val : s.exprs) {
                         internal_assert(cond_val.value.defined());
                         cond_val.value = inline_function(cond_val.value, func);
                     }
@@ -876,10 +873,10 @@ public:
 
         // Remove the inlined stages
         vector<Stage> new_stages;
-        for (size_t i = 0; i < stages.size(); i++) {
-            if (!stages[i].func.schedule().compute_level().is_inlined() ||
-                !stages[i].func.can_be_inlined()) {
-                new_stages.push_back(stages[i]);
+        for (auto &stage : stages) {
+            if (!stage.func.schedule().compute_level().is_inlined() ||
+                !stage.func.can_be_inlined()) {
+                new_stages.push_back(stage);
             }
         }
         new_stages.swap(stages);
@@ -912,9 +909,9 @@ public:
                 // Stage::define_bounds is going to compute a query
                 // halide_buffer_t per producer for bounds inference to
                 // use. We just need to extract those values.
-                for (size_t j = 0; j < args.size(); j++) {
-                    if (args[j].is_func()) {
-                        Function f(args[j].func);
+                for (const auto &arg : args) {
+                    if (arg.is_func()) {
+                        Function f(arg.func);
                         has_extern_consumer.insert(f.name());
                         string stage_name = f.name() + ".s" + std::to_string(f.updates().size());
                         Box b(f.dimensions());
@@ -1011,8 +1008,7 @@ public:
 
                 output_box.push_back(Interval(min, (min + extent) - 1));
             }
-            for (size_t i = 0; i < stages.size(); i++) {
-                Stage &s = stages[i];
+            for (auto &s : stages) {
                 if (!s.func.same_as(output)) {
                     continue;
                 }
@@ -1167,8 +1163,8 @@ public:
                 }
 
                 if (bounds_needed[i]) {
-                    for (size_t j = 0; j < stages[i].consumers.size(); j++) {
-                        bounds_needed[stages[i].consumers[j]] = true;
+                    for (int consumer : stages[i].consumers) {
+                        bounds_needed[consumer] = true;
                     }
                     body = stages[i].define_bounds(
                         body, f, stage_name, stage_index, op->name, fused_groups,
@@ -1326,9 +1322,9 @@ Stmt bounds_inference(Stmt s,
                           f.definition().schedule().fused_pairs().end(),
                           std::inserter(pairs, pairs.end()));
 
-                for (size_t i = 0; i < f.updates().size(); ++i) {
-                    std::copy(f.updates()[i].schedule().fused_pairs().begin(),
-                              f.updates()[i].schedule().fused_pairs().end(),
+                for (const auto &i : f.updates()) {
+                    std::copy(i.schedule().fused_pairs().begin(),
+                              i.schedule().fused_pairs().end(),
                               std::inserter(pairs, pairs.end()));
                 }
             }

--- a/src/Closure.cpp
+++ b/src/Closure.cpp
@@ -69,8 +69,8 @@ void Closure::visit(const Allocate *op) {
         op->new_expr.accept(this);
     }
     ScopedBinding<> p(ignore, op->name);
-    for (size_t i = 0; i < op->extents.size(); i++) {
-        op->extents[i].accept(this);
+    for (const auto &extent : op->extents) {
+        extent.accept(this);
     }
     op->condition.accept(this);
     op->body.accept(this);

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -977,8 +977,8 @@ void CodeGen_ARM::visit(const Store *op) {
         int alignment = t.bytes();
 
         // Codegen the lets
-        for (size_t i = 0; i < lets.size(); i++) {
-            sym_push(lets[i].first, codegen(lets[i].second));
+        for (auto &let : lets) {
+            sym_push(let.first, codegen(let.second));
         }
 
         // Codegen all the vector args.
@@ -1049,8 +1049,8 @@ void CodeGen_ARM::visit(const Store *op) {
         }
 
         // pop the lets from the symbol table
-        for (size_t i = 0; i < lets.size(); i++) {
-            sym_pop(lets[i].first);
+        for (auto &let : lets) {
+            sym_pop(let.first);
         }
 
         return;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1807,9 +1807,9 @@ void CodeGen_C::compile(const LoweredFunc &f, const std::map<std::string, std::s
     const std::vector<LoweredArgument> &args = f.args;
 
     have_user_context = false;
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // TODO: check that its type is void *?
-        have_user_context |= (args[i].name == "__user_context");
+        have_user_context |= (arg.name == "__user_context");
     }
 
     NameMangling name_mangling = f.name_mangling;
@@ -2385,8 +2385,8 @@ void CodeGen_C::visit(const Call *op) {
 
             // Get the args
             vector<string> values;
-            for (size_t i = 0; i < op->args.size(); i++) {
-                values.push_back(print_expr(op->args[i]));
+            for (const auto &arg : op->args) {
+                values.push_back(print_expr(arg));
             }
 
             static_assert(sizeof(halide_dimension_t) == 4 * sizeof(int32_t),
@@ -2418,8 +2418,8 @@ void CodeGen_C::visit(const Call *op) {
 
             // Get the args
             vector<string> values;
-            for (size_t i = 0; i < op->args.size(); i++) {
-                values.push_back(print_expr(op->args[i]));
+            for (const auto &arg : op->args) {
+                values.push_back(print_expr(arg));
             }
             stream << get_indent() << "struct {\n";
             // List the types.

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1232,10 +1232,10 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
     print(s);
     close_scope("kernel " + name);
 
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer) {
-            allocations.pop(args[i].name);
+        if (arg.is_buffer) {
+            allocations.pop(arg.name);
         }
     }
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1371,10 +1371,10 @@ Value *CodeGen_Hexagon::vlut256(Value *lut, Value *idx, int min_index,
                 } else if (max_index >= pass_index * native_lut_elements / lut_passes) {
                     // Not the first native LUT, accumulate the LUT
                     // with the previous result.
-                    for (int m = 0; m < 2; m++) {
+                    for (auto &m : mask) {
                         result_i =
                             call_intrin_cast(native_result_ty, vlut_acc,
-                                             {result_i, idx_i, lut_slices[j], mask[m]});
+                                             {result_i, idx_i, lut_slices[j], m});
                     }
                 }
             }
@@ -2075,8 +2075,8 @@ Value *CodeGen_Hexagon::codegen_cache_allocation_size(
     Expr total_size_hi = make_zero(UInt(32));
 
     Expr low_mask = make_const(UInt(32), (uint32_t)(0xfffff));
-    for (size_t i = 0; i < extents.size(); i++) {
-        Expr next_extent = cast(UInt(32), extents[i]);
+    for (const auto &extent : extents) {
+        Expr next_extent = cast(UInt(32), extent);
 
         // Update total_size >> 24. This math can't overflow due to
         // the loop invariant:
@@ -2219,8 +2219,8 @@ void CodeGen_Hexagon::visit(const Allocate *alloc) {
         }
         // Calculate size of allocation.
         Expr size = alloc->type.bytes();
-        for (size_t i = 0; i < alloc->extents.size(); i++) {
-            size *= alloc->extents[i];
+        for (const auto &extent : alloc->extents) {
+            size *= extent;
         }
         size += allocation_padding(alloc->type);
         Expr new_expr =

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -249,10 +249,8 @@ bool function_takes_user_context(const std::string &name) {
         "_halide_buffer_retire_crop_after_extern_stage",
         "_halide_buffer_retire_crops_after_extern_stage",
     };
-    const int num_funcs = sizeof(user_context_runtime_funcs) /
-                          sizeof(user_context_runtime_funcs[0]);
-    for (int i = 0; i < num_funcs; ++i) {
-        if (name == user_context_runtime_funcs[i]) {
+    for (auto &user_context_runtime_func : user_context_runtime_funcs) {
+        if (name == user_context_runtime_func) {
             return true;
         }
     }

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -621,11 +621,11 @@ void CodeGen_LLVM::end_func(const std::vector<LoweredArgument> &args) {
     return_with_error_code(ConstantInt::get(i32_t, 0));
 
     // Remove the arguments from the symbol table
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer()) {
-            sym_pop(args[i].name + ".buffer");
+    for (const auto &arg : args) {
+        if (arg.is_buffer()) {
+            sym_pop(arg.name + ".buffer");
         } else {
-            sym_pop(args[i].name);
+            sym_pop(arg.name);
         }
     }
 
@@ -1209,22 +1209,22 @@ void CodeGen_LLVM::optimize_module() {
             });
     }
 
-    for (llvm::Module::iterator i = module->begin(); i != module->end(); i++) {
+    for (auto &i : *module) {
         if (get_target().has_feature(Target::ASAN)) {
-            i->addFnAttr(Attribute::SanitizeAddress);
+            i.addFnAttr(Attribute::SanitizeAddress);
         }
         if (get_target().has_feature(Target::TSAN)) {
             // Do not annotate any of Halide's low-level synchronization code as it has
             // tsan interface calls to mark its behavior and is much faster if
             // it is not analyzed instruction by instruction.
-            if (!(i->getName().startswith("_ZN6Halide7Runtime8Internal15Synchronization") ||
+            if (!(i.getName().startswith("_ZN6Halide7Runtime8Internal15Synchronization") ||
                   // TODO: this is a benign data race that re-initializes the detected features;
                   // we should really fix it properly inside the implementation, rather than disabling
                   // it here as a band-aid.
-                  i->getName().startswith("halide_default_can_use_target_features") ||
-                  i->getName().startswith("halide_mutex_") ||
-                  i->getName().startswith("halide_cond_"))) {
-                i->addFnAttr(Attribute::SanitizeThread);
+                  i.getName().startswith("halide_default_can_use_target_features") ||
+                  i.getName().startswith("halide_mutex_") ||
+                  i.getName().startswith("halide_cond_"))) {
+                i.addFnAttr(Attribute::SanitizeThread);
             }
         }
     }
@@ -2882,10 +2882,10 @@ void CodeGen_LLVM::visit(const Call *op) {
 
             // Compute the maximum possible size of the message.
             int buf_size = 1;  // One for the terminating zero.
-            for (size_t i = 0; i < op->args.size(); i++) {
-                Type t = op->args[i].type();
-                if (op->args[i].as<StringImm>()) {
-                    buf_size += op->args[i].as<StringImm>()->value.size();
+            for (const auto &arg : op->args) {
+                Type t = arg.type();
+                if (arg.as<StringImm>()) {
+                    buf_size += arg.as<StringImm>()->value.size();
                 } else if (t.is_int() || t.is_uint()) {
                     buf_size += 19;  // 2^64 = 18446744073709551616
                 } else if (t.is_float()) {
@@ -2928,44 +2928,44 @@ void CodeGen_LLVM::visit(const Call *op) {
             internal_assert(append_pointer);
             internal_assert(append_buffer);
 
-            for (size_t i = 0; i < op->args.size(); i++) {
-                const StringImm *s = op->args[i].as<StringImm>();
-                Type t = op->args[i].type();
+            for (const auto &arg : op->args) {
+                const StringImm *s = arg.as<StringImm>();
+                Type t = arg.type();
                 internal_assert(t.lanes() == 1);
                 vector<Value *> call_args(2);
                 call_args[0] = dst;
                 call_args[1] = buf_end;
 
                 if (s) {
-                    call_args.push_back(codegen(op->args[i]));
+                    call_args.push_back(codegen(arg));
                     dst = builder->CreateCall(append_string, call_args);
                 } else if (t.is_bool()) {
-                    Value *a = codegen(op->args[i]);
+                    Value *a = codegen(arg);
                     Value *t = codegen(StringImm::make("true"));
                     Value *f = codegen(StringImm::make("false"));
                     call_args.push_back(builder->CreateSelect(a, t, f));
                     dst = builder->CreateCall(append_string, call_args);
                 } else if (t.is_int()) {
-                    call_args.push_back(codegen(Cast::make(Int(64), op->args[i])));
+                    call_args.push_back(codegen(Cast::make(Int(64), arg)));
                     call_args.push_back(ConstantInt::get(i32_t, 1));
                     dst = builder->CreateCall(append_int64, call_args);
                 } else if (t.is_uint()) {
-                    call_args.push_back(codegen(Cast::make(UInt(64), op->args[i])));
+                    call_args.push_back(codegen(Cast::make(UInt(64), arg)));
                     call_args.push_back(ConstantInt::get(i32_t, 1));
                     dst = builder->CreateCall(append_uint64, call_args);
                 } else if (t.is_float()) {
-                    call_args.push_back(codegen(Cast::make(Float(64), op->args[i])));
+                    call_args.push_back(codegen(Cast::make(Float(64), arg)));
                     // Use scientific notation for doubles
                     call_args.push_back(ConstantInt::get(i32_t, t.bits() == 64 ? 1 : 0));
                     dst = builder->CreateCall(append_double, call_args);
                 } else if (t == type_of<halide_buffer_t *>()) {
-                    Value *buf = codegen(op->args[i]);
+                    Value *buf = codegen(arg);
                     buf = builder->CreatePointerCast(buf, append_buffer->getFunctionType()->getParamType(2));
                     call_args.push_back(buf);
                     dst = builder->CreateCall(append_buffer, call_args);
                 } else {
                     internal_assert(t.is_handle());
-                    call_args.push_back(codegen(op->args[i]));
+                    call_args.push_back(codegen(arg));
                     dst = builder->CreateCall(append_pointer, call_args);
                 }
             }
@@ -4241,8 +4241,8 @@ void CodeGen_LLVM::visit(const IfThenElse *op) {
     Expr lhs;
     bool use_switch = blocks.size() > 1;
     vector<int> rhs;
-    for (size_t i = 0; i < blocks.size(); i++) {
-        const EQ *eq = blocks[i].first.as<EQ>();
+    for (auto &block : blocks) {
+        const EQ *eq = block.first.as<EQ>();
         const int64_t *r = eq ? as_const_int(eq->b) : nullptr;
         if (eq &&
             r &&
@@ -5121,8 +5121,7 @@ std::pair<llvm::Function *, int> CodeGen_LLVM::find_vector_runtime_function(cons
     // vector implementation).
     sizes_to_try.push_back(l * 2);
 
-    for (size_t i = 0; i < sizes_to_try.size(); i++) {
-        int l = sizes_to_try[i];
+    for (int l : sizes_to_try) {
         llvm::Function *vec_fn = module->getFunction(name + "x" + std::to_string(l));
         if (vec_fn) {
             return {vec_fn, l};

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -593,11 +593,11 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
     // The last condition is handled via the preprocessor in the kernel
     // declaration.
     vector<BufferSize> constants;
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer &&
-            CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
-            args[i].size > 0) {
-            constants.emplace_back(args[i].name, args[i].size);
+    for (const auto &arg : args) {
+        if (arg.is_buffer &&
+            CodeGen_GPU_Dev::is_buffer_constant(s, arg.name) &&
+            arg.size > 0) {
+            constants.emplace_back(arg.name, arg.size);
         }
     }
 
@@ -614,38 +614,38 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
 
     // Create preprocessor replacements for the address spaces of all our buffers.
     stream << "// Address spaces for " << name << "\n";
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
             vector<BufferSize>::iterator constant = constants.begin();
             while (constant != constants.end() &&
-                   constant->name != args[i].name) {
+                   constant->name != arg.name) {
                 constant++;
             }
 
             if (constant != constants.end()) {
                 stream << "#if " << constant->size << " < MAX_CONSTANT_BUFFER_SIZE && "
                        << constant - constants.begin() << " < MAX_CONSTANT_ARGS\n";
-                stream << "#define " << get_memory_space(args[i].name) << " constant\n";
+                stream << "#define " << get_memory_space(arg.name) << " constant\n";
                 stream << "#else\n";
-                stream << "#define " << get_memory_space(args[i].name) << " device\n";
+                stream << "#define " << get_memory_space(arg.name) << " device\n";
                 stream << "#endif\n";
             } else {
-                stream << "#define " << get_memory_space(args[i].name) << " device\n";
+                stream << "#define " << get_memory_space(arg.name) << " device\n";
             }
         }
     }
 
     // Emit a struct to hold the scalar args of the kernel
     bool any_scalar_args = false;
-    for (size_t i = 0; i < args.size(); i++) {
-        if (!args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (!arg.is_buffer) {
             if (!any_scalar_args) {
                 stream << "struct " + name + "_args {\n";
                 any_scalar_args = true;
             }
-            stream << print_type(args[i].type)
+            stream << print_type(arg.type)
                    << " "
-                   << print_name(args[i].name)
+                   << print_name(arg.name)
                    << ";\n";
         }
     }
@@ -663,18 +663,18 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
         buffer_index++;
     }
 
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
             stream << ",\n";
-            stream << " " << get_memory_space(args[i].name) << " ";
-            if (!args[i].write) {
+            stream << " " << get_memory_space(arg.name) << " ";
+            if (!arg.write) {
                 stream << "const ";
             }
-            stream << print_storage_type(args[i].type) << " *"
-                   << print_name(args[i].name) << " [[ buffer(" << buffer_index++ << ") ]]";
+            stream << print_storage_type(arg.type) << " *"
+                   << print_name(arg.name) << " [[ buffer(" << buffer_index++ << ") ]]";
             Allocation alloc;
-            alloc.type = args[i].type;
-            allocations.push(args[i].name, alloc);
+            alloc.type = arg.type;
+            allocations.push(arg.name, alloc);
         }
     }
 
@@ -708,12 +708,12 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
     open_scope();
 
     // Unpack args struct into local variables to match naming of generated code.
-    for (size_t i = 0; i < args.size(); i++) {
-        if (!args[i].is_buffer) {
-            stream << print_type(args[i].type)
+    for (const auto &arg : args) {
+        if (!arg.is_buffer) {
+            stream << print_type(arg.type)
                    << " "
-                   << print_name(args[i].name)
-                   << " = _scalar_args->" << print_name(args[i].name)
+                   << print_name(arg.name)
+                   << " = _scalar_args->" << print_name(arg.name)
                    << ";\n";
         }
     }
@@ -721,17 +721,17 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
     print(s);
     close_scope("kernel " + name);
 
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer) {
-            allocations.pop(args[i].name);
+        if (arg.is_buffer) {
+            allocations.pop(arg.name);
         }
     }
 
     // Undef all the buffer address spaces, in case they're different in another kernel.
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
-            stream << "#undef " << get_memory_space(args[i].name) << "\n";
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
+            stream << "#undef " << get_memory_space(arg.name) << "\n";
         }
     }
 }

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -936,11 +936,11 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // The last condition is handled via the preprocessor in the kernel
     // declaration.
     vector<BufferSize> constants;
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer &&
-            CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
-            args[i].size > 0) {
-            constants.emplace_back(args[i].name, args[i].size);
+    for (const auto &arg : args) {
+        if (arg.is_buffer &&
+            CodeGen_GPU_Dev::is_buffer_constant(s, arg.name) &&
+            arg.size > 0) {
+            constants.emplace_back(arg.name, arg.size);
         }
     }
 
@@ -957,23 +957,23 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
 
     // Create preprocessor replacements for the address spaces of all our buffers.
     stream << "// Address spaces for " << name << "\n";
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
             vector<BufferSize>::iterator constant = constants.begin();
             while (constant != constants.end() &&
-                   constant->name != args[i].name) {
+                   constant->name != arg.name) {
                 constant++;
             }
 
             if (constant != constants.end()) {
                 stream << "#if " << constant->size << " <= MAX_CONSTANT_BUFFER_SIZE && "
                        << constant - constants.begin() << " < MAX_CONSTANT_ARGS\n";
-                stream << "#define " << get_memory_space(args[i].name) << " __constant\n";
+                stream << "#define " << get_memory_space(arg.name) << " __constant\n";
                 stream << "#else\n";
-                stream << "#define " << get_memory_space(args[i].name) << " __global\n";
+                stream << "#define " << get_memory_space(arg.name) << " __global\n";
                 stream << "#endif\n";
             } else {
-                stream << "#define " << get_memory_space(args[i].name) << " __global\n";
+                stream << "#define " << get_memory_space(arg.name) << " __global\n";
             }
         }
     }
@@ -1059,30 +1059,30 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     open_scope();
 
     // Reinterpret half args passed as uint16 back to half
-    for (size_t i = 0; i < args.size(); i++) {
-        if (!args[i].is_buffer &&
-            args[i].type.is_float() &&
-            args[i].type.bits() < 32) {
-            stream << " const " << print_type(args[i].type)
-                   << " " << print_name(args[i].name)
-                   << " = half_from_bits(" << print_name(args[i].name + "_bits") << ");\n";
+    for (const auto &arg : args) {
+        if (!arg.is_buffer &&
+            arg.type.is_float() &&
+            arg.type.bits() < 32) {
+            stream << " const " << print_type(arg.type)
+                   << " " << print_name(arg.name)
+                   << " = half_from_bits(" << print_name(arg.name + "_bits") << ");\n";
         }
     }
 
     print(s);
     close_scope("kernel " + name);
 
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer) {
-            allocations.pop(args[i].name);
+        if (arg.is_buffer) {
+            allocations.pop(arg.name);
         }
     }
 
     // Undef all the buffer address spaces, in case they're different in another kernel.
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
-            stream << "#undef " << get_memory_space(args[i].name) << "\n";
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
+            stream << "#undef " << get_memory_space(arg.name) << "\n";
         }
     }
 }

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -218,8 +218,8 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
     debug(2) << "Done generating llvm bitcode for PTX\n";
 
     // Clear the symbol table
-    for (size_t i = 0; i < arg_sym_names.size(); i++) {
-        sym_pop(arg_sym_names[i]);
+    for (auto &arg_sym_name : arg_sym_names) {
+        sym_pop(arg_sym_name);
     }
 }
 
@@ -703,8 +703,8 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
 
     // Run optimization passes
     function_pass_manager.doInitialization();
-    for (llvm::Module::iterator i = module->begin(); i != module->end(); i++) {
-        function_pass_manager.run(*i);
+    for (auto &i : *module) {
+        function_pass_manager.run(i);
     }
     function_pass_manager.doFinalization();
     module_pass_manager.run(*module);

--- a/src/CodeGen_Posix.cpp
+++ b/src/CodeGen_Posix.cpp
@@ -38,8 +38,8 @@ Value *CodeGen_Posix::codegen_allocation_size(const std::string &name, Type type
     Expr total_size_hi = make_zero(UInt(64));
 
     Expr low_mask = make_const(UInt(64), (uint64_t)(0xffffffff));
-    for (size_t i = 0; i < extents.size(); i++) {
-        Expr next_extent = cast(UInt(32), max(0, extents[i]));
+    for (const auto &extent : extents) {
+        Expr next_extent = cast(UInt(32), max(0, extent));
 
         // Update total_size >> 32. This math can't overflow due to
         // the loop invariant:

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -107,36 +107,36 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
     }
 
     stream << get_indent() << "// Check tensors have contiguous memory and are on the correct device\n";
-    for (size_t i = 0; i < buffer_args.size(); i++) {
+    for (auto &buffer_arg : buffer_args) {
         stream << get_indent();
         stream
             << "HLPT_CHECK_CONTIGUOUS("
-            << c_print_name(buffer_args[i].name)
+            << c_print_name(buffer_arg.name)
             << ");\n";
 
         if (is_cuda) {
             stream << get_indent();
             stream
                 << "HLPT_CHECK_DEVICE("
-                << c_print_name(buffer_args[i].name)
+                << c_print_name(buffer_arg.name)
                 << ", device_id);\n";
         }
     }
     stream << "\n";
 
     stream << get_indent() << "// Wrap tensors in Halide buffers\n";
-    for (size_t i = 0; i < buffer_args.size(); i++) {
-        if (!buffer_args[i].is_buffer()) {
+    for (auto &buffer_arg : buffer_args) {
+        if (!buffer_arg.is_buffer()) {
             continue;
         }
 
         stream << get_indent();
-        std::string tp = type_to_c_type(buffer_args[i].type, false);
+        std::string tp = type_to_c_type(buffer_arg.type, false);
         stream
             << "Halide::Runtime::Buffer<" << tp << "> "
-            << c_print_name(buffer_args[i].name)
+            << c_print_name(buffer_arg.name)
             << "_buffer = Halide::PyTorch::wrap<" << tp << ">("
-            << c_print_name(buffer_args[i].name)
+            << c_print_name(buffer_arg.name)
             << ");\n";
     }
     stream << "\n";
@@ -164,19 +164,19 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
 
     if (is_cuda) {
         stream << get_indent() << "// Make sure data is on device\n";
-        for (size_t i = 0; i < buffer_args.size(); i++) {
-            if (buffer_args[i].is_buffer()) {
+        for (auto &buffer_arg : buffer_args) {
+            if (buffer_arg.is_buffer()) {
                 stream << get_indent();
                 stream
                     << "AT_ASSERTM(!"
-                    << c_print_name(buffer_args[i].name) << "_buffer.host_dirty(),"
+                    << c_print_name(buffer_arg.name) << "_buffer.host_dirty(),"
                     << "\"device not synchronized for buffer "
-                    << c_print_name(buffer_args[i].name)
+                    << c_print_name(buffer_arg.name)
                     << ", make sure all update stages are explicitly computed on GPU."
                     << "\");\n";
                 stream << get_indent();
                 stream
-                    << c_print_name(buffer_args[i].name) << "_buffer"
+                    << c_print_name(buffer_arg.name) << "_buffer"
                     << ".device_detach_native();\n";
             }
         }

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -483,8 +483,7 @@ void CodeGen_X86::visit(const Call *op) {
     // clang-format on
 
     vector<Expr> matches;
-    for (size_t i = 0; i < sizeof(patterns) / sizeof(patterns[0]); i++) {
-        const Pattern &pattern = patterns[i];
+    for (const auto &pattern : patterns) {
         if (expr_match(pattern.pattern, op, matches)) {
             value = call_overloaded_intrin(op->type, pattern.intrin, matches);
             if (value) {

--- a/src/DebugToFile.cpp
+++ b/src/DebugToFile.cpp
@@ -39,8 +39,8 @@ class DebugToFile : public IRMutator {
             // what we're doing (e.g. so we trigger a copy-back from a
             // device pointer).
             Expr num_elements = 1;
-            for (size_t i = 0; i < op->bounds.size(); i++) {
-                num_elements *= op->bounds[i].extent;
+            for (const auto &bound : op->bounds) {
+                num_elements *= bound.extent;
             }
 
             int type_code = 0;

--- a/src/Definition.cpp
+++ b/src/Definition.cpp
@@ -55,11 +55,11 @@ struct DefinitionContents {
             predicate = mutator->mutate(predicate);
         }
 
-        for (size_t i = 0; i < values.size(); ++i) {
-            values[i] = mutator->mutate(values[i]);
+        for (auto &value : values) {
+            value = mutator->mutate(value);
         }
-        for (size_t i = 0; i < args.size(); ++i) {
-            args[i] = mutator->mutate(args[i]);
+        for (auto &arg : args) {
+            arg = mutator->mutate(arg);
         }
 
         stage_schedule.mutate(mutator);
@@ -102,8 +102,8 @@ Definition::Definition(const std::vector<Expr> &args, const std::vector<Expr> &v
     contents->source_location = Introspection::get_source_location();
     if (rdom.defined()) {
         contents->predicate = rdom.predicate();
-        for (size_t i = 0; i < rdom.domain().size(); i++) {
-            contents->stage_schedule.rvars().push_back(rdom.domain()[i]);
+        for (const auto &i : rdom.domain()) {
+            contents->stage_schedule.rvars().push_back(i);
         }
     }
 }

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -235,8 +235,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
     // functions extremely difficult.
     is_forward_overwrite_detection_phase = true;
     set<FuncKey> non_overwriting_scans;
-    for (int func_id = 0; func_id < (int)funcs.size(); func_id++) {
-        const Func &func = funcs[func_id];
+    for (auto &func : funcs) {
         current_func = func;
         // Precompute the left hand side intervals for each update
         // We use this to determine if there's overlaps between the updates
@@ -247,9 +246,9 @@ void ReverseAccumulationVisitor::propagate_adjoints(
             const vector<Expr> &args = func.update_args(update_id);
             vector<Interval> intervals;
             intervals.reserve(args.size());
-            for (int arg_id = 0; arg_id < (int)args.size(); arg_id++) {
+            for (const auto &arg : args) {
                 Scope<Interval> scope;
-                ReductionDomain rdom = extract_rdom(args[arg_id]);
+                ReductionDomain rdom = extract_rdom(arg);
                 if (rdom.defined()) {
                     const vector<ReductionVariable> &rvars = rdom.domain();
                     for (const auto &r : rvars) {
@@ -257,7 +256,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                         scope.push(r.var, Interval(r.min, r_max));
                     }
                 }
-                Interval interval = bounds_of_expr_in_scope(args[arg_id], scope);
+                Interval interval = bounds_of_expr_in_scope(arg, scope);
                 intervals.push_back(interval);
             }
             boxes.emplace_back(intervals);
@@ -333,8 +332,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
             // Gather let variables
             let_var_mapping.clear();
             let_variables.clear();
-            for (auto it = expr_list.begin(); it != expr_list.end(); it++) {
-                Expr expr = *it;
+            for (const auto &expr : expr_list) {
                 if (expr.get()->node_type == IRNodeType::Let) {
                     const Let *op = expr.as<Let>();
                     // Assume Let variables are unique
@@ -347,8 +345,8 @@ void ReverseAccumulationVisitor::propagate_adjoints(
             // Set the output adjoint to 1
             // We're not really propagating adjoints, just checking if there's
             // self references
-            for (int i = 0; i < (int)output_exprs.size(); i++) {
-                expr_adjoints[output_exprs[i]] = 1.f;
+            for (auto &output_expr : output_exprs) {
+                expr_adjoints[output_expr] = 1.f;
             }
 
             // Traverse the expressions in reverse order
@@ -535,8 +533,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
     }
     // Also create stubs for buffers referenced by the functions
     map<string, BufferInfo> called_buffers_or_param;
-    for (int func_id = 0; func_id < (int)funcs.size(); func_id++) {
-        const Func &func = funcs[func_id];
+    for (auto &func : funcs) {
         map<string, BufferInfo> buffers = find_buffer_param_calls(func);
         called_buffers_or_param.insert(buffers.begin(), buffers.end());
     }
@@ -660,8 +657,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
             // Gather let variables
             let_var_mapping.clear();
             let_variables.clear();
-            for (auto it = expr_list.begin(); it != expr_list.end(); it++) {
-                Expr expr = *it;
+            for (const auto &expr : expr_list) {
                 if (expr.get()->node_type == IRNodeType::Let) {
                     const Let *op = expr.as<Let>();
                     // Assume Let variables are unique
@@ -1210,8 +1206,8 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
     // Add Let expressions
     adjoint = add_let_expression(adjoint, let_var_mapping, let_variables);
     vector<Expr> lhs = call_args;
-    for (int i = 0; i < (int)lhs.size(); i++) {
-        lhs[i] = add_let_expression(lhs[i], let_var_mapping, let_variables);
+    for (auto &lh : lhs) {
+        lh = add_let_expression(lh, let_var_mapping, let_variables);
     }
     Expr adjoint_before_canonicalize = adjoint;
     vector<Expr> lhs_before_canonicalize = lhs;
@@ -1225,8 +1221,8 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
             self_reference_adjoint[value_index] =
                 simplify(self_reference_adjoint[value_index] + adjoint);
             vector<Expr> args = call_args;
-            for (int i = 0; i < (int)args.size(); i++) {
-                args[i] = add_let_expression(args[i], let_var_mapping, let_variables);
+            for (auto &arg : args) {
+                arg = add_let_expression(arg, let_var_mapping, let_variables);
             }
             self_reference_args.push_back(args);
         }
@@ -1426,9 +1422,9 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
     // When we update d_f, the second n would be replaced by y.
     // We need to make sure we also update the call argument to g.
     // Adjoint is automatically handled in the loop above.
-    for (int i = 0; i < (int)lhs.size(); i++) {
+    for (auto &lh : lhs) {
         for (const auto &it : lhs_substitute_map) {
-            lhs[i] = substitute(it.first, it.second, lhs[i]);
+            lh = substitute(it.first, it.second, lh);
         }
     }
 
@@ -1449,9 +1445,9 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
             // For each variable found in lhs_arg, find the corresponding
             // bound (by looping through all variables) and substitute
             // with the bound reduction variable.
-            for (int var_id = 0; var_id < (int)variable_ids.size(); var_id++) {
+            for (int variable_id : variable_ids) {
                 for (int arg_id = 0; arg_id < (int)current_args.size(); arg_id++) {
-                    const string &variable = adjoint_args[variable_ids[var_id]];
+                    const string &variable = adjoint_args[variable_id];
                     if (current_args[arg_id].name() == variable &&
                         canonicalized_vars.find(
                             current_args[arg_id].name()) ==
@@ -1499,8 +1495,8 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
 
     // Simplify expressions
     adjoint = simplify(common_subexpression_elimination(adjoint));
-    for (int i = 0; i < (int)lhs.size(); i++) {
-        lhs[i] = simplify(common_subexpression_elimination(lhs[i]));
+    for (auto &lh : lhs) {
+        lh = simplify(common_subexpression_elimination(lh));
     }
 
     vector<Var> func_to_update_args = func_to_update.args();
@@ -1771,8 +1767,8 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
 
     // Simplify expressions
     adjoint = simplify(common_subexpression_elimination(adjoint));
-    for (int i = 0; i < (int)lhs.size(); i++) {
-        lhs[i] = simplify(common_subexpression_elimination(lhs[i]));
+    for (auto &lh : lhs) {
+        lh = simplify(common_subexpression_elimination(lh));
     }
 
     if (debug_flag) {

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -19,10 +19,10 @@ bool lookup_runtime_routine(const std::string &name,
     std::vector<JITModule> runtime(
         JITSharedRuntime::get(nullptr, target.with_feature(Target::JIT)));
 
-    for (size_t i = 0; i < runtime.size(); i++) {
+    for (auto &i : runtime) {
         std::map<std::string, JITModule::Symbol>::const_iterator f =
-            runtime[i].exports().find(name);
-        if (f != runtime[i].exports().end()) {
+            i.exports().find(name);
+        if (f != i.exports().end()) {
             result = reinterpret_bits<fn_type>(f->second.address);
             return true;
         }

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -228,8 +228,8 @@ struct CheckVars : public IRGraphVisitor {
         }
 
         // Is it a pure argument?
-        for (size_t i = 0; i < pure_args.size(); i++) {
-            if (var->name == pure_args[i]) {
+        for (auto &pure_arg : pure_args) {
+            if (var->name == pure_arg) {
                 return;
             }
         }
@@ -391,8 +391,8 @@ void Function::define(const vector<string> &args, vector<Expr> values) {
         << "In pure definition of Func \"" << name() << "\":\n"
         << "Func with extern definition cannot be given a pure definition.\n";
     user_assert(!name().empty()) << "A Func may not have an empty name.\n";
-    for (size_t i = 0; i < values.size(); i++) {
-        user_assert(values[i].defined())
+    for (auto &value : values) {
+        user_assert(value.defined())
             << "In pure definition of Func \"" << name() << "\":\n"
             << "Undefined expression in right-hand-side of definition.\n";
     }
@@ -467,10 +467,10 @@ void Function::define(const vector<string> &args, vector<Expr> values) {
     ReductionDomain rdom;
     contents->init_def = Definition(init_def_args, values, rdom, true);
 
-    for (size_t i = 0; i < args.size(); i++) {
-        Dim d = {args[i], ForType::Serial, DeviceAPI::None, DimType::PureVar};
+    for (const auto &arg : args) {
+        Dim d = {arg, ForType::Serial, DeviceAPI::None, DimType::PureVar};
         contents->init_def.schedule().dims().push_back(d);
-        StorageDim sd = {args[i]};
+        StorageDim sd = {arg};
         contents->func_schedule.storage_dims().push_back(sd);
     }
 
@@ -507,8 +507,8 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
         << "Func " << name() << " cannot be given a new update definition, "
         << "because it has already been realized or used in the definition of another Func.\n";
 
-    for (size_t i = 0; i < values.size(); i++) {
-        user_assert(values[i].defined())
+    for (auto &value : values) {
+        user_assert(value.defined())
             << "In update definition " << update_idx << " of Func \"" << name() << "\":\n"
             << "Undefined expression in right-hand-side of update.\n";
     }
@@ -652,12 +652,11 @@ void Function::define_update(const vector<Expr> &_args, vector<Expr> values) {
 
     // First add any reduction domain
     if (check.reduction_domain.defined()) {
-        for (size_t i = 0; i < check.reduction_domain.domain().size(); i++) {
+        for (const auto &rvar : check.reduction_domain.domain()) {
             // Is this RVar actually pure (safe to parallelize and
             // reorder)? It's pure if one value of the RVar can never
             // access from the same memory that another RVar is
             // writing to.
-            const ReductionVariable &rvar = check.reduction_domain.domain()[i];
             const string &v = rvar.var;
 
             bool pure = can_parallelize_rvar(v, name(), r);
@@ -715,9 +714,9 @@ void Function::define_extern(const std::string &function_name,
 
     std::vector<string> arg_names;
     std::vector<Expr> arg_exprs;
-    for (size_t i = 0; i < args.size(); i++) {
-        arg_names.push_back(args[i].name());
-        arg_exprs.push_back(args[i]);
+    for (const auto &arg : args) {
+        arg_names.push_back(arg.name());
+        arg_exprs.push_back(arg);
     }
     contents->args = arg_names;
     contents->extern_function_name = function_name;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -136,8 +136,8 @@ std::vector<Type> parse_halide_type_list(const std::string &types) {
 void ValueTracker::track_values(const std::string &name, const std::vector<Expr> &values) {
     std::vector<std::vector<Expr>> &history = values_history[name];
     if (history.empty()) {
-        for (size_t i = 0; i < values.size(); ++i) {
-            history.push_back({values[i]});
+        for (const auto &value : values) {
+            history.push_back({value});
         }
         return;
     }
@@ -581,8 +581,8 @@ void StubEmitter::emit() {
     stream << get_indent() << "generator_params.to_generator_params_map(),\n";
     stream << get_indent() << "{\n";
     indent_level++;
-    for (size_t i = 0; i < inputs.size(); ++i) {
-        stream << get_indent() << "Stub::to_stub_input_vector(inputs." << inputs[i]->name() << ")";
+    for (auto *input : inputs) {
+        stream << get_indent() << "Stub::to_stub_input_vector(inputs." << input->name() << ")";
         stream << ",\n";
     }
     indent_level--;

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -2269,8 +2269,8 @@ class ScatterGatherGenerator : public IRMutator {
         }
         // Calculate the size of the buffer lut in bytes.
         Expr size = ty.bytes();
-        for (size_t i = 0; i < alloc->extents.size(); i++) {
-            size *= alloc->extents[i];
+        for (const auto &extent : alloc->extents) {
+            size *= extent;
         }
         Expr src = Variable::make(Handle(), op->name);
         Expr new_index = mutate(cast(ty.with_code(Type::Int), index));
@@ -2327,8 +2327,8 @@ class ScatterGatherGenerator : public IRMutator {
         }
         // Calculate the size of the buffer in bytes.
         Expr size = ty.bytes();
-        for (size_t i = 0; i < alloc->extents.size(); i++) {
-            size *= alloc->extents[i];
+        for (const auto &extent : alloc->extents) {
+            size *= extent;
         }
         // Check for scatter-acc.
         Expr value = is_scatter_acc(op);

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -374,11 +374,11 @@ Stmt Store::make(const std::string &name, Expr value, Expr index, Parameter para
 Stmt Provide::make(const std::string &name, const std::vector<Expr> &values, const std::vector<Expr> &args, const Expr &predicate) {
     internal_assert(predicate.defined()) << "Provide with undefined predicate\n";
     internal_assert(!values.empty()) << "Provide of no values\n";
-    for (size_t i = 0; i < values.size(); i++) {
-        internal_assert(values[i].defined()) << "Provide of undefined value\n";
+    for (const auto &value : values) {
+        internal_assert(value.defined()) << "Provide of undefined value\n";
     }
-    for (size_t i = 0; i < args.size(); i++) {
-        internal_assert(args[i].defined()) << "Provide to undefined location\n";
+    for (const auto &arg : args) {
+        internal_assert(arg.defined()) << "Provide to undefined location\n";
     }
 
     Provide *node = new Provide;
@@ -393,9 +393,9 @@ Stmt Allocate::make(const std::string &name, Type type, MemoryType memory_type,
                     const std::vector<Expr> &extents,
                     Expr condition, Stmt body,
                     Expr new_expr, const std::string &free_function) {
-    for (size_t i = 0; i < extents.size(); i++) {
-        internal_assert(extents[i].defined()) << "Allocate of undefined extent\n";
-        internal_assert(extents[i].type().is_scalar() == 1) << "Allocate of vector extent\n";
+    for (const auto &extent : extents) {
+        internal_assert(extent.defined()) << "Allocate of undefined extent\n";
+        internal_assert(extent.type().is_scalar() == 1) << "Allocate of vector extent\n";
     }
     internal_assert(body.defined()) << "Allocate of undefined\n";
     internal_assert(condition.defined()) << "Allocate with undefined condition\n";
@@ -416,8 +416,8 @@ Stmt Allocate::make(const std::string &name, Type type, MemoryType memory_type,
 int32_t Allocate::constant_allocation_size(const std::vector<Expr> &extents, const std::string &name) {
     int64_t result = 1;
 
-    for (size_t i = 0; i < extents.size(); i++) {
-        if (const IntImm *int_size = extents[i].as<IntImm>()) {
+    for (const auto &extent : extents) {
+        if (const IntImm *int_size = extent.as<IntImm>()) {
             // Check if the individual dimension is > 2^31 - 1. Not
             // currently necessary because it's an int32_t, which is
             // always smaller than 2^31 - 1. If we ever upgrade the
@@ -455,11 +455,11 @@ Stmt Free::make(const std::string &name) {
 }
 
 Stmt Realize::make(const std::string &name, const std::vector<Type> &types, MemoryType memory_type, const Region &bounds, Expr condition, Stmt body) {
-    for (size_t i = 0; i < bounds.size(); i++) {
-        internal_assert(bounds[i].min.defined()) << "Realize of undefined\n";
-        internal_assert(bounds[i].extent.defined()) << "Realize of undefined\n";
-        internal_assert(bounds[i].min.type().is_scalar()) << "Realize of vector size\n";
-        internal_assert(bounds[i].extent.type().is_scalar()) << "Realize of vector size\n";
+    for (const auto &bound : bounds) {
+        internal_assert(bound.min.defined()) << "Realize of undefined\n";
+        internal_assert(bound.extent.defined()) << "Realize of undefined\n";
+        internal_assert(bound.min.type().is_scalar()) << "Realize of vector size\n";
+        internal_assert(bound.extent.type().is_scalar()) << "Realize of vector size\n";
     }
     internal_assert(body.defined()) << "Realize of undefined\n";
     internal_assert(!types.empty()) << "Realize has empty type\n";
@@ -480,11 +480,11 @@ Stmt Prefetch::make(const std::string &name, const std::vector<Type> &types,
                     const Region &bounds,
                     const PrefetchDirective &prefetch,
                     Expr condition, Stmt body) {
-    for (size_t i = 0; i < bounds.size(); i++) {
-        internal_assert(bounds[i].min.defined()) << "Prefetch of undefined\n";
-        internal_assert(bounds[i].extent.defined()) << "Prefetch of undefined\n";
-        internal_assert(bounds[i].min.type().is_scalar()) << "Prefetch of vector size\n";
-        internal_assert(bounds[i].extent.type().is_scalar()) << "Prefetch of vector size\n";
+    for (const auto &bound : bounds) {
+        internal_assert(bound.min.defined()) << "Prefetch of undefined\n";
+        internal_assert(bound.extent.defined()) << "Prefetch of undefined\n";
+        internal_assert(bound.min.type().is_scalar()) << "Prefetch of vector size\n";
+        internal_assert(bound.extent.type().is_scalar()) << "Prefetch of vector size\n";
     }
     internal_assert(!types.empty()) << "Prefetch has empty type\n";
     internal_assert(body.defined()) << "Prefetch of undefined\n";
@@ -681,15 +681,15 @@ Expr Call::make(Type type, const std::string &name, const std::vector<Expr> &arg
         internal_assert(args[i].defined()) << "Call of " << name << " with argument " << i << " undefined.\n";
     }
     if (call_type == Halide) {
-        for (size_t i = 0; i < args.size(); i++) {
-            internal_assert(args[i].type() == Int(32))
+        for (const auto &arg : args) {
+            internal_assert(arg.type() == Int(32))
                 << "Args to call to halide function must be type Int(32)\n";
         }
     } else if (call_type == Image) {
         internal_assert((param.defined() || image.defined()))
             << "Call node to undefined image\n";
-        for (size_t i = 0; i < args.size(); i++) {
-            internal_assert(args[i].type() == Int(32))
+        for (const auto &arg : args) {
+            internal_assert(arg.type() == Int(32))
                 << "Args to load from image must be type Int(32)\n";
         }
     }
@@ -771,8 +771,8 @@ Expr Shuffle::make_concat(const std::vector<Expr> &vectors) {
 
     std::vector<int> indices;
     int lane = 0;
-    for (int i = 0; i < (int)vectors.size(); i++) {
-        for (int j = 0; j < vectors[i].type().lanes(); j++) {
+    for (const auto &vector : vectors) {
+        for (int j = 0; j < vector.type().lanes(); j++) {
             indices.push_back(lane++);
         }
     }

--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -57,9 +57,9 @@ public:
     }
 
     void clear() {
-        for (size_t i = 0; i < entries.size(); i++) {
-            entries[i].a = Expr();
-            entries[i].b = Expr();
+        for (auto &entrie : entries) {
+            entrie.a = Expr();
+            entrie.b = Expr();
         }
     }
 

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -444,8 +444,7 @@ void IRPrinter::visit(const FloatImm *op) {
 
 void IRPrinter::visit(const StringImm *op) {
     stream << "\"";
-    for (size_t i = 0; i < op->value.size(); i++) {
-        unsigned char c = op->value[i];
+    for (unsigned char c : op->value) {
         if (c >= ' ' && c <= '~' && c != '\\' && c != '"') {
             stream << c;
         } else {
@@ -840,9 +839,9 @@ void IRPrinter::visit(const Provide *op) {
 void IRPrinter::visit(const Allocate *op) {
     ScopedBinding<> bind(known_type, op->name);
     stream << get_indent() << "allocate " << op->name << "[" << op->type;
-    for (size_t i = 0; i < op->extents.size(); i++) {
+    for (const auto &extent : op->extents) {
         stream << " * ";
-        print(op->extents[i]);
+        print(extent);
     }
     stream << "]";
     if (op->memory_type != MemoryType::Auto) {

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -125,16 +125,15 @@ void IRVisitor::visit(const Broadcast *op) {
 }
 
 void IRVisitor::visit(const Call *op) {
-    for (size_t i = 0; i < op->args.size(); i++) {
-        op->args[i].accept(this);
+    for (const auto &arg : op->args) {
+        arg.accept(this);
     }
 
     // Consider extern call args
     if (op->func.defined()) {
         Function f(op->func);
         if (op->call_type == Call::Halide && f.has_extern_definition()) {
-            for (size_t i = 0; i < f.extern_arguments().size(); i++) {
-                ExternFuncArgument arg = f.extern_arguments()[i];
+            for (const auto &arg : f.extern_arguments()) {
                 if (arg.is_expr()) {
                     arg.expr.accept(this);
                 }
@@ -182,17 +181,17 @@ void IRVisitor::visit(const Store *op) {
 
 void IRVisitor::visit(const Provide *op) {
     op->predicate.accept(this);
-    for (size_t i = 0; i < op->values.size(); i++) {
-        op->values[i].accept(this);
+    for (const auto &value : op->values) {
+        value.accept(this);
     }
-    for (size_t i = 0; i < op->args.size(); i++) {
-        op->args[i].accept(this);
+    for (const auto &arg : op->args) {
+        arg.accept(this);
     }
 }
 
 void IRVisitor::visit(const Allocate *op) {
-    for (size_t i = 0; i < op->extents.size(); i++) {
-        op->extents[i].accept(this);
+    for (const auto &extent : op->extents) {
+        extent.accept(this);
     }
     op->condition.accept(this);
     if (op->new_expr.defined()) {
@@ -205,18 +204,18 @@ void IRVisitor::visit(const Free *op) {
 }
 
 void IRVisitor::visit(const Realize *op) {
-    for (size_t i = 0; i < op->bounds.size(); i++) {
-        op->bounds[i].min.accept(this);
-        op->bounds[i].extent.accept(this);
+    for (const auto &bound : op->bounds) {
+        bound.min.accept(this);
+        bound.extent.accept(this);
     }
     op->condition.accept(this);
     op->body.accept(this);
 }
 
 void IRVisitor::visit(const Prefetch *op) {
-    for (size_t i = 0; i < op->bounds.size(); i++) {
-        op->bounds[i].min.accept(this);
-        op->bounds[i].extent.accept(this);
+    for (const auto &bound : op->bounds) {
+        bound.min.accept(this);
+        bound.extent.accept(this);
     }
     op->condition.accept(this);
     op->body.accept(this);
@@ -397,8 +396,8 @@ void IRGraphVisitor::visit(const Broadcast *op) {
 }
 
 void IRGraphVisitor::visit(const Call *op) {
-    for (size_t i = 0; i < op->args.size(); i++) {
-        include(op->args[i]);
+    for (const auto &arg : op->args) {
+        include(arg);
     }
 }
 
@@ -440,17 +439,17 @@ void IRGraphVisitor::visit(const Store *op) {
 }
 
 void IRGraphVisitor::visit(const Provide *op) {
-    for (size_t i = 0; i < op->values.size(); i++) {
-        include(op->values[i]);
+    for (const auto &value : op->values) {
+        include(value);
     }
-    for (size_t i = 0; i < op->args.size(); i++) {
-        include(op->args[i]);
+    for (const auto &arg : op->args) {
+        include(arg);
     }
 }
 
 void IRGraphVisitor::visit(const Allocate *op) {
-    for (size_t i = 0; i < op->extents.size(); i++) {
-        include(op->extents[i]);
+    for (const auto &extent : op->extents) {
+        include(extent);
     }
     include(op->condition);
     if (op->new_expr.defined()) {
@@ -463,18 +462,18 @@ void IRGraphVisitor::visit(const Free *op) {
 }
 
 void IRGraphVisitor::visit(const Realize *op) {
-    for (size_t i = 0; i < op->bounds.size(); i++) {
-        include(op->bounds[i].min);
-        include(op->bounds[i].extent);
+    for (const auto &bound : op->bounds) {
+        include(bound.min);
+        include(bound.extent);
     }
     include(op->condition);
     include(op->body);
 }
 
 void IRGraphVisitor::visit(const Prefetch *op) {
-    for (size_t i = 0; i < op->bounds.size(); i++) {
-        include(op->bounds[i].min);
-        include(op->bounds[i].extent);
+    for (const auto &bound : op->bounds) {
+        include(bound.min);
+        include(bound.extent);
     }
     include(op->condition);
     include(op->body);

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -38,8 +38,7 @@ void validate_schedule_inlined_function(Function f) {
                    << f.name() << " because the function is scheduled inline.\n";
     }
 
-    for (size_t i = 0; i < stage_s.dims().size(); i++) {
-        Dim d = stage_s.dims()[i];
+    for (const auto &d : stage_s.dims()) {
         if (d.is_unordered_parallel()) {
             user_error << "Cannot parallelize dimension "
                        << d.var << " of function "
@@ -55,40 +54,40 @@ void validate_schedule_inlined_function(Function f) {
         }
     }
 
-    for (size_t i = 0; i < stage_s.splits().size(); i++) {
-        if (stage_s.splits()[i].is_rename()) {
+    for (const auto &i : stage_s.splits()) {
+        if (i.is_rename()) {
             user_warning << "It is meaningless to rename variable "
-                         << stage_s.splits()[i].old_var << " of function "
-                         << f.name() << " to " << stage_s.splits()[i].outer
+                         << i.old_var << " of function "
+                         << f.name() << " to " << i.outer
                          << " because " << f.name() << " is scheduled inline.\n";
-        } else if (stage_s.splits()[i].is_fuse()) {
+        } else if (i.is_fuse()) {
             user_warning << "It is meaningless to fuse variables "
-                         << stage_s.splits()[i].inner << " and " << stage_s.splits()[i].outer
+                         << i.inner << " and " << i.outer
                          << " because " << f.name() << " is scheduled inline.\n";
         } else {
             user_warning << "It is meaningless to split variable "
-                         << stage_s.splits()[i].old_var << " of function "
+                         << i.old_var << " of function "
                          << f.name() << " into "
-                         << stage_s.splits()[i].outer << " * "
-                         << stage_s.splits()[i].factor << " + "
-                         << stage_s.splits()[i].inner << " because "
+                         << i.outer << " * "
+                         << i.factor << " + "
+                         << i.inner << " because "
                          << f.name() << " is scheduled inline.\n";
         }
     }
 
-    for (size_t i = 0; i < func_s.bounds().size(); i++) {
-        if (func_s.bounds()[i].min.defined()) {
+    for (const auto &i : func_s.bounds()) {
+        if (i.min.defined()) {
             user_warning << "It is meaningless to bound dimension "
-                         << func_s.bounds()[i].var << " of function "
+                         << i.var << " of function "
                          << f.name() << " to be within ["
-                         << func_s.bounds()[i].min << ", "
-                         << func_s.bounds()[i].extent << "] because the function is scheduled inline.\n";
-        } else if (func_s.bounds()[i].modulus.defined()) {
+                         << i.min << ", "
+                         << i.extent << "] because the function is scheduled inline.\n";
+        } else if (i.modulus.defined()) {
             user_warning << "It is meaningless to align the bounds of dimension "
-                         << func_s.bounds()[i].var << " of function "
+                         << i.var << " of function "
                          << f.name() << " to have modulus/remainder ["
-                         << func_s.bounds()[i].modulus << ", "
-                         << func_s.bounds()[i].remainder << "] because the function is scheduled inline.\n";
+                         << i.modulus << ", "
+                         << i.remainder << "] because the function is scheduled inline.\n";
         }
     }
 }

--- a/src/InlineReductions.cpp
+++ b/src/InlineReductions.cpp
@@ -93,8 +93,8 @@ private:
             return expr;
         }
 
-        for (size_t i = 0; i < free_vars.size(); i++) {
-            if (var_name == free_vars[i].name()) {
+        for (auto &free_var : free_vars) {
+            if (var_name == free_var.name()) {
                 return expr;
             }
         }

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -227,11 +227,11 @@ public:
         bool found = false;
         uint64_t pc_real = (uint64_t)fn;
         int64_t pc_adjust = 0;
-        for (size_t i = 0; i < functions.size(); i++) {
-            if (functions[i].name == "HalideIntrospectionCanary::offset_marker" &&
-                functions[i].pc_begin) {
+        for (auto &function : functions) {
+            if (function.name == "HalideIntrospectionCanary::offset_marker" &&
+                function.pc_begin) {
 
-                uint64_t pc_debug = functions[i].pc_begin;
+                uint64_t pc_debug = function.pc_begin;
 
                 if (calibrated) {
                     // If we're already calibrated, we should find a function with a matching pc
@@ -268,25 +268,23 @@ public:
 
         debug(5) << "Program counter adjustment between debug info and actual code: " << pc_adjust << "\n";
 
-        for (size_t i = 0; i < functions.size(); i++) {
-            FunctionInfo &f = functions[i];
+        for (auto &f : functions) {
             f.pc_begin += pc_adjust;
             f.pc_end += pc_adjust;
-            for (size_t j = 0; j < f.variables.size(); j++) {
-                LocalVariable &v = f.variables[j];
-                for (size_t k = 0; k < v.live_ranges.size(); k++) {
-                    v.live_ranges[k].pc_begin += pc_adjust;
-                    v.live_ranges[k].pc_end += pc_adjust;
+            for (auto &v : f.variables) {
+                for (auto &live_range : v.live_ranges) {
+                    live_range.pc_begin += pc_adjust;
+                    live_range.pc_end += pc_adjust;
                 }
             }
         }
 
-        for (size_t i = 0; i < source_lines.size(); i++) {
-            source_lines[i].pc += pc_adjust;
+        for (auto &source_line : source_lines) {
+            source_line.pc += pc_adjust;
         }
 
-        for (size_t i = 0; i < global_variables.size(); i++) {
-            global_variables[i].addr += pc_adjust;
+        for (auto &global_variable : global_variables) {
+            global_variable.addr += pc_adjust;
         }
 
         calibrated = true;
@@ -430,8 +428,7 @@ public:
         heap_object.addr = (uint64_t)obj;
 
         // Recursively enumerate the members.
-        for (size_t i = 0; i < object_type->members.size(); i++) {
-            const LocalVariable &member_spec = object_type->members[i];
+        for (auto &member_spec : object_type->members) {
             HeapObject::Member member;
             member.name = member_spec.name;
             member.type = member_spec.type;
@@ -489,8 +486,7 @@ public:
         std::stable_sort(heap_object.members.begin(), heap_object.members.end());
 
         debug(5) << "Children of heap object of type " << object_type->name << " at " << obj << ":\n";
-        for (size_t i = 0; i < heap_object.members.size(); i++) {
-            const HeapObject::Member &mem = heap_object.members[i];
+        for (auto &mem : heap_object.members) {
             debug(5) << std::hex << mem.addr << std::dec << ": " << mem.type->name << " " << mem.name << "\n";
         }
 
@@ -535,29 +531,29 @@ public:
         std::regex re(type_name);
 
         // Look in the members for the appropriate offset.
-        for (size_t i = 0; i < obj.members.size(); i++) {
-            TypeInfo *t = obj.members[i].type;
+        for (const auto &member : obj.members) {
+            TypeInfo *t = member.type;
 
             if (!t) {
                 continue;
             }
 
-            debug(5) << "Comparing to member " << obj.members[i].name
-                     << " at address " << std::hex << obj.members[i].addr << std::dec
+            debug(5) << "Comparing to member " << member.name
+                     << " at address " << std::hex << member.addr << std::dec
                      << " with type " << t->name
                      << " and type type " << (int)t->type << "\n";
 
-            if (obj.members[i].addr == addr &&
+            if (member.addr == addr &&
                 (type_name.empty() ||
                  regex_match(t->name, re))) {
-                name << obj.members[i].name;
+                name << member.name;
                 return name.str();
             }
 
             // For arrays, we only unpacked the first element.
             if (t->type == TypeInfo::Array) {
                 TypeInfo *elem_type = t->members[0].type;
-                uint64_t array_start_addr = obj.members[i].addr;
+                uint64_t array_start_addr = member.addr;
                 uint64_t array_end_addr = array_start_addr + t->size * elem_type->size;
                 debug(5) << "Array runs from " << std::hex << array_start_addr << " to " << array_end_addr << "\n";
                 if (elem_type && addr >= array_start_addr && addr < array_end_addr) {
@@ -568,17 +564,17 @@ public:
                     addr -= containing_elem * elem_type->size;
                     debug(5) << "Query belongs to this array. Adjusting query address backwards to "
                              << std::hex << addr << std::dec << "\n";
-                    name << obj.members[i].name << "[" << containing_elem << "]";
+                    name << member.name << "[" << containing_elem << "]";
                 }
             } else if (t->type == TypeInfo::Struct ||
                        t->type == TypeInfo::Class ||
                        t->type == TypeInfo::Primitive) {
                 // If I'm not this member, but am contained within it, incorporate its name.
-                uint64_t struct_start_addr = obj.members[i].addr;
+                uint64_t struct_start_addr = member.addr;
                 uint64_t struct_end_addr = struct_start_addr + t->size;
                 debug(5) << "Struct runs from " << std::hex << struct_start_addr << " to " << struct_end_addr << "\n";
                 if (addr >= struct_start_addr && addr < struct_end_addr) {
-                    name << obj.members[i].name << ".";
+                    name << member.name << ".";
                 }
             }
         }
@@ -680,16 +676,15 @@ public:
 
         std::regex re(type_name);
 
-        for (size_t j = 0; j < func->variables.size(); j++) {
-            const LocalVariable &var = func->variables[j];
+        for (auto &var : func->variables) {
             debug(5) << "Var " << var.name << " is at offset " << var.stack_offset << "\n";
 
             // Reject it if we're not in its live ranges
             if (!var.live_ranges.empty()) {
                 bool in_live_range = false;
-                for (size_t i = 0; i < var.live_ranges.size(); i++) {
-                    if (pc >= var.live_ranges[i].pc_begin &&
-                        pc < var.live_ranges[i].pc_end) {
+                for (auto live_range : var.live_ranges) {
+                    if (pc >= live_range.pc_begin &&
+                        pc < live_range.pc_end) {
                         in_live_range = true;
                         break;
                     }
@@ -830,35 +825,33 @@ public:
 
     void dump() {
         // Dump all the types
-        for (size_t i = 0; i < types.size(); i++) {
+        for (auto &type : types) {
             printf("Class %s of size %llu @ %llx: \n",
-                   types[i].name.c_str(),
-                   (unsigned long long)(types[i].size),
-                   (unsigned long long)(types[i].def_loc));
-            for (size_t j = 0; j < types[i].members.size(); j++) {
-                TypeInfo *c = types[i].members[j].type;
+                   type.name.c_str(),
+                   (unsigned long long)(type.size),
+                   (unsigned long long)(type.def_loc));
+            for (auto &member : type.members) {
+                TypeInfo *c = member.type;
                 const char *type_name = "(unknown)";
                 if (c) {
                     type_name = c->name.c_str();
                 }
                 printf("  Member %s at %d of type %s @ %llx\n",
-                       types[i].members[j].name.c_str(),
-                       types[i].members[j].stack_offset,
+                       member.name.c_str(),
+                       member.stack_offset,
                        type_name,
-                       (long long unsigned)types[i].members[j].type_def_loc);
+                       (long long unsigned)member.type_def_loc);
             }
         }
 
         // Dump all the functions and their local variables
-        for (size_t i = 0; i < functions.size(); i++) {
-            const FunctionInfo &f = functions[i];
+        for (auto &f : functions) {
             printf("Function %s at %llx - %llx (frame_base %d): \n",
                    f.name.c_str(),
                    (unsigned long long)(f.pc_begin),
                    (unsigned long long)(f.pc_end),
                    (int)f.frame_base);
-            for (size_t j = 0; j < f.variables.size(); j++) {
-                const LocalVariable &v = f.variables[j];
+            for (const auto &v : f.variables) {
                 TypeInfo *c = v.type;
                 const char *type_name = "(unknown)";
                 if (c) {
@@ -869,25 +862,24 @@ public:
                        v.stack_offset,
                        type_name,
                        (long long unsigned)v.type_def_loc);
-                for (size_t k = 0; k < v.live_ranges.size(); k++) {
+                for (auto live_range : v.live_ranges) {
                     printf("    Live range: %llx - %llx\n",
-                           (unsigned long long)v.live_ranges[k].pc_begin,
-                           (unsigned long long)v.live_ranges[k].pc_end);
+                           (unsigned long long)live_range.pc_begin,
+                           (unsigned long long)live_range.pc_end);
                 }
             }
         }
 
         // Dump the pc -> source file relationship
-        for (size_t i = 0; i < source_lines.size(); i++) {
+        for (auto &source_line : source_lines) {
             printf("%p -> %s:%d\n",
-                   (void *)(source_lines[i].pc),
-                   source_files[source_lines[i].file].c_str(),
-                   source_lines[i].line);
+                   (void *)(source_line.pc),
+                   source_files[source_line.file].c_str(),
+                   source_line.line);
         }
 
         // Dump the global variables
-        for (size_t i = 0; i < global_variables.size(); i++) {
-            const GlobalVariable &v = global_variables[i];
+        for (auto &v : global_variables) {
             TypeInfo *c = v.type;
             const char *type_name = "(unknown)";
             if (c) {
@@ -1174,8 +1166,8 @@ private:
                 if (!type_stack.empty()) {
                     containing_namespace = type_stack.back().first.name + "::";
                 } else {
-                    for (size_t i = 0; i < namespace_stack.size(); i++) {
-                        containing_namespace += namespace_stack[i].first + "::";
+                    for (auto &i : namespace_stack) {
+                        containing_namespace += i.first + "::";
                     }
                 }
 
@@ -1644,15 +1636,15 @@ private:
         // Connect function definitions to their declarations
         {
             std::map<uint64_t, FunctionInfo *> func_map;
-            for (size_t i = 0; i < functions.size(); i++) {
-                func_map[functions[i].def_loc] = &functions[i];
+            for (auto &function : functions) {
+                func_map[function.def_loc] = &function;
             }
 
-            for (size_t i = 0; i < functions.size(); i++) {
-                if (functions[i].spec_loc) {
-                    FunctionInfo *spec = func_map[functions[i].spec_loc];
+            for (auto &function : functions) {
+                if (function.spec_loc) {
+                    FunctionInfo *spec = func_map[function.spec_loc];
                     if (spec) {
-                        functions[i].name = spec->name;
+                        function.name = spec->name;
                     }
                 }
             }
@@ -1661,15 +1653,14 @@ private:
         // Connect inlined variable instances to their origins
         {
             std::map<uint64_t, LocalVariable *> var_map;
-            for (size_t i = 0; i < functions.size(); i++) {
-                for (size_t j = 0; j < functions[i].variables.size(); j++) {
-                    var_map[functions[i].variables[j].def_loc] = &(functions[i].variables[j]);
+            for (auto &function : functions) {
+                for (auto &variable : function.variables) {
+                    var_map[variable.def_loc] = &variable;
                 }
             }
 
-            for (size_t i = 0; i < functions.size(); i++) {
-                for (size_t j = 0; j < functions[i].variables.size(); j++) {
-                    LocalVariable &v = functions[i].variables[j];
+            for (auto &function : functions) {
+                for (auto &v : function.variables) {
                     uint64_t loc = v.origin_loc;
                     if (loc) {
                         LocalVariable *origin = var_map[loc];
@@ -1688,8 +1679,7 @@ private:
         // Connect global variable instances to their prototypes
         {
             std::map<uint64_t, GlobalVariable *> var_map;
-            for (size_t i = 0; i < global_variables.size(); i++) {
-                GlobalVariable &var = global_variables[i];
+            for (auto &var : global_variables) {
                 debug(5) << "var " << var.name << " is at " << var.def_loc << "\n";
                 if (var.spec_loc || var.name.empty()) {
                     // Not a prototype
@@ -1698,8 +1688,7 @@ private:
                 var_map[var.def_loc] = &var;
             }
 
-            for (size_t i = 0; i < global_variables.size(); i++) {
-                GlobalVariable &var = global_variables[i];
+            for (auto &var : global_variables) {
                 if (var.name.empty() && var.spec_loc) {
                     GlobalVariable *spec = var_map[var.spec_loc];
                     if (spec) {
@@ -1716,34 +1705,34 @@ private:
         // Hook up the type pointers
         {
             std::map<uint64_t, TypeInfo *> type_map;
-            for (size_t i = 0; i < types.size(); i++) {
-                type_map[types[i].def_loc] = &types[i];
+            for (auto &type : types) {
+                type_map[type.def_loc] = &type;
             }
 
-            for (size_t i = 0; i < functions.size(); i++) {
-                for (size_t j = 0; j < functions[i].variables.size(); j++) {
-                    functions[i].variables[j].type =
-                        type_map[functions[i].variables[j].type_def_loc];
+            for (auto &function : functions) {
+                for (auto &variable : function.variables) {
+                    variable.type =
+                        type_map[variable.type_def_loc];
                 }
             }
 
-            for (size_t i = 0; i < global_variables.size(); i++) {
-                global_variables[i].type =
-                    type_map[global_variables[i].type_def_loc];
+            for (auto &global_variable : global_variables) {
+                global_variable.type =
+                    type_map[global_variable.type_def_loc];
             }
 
-            for (size_t i = 0; i < types.size(); i++) {
-                for (size_t j = 0; j < types[i].members.size(); j++) {
-                    types[i].members[j].type =
-                        type_map[types[i].members[j].type_def_loc];
+            for (auto &type : types) {
+                for (auto &member : type.members) {
+                    member.type =
+                        type_map[member.type_def_loc];
                 }
             }
         }
 
-        for (size_t i = 0; i < types.size(); i++) {
+        for (auto &type : types) {
             // Set the names of the pointer types
             vector<std::string> suffix;
-            TypeInfo *t = &types[i];
+            TypeInfo *t = &type;
             while (t) {
                 if (t->type == TypeInfo::Pointer) {
                     suffix.emplace_back("*");
@@ -1774,18 +1763,18 @@ private:
             }
 
             if (t && !suffix.empty()) {
-                types[i].name = t->name;
+                type.name = t->name;
                 while (!suffix.empty()) {
-                    types[i].name += " " + suffix.back();
+                    type.name += " " + suffix.back();
                     suffix.pop_back();
                 }
             }
         }
 
         // Fix up the sizes of typedefs where we know the underlying type
-        for (size_t i = 0; i < types.size(); i++) {
-            TypeInfo *t = &types[i];
-            if (types[i].type == TypeInfo::Typedef &&
+        for (auto &type : types) {
+            TypeInfo *t = &type;
+            if (type.type == TypeInfo::Typedef &&
                 !t->members.empty() &&
                 t->members[0].type) {
                 t->size = t->members[0].type->size;
@@ -1793,8 +1782,8 @@ private:
         }
 
         // Unpack class members into the local variables list.
-        for (size_t i = 0; i < functions.size(); i++) {
-            vector<LocalVariable> new_vars = functions[i].variables;
+        for (auto &function : functions) {
+            vector<LocalVariable> new_vars = function.variables;
             for (size_t j = 0; j < new_vars.size(); j++) {
                 // If new_vars[j] is a class type, unpack its members
                 // immediately after this point.
@@ -1824,13 +1813,13 @@ private:
                     }
                 }
             }
-            functions[i].variables.swap(new_vars);
+            function.variables.swap(new_vars);
 
-            if (!functions[i].variables.empty()) {
-                debug(5) << "Function " << functions[i].name << ":\n";
-                for (size_t j = 0; j < functions[i].variables.size(); j++) {
-                    if (functions[i].variables[j].type) {
-                        debug(5) << " " << functions[i].variables[j].type->name << " " << functions[i].variables[j].name << "\n";
+            if (!function.variables.empty()) {
+                debug(5) << "Function " << function.name << ":\n";
+                for (auto &variable : function.variables) {
+                    if (variable.type) {
+                        debug(5) << " " << variable.type->name << " " << variable.name << "\n";
                     }
                 }
             }
@@ -1845,17 +1834,17 @@ private:
                  v.type->type == TypeInfo::Typedef)) {
                 debug(5) << "Unpacking members of " << v.name << " at " << std::hex << v.addr << "\n";
                 vector<LocalVariable> &members = v.type->members;
-                for (size_t j = 0; j < members.size(); j++) {
+                for (auto &member : members) {
                     GlobalVariable mem;
-                    if (!v.name.empty() && !members[j].name.empty()) {
-                        mem.name = v.name + "." + members[j].name;
+                    if (!v.name.empty() && !member.name.empty()) {
+                        mem.name = v.name + "." + member.name;
                     } else {
                         // Might be a member of an anonymous struct?
-                        mem.name = members[j].name;
+                        mem.name = member.name;
                     }
-                    mem.type = members[j].type;
-                    mem.type_def_loc = members[j].type_def_loc;
-                    mem.addr = v.addr + members[j].stack_offset;
+                    mem.type = member.type;
+                    mem.type_def_loc = member.type_def_loc;
+                    mem.addr = v.addr + member.stack_offset;
                     debug(5) << " Member " << mem.name << " goes at " << mem.addr << "\n";
                     global_variables.push_back(mem);
                 }
@@ -1868,8 +1857,7 @@ private:
         // name, or type.
         {
             vector<FunctionInfo> trimmed;
-            for (size_t i = 0; i < functions.size(); i++) {
-                FunctionInfo &f = functions[i];
+            for (auto &f : functions) {
                 if (!f.pc_begin ||
                     !f.pc_end ||
                     f.name.empty()) {
@@ -1878,8 +1866,7 @@ private:
                 }
 
                 vector<LocalVariable> vars;
-                for (size_t j = 0; j < f.variables.size(); j++) {
-                    LocalVariable &v = f.variables[j];
+                for (auto &v : f.variables) {
                     if (!v.name.empty() && v.type && v.stack_offset != no_location) {
                         vars.push_back(v);
                     } else {
@@ -1896,8 +1883,7 @@ private:
         // Drop globals for which we don't know the address or name
         {
             vector<GlobalVariable> trimmed;
-            for (size_t i = 0; i < global_variables.size(); i++) {
-                GlobalVariable &v = global_variables[i];
+            for (auto &v : global_variables) {
                 if (!v.name.empty() && v.addr) {
                     trimmed.push_back(v);
                 }

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -182,8 +182,7 @@ public:
     }
 
     uint64_t getSymbolAddress(const std::string &name) override {
-        for (size_t i = 0; i < modules.size(); i++) {
-            const JITModule &m = modules[i];
+        for (auto &m : modules) {
             std::map<std::string, JITModule::Symbol>::const_iterator iter = m.exports().find(name);
             if (iter == m.exports().end() && starts_with(name, "_")) {
                 iter = m.exports().find(name.substr(1));
@@ -301,8 +300,8 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
     // TODO: If this ever works in LLVM, this would allow profiling of JIT code with symbols with oprofile.
     //listeners.push_back(llvm::createOProfileJITEventListener());
 
-    for (size_t i = 0; i < listeners.size(); i++) {
-        ee->RegisterJITEventListener(listeners[i]);
+    for (auto &listener : listeners) {
+        ee->RegisterJITEventListener(listener);
     }
 
     // Retrieve function pointers from the compiled module (which also
@@ -321,16 +320,16 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
         exports[function_name + "_argv"] = argv_entrypoint;
     }
 
-    for (size_t i = 0; i < requested_exports.size(); i++) {
-        exports[requested_exports[i]] = compile_and_get_function(*ee, requested_exports[i]);
+    for (const auto &requested_export : requested_exports) {
+        exports[requested_export] = compile_and_get_function(*ee, requested_export);
     }
 
     debug(2) << "Finalizing object\n";
     ee->finalizeObject();
     // Do any target-specific post-compilation module meddling
-    for (size_t i = 0; i < listeners.size(); i++) {
-        ee->UnregisterJITEventListener(listeners[i]);
-        delete listeners[i];
+    for (auto &listener : listeners) {
+        ee->UnregisterJITEventListener(listener);
+        delete listener;
     }
     listeners.clear();
 

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -545,21 +545,21 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
 
     // Set the layout and triple on the modules before linking, so
     // llvm doesn't complain while combining them.
-    for (size_t i = 0; i < modules.size(); i++) {
+    for (auto &module : modules) {
         if (t.os == Target::Windows &&
-            !Internal::starts_with(modules[i]->getName().str(), "windows_")) {
+            !Internal::starts_with(module->getName().str(), "windows_")) {
             // When compiling for windows, all wchars are
             // 16-bit. Generic modules may have it set to 32-bit. Drop
             // any module flags on the generic modules and use the
             // more correct ones on the windows-specific modules to
             // avoid a conflict. This is safe as long as the generic
             // modules never actually use a wchar.
-            if (auto *module_flags = modules[i]->getModuleFlagsMetadata()) {
-                modules[i]->eraseNamedMetadata(module_flags);
+            if (auto *module_flags = module->getModuleFlagsMetadata()) {
+                module->eraseNamedMetadata(module_flags);
             }
         }
-        modules[i]->setDataLayout(data_layout);
-        modules[i]->setTargetTriple(triple.str());
+        module->setDataLayout(data_layout);
+        module->setTargetTriple(triple.str());
     }
 
     // Link them all together
@@ -1225,9 +1225,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_ptx_device(Target target, l
 
     // For now, the PTX backend does not handle calling functions. So mark all functions
     // AvailableExternally to ensure they are inlined or deleted.
-    for (llvm::Module::iterator iter = modules[0]->begin(); iter != modules[0]->end(); iter++) {
-        llvm::Function &f = *iter;
-
+    for (auto &f : *modules[0]) {
         // This is intended to set all definitions (not extern declarations)
         // to "available externally" which should guarantee they do not exist
         // after the resulting module is finalized to code. That is they must

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -226,15 +226,15 @@ class LoopCarryOverLoop : public IRMutator {
 
         vector<Stmt> stores;
         vector<Stmt> result;
-        for (size_t i = 0; i < v.size(); i++) {
-            if (v[i].as<Store>()) {
-                stores.push_back(v[i]);
+        for (auto &i : v) {
+            if (i.as<Store>()) {
+                stores.push_back(i);
             } else {
                 if (!stores.empty()) {
                     result.push_back(lift_carried_values_out_of_stmt(Block::make(stores)));
                     stores.clear();
                 }
-                result.push_back(mutate(v[i]));
+                result.push_back(mutate(i));
             }
         }
         if (!stores.empty()) {

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -459,8 +459,8 @@ void lower_impl(const vector<Function> &output_funcs,
                 << ", which was not found in the argument list.\n";
 
             err << "\nArgument list specified: ";
-            for (size_t i = 0; i < args.size(); i++) {
-                err << args[i].name << " ";
+            for (const auto &arg : args) {
+                err << arg.name << " ";
             }
             err << "\n\nParameters referenced in generated code: ";
             for (const InferredArgument &ia : inferred_args) {

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -27,14 +27,14 @@ public:
         if (function.has_extern_definition()) {
             const std::vector<ExternFuncArgument> &extern_args =
                 function.extern_arguments();
-            for (size_t i = 0; i < extern_args.size(); i++) {
-                if (extern_args[i].is_buffer()) {
+            for (const auto &extern_arg : extern_args) {
+                if (extern_arg.is_buffer()) {
                     // Function with an extern definition
-                    record(Halide::Internal::Parameter(extern_args[i].buffer.type(), true,
-                                                       extern_args[i].buffer.dimensions(),
-                                                       extern_args[i].buffer.name()));
-                } else if (extern_args[i].is_image_param()) {
-                    record(extern_args[i].image_param);
+                    record(Halide::Internal::Parameter(extern_arg.buffer.type(), true,
+                                                       extern_arg.buffer.dimensions(),
+                                                       extern_arg.buffer.name()));
+                } else if (extern_arg.is_image_param()) {
+                    record(extern_arg.image_param);
                 }
             }
         }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -238,8 +238,7 @@ static Registerer registerer;
 std::string indent_string(const std::string &src, const std::string &indent) {
     std::ostringstream o;
     bool prev_was_newline = true;
-    for (size_t i = 0; i < src.size(); i++) {
-        const char c = src[i];
+    for (char c : src) {
         const bool is_newline = (c == '\n');
         if (prev_was_newline && !is_newline) {
             o << indent;
@@ -448,9 +447,7 @@ void Module::append(const ExternalCode &external_code) {
 Module link_modules(const std::string &name, const std::vector<Module> &modules) {
     Module output(name, modules.front().target());
 
-    for (size_t i = 0; i < modules.size(); i++) {
-        const Module &input = modules[i];
-
+    for (const auto &input : modules) {
         if (output.target() != input.target()) {
             user_error << "Mismatched targets in modules to link ("
                        << output.name() << ", " << output.target().to_string()
@@ -902,8 +899,8 @@ void compile_multitarget(const std::string &fn_name,
         Expr can_use;
         if (target != base_target) {
             std::vector<Expr> features_struct_args;
-            for (int i = 0; i < kFeaturesWordCount; ++i) {
-                features_struct_args.emplace_back(UIntImm::make(UInt(64), cur_target_features[i]));
+            for (unsigned long cur_target_feature : cur_target_features) {
+                features_struct_args.emplace_back(UIntImm::make(UInt(64), cur_target_feature));
             }
             can_use = Call::make(Int(32), "halide_can_use_target_features",
                                  {kFeaturesWordCount, Call::make(type_of<uint64_t *>(), Call::make_struct, features_struct_args, Call::Intrinsic)},

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -493,8 +493,8 @@ class DerivativeBounds : public IRVisitor {
             return;
         }
 
-        for (size_t i = 0; i < op->args.size(); i++) {
-            op->args[i].accept(this);
+        for (const auto &arg : op->args) {
+            arg.accept(this);
             if (!is_constant(result)) {
                 // One of the args is not constant.
                 result = ConstantInterval::everything();
@@ -520,8 +520,8 @@ class DerivativeBounds : public IRVisitor {
     }
 
     void visit(const Shuffle *op) override {
-        for (size_t i = 0; i < op->vectors.size(); i++) {
-            op->vectors[i].accept(this);
+        for (const auto &vector : op->vectors) {
+            vector.accept(this);
             if (!is_constant(result)) {
                 result = ConstantInterval::everything();
                 return;

--- a/src/ParallelRVar.cpp
+++ b/src/ParallelRVar.cpp
@@ -34,9 +34,9 @@ class FindLoads : public IRVisitor {
 
     void visit(const Let *op) override {
         IRVisitor::visit(op);
-        for (size_t i = 0; i < loads.size(); i++) {
-            for (size_t j = 0; j < loads[i].size(); j++) {
-                loads[i][j] = graph_substitute(op->name, op->value, loads[i][j]);
+        for (auto &load : loads) {
+            for (auto &e : load) {
+                e = graph_substitute(op->name, op->value, e);
             }
         }
     }
@@ -98,8 +98,8 @@ bool can_parallelize_rvar(const string &v,
     const vector<ReductionVariable> &rvars = r.schedule().rvars();
 
     FindLoads find(f);
-    for (size_t i = 0; i < values.size(); i++) {
-        values[i].accept(&find);
+    for (const auto &value : values) {
+        value.accept(&find);
     }
 
     // Make an expr representing the store done by a different thread.
@@ -121,11 +121,11 @@ bool can_parallelize_rvar(const string &v,
 
     // Add expressions that are true if there's a collision between
     // the other thread's store and this thread's loads.
-    for (size_t i = 0; i < find.loads.size(); i++) {
-        internal_assert(find.loads[i].size() == other_store.size());
+    for (auto &load : find.loads) {
+        internal_assert(load.size() == other_store.size());
         Expr check = const_true();
-        for (size_t j = 0; j < find.loads[i].size(); j++) {
-            check = check && (distinct_v && (find.loads[i][j] == other_store[j]));
+        for (size_t j = 0; j < load.size(); j++) {
+            check = check && (distinct_v && (load[j] == other_store[j]));
         }
         hazard = hazard || check;
     }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -127,9 +127,9 @@ struct PipelineContents {
 
     void clear_custom_lowering_passes() {
         invalidate_cache();
-        for (size_t i = 0; i < custom_lowering_passes.size(); i++) {
-            if (custom_lowering_passes[i].deleter) {
-                custom_lowering_passes[i].deleter();
+        for (auto &custom_lowering_passe : custom_lowering_passes) {
+            if (custom_lowering_passe.deleter) {
+                custom_lowering_passe.deleter();
             }
         }
         custom_lowering_passes.clear();
@@ -527,9 +527,9 @@ std::string Pipeline::generate_function_name() const {
     user_assert(defined()) << "Pipeline is undefined\n";
     // Come up with a name for a generated function
     string name = contents->outputs[0].name();
-    for (size_t i = 0; i < name.size(); i++) {
-        if (!isalnum(name[i])) {
-            name[i] = '_';
+    for (char &i : name) {
+        if (!isalnum(i)) {
+            i = '_';
         }
     }
     return name;
@@ -995,10 +995,8 @@ Pipeline::make_externs_jit_module(const Target &target,
     // Externs that are Funcs get their own JITModule. All standalone functions are
     // held in a single JITModule at the end of the list (if there are any).
     JITModule free_standing_jit_externs;
-    for (std::map<std::string, JITExtern>::iterator iter = externs_in_out.begin();
-         iter != externs_in_out.end();
-         iter++) {
-        Pipeline pipeline = iter->second.pipeline();
+    for (auto &iter : externs_in_out) {
+        Pipeline pipeline = iter.second.pipeline();
         if (pipeline.defined()) {
             PipelineContents &pipeline_contents(*pipeline.contents);
 
@@ -1006,7 +1004,7 @@ Pipeline::make_externs_jit_module(const Target &target,
             pipeline.compile_jit(target);
 
             free_standing_jit_externs.add_dependency(pipeline_contents.jit_module);
-            free_standing_jit_externs.add_symbol_for_export(iter->first, pipeline_contents.jit_module.entrypoint_symbol());
+            free_standing_jit_externs.add_symbol_for_export(iter.first, pipeline_contents.jit_module.entrypoint_symbol());
             void *address = pipeline_contents.jit_module.entrypoint_symbol().address;
             std::vector<Type> arg_types;
             // Add the arguments to the compiled pipeline
@@ -1023,9 +1021,9 @@ Pipeline::make_externs_jit_module(const Target &target,
                 arg_types.push_back(type_of<struct halide_buffer_t *>());
             }
             ExternSignature signature(Int(32), false, arg_types);
-            iter->second = JITExtern(ExternCFunction(address, signature));
+            iter.second = JITExtern(ExternCFunction(address, signature));
         } else {
-            free_standing_jit_externs.add_extern_for_export(iter->first, iter->second.extern_c_function());
+            free_standing_jit_externs.add_extern_for_export(iter.first, iter.second.extern_c_function());
         }
     }
     if (free_standing_jit_externs.compiled() || !free_standing_jit_externs.exports().empty()) {

--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -17,13 +17,13 @@ namespace {
 
 string sanitize_name(const string &name) {
     ostringstream oss;
-    for (size_t i = 0; i < name.size(); i++) {
-        if (name[i] == '.' || name[i] == '_') {
+    for (char i : name) {
+        if (i == '.' || i == '_') {
             oss << "_";
-        } else if (!isalnum(name[i])) {
-            oss << "_" << (int)name[i];
+        } else if (!isalnum(i)) {
+            oss << "_" << (int)i;
         } else {
-            oss << name[i];
+            oss << i;
         }
     }
     return oss.str();
@@ -124,8 +124,8 @@ PythonExtensionGen::PythonExtensionGen(std::ostream &dest)
 }
 
 void PythonExtensionGen::release_buffers(const string &prefix = "    ") {
-    for (size_t i = 0; i < buffer_refs.size(); i++) {
-        dest << prefix << "PyBuffer_Release(&" << buffer_refs[i] << ");\n";
+    for (auto &buffer_ref : buffer_refs) {
+        dest << prefix << "PyBuffer_Release(&" << buffer_ref << ");\n";
     }
 }
 
@@ -328,8 +328,8 @@ void PythonExtensionGen::compile(const LoweredFunc &f) {
         dest << "    " << print_type(&args[i]).second << " py_" << arg_names[i] << ";\n";
     }
     dest << "    if (!PyArg_ParseTupleAndKeywords(args, kwargs, \"";
-    for (size_t i = 0; i < args.size(); i++) {
-        dest << print_type(&args[i]).first;
+    for (const auto &arg : args) {
+        dest << print_type(&arg).first;
     }
     dest << "\", (char**)kwlist";
     for (size_t i = 0; i < args.size(); i++) {

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -49,8 +49,8 @@ class FindImageInputs : public IRVisitor {
                 }
             }
         }
-        for (size_t i = 0; i < call->args.size(); i++) {
-            call->args[i].accept(this);
+        for (const auto &arg : call->args) {
+            arg.accept(this);
         }
     }
 
@@ -240,8 +240,8 @@ class ExprCost : public IRVisitor {
             }
         }
 
-        for (size_t i = 0; i < call->args.size(); i++) {
-            call->args[i].accept(this);
+        for (const auto &arg : call->args) {
+            arg.accept(this);
         }
     }
 
@@ -318,8 +318,8 @@ Expr get_func_value_size(const Function &f) {
     Expr size = 0;
     const vector<Type> &types = f.output_types();
     internal_assert(!types.empty());
-    for (size_t i = 0; i < types.size(); i++) {
-        size += types[i].bytes();
+    for (auto type : types) {
+        size += type.bytes();
     }
     return simplify(size);
 }

--- a/src/RemoveDeadAllocations.cpp
+++ b/src/RemoveDeadAllocations.cpp
@@ -15,8 +15,8 @@ class RemoveDeadAllocations : public IRMutator {
 
     Expr visit(const Call *op) override {
         if (op->is_extern()) {
-            for (size_t i = 0; i < op->args.size(); i++) {
-                const Variable *var = op->args[i].as<Variable>();
+            for (const auto &arg : op->args) {
+                const Variable *var = arg.as<Variable>();
                 if (var && ends_with(var->name, ".buffer")) {
                     std::string func = var->name.substr(0, var->name.find_first_of('.'));
                     if (allocs.contains(func)) {

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1684,8 +1684,7 @@ private:
                     }
                     // Now that we are going to add a stage to the order, go over dependent nodes
                     // and decrease their dependency count.
-                    for (size_t k = 0; k < adj_list[i][stage_index[i]].size(); k++) {
-                        const auto &edge = adj_list[i][stage_index[i]][k];
+                    for (auto &edge : adj_list[i][stage_index[i]]) {
                         internal_assert(stage_dependencies[edge.func_index][edge.stage_index] > 0);
                         stage_dependencies[edge.func_index][edge.stage_index]--;
                     }

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -430,9 +430,9 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         bool changed = false;
         vector<Expr> new_args;
         const StringImm *last = nullptr;
-        for (size_t i = 0; i < op->args.size(); i++) {
-            Expr arg = mutate(op->args[i], nullptr);
-            if (!arg.same_as(op->args[i])) {
+        for (const auto &i : op->args) {
+            Expr arg = mutate(i, nullptr);
+            if (!arg.same_as(i)) {
                 changed = true;
             }
             const StringImm *string_imm = arg.as<StringImm>();

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -27,8 +27,8 @@ bool extern_call_uses_buffer(const Call *op, const std::string &func) {
         if (starts_with(op->name, "halide_memoization")) {
             return false;
         }
-        for (size_t i = 0; i < op->args.size(); i++) {
-            const Variable *var = op->args[i].as<Variable>();
+        for (const auto &arg : op->args) {
+            const Variable *var = arg.as<Variable>();
             if (var &&
                 starts_with(var->name, func + ".") &&
                 ends_with(var->name, ".buffer")) {
@@ -265,8 +265,8 @@ private:
     bool memoize_call_uses_buffer(const Call *op) {
         internal_assert(op->call_type == Call::Extern);
         internal_assert(starts_with(op->name, "halide_memoization"));
-        for (size_t i = 0; i < op->args.size(); i++) {
-            const Variable *var = op->args[i].as<Variable>();
+        for (const auto &arg : op->args) {
+            const Variable *var = arg.as<Variable>();
             if (var &&
                 starts_with(var->name, buffer + ".") &&
                 ends_with(var->name, ".buffer")) {

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -1294,18 +1294,18 @@ void solve_test() {
         for (int num = 5; num <= 10; num++) {
             Expr in[] = {x * den<num, x * den <= num, x * den == num, x * den != num, x * den >= num, x * den> num,
                          x / den<num, x / den <= num, x / den == num, x / den != num, x / den >= num, x / den> num};
-            for (int j = 0; j < 12; j++) {
-                SolverResult solved = solve_expression(in[j], "x");
-                internal_assert(solved.fully_solved) << "Error: failed to solve for x in " << in[j] << "\n";
+            for (auto &j : in) {
+                SolverResult solved = solve_expression(j, "x");
+                internal_assert(solved.fully_solved) << "Error: failed to solve for x in " << j << "\n";
                 Expr out = simplify(solved.result);
                 for (int i = -10; i < 10; i++) {
-                    Expr in_val = substitute("x", i, in[j]);
+                    Expr in_val = substitute("x", i, j);
                     Expr out_val = substitute("x", i, out);
                     in_val = simplify(in_val);
                     out_val = simplify(out_val);
                     internal_assert(equal(in_val, out_val))
                         << "Error: "
-                        << in[j] << " is not equivalent to "
+                        << j << " is not equivalent to "
                         << out << " when x == " << i << "\n";
                 }
             }

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -173,8 +173,7 @@ private:
     void visit(const StringImm *op) override {
         stream << open_span("StringImm");
         stream << "\"";
-        for (size_t i = 0; i < op->value.size(); i++) {
-            unsigned char c = op->value[i];
+        for (unsigned char c : op->value) {
             if (c >= ' ' && c <= '~' && c != '\\' && c != '"') {
                 stream << c;
             } else {
@@ -486,9 +485,9 @@ private:
         stream << op->type;
         stream << close_span();
 
-        for (size_t i = 0; i < op->extents.size(); i++) {
+        for (const auto &extent : op->extents) {
             stream << " * ";
-            print(op->extents[i]);
+            print(extent);
         }
         stream << matched("]");
         if (!is_const_one(op->condition)) {

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -961,9 +961,9 @@ class StorageFolding : public IRMutator {
             Region bounds = op->bounds;
 
             // Collapse down the extent in the folded dimension
-            for (size_t i = 0; i < folder.dims_folded.size(); i++) {
-                int d = folder.dims_folded[i].dim;
-                Expr f = folder.dims_folded[i].factor;
+            for (auto &i : folder.dims_folded) {
+                int d = i.dim;
+                Expr f = i.factor;
                 internal_assert(d >= 0 &&
                                 d < (int)bounds.size());
                 bounds[d] = Range(0, f);

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -212,11 +212,11 @@ private:
             // is traced before any loads in the index.
             vector<Expr> args = op->args;
             vector<pair<string, Expr>> lets;
-            for (size_t i = 0; i < args.size(); i++) {
-                if (!args[i].as<Variable>() && !is_const(args[i])) {
+            for (auto &arg : args) {
+                if (!arg.as<Variable>() && !is_const(arg)) {
                     string name = unique_name('t');
-                    lets.emplace_back(name, args[i]);
-                    args[i] = Variable::make(args[i].type(), name);
+                    lets.emplace_back(name, arg);
+                    arg = Variable::make(arg.type(), name);
                 }
             }
 
@@ -249,9 +249,9 @@ private:
             builder.func = op->name;
             builder.parent_id = Variable::make(Int(32), "pipeline.trace_id");
             builder.event = halide_trace_begin_realization;
-            for (size_t i = 0; i < op->bounds.size(); i++) {
-                builder.coordinates.push_back(op->bounds[i].min);
-                builder.coordinates.push_back(op->bounds[i].extent);
+            for (const auto &bound : op->bounds) {
+                builder.coordinates.push_back(bound.min);
+                builder.coordinates.push_back(bound.extent);
             }
 
             // Begin realization returns a unique token to pass to further trace calls affecting this buffer.

--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -275,11 +275,11 @@ std::string type_to_c_type(Type type, bool include_space, bool c_plus_plus) {
             if (!type.handle_type->namespaces.empty() ||
                 !type.handle_type->enclosing_types.empty()) {
                 oss << "::";
-                for (size_t i = 0; i < type.handle_type->namespaces.size(); i++) {
-                    oss << type.handle_type->namespaces[i] << "::";
+                for (const auto &i : type.handle_type->namespaces) {
+                    oss << i << "::";
                 }
-                for (size_t i = 0; i < type.handle_type->enclosing_types.size(); i++) {
-                    oss << type.handle_type->enclosing_types[i].name << "::";
+                for (const auto &enclosing_type : type.handle_type->enclosing_types) {
+                    oss << enclosing_type.name << "::";
                 }
             }
             oss << type.handle_type->inner_name.name;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -254,9 +254,9 @@ string make_entity_name(void *stack_ptr, const string &type, char prefix) {
         return unique_name(prefix);
     } else {
         // Halide names may not contain '.'
-        for (size_t i = 0; i < name.size(); i++) {
-            if (name[i] == '.') {
-                name[i] = ':';
+        for (char &i : name) {
+            if (i == '.') {
+                i = ':';
             }
         }
         return unique_name(name);
@@ -557,15 +557,15 @@ std::string c_print_name(const std::string &name) {
         oss << "_";
     }
 
-    for (size_t i = 0; i < name.size(); i++) {
-        if (name[i] == '.') {
+    for (char i : name) {
+        if (i == '.') {
             oss << "_";
-        } else if (name[i] == '$') {
+        } else if (i == '$') {
             oss << "__";
-        } else if (name[i] != '_' && !isalnum(name[i])) {
+        } else if (i != '_' && !isalnum(i)) {
             oss << "___";
         } else {
-            oss << name[i];
+            oss << i;
         }
     }
     return oss.str();

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -714,8 +714,8 @@ class VectorSubs : public IRMutator {
         }
 
         // Widen the args to have the same lanes as the max lanes found
-        for (size_t i = 0; i < new_args.size(); i++) {
-            new_args[i] = widen(new_args[i], max_lanes);
+        for (auto &i : new_args) {
+            i = widen(i, max_lanes);
         }
         return Call::make(op->type.with_lanes(max_lanes), op->name, new_args,
                           op->call_type, op->func, op->value_index, op->image, op->param);
@@ -1003,8 +1003,8 @@ class VectorSubs : public IRMutator {
             new_extents.emplace_back(vv.lanes);
         }
 
-        for (size_t i = 0; i < op->extents.size(); i++) {
-            Expr extent = mutate(op->extents[i]);
+        for (const auto &i : op->extents) {
+            Expr extent = mutate(i);
             // For vector sizes, take the max over the lanes. Note
             // that we haven't changed the strides, which also may
             // vary per lane. This is a bit weird, but the way we

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -150,9 +150,9 @@ public:
         internal_assert(size <= kMaxAllocSize);
         bddebug(2) << "size -> " << size << "\n";
 
-        for (auto it = regions.begin(); it != regions.end(); it++) {
-            const uint32_t start = it->first;
-            Region &r = it->second;
+        for (auto &region : regions) {
+            const uint32_t start = region.first;
+            Region &r = region.second;
             if (!r.used && r.size >= size) {
                 bddebug(2) << "alloc @ " << start << "," << (uint32_t)r.size << "\n";
                 if (r.size > size + kAlignment) {

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -979,9 +979,9 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
         }
     }
 
-    for (size_t i = 0; i < edges.size(); i++) {
-        edges[i].producer->outgoing_edges.push_back(&(edges[i]));
-        edges[i].consumer->incoming_edges.push_back(&(edges[i]));
+    for (auto &edge : edges) {
+        edge.producer->outgoing_edges.push_back(&edge);
+        edge.consumer->incoming_edges.push_back(&edge);
     }
 
     // Compute transitive dependencies

--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -1244,12 +1244,12 @@ bool LoopNest::computes(const FunctionDAG::Node *f) const {
 // Inline a Func into all consumers within this loop.
 void LoopNest::inline_func(const FunctionDAG::Node *f) {
     // Inline it into the children
-    for (size_t i = 0; i < children.size(); i++) {
-        if (children[i]->calls(f)) {
+    for (auto &i : children) {
+        if (i->calls(f)) {
             std::unique_ptr<LoopNest> new_child{new LoopNest};
-            new_child->copy_from(*children[i]);
+            new_child->copy_from(*i);
             new_child->inline_func(f);
-            children[i] = new_child.release();
+            i = new_child.release();
         }
     }
 
@@ -1625,8 +1625,7 @@ vector<IntrusivePtr<const LoopNest>> LoopNest::compute_in_tiles(const FunctionDA
 
         const auto &c = children[child];
         int num_ones = 0;
-        for (size_t i = 0; i < c->size.size(); i++) {
-            int64_t s = c->size[i];
+        for (long s : c->size) {
             num_ones += (s == 1) ? 1 : 0;
         }
 

--- a/src/autoschedulers/adams2019/retrain_cost_model.cpp
+++ b/src/autoschedulers/adams2019/retrain_cost_model.cpp
@@ -266,8 +266,8 @@ map<int, PipelineSample> load_samples(const Flags &flags) {
             Sample sample;
             sample.filename = s;
             sample.runtimes.push_back(runtime);
-            for (int i = 0; i < kModels; i++) {
-                sample.prediction[i] = 0.0;
+            for (double &i : sample.prediction) {
+                i = 0.0;
             }
             sample.schedule_id = schedule_id;
             sample.schedule_features = Buffer<float>(head2_w, num_stages);

--- a/src/autoschedulers/common/cmdline.h
+++ b/src/autoschedulers/common/cmdline.h
@@ -377,9 +377,8 @@ class parser {
 public:
     parser() = default;
     ~parser() {
-        for (std::map<std::string, option_base *>::iterator p = options.begin();
-             p != options.end(); p++) {
-            delete p->second;
+        for (auto &option : options) {
+            delete option.second;
         }
     }
 
@@ -489,8 +488,8 @@ public:
             args.push_back(buf);
         }
 
-        for (size_t i = 0; i < args.size(); i++) {
-            std::cout << "\"" << args[i] << "\"" << std::endl;
+        for (auto &arg : args) {
+            std::cout << "\"" << arg << "\"" << std::endl;
         }
 
         return parse(args);
@@ -520,19 +519,18 @@ public:
         }
 
         std::map<char, std::string> lookup;
-        for (std::map<std::string, option_base *>::iterator p = options.begin();
-             p != options.end(); p++) {
-            if (p->first.length() == 0) {
+        for (auto &option : options) {
+            if (option.first.length() == 0) {
                 continue;
             }
-            char initial = p->second->short_name();
+            char initial = option.second->short_name();
             if (initial) {
                 if (lookup.count(initial) > 0) {
                     lookup[initial] = "";
                     errors.push_back(std::string("short option '") + initial + "' is ambiguous");
                     return false;
                 } else {
-                    lookup[initial] = p->first;
+                    lookup[initial] = option.first;
                 }
             }
         }
@@ -600,10 +598,9 @@ public:
             }
         }
 
-        for (std::map<std::string, option_base *>::iterator p = options.begin();
-             p != options.end(); p++) {
-            if (!p->second->valid()) {
-                errors.push_back("need option: --" + std::string(p->first));
+        for (auto &option : options) {
+            if (!option.second->valid()) {
+                errors.push_back("need option: --" + std::string(option.first));
             }
         }
 
@@ -637,8 +634,8 @@ public:
 
     std::string error_full() const {
         std::ostringstream oss;
-        for (size_t i = 0; i < errors.size(); i++) {
-            oss << errors[i] << std::endl;
+        for (const auto &error : errors) {
+            oss << error << std::endl;
         }
         return oss.str();
     }
@@ -646,9 +643,9 @@ public:
     std::string usage() const {
         std::ostringstream oss;
         oss << "usage: " << prog_name << " ";
-        for (size_t i = 0; i < ordered.size(); i++) {
-            if (ordered[i]->must()) {
-                oss << ordered[i]->short_description() << " ";
+        for (const auto &i : ordered) {
+            if (i->must()) {
+                oss << i->short_description() << " ";
             }
         }
 
@@ -656,21 +653,21 @@ public:
         oss << "options:" << std::endl;
 
         size_t max_width = 0;
-        for (size_t i = 0; i < ordered.size(); i++) {
-            max_width = std::max(max_width, ordered[i]->name().length());
+        for (const auto &i : ordered) {
+            max_width = std::max(max_width, i->name().length());
         }
-        for (size_t i = 0; i < ordered.size(); i++) {
-            if (ordered[i]->short_name()) {
-                oss << "  -" << ordered[i]->short_name() << ", ";
+        for (const auto &i : ordered) {
+            if (i->short_name()) {
+                oss << "  -" << i->short_name() << ", ";
             } else {
                 oss << "      ";
             }
 
-            oss << "--" << ordered[i]->name();
-            for (size_t j = ordered[i]->name().length(); j < max_width + 4; j++) {
+            oss << "--" << i->name();
+            for (size_t j = i->name().length(); j < max_width + 4; j++) {
                 oss << ' ';
             }
-            oss << ordered[i]->description() << std::endl;
+            oss << i->description() << std::endl;
         }
         return oss.str();
     }

--- a/src/autoschedulers/li2018/GradientAutoscheduler.cpp
+++ b/src/autoschedulers/li2018/GradientAutoscheduler.cpp
@@ -45,8 +45,8 @@ std::vector<int> get_int_bounds(const Box &bounds) {
 std::vector<int> get_rvar_bounds(const std::vector<ReductionVariable> &rvars) {
     std::vector<int> rvar_bounds;
     rvar_bounds.reserve(rvars.size());
-    for (int arg_id = 0; arg_id < (int)rvars.size(); arg_id++) {
-        Expr extent = simplify(substitute_var_estimates(rvars[arg_id].extent));
+    for (const auto &rvar : rvars) {
+        Expr extent = simplify(substitute_var_estimates(rvar.extent));
         const int64_t *extent_int = as_const_int(extent);
         user_assert(extent_int != nullptr)
             << "extent:" << extent << " is not constant.\n";

--- a/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
+++ b/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
@@ -72,9 +72,9 @@ string get_sanitized_name(string name) {
     if (isdigit(name[0])) {
         name = "_" + name;
     }
-    for (size_t i = 0; i < name.size(); ++i) {
-        if (!isalnum(name[i])) {
-            name[i] = '_';
+    for (char &i : name) {
+        if (!isalnum(i)) {
+            i = '_';
         }
     }
     return name;
@@ -817,8 +817,8 @@ struct AutoSchedule {
                 if (s.first > 0) {
                     schedule_ss << ".update(" << std::to_string(s.first - 1) << ")";
                 }
-                for (size_t i = 0; i < s.second.size(); ++i) {
-                    schedule_ss << "\n        ." << s.second[i];
+                for (const auto &i : s.second) {
+                    schedule_ss << "\n        ." << i;
                 }
                 schedule_ss << ";\n";
             }
@@ -1681,8 +1681,8 @@ void Partitioner::group(Partitioner::Level level) {
         debug(3) << "\n============================\n"
                  << "Current grouping candidates:\n"
                  << "============================\n";
-        for (size_t i = 0; i < cand.size(); ++i) {
-            debug(3) << "{" << cand[i].first << ", " << cand[i].second << "}\n";
+        for (auto &i : cand) {
+            debug(3) << "{" << i.first << ", " << i.second << "}\n";
         }
 
         vector<pair<GroupingChoice, GroupConfig>> best = choose_candidate_grouping(cand, level);
@@ -1911,8 +1911,8 @@ Partitioner::GroupAnalysis Partitioner::analyze_group(const Group &g, bool show_
     Box out_tile_extent;
     if (g.output.stage_num == 0) {
         const vector<string> &args = g.output.func.args();
-        for (size_t d = 0; d < args.size(); d++) {
-            const auto &iter = tile_bounds.find(args[d]);
+        for (const auto &arg : args) {
+            const auto &iter = tile_bounds.find(arg);
             if (iter != tile_bounds.end()) {
                 out_tile_extent.push_back(iter->second);
             } else {

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -556,9 +556,9 @@ WEAK void halide_memoization_cache_release(void *user_context, void *host) {
 
 WEAK void halide_memoization_cache_cleanup() {
     debug(nullptr) << "halide_memoization_cache_cleanup\n";
-    for (size_t i = 0; i < kHashTableSize; i++) {
-        CacheEntry *entry = cache_entries[i];
-        cache_entries[i] = nullptr;
+    for (auto &cache_entrie : cache_entries) {
+        CacheEntry *entry = cache_entrie;
+        cache_entrie = nullptr;
         while (entry != nullptr) {
             CacheEntry *next = entry->next;
             entry->destroy();
@@ -574,10 +574,10 @@ WEAK void halide_memoization_cache_cleanup() {
 WEAK void halide_memoization_cache_evict(void *user_context, uint64_t eviction_key) {
     ScopedMutexLock lock(&memoization_lock);
 
-    for (size_t i = 0; i < kHashTableSize; i++) {
-        CacheEntry *entry = cache_entries[i];
+    for (auto &cache_entrie : cache_entries) {
+        CacheEntry *entry = cache_entrie;
         if (entry != nullptr) {
-            CacheEntry **prev = &cache_entries[i];
+            CacheEntry **prev = &cache_entrie;
             while (entry != nullptr) {
                 CacheEntry *next = entry->next;
                 if (entry->has_eviction_key && entry->eviction_key == eviction_key) {

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -49,10 +49,10 @@ extern "C" WEAK void *halide_cuda_get_symbol(void *user_context, const char *nam
         "/Library/Frameworks/CUDA.framework/CUDA",
 #endif
     };
-    for (size_t i = 0; i < sizeof(lib_names) / sizeof(lib_names[0]); i++) {
-        lib_cuda = halide_load_library(lib_names[i]);
+    for (auto &lib_name : lib_names) {
+        lib_cuda = halide_load_library(lib_name);
         if (lib_cuda) {
-            debug(user_context) << "    Loaded CUDA runtime library: " << lib_names[i] << "\n";
+            debug(user_context) << "    Loaded CUDA runtime library: " << lib_name << "\n";
             break;
         }
     }

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -2667,12 +2667,12 @@ static bool d3d12_allocation_cache_put_buffer(void *user_context, d3d12_buffer *
 
     ScopedMutexLock lock(&buffer_pool_lock);
 
-    for (size_t i = 0; i < MaxBuffersInCache; ++i) {
-        if (buffer_pool[i] != nullptr) {
+    for (auto &i : buffer_pool) {
+        if (i != nullptr) {
             continue;
         }
         TRACEPRINT("caching allocation for later use...\n");
-        buffer_pool[i] = dbuffer;
+        i = dbuffer;
         return true;
     }
 
@@ -2824,13 +2824,12 @@ WEAK int halide_d3d12compute_device_release(void *user_context) {
     if (device) {
         d3d12compute_device_sync_internal(device, nullptr);
 
-        for (int i = 0; i < MaxFrames; ++i) {
-            d3d12_frame *frame = &frame_pool[i];
+        for (auto &i : frame_pool) {
+            d3d12_frame *frame = &i;
             release_object(frame);
         }
 
-        for (int i = 0; i < MaxBuffersInCache; ++i) {
-            d3d12_buffer *buffer = buffer_pool[i];
+        for (auto *buffer : buffer_pool) {
             release_object(buffer);
         }
 

--- a/src/runtime/hashmap.h
+++ b/src/runtime/hashmap.h
@@ -155,8 +155,8 @@ inline bool HashMap::init(void *user_context, copy_value_func _copy_value, destr
     kDefaultCacheSize = 1 << 20;
     max_cache_size = kDefaultCacheSize;
     current_cache_size = 0;
-    for (size_t i = 0; i < kHashTableSize; ++i) {
-        cache_entries[i] = nullptr;
+    for (auto &cache_entrie : cache_entries) {
+        cache_entrie = nullptr;
     }
     halide_assert(nullptr, _copy_value);
     halide_assert(nullptr, _destroy_value);
@@ -371,9 +371,9 @@ inline void HashMap::release(void *user_context, void *host) {
 
 inline void HashMap::cleanup() {
     debug(nullptr) << "halide_memoization_cache_cleanup\n";
-    for (size_t i = 0; i < kHashTableSize; i++) {
-        CacheEntry *entry = cache_entries[i];
-        cache_entries[i] = nullptr;
+    for (auto &cache_entrie : cache_entries) {
+        CacheEntry *entry = cache_entrie;
+        cache_entrie = nullptr;
         while (entry != nullptr) {
             CacheEntry *next = entry->next;
             entry->destroy(this->user_context, destroy_value);

--- a/src/runtime/hexagon_dma_pool.cpp
+++ b/src/runtime/hexagon_dma_pool.cpp
@@ -108,8 +108,8 @@ WEAK int halide_hexagon_free_dma_resource(void *user_context, void *virtual_engi
     // Lock the Mutex
     ScopedMutexLock lock(&hexagon_dma_pool_mutex);
     hexagon_dma_virtual_engine_t *virtual_engine_addr = (hexagon_dma_virtual_engine_t *)virtual_engine_id;
-    for (int j = 0; j < MAX_NUMBER_OF_WORK_UNITS; j++) {
-        int num = virtual_engine_addr->mapped_engines[j] - 1;
+    for (unsigned char &mapped_engine : virtual_engine_addr->mapped_engines) {
+        int num = mapped_engine - 1;
         if (num != -1) {
             hexagon_dma_pool->dma_engine_list[num].assigned = false;
             hexagon_dma_pool->dma_engine_list[num].used = false;
@@ -117,22 +117,22 @@ WEAK int halide_hexagon_free_dma_resource(void *user_context, void *virtual_engi
                 nDmaWrapper_FinishFrame(hexagon_dma_pool->dma_engine_list[num].engine_addr);
             }
         }
-        virtual_engine_addr->mapped_engines[j] = 0;
+        mapped_engine = 0;
     }
     virtual_engine_addr->num_of_engines = 0;
     virtual_engine_addr->in_use = false;
 
     bool delete_dma_pool = true;
-    for (int k = 0; k < MAX_NUMBER_OF_DMA_ENGINES; k++) {
-        if (hexagon_dma_pool->virtual_engine_list[k].in_use) {
+    for (auto &k : hexagon_dma_pool->virtual_engine_list) {
+        if (k.in_use) {
             delete_dma_pool = false;
         }
     }
 
     if (delete_dma_pool) {
-        for (int i = 0; i < MAX_NUMBER_OF_DMA_ENGINES; i++) {
-            if (hexagon_dma_pool->dma_engine_list[i].engine_addr) {
-                int err = nDmaWrapper_FreeDma((t_DmaWrapper_DmaEngineHandle)hexagon_dma_pool->dma_engine_list[i].engine_addr);
+        for (auto &i : hexagon_dma_pool->dma_engine_list) {
+            if (i.engine_addr) {
+                int err = nDmaWrapper_FreeDma((t_DmaWrapper_DmaEngineHandle)i.engine_addr);
                 if (err != QURT_EOK) {
                     error(user_context) << "Hexagon: Failure to Free DMA\n";
                     nRet = err;
@@ -163,17 +163,17 @@ WEAK void *halide_hexagon_allocate_dma_resource(void *user_context) {
             hexagon_dma_pool->dma_engine_list[i].engine_addr = nullptr;
             hexagon_dma_pool->dma_engine_list[i].assigned = false;
             hexagon_dma_pool->virtual_engine_list[i].in_use = false;
-            for (int j = 0; j < MAX_NUMBER_OF_WORK_UNITS; j++) {
-                hexagon_dma_pool->virtual_engine_list[i].mapped_engines[j] = 0;
+            for (unsigned char &mapped_engine : hexagon_dma_pool->virtual_engine_list[i].mapped_engines) {
+                mapped_engine = 0;
             }
             hexagon_dma_pool->virtual_engine_list[i].num_of_engines = 0;
         }
     }
 
-    for (int i = 0; i < MAX_NUMBER_OF_DMA_ENGINES; i++) {
-        if (hexagon_dma_pool->virtual_engine_list[i].in_use == false) {
-            hexagon_dma_pool->virtual_engine_list[i].in_use = true;
-            void *virtual_addr = &(hexagon_dma_pool->virtual_engine_list[i]);
+    for (auto &i : hexagon_dma_pool->virtual_engine_list) {
+        if (i.in_use == false) {
+            i.in_use = true;
+            void *virtual_addr = &i;
             return (void *)virtual_addr;
         }
     }

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -41,10 +41,10 @@ extern "C" WEAK void *halide_opencl_get_symbol(void *user_context, const char *n
         "/System/Library/Frameworks/OpenCL.framework/OpenCL",
 #endif
     };
-    for (size_t i = 0; i < sizeof(lib_names) / sizeof(lib_names[0]); i++) {
-        lib_opencl = halide_load_library(lib_names[i]);
+    for (auto &lib_name : lib_names) {
+        lib_opencl = halide_load_library(lib_name);
         if (lib_opencl) {
-            debug(user_context) << "    Loaded OpenCL runtime library: " << lib_names[i] << "\n";
+            debug(user_context) << "    Loaded OpenCL runtime library: " << lib_name << "\n";
             break;
         }
     }

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -49,8 +49,8 @@ WEAK void *mem_buf[num_buffers] = {
 };
 
 WEAK __attribute__((destructor)) void halide_allocator_cleanup() {
-    for (int i = 0; i < num_buffers; ++i) {
-        aligned_free(mem_buf[i]);
+    for (auto &i : mem_buf) {
+        aligned_free(i);
     }
 }
 

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1582,9 +1582,9 @@ bool save_mat(ImageType &im, const std::string &filename) {
     if (name.empty() || !std::isalpha(name[0])) {
         name = "v" + name;
     }
-    for (size_t i = 0; i < name.size(); i++) {
-        if (!std::isalnum(name[i])) {
-            name[i] = '_';
+    for (char &i : name) {
+        if (!std::isalnum(i)) {
+            i = '_';
         }
     }
 

--- a/util/HalideTraceDump.cpp
+++ b/util/HalideTraceDump.cpp
@@ -171,9 +171,9 @@ bool check_and_continue(bool condition, const char *msg) {
 
 void dump_func(string name, FuncInfo &func, BufferOutputOpts output_opts) {
     // Remove special characters
-    for (size_t i = 0; i < name.size(); i++) {
-        if (!std::isalnum(name[i])) {
-            name[i] = '_';
+    for (char &i : name) {
+        if (!std::isalnum(i)) {
+            i = '_';
         }
     }
 


### PR DESCRIPTION
(Note that ~all of the changes were auto-fixed by clang-tidy's --fix flag, with just a few straggling hand fixes needed.)