### PR TITLE
Fall through to LLVM for unknown shuffles on Hexagon

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1268,9 +1268,8 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
         return concat_vectors(ret);
     }
 
-    // Maybe LLVM can do something with this.
-    // Hopefully it uses vdelta in the worst case.
-    return CodeGen_Posix::shuffle_vectors(a, b, indices);
+    // Use a general delta operation.
+    return vdelta(concat_vectors({a, b}), indices);
 }
 
 Value *CodeGen_Hexagon::vlut256(Value *lut, Value *idx, int min_index,

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1226,8 +1226,7 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
             return call_intrin_cast(native_ty, intrin_id, {b, a, codegen(bytes_off)});
         }
         return CodeGen_Posix::shuffle_vectors(a, b, indices);
-    } else if (stride == 2) {
-        internal_assert(start == 0 || start == 1);
+    } else if (stride == 2 && (start == 0 || start == 1)) {
         // For stride 2 shuffles, we can use vpack or vdeal.
         // It's hard to use call_intrin here. We'll just slice and
         // concat manually.
@@ -1269,10 +1268,9 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
         return concat_vectors(ret);
     }
 
-    // TODO: There are more HVX permute instructions that could be
-    // implemented here, such as vdelta/vrdelta.
-
-    return vlut(concat_vectors({a, b}), indices);
+    // Maybe LLVM can do something with this.
+    // Hopefully it uses vdelta in the worst case.
+    return CodeGen_Posix::shuffle_vectors(a, b, indices);
 }
 
 Value *CodeGen_Hexagon::vlut256(Value *lut, Value *idx, int min_index,

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -285,9 +285,11 @@ public:
         check("vpacko(v*.w,v*.w)", hvx_width / 2, in_u16(2 * x + 1));
         check("vdeal(v*,v*,r*)", hvx_width / 4, in_u32(2 * x + 1));
 
-        check("vdelta(v*.b,v*.b,r*)", hvx_width / 1, in_u8(3 * x / 2));
-        check("vdelta(v*.b,v*.h,r*)", hvx_width / 2, in_u16(3 * x / 2));
-        check("vdelta(v*.b,v*.h,r*)", hvx_width / 2, in_u32(3 * x / 2));
+        check("vdelta(v*,v*)", hvx_width / 1, in_u8(3 * x / 2));
+        check("vdelta(v*,v*)", hvx_width / 2, in_u16(3 * x / 2));
+        check("vdelta(v*,v*)", hvx_width / 2, in_u32(3 * x / 2));
+        check("vdelta(v*,v*)", hvx_width * 3, in_u16(x * 3));
+        check("vdelta(v*,v*)", hvx_width * 3, in_u8(x * 3));
 
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(u8_1));
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(clamp(u16_1, 0, 63)));
@@ -295,11 +297,6 @@ public:
         check("vlut16(v*.b,v*.h,r*)", hvx_width / 2, in_u16(clamp(u16_1, 0, 15)));
         check("vlut16(v*.b,v*.h,r*)", hvx_width / 2, in_u32(u8_1));
         check("vlut16(v*.b,v*.h,r*)", hvx_width / 2, in_u32(clamp(u16_1, 0, 15)));
-
-        // This tests the case of vlut with > 256 elements (thus forcing us to split into
-        // multiple vluts)
-        check("vdelta(v*.b,v*.h,r*)", hvx_width * 3, in_u16(x * 3));
-        check("vdelta(v*.b,v*.b,r*)", hvx_width * 3, in_u8(x * 3));
 
         check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width / 1, u8_sat(i16_1));
         check("v*.b = vpack(v*.h,v*.h):sat", hvx_width / 1, i8_sat(i16_1));

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -285,9 +285,9 @@ public:
         check("vpacko(v*.w,v*.w)", hvx_width / 2, in_u16(2 * x + 1));
         check("vdeal(v*,v*,r*)", hvx_width / 4, in_u32(2 * x + 1));
 
-        check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(3 * x / 2));
-        check("vlut16(v*.b,v*.h,r*)", hvx_width / 2, in_u16(3 * x / 2));
-        check("vlut16(v*.b,v*.h,r*)", hvx_width / 2, in_u32(3 * x / 2));
+        check("vdelta(v*.b,v*.b,r*)", hvx_width / 1, in_u8(3 * x / 2));
+        check("vdelta(v*.b,v*.h,r*)", hvx_width / 2, in_u16(3 * x / 2));
+        check("vdelta(v*.b,v*.h,r*)", hvx_width / 2, in_u32(3 * x / 2));
 
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(u8_1));
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(clamp(u16_1, 0, 63)));
@@ -298,8 +298,8 @@ public:
 
         // This tests the case of vlut with > 256 elements (thus forcing us to split into
         // multiple vluts)
-        check("vlut16(v*.b,v*.h,r*)", hvx_width * 3, in_u16(x * 3));
-        check("vlut32(v*.b,v*.b,r*)", hvx_width * 3, in_u8(x * 3));
+        check("vdelta(v*.b,v*.h,r*)", hvx_width * 3, in_u16(x * 3));
+        check("vdelta(v*.b,v*.b,r*)", hvx_width * 3, in_u8(x * 3));
 
         check("v*.ub = vpack(v*.h,v*.h):sat", hvx_width / 1, u8_sat(i16_1));
         check("v*.b = vpack(v*.h,v*.h):sat", hvx_width / 1, i8_sat(i16_1));


### PR DESCRIPTION
I think LLVM handles some unknown shuffles better than we do with vlut. We could also fall through to vdelta instead, but I suspect LLVM does this anyways, and might do something smarter in some special cases.

@aankit-ca @pranavb-ca does this seem like a good thing to do?