### PR TITLE
Use thread-local context and stream in CUDA runtime.

### DIFF
--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -192,34 +192,11 @@ void halide_thread_yield();
 }  // extern "C"
 
 namespace {
-template <typename T>
-struct remove_reference {
-    using type = T;
-};
-
-template <typename T>
-struct remove_reference<T &> {
-    using type = T;
-};
-
-template <typename T>
-struct remove_reference<T &&> {
-    using type = T;
-};
-
-template <typename T>
-using remove_reference_t = typename remove_reference<T>::type;
-
-template <typename T>
-ALWAYS_INLINE constexpr remove_reference_t<T> &&move(T && t) noexcept {
-    return static_cast<remove_reference_t<T> &&>(t);
-}
-
 template<typename T>
 ALWAYS_INLINE void swap(T &a, T &b) {
-    T tmp = move(a);
-    a = move(b);
-    b = move(tmp);
+    T t = a;
+    a = b;
+    b = t;
 }
 
 template<typename T>


### PR DESCRIPTION
Workaround for issue #6255 

This change makes it possible to set a thread-local CUDA context and stream by explosing the following functions:
`halide_cuda_set_current_context` and `halide_cuda_set_current_stream`. Executing kernels and buffer copies on custom stream and context is essential for work on multi-gpu systems.

TODO: Facilitate calling of the CUDA runtime functions in JIT mode. Now these functions are relatively easily accessible only in AOT, with JIT it's necessary (?) to go over JIT runtime modules and look for symbols.

NOTE: This does not work when there's a `parallel` schedule outside a GPU schedule - threads from Halide's internal thread pool will still see a global context, possibly on a different device.
