### PR TITLE
Remove unbound variable in documentation

### DIFF
--- a/src/RDom.h
+++ b/src/RDom.h
@@ -311,7 +311,7 @@ public:
      *
      \code
      for (int r.y = 14; r.y < 20; r.y++) {
-       f[r.x, r.y] += 1;
+       f[10, r.y] += 1;
      }
      \endcode
      *


### PR DESCRIPTION
In the example for RDom::where, the simplified case contains a free occurence of `r.x`, which should be replaced with `10` since we are in the case `r.x == 10`.