### PR TITLE
[hannk] Fix > and >= op implementations

### DIFF
--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -583,11 +583,11 @@ private:
     }
 
     OpPtr BuildGreater(TfLiteContext *context, TfLiteNode *node) {
-        return BuildBinary(context, node, BinaryOp::Less, true);
+        return BuildBinary(context, node, BinaryOp::LessEqual, true);
     }
 
     OpPtr BuildGreaterEqual(TfLiteContext *context, TfLiteNode *node) {
-        return BuildBinary(context, node, BinaryOp::LessEqual, true);
+        return BuildBinary(context, node, BinaryOp::Less, true);
     }
 
     OpPtr BuildEqual(TfLiteContext *context, TfLiteNode *node) {

--- a/apps/hannk/tflite/tflite_parser.cpp
+++ b/apps/hannk/tflite/tflite_parser.cpp
@@ -438,9 +438,9 @@ public:
         case tflite::BuiltinOperator_GATHER:
             return parse_gather(op);
         case tflite::BuiltinOperator_GREATER:
-            return parse_binary(op, BinaryOp::Less, true);
-        case tflite::BuiltinOperator_GREATER_EQUAL:
             return parse_binary(op, BinaryOp::LessEqual, true);
+        case tflite::BuiltinOperator_GREATER_EQUAL:
+            return parse_binary(op, BinaryOp::Less, true);
         case tflite::BuiltinOperator_L2_NORMALIZATION:
             return parse_l2_normalization(op);
         case tflite::BuiltinOperator_LESS:


### PR DESCRIPTION
a>b should be b<=a (not b <a)
a>=b should be b<a (not b<=a)