### PR TITLE
[hannk] Fix MeanOp

### DIFF
--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -799,8 +799,13 @@ private:
         auto indices = GetTensorById(context, node->inputs->data[1]);
         auto output = GetTensorById(context, node->outputs->data[0]);
         const TfLiteReducerParams *params = (const TfLiteReducerParams *)(node->builtin_data);
+#ifndef NDEBUG
         const bool keep_dims = params ? params->keep_dims : false;
-        return make_op<ReductionOp>(ReductionOp::Mean, input, indices, keep_dims, output);
+        // TODO: I have yet to find any examples of keep_dims == false in the wild.
+        // If/when we do, handle it appropriately.
+        assert(keep_dims == true);
+#endif
+        return make_op<ReductionOp>(ReductionOp::Mean, input, indices, output);
     }
 
     OpPtr BuildSpaceToDepth(TfLiteContext *context, TfLiteNode *node) {

--- a/apps/hannk/delegate/hannk_delegate.cpp
+++ b/apps/hannk/delegate/hannk_delegate.cpp
@@ -792,7 +792,9 @@ private:
         auto input = GetTensorById(context, node->inputs->data[0]);
         auto indices = GetTensorById(context, node->inputs->data[1]);
         auto output = GetTensorById(context, node->outputs->data[0]);
-        return make_op<ReductionOp>(input, indices, output, ReductionOp::Mean);
+        const TfLiteReducerParams *params = (const TfLiteReducerParams *)(node->builtin_data);
+        const bool keep_dims = params ? params->keep_dims : false;
+        return make_op<ReductionOp>(ReductionOp::Mean, input, indices, keep_dims, output);
     }
 
     OpPtr BuildSpaceToDepth(TfLiteContext *context, TfLiteNode *node) {

--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -1425,10 +1425,6 @@ void ReductionOp::execute() {
         pad_to_rank(4, input_buf);
         pad_to_rank(4, output_buf);
 
-        // TODO: I have yet to find a test case where the setting of keep_dims_
-        // seems to have any effect on the correctness of the output. Revisit
-        // if/when we find such a case.
-
         if (op_ == Mean) {
             int mins[4] = {0, 0, 0, 0};
             int extents[4] = {1, 1, 1, 1};

--- a/apps/hannk/interpreter/ops.h
+++ b/apps/hannk/interpreter/ops.h
@@ -333,13 +333,12 @@ public:
 
 protected:
     const Operator op_;
-    const bool keep_dims_;
 
     bool reducing(int d) const;
 
 public:
-    ReductionOp(Operator op, const TensorPtr &input, const TensorPtr &indices, bool keep_dims, const TensorPtr &output)
-        : Op({input, indices}, {output}), op_(op), keep_dims_(keep_dims) {
+    ReductionOp(Operator op, const TensorPtr &input, const TensorPtr &indices, const TensorPtr &output)
+        : Op({input, indices}, {output}), op_(op) {
     }
 
     BoundsMap map_bounds(int input_idx, int output_idx) const override;

--- a/apps/hannk/interpreter/ops.h
+++ b/apps/hannk/interpreter/ops.h
@@ -319,13 +319,14 @@ public:
     static const char *to_string(Operator op);
 
 protected:
-    Operator op_;
+    const Operator op_;
+    const bool keep_dims_;
 
     bool reducing(int d) const;
 
 public:
-    ReductionOp(const TensorPtr &input, const TensorPtr &indices, const TensorPtr &output, Operator op)
-        : Op({input, indices}, {output}), op_(op) {
+    ReductionOp(Operator op, const TensorPtr &input, const TensorPtr &indices, bool keep_dims, const TensorPtr &output)
+        : Op({input, indices}, {output}), op_(op), keep_dims_(keep_dims) {
     }
 
     BoundsMap map_bounds(int input_idx, int output_idx) const override;

--- a/apps/hannk/tflite/tflite_parser.cpp
+++ b/apps/hannk/tflite/tflite_parser.cpp
@@ -372,7 +372,9 @@ public:
         TensorPtr input = tensors_[op->inputs()->Get(0)];
         TensorPtr indices = tensors_[op->inputs()->Get(1)];
         TensorPtr output = tensors_[op->outputs()->Get(0)];
-        return make_op<ReductionOp>(input, indices, output, reduction_op);
+        const tflite::ReducerOptions *options = op->builtin_options_as_ReducerOptions();
+        const bool keep_dims = options ? options->keep_dims() : false;
+        return make_op<ReductionOp>(reduction_op, input, indices, keep_dims, output);
     }
 
     OpPtr parse_unary(const tflite::Operator *op, UnaryOp::Operator type) {

--- a/apps/hannk/tflite/tflite_parser.cpp
+++ b/apps/hannk/tflite/tflite_parser.cpp
@@ -375,8 +375,13 @@ public:
         TensorPtr indices = tensors_[op->inputs()->Get(1)];
         TensorPtr output = tensors_[op->outputs()->Get(0)];
         const tflite::ReducerOptions *options = op->builtin_options_as_ReducerOptions();
+#ifndef NDEBUG
         const bool keep_dims = options ? options->keep_dims() : false;
-        return make_op<ReductionOp>(reduction_op, input, indices, keep_dims, output);
+        // TODO: I have yet to find any examples of keep_dims == false in the wild.
+        // If/when we do, handle it appropriately.
+        assert(keep_dims == true);
+#endif
+        return make_op<ReductionOp>(reduction_op, input, indices, output);
     }
 
     OpPtr parse_unary(const tflite::Operator *op, UnaryOp::Operator type) {


### PR DESCRIPTION
The `reducing()` method didn't handle negative values for indices, and didn't reverse the value of the axis as we do elsewhere, so results were incorrect.

~~Also, we now parse and save the value of `keep_dims`, though I can't find evidence that it does much of anything: test cases pass different values for it but none of them fail (even though we ignore it), and at least one reference implementation I see doesn't seem to do anything with it.~~