### PR TITLE
[Draft] Pass JITUserContext::user_context to custom handlers. Add UserContext param. 

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -156,6 +156,7 @@ set(HEADER_FILES
     UnpackBuffers.h
     UnrollLoops.h
     UnsafePromises.h
+    UserContextParam.h
     Util.h
     Var.h
     VectorizeLoops.h

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -512,7 +512,7 @@ void merge_handlers(JITHandlers &base, const JITHandlers &addins) {
 void print_handler(void *context, const char *msg) {
     if (context) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        (*jit_user_context->handlers.custom_print)(context, msg);
+        (*jit_user_context->handlers.custom_print)(jit_user_context->user_context, msg);
     } else {
         return (*active_handlers.custom_print)(context, msg);
     }
@@ -521,7 +521,7 @@ void print_handler(void *context, const char *msg) {
 void *malloc_handler(void *context, size_t x) {
     if (context) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        return (*jit_user_context->handlers.custom_malloc)(context, x);
+        return (*jit_user_context->handlers.custom_malloc)(jit_user_context->user_context, x);
     } else {
         return (*active_handlers.custom_malloc)(context, x);
     }
@@ -530,7 +530,7 @@ void *malloc_handler(void *context, size_t x) {
 void free_handler(void *context, void *ptr) {
     if (context) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        (*jit_user_context->handlers.custom_free)(context, ptr);
+        (*jit_user_context->handlers.custom_free)(jit_user_context->user_context, ptr);
     } else {
         (*active_handlers.custom_free)(context, ptr);
     }
@@ -540,7 +540,7 @@ int do_task_handler(void *context, halide_task f, int idx,
                     uint8_t *closure) {
     if (context) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        return (*jit_user_context->handlers.custom_do_task)(context, f, idx, closure);
+        return (*jit_user_context->handlers.custom_do_task)(jit_user_context->user_context, f, idx, closure);
     } else {
         return (*active_handlers.custom_do_task)(context, f, idx, closure);
     }
@@ -550,7 +550,7 @@ int do_par_for_handler(void *context, halide_task f,
                        int min, int size, uint8_t *closure) {
     if (context) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        return (*jit_user_context->handlers.custom_do_par_for)(context, f, min, size, closure);
+        return (*jit_user_context->handlers.custom_do_par_for)(jit_user_context->user_context, f, min, size, closure);
     } else {
         return (*active_handlers.custom_do_par_for)(context, f, min, size, closure);
     }
@@ -559,7 +559,7 @@ int do_par_for_handler(void *context, halide_task f,
 void error_handler_handler(void *context, const char *msg) {
     if (context) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        (*jit_user_context->handlers.custom_error)(context, msg);
+        (*jit_user_context->handlers.custom_error)(jit_user_context->user_context, msg);
     } else {
         (*active_handlers.custom_error)(context, msg);
     }
@@ -568,7 +568,7 @@ void error_handler_handler(void *context, const char *msg) {
 int32_t trace_handler(void *context, const halide_trace_event_t *e) {
     if (context) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        return (*jit_user_context->handlers.custom_trace)(context, e);
+        return (*jit_user_context->handlers.custom_trace)(jit_user_context->user_context, e);
     } else {
         return (*active_handlers.custom_trace)(context, e);
     }

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -509,17 +509,19 @@ void merge_handlers(JITHandlers &base, const JITHandlers &addins) {
     }
 }
 
+#define USE_CUSTOM_HANDLER(handler) (context && ((JITUserContext *)context)->handlers.custom_##handler != active_handlers.custom_##handler)
+
 void print_handler(void *context, const char *msg) {
-    if (context) {
+    if (USE_CUSTOM_HANDLER(print)) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
-        (*jit_user_context->handlers.custom_print)(jit_user_context->user_context, msg);
+        (*jit_user_context->handlers.custom_print)(context, msg);
     } else {
         return (*active_handlers.custom_print)(context, msg);
     }
 }
 
 void *malloc_handler(void *context, size_t x) {
-    if (context) {
+    if (USE_CUSTOM_HANDLER(malloc)) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
         return (*jit_user_context->handlers.custom_malloc)(jit_user_context->user_context, x);
     } else {
@@ -528,7 +530,7 @@ void *malloc_handler(void *context, size_t x) {
 }
 
 void free_handler(void *context, void *ptr) {
-    if (context) {
+    if (USE_CUSTOM_HANDLER(free)) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
         (*jit_user_context->handlers.custom_free)(jit_user_context->user_context, ptr);
     } else {
@@ -538,7 +540,7 @@ void free_handler(void *context, void *ptr) {
 
 int do_task_handler(void *context, halide_task f, int idx,
                     uint8_t *closure) {
-    if (context) {
+    if (USE_CUSTOM_HANDLER(do_task)) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
         return (*jit_user_context->handlers.custom_do_task)(jit_user_context->user_context, f, idx, closure);
     } else {
@@ -548,7 +550,7 @@ int do_task_handler(void *context, halide_task f, int idx,
 
 int do_par_for_handler(void *context, halide_task f,
                        int min, int size, uint8_t *closure) {
-    if (context) {
+    if (USE_CUSTOM_HANDLER(do_par_for)) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
         return (*jit_user_context->handlers.custom_do_par_for)(jit_user_context->user_context, f, min, size, closure);
     } else {
@@ -557,7 +559,7 @@ int do_par_for_handler(void *context, halide_task f,
 }
 
 void error_handler_handler(void *context, const char *msg) {
-    if (context) {
+    if (USE_CUSTOM_HANDLER(error)) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
         (*jit_user_context->handlers.custom_error)(jit_user_context->user_context, msg);
     } else {
@@ -566,7 +568,7 @@ void error_handler_handler(void *context, const char *msg) {
 }
 
 int32_t trace_handler(void *context, const halide_trace_event_t *e) {
-    if (context) {
+    if (USE_CUSTOM_HANDLER(trace)) {
         JITUserContext *jit_user_context = (JITUserContext *)context;
         return (*jit_user_context->handlers.custom_trace)(jit_user_context->user_context, e);
     } else {

--- a/src/ParamMap.h
+++ b/src/ParamMap.h
@@ -8,8 +8,8 @@
 #include <map>
 
 #include "Param.h"
-#include "UserContextParam.h"
 #include "Parameter.h"
+#include "UserContextParam.h"
 
 namespace Halide {
 
@@ -31,12 +31,12 @@ public:
         }
 
         ParamMapping(const ImageParam &p, Buffer<> &buf)
-            : image_param(&p), buf(buf), buf_out_param(nullptr) {
+            : image_param(&p), buf(buf) {
         }
 
         template<typename T>
         ParamMapping(const ImageParam &p, Buffer<T> &buf)
-            : image_param(&p), buf(buf), buf_out_param(nullptr) {
+            : image_param(&p), buf(buf) {
         }
 
         ParamMapping(const ImageParam &p, Buffer<> *buf_ptr)

--- a/src/ParamMap.h
+++ b/src/ParamMap.h
@@ -8,6 +8,7 @@
 #include <map>
 
 #include "Param.h"
+#include "UserContextParam.h"
 #include "Parameter.h"
 
 namespace Halide {
@@ -21,7 +22,7 @@ public:
         const ImageParam *image_param{nullptr};
         halide_scalar_value_t value;
         Buffer<> buf;
-        Buffer<> *buf_out_param;
+        Buffer<> *buf_out_param{nullptr};
 
         template<typename T>
         ParamMapping(const Param<T> &p, const T &val)
@@ -45,6 +46,11 @@ public:
         template<typename T>
         ParamMapping(const ImageParam &p, Buffer<T> *buf_ptr)
             : image_param(&p), buf_out_param((Buffer<> *)buf_ptr) {
+        }
+
+        ParamMapping(const UserContextParam &p, void *user_context)
+            : parameter(&p.parameter()) {
+            value.u.handle = user_context;
         }
     };
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -825,8 +825,7 @@ struct ErrorBuffer {
 
     static void handler(void *ctx, const char *message) {
         if (ctx) {
-            JITUserContext *ctx1 = (JITUserContext *)ctx;
-            ErrorBuffer *buf = (ErrorBuffer *)ctx1->user_context;
+            ErrorBuffer *buf = (ErrorBuffer *)ctx;
             buf->concat(message);
         }
     }

--- a/src/UserContextParam.h
+++ b/src/UserContextParam.h
@@ -1,0 +1,35 @@
+#ifndef HALIDE_USER_CONTEXT_PARAM_H
+#define HALIDE_USER_CONTEXT_PARAM_H
+
+#include "Param.h"
+#include "Parameter.h"
+
+/** \file
+ *
+ * Class for passing custom user context to pipeline realization
+ */
+
+namespace Halide {
+
+class UserContextParam {
+    /** A reference-counted handle on the internal parameter object */
+    Internal::Parameter param;
+public:
+    UserContextParam() : param(type_of<void*>(), false, 0, "__user_context") {}
+
+    explicit UserContextParam(void *user_context) : param(type_of<void*>(), false, 0, "__user_context") {
+        param.set_scalar<void*>(user_context);
+    }
+
+    const Internal::Parameter &parameter() const {
+        return param;
+    }
+
+    Internal::Parameter &parameter() {
+        return param;
+    }
+};
+
+}  // namespace Halide
+
+#endif

--- a/src/UserContextParam.h
+++ b/src/UserContextParam.h
@@ -14,11 +14,15 @@ namespace Halide {
 class UserContextParam {
     /** A reference-counted handle on the internal parameter object */
     Internal::Parameter param;
-public:
-    UserContextParam() : param(type_of<void*>(), false, 0, "__user_context") {}
 
-    explicit UserContextParam(void *user_context) : param(type_of<void*>(), false, 0, "__user_context") {
-        param.set_scalar<void*>(user_context);
+public:
+    UserContextParam()
+        : param(type_of<void *>(), false, 0, "__user_context") {
+    }
+
+    explicit UserContextParam(void *user_context)
+        : param(type_of<void *>(), false, 0, "__user_context") {
+        param.set_scalar<void *>(user_context);
     }
 
     const Internal::Parameter &parameter() const {


### PR DESCRIPTION
_The draft intended as a live demonstration of ideas discussed in #6255. It is still not ready for review, let alone merging._

Problem recap: currently, it's impossible to pass per-launch user context and handlers to JIT compiled functions. This becomes problematic when the target is an accelerator (e.g. CUDA device), where it may be desirable o execute the code in user-provided context. It's especially important when running in multi-device systems.
It also decouples the user context passed to custom JIT handlers from JITUserContext.

This draft explores possibilities of passing user context to JIT-compiled code.

Usage:

```C++
struct MyMemPool {
  // ...
  void *allocate(size_t);
  void free(void *);

  static MyMemPool &get(int device_id);
};

void *my_malloc(void *pool, size_t size) {
  return ((MyMemPool*)pool)->allocate(size);
}

void my_free(void *pool, void *mem) {
  return ((MyMemPool*)pool)->free(mem);
}

int main() {
  Func f("my_func");
  Param<float> scale;
  // define the function
  f.set_custom_allocator(my_malloc, my_free);
  f.compile_jit();

  // now the function can run in parallel with 2 different allocators
  
  std::thread t1([&]() {
    UserContextParam uc;
    ParamMap pm1({
      { scale, 2 },
      { uc, &MyMemPool::get(0) }
    });
    Buffer<uint8_t> out_buf1( /* sizes here */);
    f.realize(out_buf1, pm1);
  });

  std::thread t2([&]() {
    ParamMap pm2({
      { scale, 2 },
      { uc, &MyMemPool::get(1) }
    });
    Buffer<uint8_t> out_buf2( /* sizes here */);
    f.realize(out_buf2, pm2);
  });

  t1.join();
  t2.join();
}
```

Signed-off-by: Michał Zientkiewicz <mzient@gmail.com>