### PR TITLE
Fix default device wrap native function

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -411,7 +411,7 @@ WEAK int halide_device_detach_native(void *user_context, struct halide_buffer_t 
 WEAK int halide_default_device_wrap_native(void *user_context, struct halide_buffer_t *buf, uint64_t handle) {
     halide_assert(user_context, buf->device == 0);
     if (buf->device != 0) {
-        return -2;
+        return halide_error_code_device_wrap_native_failed;
     }
     buf->device_interface->impl->use_module();
     buf->device = handle;


### PR DESCRIPTION
Currently, an attempt to call `device_wrap_native` on a target that uses
the default device wrap native function will result in an error of type
`halide_error_device_interface_no_device`, namely in the OpenGLCompute and
the Hexagon targets. This happens because the default wrap native
function calls `debug_log_and_validate_buf` after the `device_interface` is
set in `halide_device_wrap_native` but before the `device` handle is set,
which is validated as a bad state.

This patch removes the validation call and adds an assert for the handle
much like the other wrap_native implementations in other targets.