### PR TITLE
Upgrade clang-format and clang-tidy to LLVM-12

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,6 +30,7 @@ Checks: >
     performance-*,
     -performance-inefficient-string-concatenation,
     -performance-inefficient-vector-operation,
+    -performance-no-int-to-ptr,
     readability-avoid-const-params-in-decls,
     readability-braces-around-statements,
     readability-const-return-type,

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.11
+      - uses: DoozyX/clang-format-lint-action@v0.12
         with:
           source: '.'
           extensions: 'h,c,cpp'
-          clangFormatVersion: 11
+          clangFormatVersion: 12
   check_clang_tidy:
     name: Check clang-tidy
     runs-on: ubuntu-20.04
@@ -28,12 +28,12 @@ jobs:
       - name: Install clang-tidy
         run: |
           sudo apt-get update
-          sudo apt-get install llvm-11 clang-11 liblld-11-dev libclang-11-dev clang-tidy-11 ninja-build
+          sudo apt-get install llvm-12 clang-12 liblld-12-dev libclang-12-dev clang-tidy-12 ninja-build
       - name: Run clang-tidy
         run: |
-          export CC=clang-11
-          export CXX=clang++-11
-          export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-11
+          export CC=clang-12
+          export CXX=clang++-12
+          export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-12
           ./run-clang-tidy.sh
   check_cmake_file_lists:
     name: Check CMake file lists

--- a/Makefile
+++ b/Makefile
@@ -2336,7 +2336,7 @@ $(BIN_DIR)/HalideTraceDump: $(ROOT_DIR)/util/HalideTraceDump.cpp $(ROOT_DIR)/uti
 
 # Note: you must have CLANG_FORMAT_LLVM_INSTALL_DIR set for this rule to work.
 # Let's default to the Ubuntu install location.
-CLANG_FORMAT_LLVM_INSTALL_DIR ?= /usr/lib/llvm-11
+CLANG_FORMAT_LLVM_INSTALL_DIR ?= /usr/lib/llvm-12
 
 .PHONY: format
 format:
@@ -2344,7 +2344,7 @@ format:
 
 # Note: you must have CLANG_TIDY_LLVM_INSTALL_DIR set for these rules to work.
 # Let's default to the Ubuntu install location.
-CLANG_TIDY_LLVM_INSTALL_DIR ?= /usr/lib/llvm-11
+CLANG_TIDY_LLVM_INSTALL_DIR ?= /usr/lib/llvm-12
 
 .PHONY: clang-tidy
 clang-tidy:

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -4,23 +4,23 @@ set -e
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# We are currently standardized on using LLVM/Clang11 for this script.
+# We are currently standardized on using LLVM/Clang12 for this script.
 # Note that this is totally independent of the version of LLVM that you
-# are using to build Halide itself. If you don't have LLVM11 installed,
+# are using to build Halide itself. If you don't have LLVM12 installed,
 # you can usually install what you need easily via:
 #
-# sudo apt-get install llvm-11 clang-11 libclang-11-dev clang-tidy-11
-# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-11
+# sudo apt-get install llvm-12 clang-12 libclang-12-dev clang-tidy-12
+# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-12
 
 [ -z "$CLANG_FORMAT_LLVM_INSTALL_DIR" ] && echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_FORMAT_LLVM_INSTALL_DIR = ${CLANG_FORMAT_LLVM_INSTALL_DIR}
 
 VERSION=$(${CLANG_FORMAT_LLVM_INSTALL_DIR}/bin/clang-format --version)
-if [[ ${VERSION} =~ .*version\ 11.* ]]
+if [[ ${VERSION} =~ .*version\ 12.* ]]
 then
-    echo "clang-format version 11 found."
+    echo "clang-format version 12 found."
 else
-    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 11 install!"
+    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 12 install!"
     exit 1
 fi
 

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -8,23 +8,23 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 FIX=$1
 
-# We are currently standardized on using LLVM/Clang11 for this script.
+# We are currently standardized on using LLVM/Clang12 for this script.
 # Note that this is totally independent of the version of LLVM that you
-# are using to build Halide itself. If you don't have LLVM11 installed,
+# are using to build Halide itself. If you don't have LLVM12 installed,
 # you can usually install what you need easily via:
 #
-# sudo apt-get install llvm-11 clang-11 libclang-11-dev clang-tidy-11
-# export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-11
+# sudo apt-get install llvm-12 clang-12 libclang-12-dev clang-tidy-12
+# export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-12
 
 [ -z "$CLANG_TIDY_LLVM_INSTALL_DIR" ] && echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_TIDY_LLVM_INSTALL_DIR = ${CLANG_TIDY_LLVM_INSTALL_DIR}
 
 VERSION=$(${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-tidy --version)
-if [[ ${VERSION} =~ .*version\ 11.* ]]
+if [[ ${VERSION} =~ .*version\ 12.* ]]
 then
-    echo "clang-tidy version 11 found."
+    echo "clang-tidy version 12 found."
 else
-    echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM 11 install!"
+    echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM 12 install!"
     exit 1
 fi
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -752,7 +752,7 @@ std::string halide_type_to_c_type(const Type &t) {
 
 int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output) {
     const char kUsage[] =
-        "gengen\n"
+        "gengen \n"
         "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME] [-d 1|0]\n"
         "  [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME] [-s AUTOSCHEDULER_NAME] [-t TIMEOUT]\n"
         "       target=target-string[,target-string...] [generator_arg=value [...]]\n"

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -752,7 +752,7 @@ std::string halide_type_to_c_type(const Type &t) {
 
 int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output) {
     const char kUsage[] =
-        "gengen \n"
+        "gengen\n"
         "  [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME] [-d 1|0]\n"
         "  [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME] [-s AUTOSCHEDULER_NAME] [-t TIMEOUT]\n"
         "       target=target-string[,target-string...] [generator_arg=value [...]]\n"


### PR DESCRIPTION
Pretty minor -- no formatting changes, only one new warning needing disabling -- just keeping our tooling not too far from top of tree.