### PR TITLE
Remove torch/extension dependency and fix PyTorch example, adding the correct (GPU) autoscheduler

### DIFF
--- a/apps/HelloPyTorch/Makefile
+++ b/apps/HelloPyTorch/Makefile
@@ -94,6 +94,8 @@ $(BIN)/%/add_halidegrad_float32.a: $(GENERATOR_BIN)/add.generator
 		$(ADD_TYPES_F32) \
 		-f add_halidegrad_float32 \
 		-e static_library,c_header,pytorch_wrapper \
+		-p $(HALIDE_DISTRIB_PATH)/lib/libautoschedule_li2018.so \
+		-s Li2018 \
 		-o $(@D) \
 		-d 1 \
 		target=$* \
@@ -129,6 +131,8 @@ $(BIN)/%/add_halidegrad_float64.a: $(GENERATOR_BIN)/add.generator
 		-f add_halidegrad_float64 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
+		-p $(HALIDE_DISTRIB_PATH)/lib/libautoschedule_li2018.so \
+		-s Li2018 \
 		target=$* \
 		-d 1 \
 		target=$* \
@@ -167,6 +171,8 @@ $(BIN)/%/add_halidegrad_cuda_float32.a: $(GENERATOR_BIN)/add.generator
 		-f add_halidegrad_cuda_float32 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
+		-p $(HALIDE_DISTRIB_PATH)/lib/libautoschedule_li2018.so \
+		-s Li2018 \
 		-d 1 \
 		target=$(CUDA_TARGET) \
 		auto_schedule=true
@@ -201,6 +207,8 @@ $(BIN)/%/add_halidegrad_cuda_float64.a: $(GENERATOR_BIN)/add.generator
 		-f add_halidegrad_cuda_float64 \
 		-e static_library,c_header,pytorch_wrapper \
 		-o $(@D) \
+		-p $(HALIDE_DISTRIB_PATH)/lib/libautoschedule_li2018.so \
+		-s Li2018 \
 		-d 1 \
 		target=$(CUDA_TARGET) \
 		auto_schedule=true

--- a/apps/HelloPyTorch/modules.py
+++ b/apps/HelloPyTorch/modules.py
@@ -112,9 +112,9 @@ class Add(th.nn.Module):
     def __init__(self, backward_op):
         super(Add, self).__init__()
         if backward_op == "add_grad":
-          self._adder = AddFunction_Grad()
+          self._adder = AddFunction_Grad
         elif backward_op == "add_halidegrad":
-          self._adder = AddFunction_HalideGrad()
+          self._adder = AddFunction_HalideGrad
         else:
           assert False
 

--- a/apps/HelloPyTorch/setup.py
+++ b/apps/HelloPyTorch/setup.py
@@ -11,12 +11,10 @@ import torch as th
 def generate_pybind_wrapper(path, headers, has_cuda):
     s = "#include \"torch/extension.h\"\n\n"
     if has_cuda:
-        s += "#define HL_PT_CUDA\n"
+        s += "#include \"HalidePyTorchCudaHelpers.h\"\n"
     s += "#include \"HalidePyTorchHelpers.h\"\n"
     for h in headers:
         s += "#include \"{}\"\n".format(os.path.splitext(h)[0]+".pytorch.h")
-    if has_cuda:
-        s += "#undef HL_PT_CUDA\n"
 
     s += "\nPYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {\n"
     for h in headers:

--- a/apps/HelloPyTorch/test.py
+++ b/apps/HelloPyTorch/test.py
@@ -56,17 +56,21 @@ class TestAdd(unittest.TestCase):
             diff = (output-self.gt).sum().item()
             assert diff == 0.0, "Test failed: sum should be 4, got %f" % diff
 
-            # Test the gradient is correct
             self.a.requires_grad = True
             self.b.requires_grad = True
 
-            with warnings.catch_warnings():
-                # Inputs are float, the gradient checker wants double inputs and
-                # will issue a warning.
-                warnings.filterwarnings(
-                    "ignore", message="At least one of the inputs that requires "
-                    "gradient is not of double precision")
-                res = th.autograd.gradcheck(add, [self.a, self.b], eps=1e-2)
+            for i in range(100):
+                output = add(self.a, self.b).sum()
+                output.backward()
+            
+            # # Test the gradient is correct
+            # with warnings.catch_warnings():
+            # Inputs are float, the gradient checker wants double inputs and
+            # will issue a warning.
+            warnings.filterwarnings(
+                "ignore", message="At least one of the inputs that requires "
+                "gradient is not of double precision")
+            res = th.autograd.gradcheck(add, [self.a, self.b], eps=1e-2)
 
             print("  Test ran successfully: difference is", diff)
 

