### PR TITLE
Don't set environment for RISCV Linux as apparently it is not used.

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -504,8 +504,6 @@ llvm::Triple get_triple_for_target(const Target &target) {
 
         if (target.os == Target::Linux) {
             triple.setOS(llvm::Triple::Linux);
-            // TODO: Check what options there are here.
-            triple.setEnvironment(llvm::Triple::GNUEABIHF);
         } else if (target.os == Target::NoOS) {
             // for baremetal environment
         } else {


### PR DESCRIPTION
No behavior should change here.

Per issue: https://github.com/halide/Halide/issues/6281