### PR TITLE
[CMake] Add an option to specify filename suffix to add to libHalide …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -366,6 +366,10 @@ add_library(Halide
             $<TARGET_OBJECTS:Halide_initmod>)
 add_library(Halide::Halide ALIAS Halide)
 
+set(Halide_LIBHALIDE_SUFFIX "" CACHE STRING "Suffix to add to libHalide library")
+
+set_target_properties(Halide PROPERTIES OUTPUT_NAME Halide${Halide_LIBHALIDE_SUFFIX})
+
 target_link_libraries(Halide PUBLIC Threads::Threads)
 target_link_libraries(Halide PRIVATE Halide::LLVM)
 target_link_libraries(Halide PUBLIC Halide::LanguageOptions)


### PR DESCRIPTION
…library name

... which is empty by default, but can be helpful to support
side-by-side installation of multiple versions of the library.

I'm open to the exact option name, and the location where the option is introduced.