--- a/apps/HelloPyTorch/test.py
+++ b/apps/HelloPyTorch/test.py
@@ -49,9 +49,9 @@ class TestAdd(unittest.TestCase):
             output = add(self.a, self.b)
 
             if is_double:
-                print("  Double-precision mode, backward_op:", backward_op)
+                print("  .Double-precision mode, backward_op:", backward_op)
             else:
-                print("  Single-precision mode, backward_op:", backward_op)
+                print("  .Single-precision mode, backward_op:", backward_op)
 
             diff = (output-self.gt).sum().item()
             assert diff == 0.0, "Test failed: sum should be 4, got %f" % diff
@@ -63,16 +63,15 @@ class TestAdd(unittest.TestCase):
                 output = add(self.a, self.b).sum()
                 output.backward()
             
-            # # Test the gradient is correct
-            # with warnings.catch_warnings():
             # Inputs are float, the gradient checker wants double inputs and
             # will issue a warning.
             warnings.filterwarnings(
-                "ignore", message="At least one of the inputs that requires "
-                "gradient is not of double precision")
+                "ignore", module=r".*gradcheck*")
+
+            # Test the gradient is correct
             res = th.autograd.gradcheck(add, [self.a, self.b], eps=1e-2)
 
-            print("  Test ran successfully: difference is", diff)
+            print("     Test ran successfully: difference is", diff)
 
 
 if __name__ == "__main__":

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -96,11 +96,10 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
         stream << get_indent() << "CUresult res = cuCtxGetCurrent(&ctx);\n";
         stream << get_indent() << "AT_ASSERTM(res == 0, \"Could not acquire CUDA context\");\n";
         stream << get_indent() << "cudaStream_t stream = at::cuda::getCurrentCUDAStream(device_id);\n";
-        stream << get_indent() << "struct UserContext {int device_id; CUcontext *cuda_context; cudaStream_t *stream; } user_ctx;\n";
+        stream << get_indent() << "struct UserContext { int device_id; CUcontext *cuda_context; cudaStream_t *stream; } user_ctx;\n";
         stream << get_indent() << "user_ctx.device_id = device_id;\n";
         stream << get_indent() << "user_ctx.cuda_context = &ctx;\n";
         stream << get_indent() << "user_ctx.stream = &stream;\n";
