### PR TITLE
Use CTest module for running tests with wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,10 @@ project(Halide
         DESCRIPTION "Halide compiler and libraries"
         HOMEPAGE_URL "https://halide-lang.org")
 
-enable_testing()
+string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" is_top_level)
+if (is_top_level)
+    include(CTest)
+endif ()
 
 ##
 # Set up project-wide properties

--- a/tools/ctest-sde.sh
+++ b/tools/ctest-sde.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+LOGFILE="$1"
+shift
+
+die () {
+  echo "$@"
+  exit 1
+}
+
+[[ $LOGFILE == --log-file=* ]] || die "Expected --log-file=* as first argument!"
+
+LOGFILE=${LOGFILE#--log-file=}
+touch "$LOGFILE"
+
+[[ -z "${INTEL_SDE}" ]] && INTEL_SDE=$(dirname "$(realpath -s "$BASH_SOURCE")")/intel-sde/sde64
+[[ -f "${INTEL_SDE}" ]] || die "$INTEL_SDE is not a valid path"
+
+$INTEL_SDE $@
+


### PR DESCRIPTION
Also adds a wrapper for Intel SDE. To use SDE (using Ubuntu shared LLVM 12), run:

```
$ cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
    -DHalide_SHARED_LLVM=YES \
    -DLLVM_ROOT=/usr/lib/llvm-12 \
    -DMEMORYCHECK_COMMAND=$PWD/tools/ctest-sde.sh \
    -DMEMORYCHECK_COMMAND_OPTIONS="--" \
    -DMEMORYCHECK_TYPE=Valgrind
$ cmake --build build
$ cd build
build$ export INTEL_SDE=/path/to/sde64
build$ ctest -T memcheck
```

The three new variables here are:

* `MEMORYCHECK_COMMAND`: path to the wrapper executable
* `MEMORYCHECK_COMMAND_OPTIONS`: options to pass to the wrapper. If empty, uses defaults, so set to SDE's `--` option (can add other options before the `--`)
* `MEMORYCHECK_TYPE`: the interface CTest will use when talking to the script

Set up like this, CTest will call our script like so (for example on `demo_apps_autoscheduler`):

```
/home/alex/Development/halide/tools/ctest-sde.sh "--log-file=/home/alex/Development/halide/build/Testing/Temporary/MemoryChecker.1.log" "--" "/home/alex/Development/halide/build/src/autoschedulers/adams2019/demo_apps_autoscheduler" "--benchmarks=all" "--benchmark_min_time=1" "--estimate_all"
```