### PR TITLE
[hannk] Improve GatherOp

### DIFF
--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -709,12 +709,18 @@ private:
         auto output = GetTensorById(context, node->outputs->data[0]);
         const TfLiteGatherParams *params = (const TfLiteGatherParams *)(node->builtin_data);
         int axis = params->axis;
+        int batch_dims = params->batch_dims;
         if (axis < 0) {
             axis += input->rank();
         }
         axis = input->rank() - 1 - axis;
-        return make_op<GatherOp>(input, indices, output, axis);
+        return make_op<GatherOp>(input, indices, output, axis, batch_dims);
     }
+
+    // TODO: support GATHER_ND once we find a testcase for it
+    // OpPtr BuildGatherNd(TfLiteContext *context, TfLiteNode *node) {
+    //     return BuildGather(context, node);
+    // }
 
     OpPtr BuildReshape(TfLiteContext *context, TfLiteNode *node) {
         auto input = GetTensorById(context, node->inputs->data[0]);
@@ -1341,8 +1347,24 @@ class NodeSupport {
         if (!InputsHaveCorrectTypes({ANY, I32})) {
             return false;
         }
+        const TfLiteGatherParams *params = (const TfLiteGatherParams *)(node_->builtin_data);
+        if (params->batch_dims != 0) {
+            // TODO: we don't support other values for this yet, but we should.
+            return false;
+        }
         return true;
     }
+
+    // TODO: support GATHER_ND once we find a testcase for it
+    // bool IsNodeSupported_GatherNd() const {
+    //     if (!IsVersionOK(1, 2)) {
+    //         return false;
+    //     }
+    //     if (!InputsHaveCorrectTypes({ANY, I32})) {
+    //         return false;
+    //     }
+    //     return true;
+    // }
 
     bool IsNodeSupported_Conv2d() const {
         if (!IsVersionOK(1, 2)) {

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -1058,15 +1058,46 @@ void GatherOp::execute() {
     HalideBuffer<const int32_t> indices = input(1)->buffer();
     const HalideBuffer<void> &out = output()->buffer();
 
+    // Haven't yet found an instance of TFLite's Gather op that
+    // specifies a nonzero values. Implement and test once we do.
+    HCHECK(batch_dims_ == 0) << "TODO: GatherOp doesn't yet support batch_dim != 0";
+
     if (indices.dimensions() == 0) {
-        indices.embed(0, 0);
+        // Yes, a 0D (scalar) here is documented as legal in TFLite
+        indices.embed(0, 0);  // make 1-D
     }
 
-    for (int i = out.dim(axis_).min(); i <= out.dim(axis_).max(); i++) {
-        HalideBuffer<const void> in_i = in.sliced(axis_, indices(i));
-        HalideBuffer<void> out_i = out.sliced(axis_, i);
-        out_i.copy_from(in_i);
+#ifndef NDEBUG
+    assert(out.dimensions() == in.dimensions() + indices.dimensions() - 1);
+    for (int i = 0; i < out.dimensions(); i++) {
+        if (i < axis_) {
+            assert(out.dim(i).extent() == in.dim(i).extent());
+        } else if (i < axis_ + indices.dimensions()) {
+            assert(out.dim(i).extent() == indices.dim(i - axis_).extent());
+        } else {
+            assert(out.dim(i).extent() == in.dim(i - indices.dimensions() + 1).extent());
+        }
     }
+
+    // Negative values for axis_ are handled by the parser
+    assert(axis_ >= 0 && axis_ < in.dimensions());
+#endif
+
+    // Note that the TFLite Gather op restricts indices to 1D (or 0D),
+    // but other NN libraries (eg NNAPI) alloe for it to be multidimensional,
+    // so we must copy more robustly.
+    //
+    // (TODO: support TFLite's GatherNd op, which is similar to this.)
+    const int pos_dims = indices.dimensions();
+    indices.for_each_element([&](const int *pos) {
+        const int index = indices(pos);
+        HalideBuffer<const void> in_i = in.sliced(axis_, index);
+        HalideBuffer<void> out_i = out.sliced(axis_, pos[0]);
+        for (int i = 1; i < pos_dims; i++) {
+            out_i = out_i.sliced(axis_, pos[i]);
+        }
+        out_i.copy_from(in_i);
+    });
 }
 
 BoundsMap L2NormalizationOp::map_bounds(int input_idx, int output_idx) const {

--- a/apps/hannk/interpreter/ops.h
+++ b/apps/hannk/interpreter/ops.h
@@ -208,11 +208,12 @@ public:
 };
 
 class GatherOp : public Op {
-    int axis_;
+    const int axis_;
+    const int batch_dims_;
 
 public:
-    GatherOp(TensorPtr input, TensorPtr indices, TensorPtr output, int axis)
-        : Op({input, indices}, {output}), axis_(axis) {
+    GatherOp(TensorPtr input, TensorPtr indices, TensorPtr output, int axis, int batch_dims)
+        : Op({input, indices}, {output}), axis_(axis), batch_dims_(batch_dims) {
     }
 
     void accept(OpVisitor *v);

--- a/apps/hannk/tflite/tflite_parser.cpp
+++ b/apps/hannk/tflite/tflite_parser.cpp
@@ -98,7 +98,7 @@ public:
                 shape.push_back(t->shape()->Get(shape_size - 1 - i));
             }
         }
-        //HCHECK(t->shape()) << "Dynamic shapes not supported.";
+        // HCHECK(t->shape()) << "Dynamic shapes not supported.";
 
         halide_type_t type = parse_type(t->type());
 
@@ -294,6 +294,7 @@ public:
         const tflite::GatherOptions *options =
             op->builtin_options_as_GatherOptions();
         int axis = options->axis();
+        int batch_dims = options->batch_dims();
         TensorPtr input = tensors_[op->inputs()->Get(0)];
         TensorPtr indices = tensors_[op->inputs()->Get(1)];
         TensorPtr output = tensors_[op->outputs()->Get(0)];
@@ -301,7 +302,7 @@ public:
             axis += input->rank();
         }
         axis = input->rank() - 1 - axis;
-        return make_op<GatherOp>(input, indices, output, axis);
+        return make_op<GatherOp>(input, indices, output, axis, batch_dims);
     }
 
     OpPtr parse_space_to_depth(const tflite::Operator *op) {
@@ -437,6 +438,9 @@ public:
             return parse_fully_connected(op);
         case tflite::BuiltinOperator_GATHER:
             return parse_gather(op);
+        // TODO: support GATHER_ND once we find a testcase for it
+        // case tflite::BuiltinOperator_GATHER_ND:
+        //     return parse_gather_nd(op);
         case tflite::BuiltinOperator_GREATER:
             return parse_binary(op, BinaryOp::LessEqual, true);
         case tflite::BuiltinOperator_GREATER_EQUAL:


### PR DESCRIPTION
We (mostly) implemented GatherOp for TFLite's Gather op, but missed some things:
- There's a batch_dim param for Gather that we were ignoring. I added code to fill it in, but we punt for values != 0, because I haven't yet found a test case that handles it. Should be easy to fill in when we do.
- TFLite's GatherNd op (and NNAPI's GATHER op) allow for the indices arg to be multidimensional; I rewrote the code to handle this and it's passing the acceptance tests for NNAPI's cases. (It doesn't yet handle the GatherNd op because, again, I haven't found a good test case. Should be simple to do when we do.)