### PR TITLE
Hoist unrolled prefetches to top of the block

### DIFF
--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -1,6 +1,7 @@
 #include "IR.h"
 
 #include "IRMutator.h"
+#include "IROperator.h"
 #include "IRPrinter.h"
 #include "IRVisitor.h"
 #include <numeric>
@@ -490,6 +491,8 @@ Stmt Prefetch::make(const std::string &name, const std::vector<Type> &types,
     internal_assert(body.defined()) << "Prefetch of undefined\n";
     internal_assert(condition.defined()) << "Prefetch with undefined condition\n";
     internal_assert(condition.type().is_bool()) << "Prefetch condition is not boolean\n";
+
+    user_assert(is_pure(prefetch.offset)) << "The offset to the prefetch directive must be pure.";
 
     Prefetch *node = new Prefetch;
     node->name = name;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -390,6 +390,10 @@ void lower_impl(const vector<Function> &output_funcs,
     s = find_intrinsics(s);
     log("Lowering after finding intrinsics:", s);
 
+    debug(1) << "Hoisting prefetches...\n";
+    s = hoist_prefetches(s);
+    log("Lowering after hoisting prefetches:", s);
+
     debug(1) << "Lowering after final simplification:\n"
              << s << "\n\n";
 

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -405,10 +405,11 @@ class HoistPrefetches : public IRMutator {
     using IRMutator::visit;
 
     Stmt visit(const Block *op) override {
-        Stmt s = IRMutator::visit(op);
+        Stmt s = op;
 
         Stmt prefetches, body;
-        traverse_block(s, [&prefetches, &body](const Stmt &s) {
+        traverse_block(s, [this, &prefetches, &body](const Stmt &s_in) {
+            Stmt s = IRMutator::mutate(s_in);
             const Evaluate *eval = s.as<Evaluate>();
             if (eval && Call::as_intrinsic(eval->value, {Call::prefetch})) {
                 prefetches = prefetches.defined() ? Block::make(prefetches, s) : s;

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -391,6 +391,43 @@ public:
     }
 };
 
+void traverse_block(const Stmt &s, std::function<void(const Stmt &)> f) {
+    const Block *b = s.as<Block>();
+    if (!b) {
+        f(s);
+    } else {
+        traverse_block(b->first, f);
+        traverse_block(b->rest, f);
+    }
+}
+
+class HoistPrefetches : public IRMutator {
+    using IRMutator::visit;
+
+    Stmt visit(const Block *op) override {
+        Stmt s = IRMutator::visit(op);
+
+        Stmt prefetches, body;
+        traverse_block(s, [&prefetches, &body](const Stmt &s) {
+            const Evaluate *eval = s.as<Evaluate>();
+            if (eval && Call::as_intrinsic(eval->value, {Call::prefetch})) {
+                prefetches = prefetches.defined() ? Block::make(prefetches, s) : s;
+            } else {
+                body = body.defined() ? Block::make(body, s) : s;
+            }
+        });
+        if (prefetches.defined()) {
+            if (body.defined()) {
+                return Block::make(prefetches, body);
+            } else {
+                return prefetches;
+            }
+        } else {
+            return body;
+        }
+    }
+};
+
 }  // anonymous namespace
 
 Stmt inject_placeholder_prefetch(const Stmt &s, const map<string, Function> &env,
@@ -432,6 +469,10 @@ Stmt reduce_prefetch_dimension(Stmt stmt, const Target &t) {
         stmt = SplitPrefetch(max_byte_size).mutate(stmt);
     }
     return stmt;
+}
+
+Stmt hoist_prefetches(const Stmt &s) {
+    return HoistPrefetches().mutate(s);
 }
 
 }  // namespace Internal

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -391,7 +391,7 @@ public:
     }
 };
 
-void traverse_block(const Stmt &s, std::function<void(const Stmt &)> f) {
+void traverse_block(const Stmt &s, const std::function<void(const Stmt &)> &f) {
     const Block *b = s.as<Block>();
     if (!b) {
         f(s);

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -391,7 +391,8 @@ public:
     }
 };
 
-void traverse_block(const Stmt &s, const std::function<void(const Stmt &)> &f) {
+template<typename Fn>
+void traverse_block(const Stmt &s, Fn &&f) {
     const Block *b = s.as<Block>();
     if (!b) {
         f(s);

--- a/src/Prefetch.h
+++ b/src/Prefetch.h
@@ -38,6 +38,15 @@ Stmt inject_prefetch(const Stmt &s, const std::map<std::string, Function> &env);
  * on the architecture), this also adds an outer loops that tile the prefetches. */
 Stmt reduce_prefetch_dimension(Stmt stmt, const Target &t);
 
+/** Hoist all the prefetches in a Block to the beginning of the Block.
+ * This generally only happens when a loop with prefetches is unrolled;
+ * in some cases, LLVM's code generation can be suboptimal (unnecessary register spills)
+ * when prefetches are scattered through the loop. Hoisting to the top of the
+ * loop is a good way to mitigate this, at the cost of the prefetch calls possibly
+ * being less useful due to distance from use point. (This is a bit experimental
+ * and may need revisiting.) See also https://bugs.llvm.org/show_bug.cgi?id=51172 */
+Stmt hoist_prefetches(const Stmt &s);
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/src/PrefetchDirective.h
+++ b/src/PrefetchDirective.h
@@ -38,7 +38,7 @@ struct PrefetchDirective {
     std::string name;
     std::string at;    // the loop in which to do the prefetch
     std::string from;  // the loop-var to use as the base for prefetching. It must be nested outside loop_var (or be equal to loop_var).
-    Expr offset;       // 'fetch_var + offset' will determine the bounds being prefetched.
+    Expr offset;       // 'from + offset' will determine the bounds being prefetched.
     PrefetchBoundStrategy strategy;
     // If it's a prefetch load from an image parameter, this points to that.
     Parameter param;


### PR DESCRIPTION
When a loop with prefetch is unrolled, the prefetch instructions getting scattered through the loop can cause LLVM codegen issues in some cases (see https://bugs.llvm.org/show_bug.cgi?id=51172). As a partial mitigation for that issue, this PR adds a pass to hoist all prefetch instructions to the top of their loop. This is still a bit experimental; it definitely addresses the codegen issues we see, but makes the use of prefetch potentially less effective (since the hoisted prefetch may be too far from the eventual use to be effective).