### PR TITLE
Fix bug in prefetch()

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -911,7 +911,7 @@ void IRPrinter::visit(const Prefetch *op) {
         indent++;
         stream << get_indent();
     }
-    stream << "prefetch " << op->name << "(";
+    stream << "prefetch " << op->name << ", " << op->prefetch.at << ", " << op->prefetch.from << ", (";
     for (size_t i = 0; i < op->bounds.size(); i++) {
         stream << "[";
         print_no_parens(op->bounds[i].min);

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -39,7 +39,7 @@ bool check(const vector<vector<Expr>> &expected, vector<vector<Expr>> &result) {
         for (size_t j = 0; j < expected[i].size(); ++j) {
             if (!equal(expected[i][j], result[i][j])) {
                 std::cout << "Expect \"" << expected[i][j] << "\" at arg index "
-                          << j << ", got \"" << result[i][j] << " instead\n";
+                          << j << ", got \"" << result[i][j] << "\" instead\n";
                 return false;
             }
         }

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -20,6 +20,7 @@ tests(GROUPS error
       bad_extern_split.cpp
       bad_fold.cpp
       bad_host_alignment.cpp
+      bad_prefetch.cpp
       bad_reorder.cpp
       bad_reorder_storage.cpp
       bad_rvar_order.cpp

--- a/test/error/bad_prefetch.cpp
+++ b/test/error/bad_prefetch.cpp
@@ -1,0 +1,23 @@
+#include "Halide.h"
+
+#include <map>
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f("f"), g("g");
+    Var x("x"), y("y");
+
+    f(x, y) = x + y;
+    g(x, y) = f(0, 0);
+
+    f.compute_root();
+    g.prefetch(f, y, x, 8);
+    g.print_loop_nest();
+
+    Module m = g.compile_to_module({});
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
In #6155, we incorrectly assume that we can qualify the 'from' prefetch var by just adding 'prefix'; this isn't true if (e.g.) there are any splits involved. Instead, we need to walk through the active loops to find a suitable match. In addition, if no match is found, we now fail with an error (rather than quietly doing something undefined), as the 'from' var is required to be from an active loop.

(Addresses some-but-not-all of #6219)