### PR TITLE
Update Emscripten settings

### DIFF
--- a/apps/hannk/.gitignore
+++ b/apps/hannk/.gitignore
@@ -1,2 +1,2 @@
-build/
+build*/
 bin/

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -91,9 +91,8 @@ function(add_wasm_executable TARGET)
         -Wsuggest-override
         -s ASSERTIONS=1
         -s ALLOW_MEMORY_GROWTH=1
-        -s WASM_BIGINT=1
-        -s STANDALONE_WASM=1
-        -s ENVIRONMENT=node)
+        -s ENVIRONMENT=node
+    )
 
     set(SRCS)
     foreach (S IN LISTS args_SRCS)


### PR DESCRIPTION
The settings we use to build C++ in wasm were slightly out of date now that we've updated our runtime to Node instead of d8. Also drive-by gitignore fix.