### PR TITLE
Modernize loops, part 2

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -267,25 +267,24 @@ Stmt add_image_checks_inner(Stmt s,
         if (param.defined()) {
             // Find the extern users.
             vector<string> extern_users;
-            for (size_t i = 0; i < order.size(); i++) {
-                Function f = env.find(order[i])->second;
+            for (const auto &func_name : order) {
+                Function f = env.find(func_name)->second;
                 if (f.has_extern_definition() &&
                     !f.extern_definition_proxy_expr().defined()) {
                     const vector<ExternFuncArgument> &args = f.extern_arguments();
-                    for (size_t j = 0; j < args.size(); j++) {
-                        if ((args[j].image_param.defined() &&
-                             args[j].image_param.name() == param.name()) ||
-                            (args[j].buffer.defined() &&
-                             args[j].buffer.name() == param.name())) {
-                            extern_users.push_back(order[i]);
+                    for (const auto &arg : args) {
+                        if ((arg.image_param.defined() &&
+                             arg.image_param.name() == param.name()) ||
+                            (arg.buffer.defined() &&
+                             arg.buffer.name() == param.name())) {
+                            extern_users.push_back(func_name);
                         }
                     }
                 }
             }
 
             // Expand the box by the result of the bounds query from each.
-            for (size_t i = 0; i < extern_users.size(); i++) {
-                const string &extern_user = extern_users[i];
+            for (auto &extern_user : extern_users) {
                 Box query_box;
                 Expr query_buf = Variable::make(type_of<struct halide_buffer_t *>(),
                                                 param.name() + ".bounds_query." + extern_user);
@@ -592,20 +591,20 @@ Stmt add_image_checks_inner(Stmt s,
         }
 
         // Assert all the conditions, and set the new values
-        for (size_t i = 0; i < constraints.size(); i++) {
-            Expr var = constraints[i].first;
+        for (const auto &constraint : constraints) {
+            Expr var = constraint.first;
             const string &name = var.as<Variable>()->name;
             Expr constrained_var = Variable::make(Int(32), name + ".constrained");
 
             std::ostringstream ss;
-            ss << constraints[i].second;
+            ss << constraint.second;
             string constrained_var_str = ss.str();
 
-            lets_constrained.emplace_back(name + ".constrained", constraints[i].second);
+            lets_constrained.emplace_back(name + ".constrained", constraint.second);
 
             // Substituting in complex expressions is not typically a good idea
-            if (constraints[i].second.as<Variable>() ||
-                is_const(constraints[i].second)) {
+            if (constraint.second.as<Variable>() ||
+                is_const(constraint.second)) {
                 replace_with_constrained[name] = constrained_var;
             }
 

--- a/src/AddParameterChecks.cpp
+++ b/src/AddParameterChecks.cpp
@@ -89,13 +89,12 @@ Stmt add_parameter_checks(const vector<Stmt> &preconditions, Stmt s, const Targe
     s = substitute(replace_with_constrained, s);
 
     // Inject the let statements
-    for (size_t i = 0; i < lets.size(); i++) {
-        s = LetStmt::make(lets[i].first, lets[i].second, s);
+    for (const auto &let : lets) {
+        s = LetStmt::make(let.first, let.second, s);
     }
 
     // Inject the assert statements
-    for (size_t i = 0; i < asserts.size(); i++) {
-        ParamAssert p = asserts[i];
+    for (ParamAssert &p : asserts) {
         // Upgrade the types to 64-bit versions for the error call
         Type wider = p.value.type().with_bits(64);
         p.limit_value = cast(wider, p.limit_value);

--- a/src/AllocationBoundsInference.cpp
+++ b/src/AllocationBoundsInference.cpp
@@ -57,8 +57,7 @@ class AllocationInference : public IRMutator {
         for (size_t i = 0; i < b.size(); i++) {
             // Get any applicable bound on this dimension
             Bound bound;
-            for (size_t j = 0; j < f.schedule().bounds().size(); j++) {
-                Bound b = f.schedule().bounds()[j];
+            for (const auto &b : f.schedule().bounds()) {
                 if (f_args[i] == b.var) {
                     bound = b;
                 }
@@ -132,13 +131,11 @@ public:
     AllocationInference(const map<string, Function> &e, const FuncValueBounds &fb)
         : env(e), func_bounds(fb) {
         // Figure out which buffers are touched by extern stages
-        for (map<string, Function>::const_iterator iter = e.begin();
-             iter != e.end(); ++iter) {
-            Function f = iter->second;
+        for (const auto &iter : e) {
+            Function f = iter.second;
             if (f.has_extern_definition()) {
                 touched_by_extern.insert(f.name());
-                for (size_t i = 0; i < f.extern_arguments().size(); i++) {
-                    ExternFuncArgument arg = f.extern_arguments()[i];
+                for (const auto &arg : f.extern_arguments()) {
                     if (!arg.is_func()) {
                         continue;
                     }

--- a/src/AutoScheduleUtils.h
+++ b/src/AutoScheduleUtils.h
@@ -31,8 +31,8 @@ class FindAllCalls : public IRVisitor {
             funcs_called.insert(call->name);
             call_args.emplace_back(call->name, call->args);
         }
-        for (size_t i = 0; i < call->args.size(); i++) {
-            call->args[i].accept(this);
+        for (const auto &arg : call->args) {
+            arg.accept(this);
         }
     }
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2862,11 +2862,11 @@ private:
         }
 
         if (consider_calls) {
-            for (size_t i = 0; i < op->args.size(); i++) {
-                op->args[i].accept(this);
+            for (const auto &arg : op->args) {
+                arg.accept(this);
             }
-            for (size_t i = 0; i < op->values.size(); i++) {
-                op->values[i].accept(this);
+            for (const auto &value : op->values) {
+                value.accept(this);
             }
         }
     }
@@ -3141,8 +3141,8 @@ FuncValueBounds compute_function_value_bounds(const vector<string> &order,
                                               const map<string, Function> &env) {
     FuncValueBounds fb;
 
-    for (size_t i = 0; i < order.size(); i++) {
-        Function f = env.find(order[i])->second;
+    for (const auto &func_name : order) {
+        Function f = env.find(func_name)->second;
         const vector<string> f_args = f.args();
         for (int j = 0; j < f.outputs(); j++) {
             pair<string, int> key = {f.name(), j};
@@ -3184,7 +3184,7 @@ FuncValueBounds compute_function_value_bounds(const vector<string> &order,
             }
 
             debug(2) << "Bounds on value " << j
-                     << " for func " << order[i]
+                     << " for func " << func_name
                      << " are: " << result.min << ", " << result.max << "\n";
         }
     }

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -547,8 +547,7 @@ public:
                 LoopLevel compute_at = func.schedule().compute_level();
                 LoopLevel store_at = func.schedule().store_level();
 
-                for (size_t i = 0; i < func.schedule().bounds().size(); i++) {
-                    Bound bound = func.schedule().bounds()[i];
+                for (auto bound : func.schedule().bounds()) {
                     string min_var = prefix + bound.var + ".min";
                     string max_var = prefix + bound.var + ".max";
                     Expr min_required = Variable::make(Int(32), min_var);
@@ -656,11 +655,11 @@ public:
             Expr null_handle = make_zero(Handle());
 
             vector<pair<Expr, int>> buffers_to_annotate;
-            for (size_t j = 0; j < args.size(); j++) {
-                if (args[j].is_expr()) {
-                    bounds_inference_args.push_back(args[j].expr);
-                } else if (args[j].is_func()) {
-                    Function input(args[j].func);
+            for (const auto &arg : args) {
+                if (arg.is_expr()) {
+                    bounds_inference_args.push_back(arg.expr);
+                } else if (arg.is_func()) {
+                    Function input(arg.func);
                     for (int k = 0; k < input.outputs(); k++) {
                         string name = input.name() + ".o" + std::to_string(k) + ".bounds_query." + func.name();
 
@@ -673,11 +672,11 @@ public:
                         bounds_inference_args.push_back(Variable::make(type_of<struct halide_buffer_t *>(), name));
                         buffers_to_annotate.emplace_back(bounds_inference_args.back(), input.dimensions());
                     }
-                } else if (args[j].is_image_param() || args[j].is_buffer()) {
-                    Parameter p = args[j].image_param;
-                    Buffer<> b = args[j].buffer;
-                    string name = args[j].is_image_param() ? p.name() : b.name();
-                    int dims = args[j].is_image_param() ? p.dimensions() : b.dimensions();
+                } else if (arg.is_image_param() || arg.is_buffer()) {
+                    Parameter p = arg.image_param;
+                    Buffer<> b = arg.buffer;
+                    string name = arg.is_image_param() ? p.name() : b.name();
+                    int dims = arg.is_image_param() ? p.dimensions() : b.dimensions();
 
                     Expr in_buf = Variable::make(type_of<struct halide_buffer_t *>(), name + ".buffer");
 
@@ -776,8 +775,8 @@ public:
             s = Block::make(check, s);
 
             // Wrap in let stmts defining the args
-            for (size_t i = 0; i < lets.size(); i++) {
-                s = LetStmt::make(lets[i].first, lets[i].second, s);
+            for (const auto &let : lets) {
+                s = LetStmt::make(let.first, let.second, s);
             }
 
             return s;
@@ -863,10 +862,8 @@ public:
         for (size_t i = f.size(); i > 0; i--) {
             Function func = f[i - 1];
             if (inlined[i - 1]) {
-                for (size_t j = 0; j < stages.size(); j++) {
-                    Stage &s = stages[j];
-                    for (size_t k = 0; k < s.exprs.size(); k++) {
-                        CondValue &cond_val = s.exprs[k];
+                for (auto &s : stages) {
+                    for (auto &cond_val : s.exprs) {
                         internal_assert(cond_val.value.defined());
                         cond_val.value = inline_function(cond_val.value, func);
                     }
@@ -876,10 +873,10 @@ public:
 
         // Remove the inlined stages
         vector<Stage> new_stages;
-        for (size_t i = 0; i < stages.size(); i++) {
-            if (!stages[i].func.schedule().compute_level().is_inlined() ||
-                !stages[i].func.can_be_inlined()) {
-                new_stages.push_back(stages[i]);
+        for (const auto &stage : stages) {
+            if (!stage.func.schedule().compute_level().is_inlined() ||
+                !stage.func.can_be_inlined()) {
+                new_stages.push_back(stage);
             }
         }
         new_stages.swap(stages);
@@ -912,9 +909,9 @@ public:
                 // Stage::define_bounds is going to compute a query
                 // halide_buffer_t per producer for bounds inference to
                 // use. We just need to extract those values.
-                for (size_t j = 0; j < args.size(); j++) {
-                    if (args[j].is_func()) {
-                        Function f(args[j].func);
+                for (const auto &arg : args) {
+                    if (arg.is_func()) {
+                        Function f(arg.func);
                         has_extern_consumer.insert(f.name());
                         string stage_name = f.name() + ".s" + std::to_string(f.updates().size());
                         Box b(f.dimensions());
@@ -1011,8 +1008,7 @@ public:
 
                 output_box.push_back(Interval(min, (min + extent) - 1));
             }
-            for (size_t i = 0; i < stages.size(); i++) {
-                Stage &s = stages[i];
+            for (auto &s : stages) {
                 if (!s.func.same_as(output)) {
                     continue;
                 }
@@ -1167,8 +1163,8 @@ public:
                 }
 
                 if (bounds_needed[i]) {
-                    for (size_t j = 0; j < stages[i].consumers.size(); j++) {
-                        bounds_needed[stages[i].consumers[j]] = true;
+                    for (int consumer : stages[i].consumers) {
+                        bounds_needed[consumer] = true;
                     }
                     body = stages[i].define_bounds(
                         body, f, stage_name, stage_index, op->name, fused_groups,
@@ -1326,9 +1322,9 @@ Stmt bounds_inference(Stmt s,
                           f.definition().schedule().fused_pairs().end(),
                           std::inserter(pairs, pairs.end()));
 
-                for (size_t i = 0; i < f.updates().size(); ++i) {
-                    std::copy(f.updates()[i].schedule().fused_pairs().begin(),
-                              f.updates()[i].schedule().fused_pairs().end(),
+                for (const auto &update : f.updates()) {
+                    std::copy(update.schedule().fused_pairs().begin(),
+                              update.schedule().fused_pairs().end(),
                               std::inserter(pairs, pairs.end()));
                 }
             }

--- a/src/Closure.cpp
+++ b/src/Closure.cpp
@@ -69,8 +69,8 @@ void Closure::visit(const Allocate *op) {
         op->new_expr.accept(this);
     }
     ScopedBinding<> p(ignore, op->name);
-    for (size_t i = 0; i < op->extents.size(); i++) {
-        op->extents[i].accept(this);
+    for (const auto &extent : op->extents) {
+        extent.accept(this);
     }
     op->condition.accept(this);
     op->body.accept(this);

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -977,8 +977,8 @@ void CodeGen_ARM::visit(const Store *op) {
         int alignment = t.bytes();
 
         // Codegen the lets
-        for (size_t i = 0; i < lets.size(); i++) {
-            sym_push(lets[i].first, codegen(lets[i].second));
+        for (auto &let : lets) {
+            sym_push(let.first, codegen(let.second));
         }
 
         // Codegen all the vector args.
@@ -1049,8 +1049,8 @@ void CodeGen_ARM::visit(const Store *op) {
         }
 
         // pop the lets from the symbol table
-        for (size_t i = 0; i < lets.size(); i++) {
-            sym_pop(lets[i].first);
+        for (auto &let : lets) {
+            sym_pop(let.first);
         }
 
         return;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1807,9 +1807,9 @@ void CodeGen_C::compile(const LoweredFunc &f, const std::map<std::string, std::s
     const std::vector<LoweredArgument> &args = f.args;
 
     have_user_context = false;
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // TODO: check that its type is void *?
-        have_user_context |= (args[i].name == "__user_context");
+        have_user_context |= (arg.name == "__user_context");
     }
 
     NameMangling name_mangling = f.name_mangling;
@@ -2385,8 +2385,8 @@ void CodeGen_C::visit(const Call *op) {
 
             // Get the args
             vector<string> values;
-            for (size_t i = 0; i < op->args.size(); i++) {
-                values.push_back(print_expr(op->args[i]));
+            for (const auto &arg : op->args) {
+                values.push_back(print_expr(arg));
             }
 
             static_assert(sizeof(halide_dimension_t) == 4 * sizeof(int32_t),
@@ -2418,8 +2418,8 @@ void CodeGen_C::visit(const Call *op) {
 
             // Get the args
             vector<string> values;
-            for (size_t i = 0; i < op->args.size(); i++) {
-                values.push_back(print_expr(op->args[i]));
+            for (const auto &arg : op->args) {
+                values.push_back(print_expr(arg));
             }
             stream << get_indent() << "struct {\n";
             // List the types.

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -1232,10 +1232,10 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
     print(s);
     close_scope("kernel " + name);
 
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer) {
-            allocations.pop(args[i].name);
+        if (arg.is_buffer) {
+            allocations.pop(arg.name);
         }
     }
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1362,16 +1362,14 @@ Value *CodeGen_Hexagon::vlut256(Value *lut, Value *idx, int min_index,
                     // The first native LUT, use vlut.
                     result_i = call_intrin_cast(native_result_ty, vlut,
                                                 {idx_i, lut_slices[j], mask[0]});
-                    result_i =
-                        call_intrin_cast(native_result_ty, vlut_acc,
-                                         {result_i, idx_i, lut_slices[j], mask[1]});
+                    result_i = call_intrin_cast(native_result_ty, vlut_acc,
+                                                {result_i, idx_i, lut_slices[j], mask[1]});
                 } else if (max_index >= pass_index * native_lut_elements / lut_passes) {
                     // Not the first native LUT, accumulate the LUT
                     // with the previous result.
-                    for (int m = 0; m < 2; m++) {
-                        result_i =
-                            call_intrin_cast(native_result_ty, vlut_acc,
-                                             {result_i, idx_i, lut_slices[j], mask[m]});
+                    for (Value *v : mask) {
+                        result_i = call_intrin_cast(native_result_ty, vlut_acc,
+                                                    {result_i, idx_i, lut_slices[j], v});
                     }
                 }
             }
@@ -2080,8 +2078,8 @@ Value *CodeGen_Hexagon::codegen_cache_allocation_size(
     Expr total_size_hi = make_zero(UInt(32));
 
     Expr low_mask = make_const(UInt(32), (uint32_t)(0xfffff));
-    for (size_t i = 0; i < extents.size(); i++) {
-        Expr next_extent = cast(UInt(32), extents[i]);
+    for (const auto &extent : extents) {
+        Expr next_extent = cast(UInt(32), extent);
 
         // Update total_size >> 24. This math can't overflow due to
         // the loop invariant:
@@ -2224,8 +2222,8 @@ void CodeGen_Hexagon::visit(const Allocate *alloc) {
         }
         // Calculate size of allocation.
         Expr size = alloc->type.bytes();
-        for (size_t i = 0; i < alloc->extents.size(); i++) {
-            size *= alloc->extents[i];
+        for (const auto &extent : alloc->extents) {
+            size *= extent;
         }
         size += allocation_padding(alloc->type);
         Expr new_expr =

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -249,10 +249,8 @@ bool function_takes_user_context(const std::string &name) {
         "_halide_buffer_retire_crop_after_extern_stage",
         "_halide_buffer_retire_crops_after_extern_stage",
     };
-    const int num_funcs = sizeof(user_context_runtime_funcs) /
-                          sizeof(user_context_runtime_funcs[0]);
-    for (int i = 0; i < num_funcs; ++i) {
-        if (name == user_context_runtime_funcs[i]) {
+    for (const char *user_context_runtime_func : user_context_runtime_funcs) {
+        if (name == user_context_runtime_func) {
             return true;
         }
     }

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -593,11 +593,11 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
     // The last condition is handled via the preprocessor in the kernel
     // declaration.
     vector<BufferSize> constants;
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer &&
-            CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
-            args[i].size > 0) {
-            constants.emplace_back(args[i].name, args[i].size);
+    for (const auto &arg : args) {
+        if (arg.is_buffer &&
+            CodeGen_GPU_Dev::is_buffer_constant(s, arg.name) &&
+            arg.size > 0) {
+            constants.emplace_back(arg.name, arg.size);
         }
     }
 
@@ -614,38 +614,38 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
 
     // Create preprocessor replacements for the address spaces of all our buffers.
     stream << "// Address spaces for " << name << "\n";
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
             vector<BufferSize>::iterator constant = constants.begin();
             while (constant != constants.end() &&
-                   constant->name != args[i].name) {
+                   constant->name != arg.name) {
                 constant++;
             }
 
             if (constant != constants.end()) {
                 stream << "#if " << constant->size << " < MAX_CONSTANT_BUFFER_SIZE && "
                        << constant - constants.begin() << " < MAX_CONSTANT_ARGS\n";
-                stream << "#define " << get_memory_space(args[i].name) << " constant\n";
+                stream << "#define " << get_memory_space(arg.name) << " constant\n";
                 stream << "#else\n";
-                stream << "#define " << get_memory_space(args[i].name) << " device\n";
+                stream << "#define " << get_memory_space(arg.name) << " device\n";
                 stream << "#endif\n";
             } else {
-                stream << "#define " << get_memory_space(args[i].name) << " device\n";
+                stream << "#define " << get_memory_space(arg.name) << " device\n";
             }
         }
     }
 
     // Emit a struct to hold the scalar args of the kernel
     bool any_scalar_args = false;
-    for (size_t i = 0; i < args.size(); i++) {
-        if (!args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (!arg.is_buffer) {
             if (!any_scalar_args) {
                 stream << "struct " + name + "_args {\n";
                 any_scalar_args = true;
             }
-            stream << print_type(args[i].type)
+            stream << print_type(arg.type)
                    << " "
-                   << print_name(args[i].name)
+                   << print_name(arg.name)
                    << ";\n";
         }
     }
@@ -663,18 +663,18 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
         buffer_index++;
     }
 
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
             stream << ",\n";
-            stream << " " << get_memory_space(args[i].name) << " ";
-            if (!args[i].write) {
+            stream << " " << get_memory_space(arg.name) << " ";
+            if (!arg.write) {
                 stream << "const ";
             }
-            stream << print_storage_type(args[i].type) << " *"
-                   << print_name(args[i].name) << " [[ buffer(" << buffer_index++ << ") ]]";
+            stream << print_storage_type(arg.type) << " *"
+                   << print_name(arg.name) << " [[ buffer(" << buffer_index++ << ") ]]";
             Allocation alloc;
-            alloc.type = args[i].type;
-            allocations.push(args[i].name, alloc);
+            alloc.type = arg.type;
+            allocations.push(arg.name, alloc);
         }
     }
 
@@ -708,12 +708,12 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
     open_scope();
 
     // Unpack args struct into local variables to match naming of generated code.
-    for (size_t i = 0; i < args.size(); i++) {
-        if (!args[i].is_buffer) {
-            stream << print_type(args[i].type)
+    for (const auto &arg : args) {
+        if (!arg.is_buffer) {
+            stream << print_type(arg.type)
                    << " "
-                   << print_name(args[i].name)
-                   << " = _scalar_args->" << print_name(args[i].name)
+                   << print_name(arg.name)
+                   << " = _scalar_args->" << print_name(arg.name)
                    << ";\n";
         }
     }
@@ -721,17 +721,17 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::add_kernel(const Stmt &s,
     print(s);
     close_scope("kernel " + name);
 
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer) {
-            allocations.pop(args[i].name);
+        if (arg.is_buffer) {
+            allocations.pop(arg.name);
         }
     }
 
     // Undef all the buffer address spaces, in case they're different in another kernel.
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
-            stream << "#undef " << get_memory_space(args[i].name) << "\n";
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
+            stream << "#undef " << get_memory_space(arg.name) << "\n";
         }
     }
 }

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -936,11 +936,11 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     // The last condition is handled via the preprocessor in the kernel
     // declaration.
     vector<BufferSize> constants;
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer &&
-            CodeGen_GPU_Dev::is_buffer_constant(s, args[i].name) &&
-            args[i].size > 0) {
-            constants.emplace_back(args[i].name, args[i].size);
+    for (const auto &arg : args) {
+        if (arg.is_buffer &&
+            CodeGen_GPU_Dev::is_buffer_constant(s, arg.name) &&
+            arg.size > 0) {
+            constants.emplace_back(arg.name, arg.size);
         }
     }
 
@@ -957,23 +957,23 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
 
     // Create preprocessor replacements for the address spaces of all our buffers.
     stream << "// Address spaces for " << name << "\n";
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
             vector<BufferSize>::iterator constant = constants.begin();
             while (constant != constants.end() &&
-                   constant->name != args[i].name) {
+                   constant->name != arg.name) {
                 constant++;
             }
 
             if (constant != constants.end()) {
                 stream << "#if " << constant->size << " <= MAX_CONSTANT_BUFFER_SIZE && "
                        << constant - constants.begin() << " < MAX_CONSTANT_ARGS\n";
-                stream << "#define " << get_memory_space(args[i].name) << " __constant\n";
+                stream << "#define " << get_memory_space(arg.name) << " __constant\n";
                 stream << "#else\n";
-                stream << "#define " << get_memory_space(args[i].name) << " __global\n";
+                stream << "#define " << get_memory_space(arg.name) << " __global\n";
                 stream << "#endif\n";
             } else {
-                stream << "#define " << get_memory_space(args[i].name) << " __global\n";
+                stream << "#define " << get_memory_space(arg.name) << " __global\n";
             }
         }
     }
@@ -1059,30 +1059,30 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::add_kernel(Stmt s,
     open_scope();
 
     // Reinterpret half args passed as uint16 back to half
-    for (size_t i = 0; i < args.size(); i++) {
-        if (!args[i].is_buffer &&
-            args[i].type.is_float() &&
-            args[i].type.bits() < 32) {
-            stream << " const " << print_type(args[i].type)
-                   << " " << print_name(args[i].name)
-                   << " = half_from_bits(" << print_name(args[i].name + "_bits") << ");\n";
+    for (const auto &arg : args) {
+        if (!arg.is_buffer &&
+            arg.type.is_float() &&
+            arg.type.bits() < 32) {
+            stream << " const " << print_type(arg.type)
+                   << " " << print_name(arg.name)
+                   << " = half_from_bits(" << print_name(arg.name + "_bits") << ");\n";
         }
     }
 
     print(s);
     close_scope("kernel " + name);
 
-    for (size_t i = 0; i < args.size(); i++) {
+    for (const auto &arg : args) {
         // Remove buffer arguments from allocation scope
-        if (args[i].is_buffer) {
-            allocations.pop(args[i].name);
+        if (arg.is_buffer) {
+            allocations.pop(arg.name);
         }
     }
 
     // Undef all the buffer address spaces, in case they're different in another kernel.
-    for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].is_buffer) {
-            stream << "#undef " << get_memory_space(args[i].name) << "\n";
+    for (const auto &arg : args) {
+        if (arg.is_buffer) {
+            stream << "#undef " << get_memory_space(arg.name) << "\n";
         }
     }
 }

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -218,8 +218,8 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
     debug(2) << "Done generating llvm bitcode for PTX\n";
 
     // Clear the symbol table
-    for (size_t i = 0; i < arg_sym_names.size(); i++) {
-        sym_pop(arg_sym_names[i]);
+    for (const auto &arg_sym_name : arg_sym_names) {
+        sym_pop(arg_sym_name);
     }
 }
 
@@ -703,8 +703,8 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
 
     // Run optimization passes
     function_pass_manager.doInitialization();
-    for (llvm::Module::iterator i = module->begin(); i != module->end(); i++) {
-        function_pass_manager.run(*i);
+    for (auto &function : *module) {
+        function_pass_manager.run(function);
     }
     function_pass_manager.doFinalization();
     module_pass_manager.run(*module);

--- a/src/CodeGen_Posix.cpp
+++ b/src/CodeGen_Posix.cpp
@@ -38,8 +38,8 @@ Value *CodeGen_Posix::codegen_allocation_size(const std::string &name, Type type
     Expr total_size_hi = make_zero(UInt(64));
 
     Expr low_mask = make_const(UInt(64), (uint64_t)(0xffffffff));
-    for (size_t i = 0; i < extents.size(); i++) {
-        Expr next_extent = cast(UInt(32), max(0, extents[i]));
+    for (const auto &extent : extents) {
+        Expr next_extent = cast(UInt(32), max(0, extent));
 
         // Update total_size >> 32. This math can't overflow due to
         // the loop invariant:

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -104,36 +104,36 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
     }
 
     stream << get_indent() << "// Check tensors have contiguous memory and are on the correct device\n";
-    for (size_t i = 0; i < buffer_args.size(); i++) {
+    for (auto &buffer_arg : buffer_args) {
         stream << get_indent();
         stream
             << "HLPT_CHECK_CONTIGUOUS("
-            << c_print_name(buffer_args[i].name)
+            << c_print_name(buffer_arg.name)
             << ");\n";
 
         if (is_cuda) {
             stream << get_indent();
             stream
                 << "HLPT_CHECK_DEVICE("
-                << c_print_name(buffer_args[i].name)
+                << c_print_name(buffer_arg.name)
                 << ", device_id);\n";
         }
     }
     stream << "\n";
 
     stream << get_indent() << "// Wrap tensors in Halide buffers\n";
-    for (size_t i = 0; i < buffer_args.size(); i++) {
-        if (!buffer_args[i].is_buffer()) {
+    for (auto &buffer_arg : buffer_args) {
+        if (!buffer_arg.is_buffer()) {
             continue;
         }
 
         stream << get_indent();
-        std::string tp = type_to_c_type(buffer_args[i].type, false);
+        std::string tp = type_to_c_type(buffer_arg.type, false);
         stream
             << "Halide::Runtime::Buffer<" << tp << "> "
-            << c_print_name(buffer_args[i].name)
+            << c_print_name(buffer_arg.name)
             << "_buffer = Halide::PyTorch::wrap<" << tp << ">("
-            << c_print_name(buffer_args[i].name)
+            << c_print_name(buffer_arg.name)
             << ");\n";
     }
     stream << "\n";
@@ -161,19 +161,19 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
 
     if (is_cuda) {
         stream << get_indent() << "// Make sure data is on device\n";
-        for (size_t i = 0; i < buffer_args.size(); i++) {
-            if (buffer_args[i].is_buffer()) {
+        for (auto &buffer_arg : buffer_args) {
+            if (buffer_arg.is_buffer()) {
                 stream << get_indent();
                 stream
                     << "AT_ASSERTM(!"
-                    << c_print_name(buffer_args[i].name) << "_buffer.host_dirty(),"
+                    << c_print_name(buffer_arg.name) << "_buffer.host_dirty(),"
                     << "\"device not synchronized for buffer "
-                    << c_print_name(buffer_args[i].name)
+                    << c_print_name(buffer_arg.name)
                     << ", make sure all update stages are explicitly computed on GPU."
                     << "\");\n";
                 stream << get_indent();
                 stream
-                    << c_print_name(buffer_args[i].name) << "_buffer"
+                    << c_print_name(buffer_arg.name) << "_buffer"
                     << ".device_detach_native();\n";
             }
         }

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -483,8 +483,7 @@ void CodeGen_X86::visit(const Call *op) {
     // clang-format on
 
     vector<Expr> matches;
-    for (size_t i = 0; i < sizeof(patterns) / sizeof(patterns[0]); i++) {
-        const Pattern &pattern = patterns[i];
+    for (const auto &pattern : patterns) {
         if (expr_match(pattern.pattern, op, matches)) {
             value = call_overloaded_intrin(op->type, pattern.intrin, matches);
             if (value) {


### PR DESCRIPTION
Part 2 of getting code ready for clang-tidy's modernize-loop check