### PR TITLE
More prefetch fixes 

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2521,9 +2521,10 @@ void CodeGen_C::visit(const Call *op) {
 
         const Variable *base = base_address.as<Variable>();
         internal_assert(base && base->type.is_handle());
+        // TODO: provide some way to customize the rw and locality?
         rhs << "__builtin_prefetch("
             << "((" << print_type(op->type) << " *)" << print_name(base->name)
-            << " + " << print_expr(base_offset) << "), 1)";
+            << " + " << print_expr(base_offset) << "), /*rw*/0, /*locality*/0)";
     } else if (op->is_intrinsic(Call::size_of_halide_buffer_t)) {
         rhs << "(sizeof(halide_buffer_t))";
     } else if (op->is_intrinsic(Call::strict_float)) {

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -235,7 +235,7 @@ private:
                 string from_var;
                 for (int j = (int)loop_nest.size() - 1; j >= 0; --j) {
                     if (starts_with(loop_nest[j], prefix) && ends_with(loop_nest[j], "." + p.from)) {
-                        from_var = loop_nest[i];
+                        from_var = loop_nest[j];
                         break;
                     }
                 }

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -198,7 +198,7 @@ private:
     using IRMutator::visit;
 
     Stmt add_placeholder_prefetch(const string &at, const string &from, PrefetchDirective p, Stmt body) {
-        debug(5) << "...Injecting placeholder prefetch for loop " << at << "fetch " << from << "\n";
+        debug(5) << "...Injecting placeholder prefetch for loop " << at << " from " << from << "\n";
         p.at = at;
         p.from = from;
         internal_assert(body.defined());
@@ -236,6 +236,7 @@ private:
                 for (int j = (int)loop_nest.size() - 1; j >= 0; --j) {
                     if (starts_with(loop_nest[j], prefix) && ends_with(loop_nest[j], "." + p.from)) {
                         from_var = loop_nest[j];
+                        debug(5) << "Prefetch from " << p.from << " -> from_var " << from_var << "\n";
                         break;
                     }
                 }
@@ -279,11 +280,14 @@ class ReducePrefetchDimension : public IRMutator {
 
         const size_t max_arg_size = 2 + 2 * max_dim;  // Prefetch: {base, offset, extent0, stride0, extent1, stride1, ...}
         if (prefetch && (prefetch->args.size() > max_arg_size)) {
-            const Variable *base = prefetch->args[0].as<Variable>();
+            const Expr &base_address = prefetch->args[0];
+            const Expr &base_offset = prefetch->args[1];
+
+            const Variable *base = base_address.as<Variable>();
             internal_assert(base && base->type.is_handle());
 
             vector<string> index_names;
-            Expr new_offset = prefetch->args[1];
+            Expr new_offset = base_offset;
             for (size_t i = max_arg_size; i < prefetch->args.size(); i += 2) {
                 // const Expr &extent = prefetch->args[i + 0];  // unused
                 const Expr &stride = prefetch->args[i + 1];
@@ -329,14 +333,17 @@ class SplitPrefetch : public IRMutator {
         op = stmt.as<Evaluate>();
         internal_assert(op);
         if (const Call *prefetch = Call::as_intrinsic(op->value, {Call::prefetch})) {
-            const Variable *base = prefetch->args[0].as<Variable>();
+            const Expr &base_address = prefetch->args[0];
+            const Expr &base_offset = prefetch->args[1];
+
+            const Variable *base = base_address.as<Variable>();
             internal_assert(base && base->type.is_handle());
 
             int elem_size = prefetch->type.bytes();
 
             vector<string> index_names;
             vector<Expr> extents;
-            Expr new_offset = prefetch->args[1];
+            Expr new_offset = base_offset;
             for (size_t i = 2; i < prefetch->args.size(); i += 2) {
                 Expr extent = prefetch->args[i];
                 Expr stride = prefetch->args[i + 1];

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -3,6 +3,7 @@
 
 #include "CSE.h"
 #include "CodeGen_GPU_Dev.h"
+#include "Deinterleave.h"
 #include "ExprUsesVar.h"
 #include "IREquality.h"
 #include "IRMutator.h"
@@ -717,7 +718,21 @@ class VectorSubs : public IRMutator {
         for (size_t i = 0; i < new_args.size(); i++) {
             new_args[i] = widen(new_args[i], max_lanes);
         }
-        return Call::make(op->type.with_lanes(max_lanes), op->name, new_args,
+        Type new_op_type = op->type.with_lanes(max_lanes);
+
+        if (op->is_intrinsic(Call::prefetch)) {
+            // We don't want prefetch args to ve vectorized, but we can't just skip the mutation
+            // (otherwise we can end up with dead loop variables. Instead, use extract_lane() on each arg
+            // to scalarize it again.
+            for (auto &arg : new_args) {
+                if (arg.type().is_vector()) {
+                    arg = extract_lane(arg, 0);
+                }
+            }
+            new_op_type = op->type;
+        }
+
+        return Call::make(new_op_type, op->name, new_args,
                           op->call_type, op->func, op->value_index, op->image, op->param);
     }
 

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -284,8 +284,18 @@ int test9(const Target &t) {
 
     vector<vector<Expr>> expected;
     for (int i = 0; i < 4; i++) {
+        Expr base = Variable::make(Handle(), f.name());
         // The offset arg is a variable that is ticklish to get right, so just use a wildcard for matching
-        expected.push_back({Variable::make(Handle(), f.name()), wild<int>(), 1, get_stride(t, 4)});
+        Expr offset = wild<int>();
+        Expr extent0 = 1;
+        Expr stride0 = get_stride(t, 4);
+        if (t.has_feature(Target::HVX)) {
+            Expr extent1 = 1;
+            Expr stride1 = wild<int>();
+            expected.push_back({base, offset, extent0, stride0, extent1, stride1});
+        } else {
+            expected.push_back({base, offset, extent0, stride0});
+        }
     }
     if (!check(expected, collect.prefetches)) {
         return -1;
@@ -320,8 +330,20 @@ int test10(const Target &t) {
 
     vector<vector<Expr>> expected;
     for (int i = 0; i < 8; i++) {
+        Expr base = Variable::make(Handle(), f.name());
         // The offset arg is a variable that is ticklish to get right, so just use a wildcard for matching
-        expected.push_back({Variable::make(Handle(), f.name()), wild<int>(), 1, get_stride(t, 4)});
+        Expr offset = wild<int>();
+        if (t.has_feature(Target::HVX)) {
+            Expr extent0 = 4;
+            Expr stride0 = get_stride(t, 4);
+            Expr extent1 = 1;
+            Expr stride1 = wild<int>();
+            expected.push_back({base, offset, extent0, stride0, extent1, stride1});
+        } else {
+            Expr extent0 = 1;
+            Expr stride0 = get_stride(t, 4);
+            expected.push_back({base, offset, extent0, stride0});
+        }
     }
     if (!check(expected, collect.prefetches)) {
         return -1;
@@ -356,8 +378,20 @@ int test11(const Target &t) {
 
     vector<vector<Expr>> expected;
     for (int i = 0; i < 8; i++) {
+        Expr base = Variable::make(Handle(), f.name());
         // The offset arg is a variable that is ticklish to get right, so just use a wildcard for matching
-        expected.push_back({Variable::make(Handle(), f.name()), wild<int>(), 1, get_stride(t, 4)});
+        Expr offset = wild<int>();
+        if (t.has_feature(Target::HVX)) {
+            Expr extent0 = 4;
+            Expr stride0 = get_stride(t, 4);
+            Expr extent1 = 1;
+            Expr stride1 = wild<int>();
+            expected.push_back({base, offset, extent0, stride0, extent1, stride1});
+        } else {
+            Expr extent0 = 1;
+            Expr stride0 = get_stride(t, 4);
+            expected.push_back({base, offset, extent0, stride0});
+        }
     }
     if (!check(expected, collect.prefetches)) {
         return -1;

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -82,7 +82,7 @@ int test1(const Target &t) {
     f.compute_root();
     g.prefetch(f, x, x, 8);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -106,7 +106,7 @@ int test2(const Target &t) {
     g.specialize(p).prefetch(f, x, x, 8);
     g.specialize_fail("No prefetch");
 
-    Module m = g.compile_to_module({p});
+    Module m = g.compile_to_module({p}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -130,7 +130,7 @@ int test3(const Target &t) {
     h.compute_at(g, xo);
     g.prefetch(f, xo, xo, 1);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -153,7 +153,7 @@ int test4(const Target &t) {
     h.compute_root();
     g.prefetch(f, x, x, 1);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -176,7 +176,7 @@ int test5(const Target &t) {
     f.compute_root();
     g.prefetch(f, x, y, 8);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -200,7 +200,7 @@ int test6(const Target &t) {
     g.specialize(p).prefetch(f, x, y, 8);
     g.specialize_fail("No prefetch");
 
-    Module m = g.compile_to_module({p});
+    Module m = g.compile_to_module({p}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -224,7 +224,7 @@ int test7(const Target &t) {
     h.compute_at(g, xo);
     g.prefetch(f, xo, y, 1);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -247,7 +247,7 @@ int test8(const Target &t) {
     h.compute_root();
     g.prefetch(f, x, y, 1);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -278,7 +278,7 @@ int test9(const Target &t) {
         .unroll(y)
         .prefetch(f, x, y, 123, PrefetchBoundStrategy::NonFaulting);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -314,7 +314,7 @@ int test10(const Target &t) {
         .unroll(y)
         .prefetch(f, y, xo, 123 / 4, PrefetchBoundStrategy::NonFaulting);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -350,7 +350,7 @@ int test11(const Target &t) {
         .unroll(y)
         .prefetch(f, xo, xo, 123 / 4, PrefetchBoundStrategy::NonFaulting);
 
-    Module m = g.compile_to_module({});
+    Module m = g.compile_to_module({}, "", t);
     CollectPrefetches collect;
     m.functions()[0].body.accept(&collect);
 
@@ -369,6 +369,7 @@ int test11(const Target &t) {
 
 int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
+    std::cout << "Testing target: " << t << "\n";
 
     using Fn = int (*)(const Target &t);
     std::vector<Fn> tests = {test1, test2, test3, test4, test5, test6, test7, test8, test9, test10, test11};

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -322,6 +322,8 @@ int test10(const Target &t) {
         .unroll(xo)
         .reorder(xi, y, xo)
         .unroll(y)
+        // 123/4 because it's supposed to be equivalent to prefetching 123 elements ahead in the x direction.
+        // Because this is the xo loop, the correct amount is 123/4.
         .prefetch(f, y, xo, 123 / 4, PrefetchBoundStrategy::NonFaulting);
 
     Module m = g.compile_to_module({}, "", t);
@@ -370,6 +372,8 @@ int test11(const Target &t) {
         .unroll(xo)
         .reorder(xi, xo, y)
         .unroll(y)
+        // 123/4 because it's supposed to be equivalent to prefetching 123 elements ahead in the x direction.
+        // Because this is the xo loop, the correct amount is 123/4.
         .prefetch(f, xo, xo, 123 / 4, PrefetchBoundStrategy::NonFaulting);
 
     Module m = g.compile_to_module({}, "", t);


### PR DESCRIPTION
- Arguments to Call::prefetch() must be scalars, not vectors
- Add more testcases to correctness_prefetch