### PR TITLE
Usage of C++ `<thread>` header requires linking to threading library

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Then build it like so:
 % cmake --install llvm-build --prefix llvm-install
 ```
 
-Running a serial build will be slow. To improve speed, try running a parallel  
-build. That's done by default in Ninja; for make, use the option -j NNN,   
+Running a serial build will be slow. To improve speed, try running a parallel
+build. That's done by default in Ninja; for make, use the option -j NNN,
 where NNN is the number of parallel jobs, e.g. the number of CPUs you have.
 Then, point Halide to it:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -366,6 +366,7 @@ add_library(Halide
             $<TARGET_OBJECTS:Halide_initmod>)
 add_library(Halide::Halide ALIAS Halide)
 
+target_link_libraries(Halide PUBLIC Threads::Threads)
 target_link_libraries(Halide PRIVATE Halide::LLVM)
 target_link_libraries(Halide PUBLIC Halide::LanguageOptions)
 target_compile_definitions(Halide PRIVATE $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:Halide_STATIC_DEFINE>)


### PR DESCRIPTION
Usage of C++ `<thread>` header requires linking to threading library

`Generator.cpp` and `ThreadPool.h` both `#include <thread>`,
but don't link to the threading implementation.

This fixes build for me on debian sid, which is failing otherwise with:
```
$ ninja
[  0% 2/1480][  0% 0:00:00 + 0:33:06] Linking CXX executable src/autoschedulers/adams2019/get_host_target
FAILED: src/autoschedulers/adams2019/get_host_target
: && /usr/local/bin/clang++ -pipe -O3 -DNDEBUG  src/autoschedulers/adams2019/CMakeFiles/get_host_target.dir/get_host_target.cpp.o -o src/autoschedulers/adams2019/get_host_target  -Wl,-rpath,/repositories/halide/build/src:  src/libHalide.so.13.0.0 && :
ld: error: /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so: undefined reference to pthread_create [--no-allow-shlib-undefined]
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[  0% 5/1480][  0% 0:00:00 + 0:12:47] Linking CXX executable src/autoschedulers/adams2019/test_apps_autoscheduler
FAILED: src/autoschedulers/adams2019/test_apps_autoscheduler
: && /usr/local/bin/clang++ -pipe -O3 -DNDEBUG  src/autoschedulers/adams2019/CMakeFiles/test_apps_autoscheduler.dir/test.cpp.o -o src/autoschedulers/adams2019/test_apps_autoscheduler  -Wl,-rpath,/repositories/halide/build/src  src/libHalide.so.13.0.0  -ldl && :
ld: error: /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so: undefined reference to pthread_create [--no-allow-shlib-undefined]
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[  0% 7/1480][  0% 0:00:00 + 0:08:53] Linking CXX executable src/autoschedulers/adams2019/test_function_dag
FAILED: src/autoschedulers/adams2019/test_function_dag
: && /usr/local/bin/clang++ -pipe -O3 -DNDEBUG  src/autoschedulers/adams2019/CMakeFiles/test_function_dag.dir/test_function_dag.cpp.o src/autoschedulers/adams2019/CMakeFiles/test_function_dag.dir/FunctionDAG.cpp.o src/autoschedulers/adams2019/CMakeFiles/test_function_dag.dir/ASLog.cpp.o -o src/autoschedulers/adams2019/test_function_dag  -Wl,-rpath,/repositories/halide/build/src  src/libHalide.so.13.0.0 && :
ld: error: /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so: undefined reference to pthread_create [--no-allow-shlib-undefined]
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[  0% 9/1480][  0% 0:00:00 + 0:06:41] Linking CXX executable src/autoschedulers/li2018/gradient_autoscheduler_test_cpp
FAILED: src/autoschedulers/li2018/gradient_autoscheduler_test_cpp
: && /usr/local/bin/clang++ -pipe -O3 -DNDEBUG  src/autoschedulers/li2018/CMakeFiles/gradient_autoscheduler_test_cpp.dir/test.cpp.o -o src/autoschedulers/li2018/gradient_autoscheduler_test_cpp  -Wl,-rpath,/repositories/halide/build/src  src/libHalide.so.13.0.0 && :
ld: error: /usr/lib/gcc/x86_64-linux-gnu/11/libstdc++.so: undefined reference to pthread_create [--no-allow-shlib-undefined]
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[  2% 35/1480][  0% 0:00:00 + 0:05:09] Generating included_schedule_file.runtime.o
ninja: build stopped: subcommand failed.

```