-        // stream << get_indent() << "Halide::PyTorch::UserContext user_ctx(device_id, &ctx, &stream);\n";
         stream << get_indent() << "void* __user_context = (void*) &user_ctx;\n\n";
     }
 

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -365,7 +365,7 @@ inline int test1_th_(at::Tensor &_buf, float _alpha, int32_t _beta) {
     CUresult res = cuCtxGetCurrent(&ctx);
     AT_ASSERTM(res == 0, "Could not acquire CUDA context");
     cudaStream_t stream = at::cuda::getCurrentCUDAStream(device_id);
-    struct UserContext {int device_id; CUcontext *cuda_context; cudaStream_t *stream; } user_ctx;
+    struct UserContext { int device_id; CUcontext *cuda_context; cudaStream_t *stream; } user_ctx;
     user_ctx.device_id = device_id;
     user_ctx.cuda_context = &ctx;
     user_ctx.stream = &stream;

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -28,11 +28,9 @@ void CodeGen_PyTorch::compile(const Module &module) {
         stream << "#include \"HalideBuffer.h\"\n";
         stream << "#include \"HalidePyTorchCudaHelpers.h\"\n";
         stream << "#include \"HalidePyTorchHelpers.h\"\n";
-        stream << "#include \"torch/extension.h\"\n";
     } else {
         stream << "#include \"HalideBuffer.h\"\n";
         stream << "#include \"HalidePyTorchHelpers.h\"\n";
-        stream << "#include \"torch/extension.h\"\n";
     }
 
     stream << "\n";
@@ -259,7 +257,6 @@ void CodeGen_PyTorch::test() {
         std::string correct_src =
             R"GOLDEN_CODE(#include "HalideBuffer.h"
 #include "HalidePyTorchHelpers.h"
-#include "torch/extension.h"
 
 struct halide_buffer_t;
 struct halide_filter_metadata_t;
@@ -327,7 +324,6 @@ inline int test1_th_(at::Tensor &_buf, float _alpha, int32_t _beta) {
 #include "HalideBuffer.h"
 #include "HalidePyTorchCudaHelpers.h"
 #include "HalidePyTorchHelpers.h"
-#include "torch/extension.h"
 
 struct halide_buffer_t;
 struct halide_filter_metadata_t;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1571,7 +1571,7 @@ Module GeneratorBase::build_gradient_module(const std::string &function_name) {
     // rather being promoted into zero-dimensional buffers.
     for (const auto *input : pi.inputs()) {
         // There can be multiple Funcs/Parameters per input if the
-        // input is an Array
+        // input is an Array.
         if (input->is_array()) {
             internal_assert(input->parameters_.size() == input->funcs_.size());
         }

--- a/src/runtime/HalidePyTorchCudaHelpers.h
+++ b/src/runtime/HalidePyTorchCudaHelpers.h
@@ -3,12 +3,14 @@
 
 /** \file
  * Override Halide's CUDA hooks so that the Halide code called from PyTorch uses
- * the correct GPU device and stream.
+ * the correct GPU device and stream. This header should be included once in
+ * the PyTorch/C++ binding source file (see apps/HelloPyTorch/setup.py for an
+ * example).
  */
 
-#ifdef HL_PT_CUDA
 #include "HalideRuntimeCuda.h"
 #include "cuda.h"
+#include "cuda_runtime.h"
 
 namespace Halide {
 namespace PyTorch {
@@ -58,7 +60,5 @@ int halide_get_gpu_device(void *user_context) {
 }
 
 }  // extern "C"
-
-#endif  // HL_PT_CUDA
 
 #endif /* end of include guard: HL_PYTORCH_CUDA_HELPERS_H */

--- a/src/runtime/HalidePyTorchHelpers.h
+++ b/src/runtime/HalidePyTorchHelpers.h
@@ -3,7 +3,8 @@
 
 /** \file
  * Set of utility functions to wrap PyTorch tensors into Halide buffers,
- * making sure the data in on the correct device (CPU/GPU).
+ * making sure the data in on the correct device (CPU/GPU). This header
+ * is included in each generated op by the PyTorch CodeGen.
  */
 
 #include <exception>
@@ -14,11 +15,9 @@
 
 #include "HalideBuffer.h"
 
-#ifdef HL_PT_CUDA
 #include "HalideRuntimeCuda.h"
-#include "cuda.h"
-#include "cuda_runtime.h"
-#endif
+// #include "cuda.h"
+// #include "cuda_runtime.h"
 
 #define HLPT_CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
 #define HLPT_CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")
@@ -95,15 +94,11 @@ inline Buffer<scalar_t> wrap(at::Tensor &tensor) {
 
     // TODO(mgharbi): force Halide to put input/output on GPU?
     if (tensor.is_cuda()) {
-#ifdef HL_PT_CUDA
         buffer = Buffer<scalar_t>(dims);
         const halide_device_interface_t *cuda_interface = halide_cuda_device_interface();
         int err = buffer.device_wrap_native(cuda_interface, (uint64_t)pData);
-        AT_ASSERTM(err == 0, "halide_device_wrap failed");
+        AT_ASSERTM(err == 0, "(CUDA) halide_device_wrap failed");
         buffer.set_device_dirty();
-#else
-        AT_ERROR("Trying to wrap a CUDA tensor, but HL_PT_CUDA was not defined: cuda is not available");
-#endif
     } else {
         buffer = Buffer<scalar_t>(pData, dims);
     }

--- a/src/runtime/HalidePyTorchHelpers.h
+++ b/src/runtime/HalidePyTorchHelpers.h
@@ -16,8 +16,6 @@
 #include "HalideBuffer.h"
 
 #include "HalideRuntimeCuda.h"
-// #include "cuda.h"
-// #include "cuda_runtime.h"
 
 #define HLPT_CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
 #define HLPT_CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")

--- a/src/runtime/HalidePyTorchHelpers.h
+++ b/src/runtime/HalidePyTorchHelpers.h
@@ -12,8 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "torch/extension.h"
-
 #include "HalideBuffer.h"
 
 #ifdef HL_PT_CUDA


### PR DESCRIPTION
1. The runtime helpers for the PyTorch extension include "torch/extension.h". This is unnecessary and creates an unnecessary dependency on "Python.h" for libraries that include PyTorch Halide extensions (e.g. a PyTorch C++ TorchScript extension does not need the Python frontend). This pull request removes this dependency.
2. The HelloPyTorch app was broken: the default autoscheduler [2016] does not work on GPU, for the automatically generated gradient. This pull request fixes it.