### PR TITLE
Fix wrong type in Ramp CodeGen for OpenGLCompute

### DIFF
--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -564,7 +564,7 @@ void CodeGen_OpenGLCompute_C::visit(const Ramp *op) {
     }
 
     rhs << ")";
-    print_assignment(op->base.type(), rhs.str());
+    print_assignment(op->type, rhs.str());
 }
 
 void CodeGen_OpenGLCompute_C::visit(const Broadcast *op) {


### PR DESCRIPTION
The variable type of the Ramp in OpenGLCompute is assigned the type of
the base member of the ramp, which is a scalar, while the ramp is a
vector. Instead, we should use the type of the ramp to take vectorization
into account.

Partially resolves #1687.