### PR TITLE
Remove remaining bits of LLVM10 support

### DIFF
--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -56,13 +56,6 @@ endif ()
 set(active_components mcjit bitwriter linker passes)
 set(known_components AArch64 AMDGPU ARM Hexagon Mips NVPTX PowerPC RISCV WebAssembly X86)
 
-# We don't support LLVM10 or below for wasm codegen.
-# TODO: we should probably move this to LLVM 12 or 13, since LLVM11 won't
-# support SIMD usefully enough for Halide
-if (LLVM_PACKAGE_VERSION VERSION_LESS 11.0)
-    list(REMOVE_ITEM known_components WebAssembly)
-endif ()
-
 foreach (comp IN LISTS known_components)
     string(TOUPPER "TARGET_${comp}" OPTION)
     string(TOUPPER "WITH_${comp}" DEFINE)

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -311,7 +311,6 @@ int CodeGen_WebAssembly::native_vector_bits() const {
 }  // namespace
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target) {
-    user_assert(LLVM_VERSION >= 110) << "Generating WebAssembly is only supported under LLVM 11+.";
     user_assert(target.bits == 32) << "Only wasm32 is supported.";
     return std::make_unique<CodeGen_WebAssembly>(target);
 }

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1368,9 +1368,6 @@ WasmModuleContents::WasmModuleContents(
       trampolines(JITModule::make_trampolines_module(get_host_target(), jit_externs, kTrampolineSuffix, extern_deps)) {
 
 #if WITH_WABT
-    // TODO: we should probably move this to LLVM 12 or 13, since LLVM11 won't support SIMD usefully enough for Halide
-    user_assert(LLVM_VERSION >= 110) << "Using the WebAssembly JIT is only supported under LLVM 11+.";
-
     user_assert(!target.has_feature(Target::WasmThreads)) << "wasm_threads requires Emscripten (or a similar compiler); it will never be supported under JIT.";
 
     wdebug(1) << "Compiling wasm function " << fn_name << "\n";

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2258,12 +2258,6 @@ int main(int argc, char **argv) {
     printf("host is:      %s\n", host.to_string().c_str());
     printf("HL_TARGET is: %s\n", hl_target.to_string().c_str());
 
-    if (Halide::Internal::get_llvm_version() < 110 &&
-        hl_target.arch == Target::WebAssembly) {
-        printf("[SKIP] WebAssembly simd code is only supported with LLVM 11+ (saw %d).\n", Halide::Internal::get_llvm_version());
-        return 0;
-    }
-
     SimdOpCheck test(hl_target);
 
     if (argc > 1) {

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -347,13 +347,7 @@ bool test(int lanes, int seed) {
     }
 
     // Extern function call
-    // Skip the hypot() test for LLVM10: on machines with AVX2, the accuracy
-    // of the generated code deviates outside the expected error range for
-    // some cases. Since this is no longer the case in LLVM11+ (and Halide
-    // support for LLVM10 is in bug-fix mode only), we'll just skip this entirely
-    // for LLVM10, rather than try to tweak the error detection to deal with
-    // this corner case.
-    if (Halide::Internal::get_llvm_version() >= 110) {
+    {
         if (verbose) printf("External call to hypot\n");
         Func f8;
         f8(x, y) = hypot(1.1f, cast<float>(input(x, y)));


### PR DESCRIPTION
Update various parts of the source that still assume LLVM10 is supported. ~~(We probably need to update the buildbots as well before this lands.)~~