### PR TITLE
store_in(MemoryType::Stack) should use alloca if the size is small

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -262,6 +262,7 @@ bool function_takes_user_context(const std::string &name) {
 
 bool can_allocation_fit_on_stack(int64_t size) {
     user_assert(size > 0) << "Allocation size should be a positive number\n";
+    // Should match the threshold defined in runtime/pseudostack.cpp
     return (size <= 1024 * 16);
 }
 

--- a/src/CodeGen_Posix.cpp
+++ b/src/CodeGen_Posix.cpp
@@ -221,42 +221,33 @@ CodeGen_Posix::Allocation CodeGen_Posix::create_allocation(const std::string &na
 
         // Even if we're reusing a stack slot, we need to call
         // pseudostack_alloc to potentially reallocate.
-        llvm::Function *malloc_fn = module->getFunction("pseudostack_alloc");
-        internal_assert(malloc_fn) << "Could not find pseudostack_alloc in module\n";
-        malloc_fn->setReturnDoesNotAlias();
+        llvm::Function *alloc_fn = module->getFunction("pseudostack_alloc");
+        internal_assert(alloc_fn) << "Could not find pseudostack_alloc in module\n";
+        alloc_fn->setReturnDoesNotAlias();
 
-        llvm::Function::arg_iterator arg_iter = malloc_fn->arg_begin();
+        llvm::Function::arg_iterator arg_iter = alloc_fn->arg_begin();
         ++arg_iter;  // skip the user context *
         slot = builder->CreatePointerCast(slot, arg_iter->getType());
         ++arg_iter;  // skip the pointer to the stack slot
         llvm::Type *size_type = arg_iter->getType();
         llvm_size = builder->CreateIntCast(llvm_size, size_type, false);
         Value *args[3] = {get_user_context(), slot, llvm_size};
-        Value *call = builder->CreateCall(malloc_fn, args);
+        Value *call = builder->CreateCall(alloc_fn, args);
         llvm::Type *ptr_type = llvm_type_of(type)->getPointerTo();
         call = builder->CreatePointerCast(call, ptr_type);
 
         // Figure out how much we need to allocate on the real stack
         Value *returned_null = builder->CreateIsNull(call);
-        debug(0) << "a\n";
-        size_type->dump();
         Value *size_zero = ConstantInt::get(size_type, 0);
-        debug(0) << "b\n";
         Value *alloca_size = builder->CreateSelect(returned_null, llvm_size, size_zero);
         // Allocate it. It's zero most of the time.
-        // TODO: Stack alignment?
-        debug(0) << "c\n";
         Value *stack_ptr = builder->CreateAlloca(i8_t->getPointerTo(), alloca_size);
-        debug(0) << "d\n";
         stack_ptr = builder->CreatePointerCast(stack_ptr, ptr_type);
-        // Set the stack ptr to the right thing
-        debug(0) << "e\n";
+        // Set the pseudostack slot ptr to the right thing so we reuse
+        // this pointer next time around.
         Value *slot_ptr_ptr = builder->CreatePointerCast(slot, ptr_type->getPointerTo());
-        debug(0) << "f\n";
         Value *ptr = builder->CreateSelect(returned_null, stack_ptr, call);
-        debug(0) << "g\n";
         builder->CreateStore(ptr, slot_ptr_ptr);
-        debug(0) << "h\n";
 
         allocation.ptr = ptr;
         allocation.pseudostack_slot = slot;

--- a/src/runtime/pseudostack.cpp
+++ b/src/runtime/pseudostack.cpp
@@ -3,14 +3,18 @@
 
 extern "C" {
 
-#define HEAP_THRESHOLD (16 * 1024)
+namespace {
+// Should match the threshold defined in CodeGen_Internal.cpp
+constexpr size_t heap_threshold = 16 * 1024;
+}  // namespace
 
 WEAK_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, halide_pseudostack_slot_t *slot, size_t sz) {
     if (__builtin_expect(sz > slot->size, 0)) {
-        if (slot->ptr && slot->size > HEAP_THRESHOLD) {
+        if (slot->ptr && slot->cumulative_size > heap_threshold) {
             halide_free(user_context, slot->ptr);
         }
-        if (sz > HEAP_THRESHOLD) {
+        slot->cumulative_size += sz;
+        if (slot->cumulative_size > heap_threshold) {
             slot->ptr = halide_malloc(user_context, sz);
         } else {
             slot->ptr = nullptr;
@@ -23,10 +27,11 @@ WEAK_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, ha
 // Only called as a destructor at function exit
 WEAK_INLINE __attribute__((used)) void pseudostack_free(void *user_context, void *ptr) {
     halide_pseudostack_slot_t *slot = (halide_pseudostack_slot_t *)ptr;
-    if (slot->ptr && slot->size > HEAP_THRESHOLD) {
+    if (slot->ptr && slot->cumulative_size > heap_threshold) {
         halide_free(user_context, slot->ptr);
     }
-    slot->size = 0;
     slot->ptr = nullptr;
+    slot->size = 0;
+    slot->cumulative_size = 0;
 }
 }

--- a/src/runtime/pseudostack.cpp
+++ b/src/runtime/pseudostack.cpp
@@ -3,12 +3,18 @@
 
 extern "C" {
 
+#define HEAP_THRESHOLD (16 * 1024)
+
 WEAK_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, halide_pseudostack_slot_t *slot, size_t sz) {
     if (__builtin_expect(sz > slot->size, 0)) {
-        if (slot->ptr) {
+        if (slot->ptr && slot->size > HEAP_THRESHOLD) {
             halide_free(user_context, slot->ptr);
         }
-        slot->ptr = halide_malloc(user_context, sz);
+        if (sz > HEAP_THRESHOLD) {
+            slot->ptr = halide_malloc(user_context, sz);
+        } else {
+            slot->ptr = nullptr;
+        }
         slot->size = sz;
     }
     return slot->ptr;
@@ -17,10 +23,10 @@ WEAK_INLINE __attribute__((used)) void *pseudostack_alloc(void *user_context, ha
 // Only called as a destructor at function exit
 WEAK_INLINE __attribute__((used)) void pseudostack_free(void *user_context, void *ptr) {
     halide_pseudostack_slot_t *slot = (halide_pseudostack_slot_t *)ptr;
-    slot->size = 0;
-    if (slot->ptr) {
+    if (slot->ptr && slot->size > HEAP_THRESHOLD) {
         halide_free(user_context, slot->ptr);
     }
+    slot->size = 0;
     slot->ptr = nullptr;
 }
 }

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -180,6 +180,7 @@ WEAK int halide_trace_helper(void *user_context,
 struct halide_pseudostack_slot_t {
     void *ptr;
     size_t size;
+    size_t cumulative_size;
 };
 
 WEAK void halide_use_jit_module();

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -153,6 +153,7 @@ tests(GROUPS correctness
       gpu_transpose.cpp
       gpu_vectorize.cpp
       gpu_vectorized_shared_memory.cpp
+      growing_stack.cpp
       half_native_interleave.cpp
       halide_buffer.cpp
       handle.cpp

--- a/test/correctness/growing_stack.cpp
+++ b/test/correctness/growing_stack.cpp
@@ -1,0 +1,26 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f, g;
+    Var x;
+
+    f(x) = x;
+    g(x) = f(x) + f(2 * x);
+
+    f.compute_at(g, x).store_in(MemoryType::Stack);
+
+    // We never free stack until function exit, so the schedule above
+    // would seem to grab more and more stack because the allocation
+    // size for f keeps growing. Fear not! After crossing a threshold
+    // of total stack used per Func, we bail and start making heap
+    // allocations instead.
+
+    // The following would use 200 mb of stack if we just kept
+    // reallocating:
+    g.realize({10240});
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -24,6 +24,7 @@ tests(GROUPS performance
       realize_overhead.cpp
       rfactor.cpp
       rgb_interleaved.cpp
+      stack_vs_heap.cpp
       sort.cpp
       thread_safe_jit.cpp
       vectorize.cpp

--- a/test/performance/stack_vs_heap.cpp
+++ b/test/performance/stack_vs_heap.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
 
     double times[3] = {0.f, 0.f, 0.f};
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 3; i++) {
         for (int c = 0; c < 3; c++) {
             MemoryType mem_type;
             bool use_bound;
@@ -35,8 +35,10 @@ int main(int argc, char **argv) {
 
             Var yo, yi;
             // Place the y loop body in its own function with its own
-            // stack frame by making a parallel loop of size 1.
-            g.split(y, yo, yi, 1).parallel(yi);
+            // stack frame by making a parallel loop of some size
+            // which will be 1 in practice.
+            Param<int> task_size;
+            g.split(y, yo, yi, task_size).parallel(yi);
             f.compute_at(g, yi).store_in(mem_type);
 
             if (use_bound) {
@@ -44,6 +46,7 @@ int main(int argc, char **argv) {
             }
 
             Buffer<float> out(8, 1024);
+            task_size.set(1);
             double t = 1e3 * Tools::benchmark(10, 100, [&]() {
                            g.realize(out);
                        });

--- a/test/performance/stack_vs_heap.cpp
+++ b/test/performance/stack_vs_heap.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+#include "halide_benchmark.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+
+    for (int i = 0; i < 10; i++) {
+        for (auto mem_type : {MemoryType::Stack, MemoryType::Heap}) {
+            Func f;
+            Var x, y;
+            f(x, y) = x / 18.3f + y;
+
+            Func g;
+            g(x, y) = f(x, y) + f(x, y + 1);
+
+            g.parallel(y);
+            f.compute_at(g, y).store_in(mem_type);
+
+            Buffer<float> out(32, 1024);
+            double t = 1e3 * Tools::benchmark(10, 100, [&]() {
+                           g.realize(out);
+                       });
+
+            std::cout << mem_type << ": " << t << "\n";
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
If an allocation for a Func marked as store_in MemoryType::Stack is just made once (e.g. because it's compute_at just inside a parallel loop), then we currently just call malloc and there's no win from placing it on the stack. 

This PR changes the behavior of MemoryType::Stack to call alloca instead when the size is small. This helps a lot in the single-use case. 

It's the same pseudostack logic as in master. It allocates on first use (even if inside a loop), and reallocates only if the required size grows. Stack is never freed. If the cumulative stack usage for all reallocations for one Func exceeds our can_fit_on_stack threshold, we switch to heap for all future reallocations of this Func.

The following three runtimes are from a test of the single-use case where in the first case we statically know the allocation size, so we can just size the original stack frame appropriately. In the second case we use the new behavior in this PR and subtract from the stack pointer by a computed amount. In the third case we call malloc, as we would on master.

```
Constant-sized stack allocation: 0.165252
Use alloca: 0.184218
Use malloc: 0.215683
```

The runtimes are close together because allocating isn't the only thing this pipeline does. You should view the first of the three figures as the zero, which means the new behavior is about 2.5x faster than the old behavior when it comes to the cost of allocating.

Those numbers are from linux. On macos malloc is slower and the win is 7x.
