### PR TITLE
Specify template parameter of ScopedValue

### DIFF
--- a/src/ClampUnsafeAccesses.cpp
+++ b/src/ClampUnsafeAccesses.cpp
@@ -50,7 +50,7 @@ protected:
             }
         }
 
-        ScopedValue s(is_inside_indexing, true);
+        ScopedValue<bool> s(is_inside_indexing, true);
         return IRMutator::visit(call);
     }
 
@@ -60,7 +60,7 @@ private:
         ScopedBinding<bool> binding(let_var_inside_indexing, let->name, false);
         Body body = mutate(let->body);
 
-        ScopedValue s(is_inside_indexing, is_inside_indexing || let_var_inside_indexing.get(let->name));
+        ScopedValue<bool> s(is_inside_indexing, is_inside_indexing || let_var_inside_indexing.get(let->name));
         Expr value = mutate(let->value);
 
         return L::make(let->name, std::move(value), std::move(body));


### PR DESCRIPTION
Otherwise fails with '''ScopedValue' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]'