### PR TITLE
[hannk] Clean up aliasing (v2)

### DIFF
--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -1944,4 +1944,10 @@ void UnaryOp::accept(OpVisitor *v) {
     v->visit(this);
 }
 
+void LeafOpVisitor::visit(OpGroup *op) {
+    for (int i = 0; i < op->op_count(); i++) {
+        op->op(i)->accept(this);
+    }
+}
+
 }  // namespace hannk

--- a/apps/hannk/interpreter/ops.h
+++ b/apps/hannk/interpreter/ops.h
@@ -587,6 +587,13 @@ public:
     }
 };
 
+class LeafOpVisitor : public OpVisitor {
+public:
+    using OpVisitor::visit;
+
+    void visit(OpGroup *op) override;
+};
+
 }  // namespace hannk
 
 #endif  // HANNK_OPS_H_

--- a/apps/hannk/interpreter/tensor.cpp
+++ b/apps/hannk/interpreter/tensor.cpp
@@ -74,17 +74,23 @@ TensorStoragePtr Tensor::storage() {
 void Tensor::set_external_buffer(HalideBuffer<void> external_buffer) {
     assert(!is_dynamic());
     assert(is_external());
-    assert(storage_ == nullptr);
 
     // No: it's ok to set this to different values over time,
     // so don't assert that host is currently null (or already equal to the new value)
     // assert(!is_allocated());
 
-    for (int i = 0; i < buffer_.dimensions(); i++) {
-        assert(external_buffer.dim(i).min() == buffer_.dim(i).min());
-        assert(external_buffer.dim(i).extent() == buffer_.dim(i).extent());
+    storage()->buffer = std::move(external_buffer);
+    finish_buffer_allocation();
+
+    if (aliases_ != nullptr) {
+        for (const auto &weak : *aliases_) {
+            TensorPtr tp = weak.lock();  // null if the weak_ptr has expired
+            if (tp != nullptr && tp.get() != this) {
+                assert(!tp->is_external());
+                tp->finish_buffer_allocation();
+            }
+        }
     }
-    buffer_ = std::move(external_buffer);
 }
 
 void Tensor::allocate_from_arena_pointer(void *host) {
@@ -117,7 +123,7 @@ void Tensor::finish_buffer_allocation() {
     halide_buffer_t *raw_storage_buffer = storage_buffer.raw_buffer();
     assert(raw_storage_buffer->host);
 
-    if (is_reshape_alias_) {
+    if (alias_type_ == AliasType::Reshaped) {
         assert(raw_storage_buffer->number_of_elements() == buffer_.number_of_elements());
         assert(raw_storage_buffer->type == buffer_.type());
         assert(storage_offset_.empty());
@@ -191,67 +197,162 @@ void Tensor::resize_dynamic(const Box &new_shape) {
     storage_ = nullptr;
 }
 
-void Tensor::set_alias_of(const TensorPtr &t, const SmallVector<int, max_rank> &storage_offset, bool is_reshape) {
-    assert(!is_dynamic());
-    assert(!is_external());
-    assert(!is_alias());
-
-    // No: 't' may (or may not) already have is_alias_ = true,
-    // but both will be considered an alias after this call.
-    // assert(!t->is_alias_);
-
-    storage_ = t->storage();
-    storage_offset_ = storage_offset;
-
-    if (is_reshape) {
-        is_reshape_alias_ = true;
-
-        // No: assume that t->storage() matches the rank+dimensions expected by t
-        // (or, if not, that t->is_reshape_alias_ is already set to true).
-        //
-        // t->is_reshape_alias_ = true;
+bool Tensor::has_external_alias() const {
+    if (aliases_ != nullptr) {
+        for (const auto &weak : *aliases_) {
+            TensorPtr tp = weak.lock();  // null if the weak_ptr has expired
+            if (tp != nullptr && tp->is_external()) {
+                return true;
+            }
+        }
     }
+    return false;
+}
+
+// Return true iff 'this' can be an alias of 'source' of the given type.
+bool Tensor::can_alias(const TensorPtr &source, AliasType alias_type) const {
+    if (alias_type == AliasType::None || this == source.get()) {
+        return false;  // Bad inputs, just say no
+    }
+
+    if (this->is_allocated()) {
+        // Can't alias a tensor that already has an allocation.
+        return false;
+    }
+
+    // If either tensor is dynamic, can't alias them.
+    if (this->is_dynamic() || source->is_dynamic()) {
+        return false;
+    }
+
+    if (this->type().bytes() != source->type().bytes()) {
+        // We can't alias tensors with types of different size.
+        return false;
+    }
+
+    if (this->alias_type() != AliasType::None || this->aliases_ != nullptr) {
+        // Can't alias a tensor multiple times.
+        return false;
+    }
+
+    if (source->alias_type() != AliasType::None && source->alias_type() != alias_type) {
+        // The source of the aliasing must either be unaliased or of the type we want
+        return false;
+    }
+
+    if (alias_type == AliasType::Offset) {
+        // AliasType::Offset allows for NO external tensors in the alias group
+        if (this->is_external() || source->is_external()) {
+            return false;
+        }
+
+        if (this->rank() != source->rank()) {
+            // AliasType::Offset can't alias tensors with different rank.
+            return false;
+        }
+    } else if (alias_type == AliasType::Reshaped) {
+        // AliasType::Reshaped allows for at most one external tensor in the alias group
+        const bool this_external = this->is_external() || this->has_external_alias();
+        const bool source_external = source->is_external() || source->has_external_alias();
+        if (this_external && source_external) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/*static*/ void Tensor::make_offset_alias(TensorPtr alias, TensorPtr source, const TensorOffset &storage_offset) {
+    assert(alias->can_alias(source, AliasType::Offset));
+
+    if (source->aliases_ == nullptr) {
+        source->aliases_ = std::make_shared<std::vector<std::weak_ptr<Tensor>>>(1, source);
+        source->alias_type_ = AliasType::Offset;
+    }
+
+    assert(alias->aliases_ == nullptr);
+    alias->aliases_ = source->aliases_;
+    alias->aliases_->push_back(alias);
+
+    assert(alias->alias_type_ == AliasType::None);
+    alias->alias_type_ = AliasType::Offset;
+
+    assert(alias->storage_ == nullptr);
+    alias->storage_ = source->storage();
+    assert(alias->storage_offset_.empty());
+    alias->storage_offset_ = storage_offset;
 
 #ifndef NDEBUG
-    if (is_reshape) {
-        assert(storage_offset_.empty());
-        assert(this->buffer().type() == t->buffer().type());
-        assert(this->buffer().number_of_elements() == t->buffer().number_of_elements());
-    } else {
-        // Reality-check.
-        Box offset_bounds = bounds();
-        for (int i = 0; i < (int)storage_offset_.size(); i++) {
-            offset_bounds[i] += storage_offset_[i];
-        }
-        auto &shared_buffer = storage_->buffer;
-        assert(shared_buffer.type().bytes() == type().bytes());
-        assert(shared_buffer.dimensions() == (int)offset_bounds.size());
-        assert(!shared_buffer.data());
+    // Reality-check.
+    Box offset_bounds = alias->bounds();
+    for (int i = 0; i < (int)alias->storage_offset_.size(); i++) {
+        offset_bounds[i] += alias->storage_offset_[i];
+    }
+    auto &shared_buffer = alias->storage_->buffer;
+    assert(shared_buffer.type().bytes() == alias->type().bytes());
+    assert(shared_buffer.dimensions() == (int)offset_bounds.size());
+    assert(!shared_buffer.data());
 
-        // Check that the storage is big enough for this buffer.
-        for (int i = 0; i < shared_buffer.dimensions(); i++) {
-            assert(offset_bounds[i].min >= shared_buffer.dim(i).min());
-            assert(offset_bounds[i].max <= shared_buffer.dim(i).max());
-        }
+    // Check that the storage is big enough for this buffer.
+    for (int i = 0; i < shared_buffer.dimensions(); i++) {
+        assert(offset_bounds[i].min >= shared_buffer.dim(i).min());
+        assert(offset_bounds[i].max <= shared_buffer.dim(i).max());
     }
 #endif
+}
 
-    is_alias_ = true;
-    t->is_alias_ = true;
+/*static*/ void Tensor::make_reshape_alias(TensorPtr alias, TensorPtr source) {
+    assert(alias->can_alias(source, AliasType::Reshaped));
+
+    if (alias->is_external()) {
+        assert(!source->has_external_alias());
+    } else if (source->is_external()) {
+        assert(!alias->has_external_alias());
+    }
+
+    if (source->aliases_ == nullptr) {
+        source->aliases_ = std::make_shared<std::vector<std::weak_ptr<Tensor>>>(1, source);
+        assert(source->alias_type_ == AliasType::None);
+        source->alias_type_ = AliasType::Reshaped;
+    } else {
+        assert(source->alias_type_ == AliasType::Reshaped);
+    }
+
+    assert(alias->aliases_ == nullptr);
+    alias->aliases_ = source->aliases_;
+    alias->aliases_->push_back(alias);
+
+    assert(alias->alias_type_ == AliasType::None);
+    alias->alias_type_ = AliasType::Reshaped;
+
+    assert(alias->storage_ == nullptr);
+    alias->storage_ = source->storage();
+    assert(alias->storage_offset_.empty());
+
+#ifndef NDEBUG
+    assert(alias->storage_offset_.empty());
+    assert(alias->buffer().type().bytes() == source->buffer().type().bytes());
+    assert(alias->buffer().number_of_elements() == source->buffer().number_of_elements());
+#endif
 }
 
 void Tensor::dump(std::ostream &os) const {
-    os << "  " << buffer_.type() << " x ";
+    os << "  \"" << name() << "\" this:@" << (const void *)this;
 
-    const auto *b = buffer_.raw_buffer();
-    os << '{';
-    for (int i = 0; i < b->dimensions; i++) {
-        if (i > 0) {
-            os << ", ";
+    os << " " << buffer_.type() << " x ";
+
+    const auto dump_dims = [&os](const halide_buffer_t *b) {
+        os << '{';
+        for (int i = 0; i < b->dimensions; i++) {
+            if (i > 0) {
+                os << ", ";
+            }
+            os << b->dim[i];
         }
-        os << b->dim[i];
-    }
-    os << '}';
+        os << '}';
+    };
+
+    dump_dims(buffer_.raw_buffer());
 
     if (is_allocated()) {
         os << " allocated";
@@ -267,9 +368,13 @@ void Tensor::dump(std::ostream &os) const {
     if (is_dynamic()) {
         os << " dynamic";
     }
-    if (is_alias()) {
-        os << " alias";
-        os << " storage_offset{";
+    if (alias_type_ != AliasType::None) {
+        os << (alias_type_ == AliasType::Offset ? " alias_offset{" : " alias_reshaped{");
+        for (const auto &weak : *aliases_) {
+            TensorPtr tp = weak.lock();  // null if the weak_ptr has expired
+            os << " " << (void *)tp.get();
+        }
+        os << " } storage_offset{";
         for (size_t i = 0; i < storage_offset_.size(); i++) {
             if (i > 0) {
                 os << ", ";
@@ -285,8 +390,12 @@ void Tensor::dump(std::ostream &os) const {
     }
 
     os << " storage:@" << (void *)storage_.get();
+    if (storage_) {
+        os << ' ';
+        dump_dims(storage_->buffer.raw_buffer());
+    }
 
-    os << " " << name() << " this:@" << (const void *)this << std::endl;
+    os << std::endl;
 }
 
 }  // namespace hannk

--- a/apps/hannk/interpreter/tensor.h
+++ b/apps/hannk/interpreter/tensor.h
@@ -62,6 +62,14 @@ public:
 };
 using TensorStoragePtr = std::shared_ptr<TensorStorage>;
 
+enum class AliasType {
+    None,
+    Offset,    // The aliased Tensors are translated/cropped views of the same buffer.
+               // External tensors cannot be in an offset-alias group.
+    Reshaped,  // The aliased Tensors share the same host pointer and have identical elem_count but different shapes
+               // At most one External tensor can be in a reshape-alias group.
+};
+
 class Tensor {
     std::string name_;
     HalideBuffer<void> buffer_;
@@ -78,12 +86,13 @@ class Tensor {
     // for a Tensor to be dynamic if it is also constant or external.
     // Currently only used in conjunction with the TFLite delegate.
     bool is_dynamic_ = false;
-    // If true, this Tensor shares its TensorStorage with at least one other Tensor.
-    bool is_alias_ = false;
-    // If true, this Tensor is aliased to another via reshape (rather than cropping),
-    // and may have a different rank from the underlying storage.
-    // Only used if is_alias_ = true.
-    bool is_reshape_alias_ = false;
+
+    // All the Tensors in this list share their TensorStorage with each other.
+    // An arbitrary number of Tensors can alias each other, but at most *one* may be external.
+    //
+    // Note that this list should never have size() of 0 or 1 (the pointer should simply be null).
+    std::shared_ptr<std::vector<std::weak_ptr<Tensor>>> aliases_;
+    AliasType alias_type_ = AliasType::None;
 
     // Possibly shared storage for this tensor.
     TensorStoragePtr storage_;
@@ -97,6 +106,8 @@ class Tensor {
     std::list<Op *> consumers_;
 
     void finish_buffer_allocation();
+
+    bool has_external_alias() const;
 
 public:
     Tensor() = delete;
@@ -167,6 +178,7 @@ public:
 
     void set_external(bool external = true) {
         assert(!(external && is_dynamic()));
+        assert(!(external && alias_type() != AliasType::None));
         is_external_ = external;
     }
 
@@ -207,10 +219,17 @@ public:
 
     void resize_dynamic(const Box &new_shape);
 
-    bool is_alias() const {
-        return is_alias_;
+    // Return true iff this Tensor aliases another Tensor.
+    AliasType alias_type() const {
+        return alias_type_;
     }
-    void set_alias_of(const TensorPtr &t, const TensorOffset &offset = {}, bool is_reshape = false);
+
+    // Return true iff 'this' can be an alias of 'source' of the given type.
+    bool can_alias(const TensorPtr &source, AliasType alias_type) const;
+
+    // Needs to be static so we can pass via shared_ptr (necessary for weak_ptr usage internally)
+    static void make_offset_alias(TensorPtr alias, TensorPtr source, const TensorOffset &offset);
+    static void make_reshape_alias(TensorPtr alias, TensorPtr source);
 
     bool is_dense() const;
 

--- a/apps/hannk/interpreter/transforms.cpp
+++ b/apps/hannk/interpreter/transforms.cpp
@@ -84,56 +84,41 @@ void remove_dead_ops(OpGroup *root) {
 
 namespace {
 
-// Check if a tensor already has storage configured.
-bool has_storage(const TensorPtr &t) {
-    return t->is_alias() || t->is_allocated();
-}
+class InPlaceReshape : public LeafOpVisitor {
+    using OpVisitor::visit;
+
+    void visit(ReshapeOp *op) override {
+        TensorPtr input = op->input();
+        TensorPtr output = op->output();
+
+        HCHECK(input->type().bytes() == output->type().bytes());
+        HCHECK(input->is_dense() == output->is_dense());
+        HCHECK(input->number_of_elements() == output->number_of_elements());
+
+        if (input->can_alias(output, AliasType::Reshaped)) {
+            Tensor::make_reshape_alias(input, output);
+        } else if (output->can_alias(input, AliasType::Reshaped)) {
+            Tensor::make_reshape_alias(output, input);
+        }
+    }
+};
 
 // Try to alias outputs to inputs when it is safe.
 class InPlace : public LeafOpVisitor {
     using OpVisitor::visit;
 
-    bool is_alias_possible(TensorPtr input, TensorPtr output) const {
-        // If either tensor is dynamic, can't alias them.
-        if (input->is_dynamic() || output->is_dynamic()) {
-            return false;
-        }
-
-        // If either tensor is external, can't alias them.
-        // TODO: maybe we can, but it's not clear how to update storage_.host in that case?
-        if (input->is_external() || output->is_external()) {
-            return false;
-        }
-
-        if (input->type().bytes() != output->type().bytes()) {
-            // We can't alias tensors with types of different size.
-            return false;
-        }
-
+    // We can alias two tensors if the input is not used after the output is written,
+    // and we meet a number of other requirements.
+    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, TensorOffset offset = {}) const {
         // We can't alias an input that is an input or output of the root graph.
         // TODO: We could, if we don't change the shape.
         if (is_root_input_or_output(input)) {
             return false;
         }
 
-        return true;
-    }
-
-    // We can alias two tensors if the input is not used after the output is written,
-    // and we meet a number of other requirements.
-    bool maybe_alias_tensors(TensorPtr input, TensorPtr output, TensorOffset offset = {}) const {
-        if (!is_alias_possible(input, output)) {
-            return false;
-        }
-
         // If the input is used anywhere else, we should not alias it.
         // TODO: This is conservative, we could alias it if it is the *last* use.
         if (input->consumers().size() != 1) {
-            return false;
-        }
-
-        // rank has to match for most aliasing (note that Reshape is an exception to this)
-        if (input->rank() != output->rank()) {
             return false;
         }
 
@@ -146,16 +131,15 @@ class InPlace : public LeafOpVisitor {
             input_bounds_with_offset[i] += offset[i];
             output_bounds_with_negative_offset[i] -= offset[i];
         }
-        bool input_subset_of_output = is_subset_of(input_bounds_with_offset, output->bounds());
-        bool output_subset_of_input = is_subset_of(output_bounds_with_negative_offset, input->bounds());
-        if (input_subset_of_output && !has_storage(input)) {
-            input->set_alias_of(output, offset);
+
+        if (is_subset_of(input_bounds_with_offset, output->bounds()) && input->can_alias(output, AliasType::Offset)) {
+            Tensor::make_offset_alias(input, output, offset);
             return true;
-        } else if (output_subset_of_input && !has_storage(output)) {
+        } else if (is_subset_of(output_bounds_with_negative_offset, input->bounds()) && output->can_alias(input, AliasType::Offset)) {
             for (int &i : offset) {
                 i = -i;
             }
-            output->set_alias_of(input, offset);
+            Tensor::make_offset_alias(output, input, offset);
             return true;
         }
 
@@ -229,30 +213,6 @@ class InPlace : public LeafOpVisitor {
         maybe_alias_tensors(op->input(), op->output(), offset);
     }
 
-    void visit(ReshapeOp *op) override {
-        const TensorPtr &input = op->input();
-        const TensorPtr &output = op->output();
-
-        // Reshape is unusual in that it's OK to alias Reshapes with mismatched rank
-        // (indeed, this is almost always the case), so we handle everything here
-        // instead of calling maybe_alias_tensors().
-        if (!is_alias_possible(input, output)) {
-            return;
-        }
-
-        if (!input->is_dense() || !output->is_dense()) {
-            // Can't alias a Reshape unless both Tensors have dense strides.
-            return;
-        }
-
-        constexpr bool is_reshape = true;
-        if (!has_storage(input)) {
-            input->set_alias_of(output, {}, is_reshape);
-        } else if (!has_storage(output)) {
-            output->set_alias_of(input, {}, is_reshape);
-        }
-    }
-
     const Op *const root_;
 
     bool is_root_input_or_output(const TensorPtr &t) const {
@@ -268,6 +228,12 @@ public:
 }  // namespace
 
 void in_place(Op *op) {
+    // Always check for ReshapeOp before anything else; we want
+    // to try our best to alias those tensors, and the luck of the
+    // draw could put other aliases in place first that could thwart this.
+    InPlaceReshape handle_reshapes;
+    op->accept(&handle_reshapes);
+
     InPlace v(op);
     op->accept(&v);
 }


### PR DESCRIPTION
The code for aliasing tensors was janky. This cleans it up and makes a clear distinction between aliasing done to overlay buffers with crop-and-translate, vs the aliasing done when we reshape tensors. We no longer allow a given tensor to do both of these, and we give preference to Reshape aliasing first.

(Cherry-picked from #6321)