### PR TITLE
Use explicit host build strategy for cross compiling HANNK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.20)
 project(Halide
-        VERSION 13.0.0
+        VERSION 14.0.0
         DESCRIPTION "Halide compiler and libraries"
         HOMEPAGE_URL "https://halide-lang.org")
 

--- a/apps/hannk/.gitignore
+++ b/apps/hannk/.gitignore
@@ -1,2 +1,3 @@
 build*/
 bin/
+emsdk

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -72,12 +72,13 @@ target_include_directories(compare_vs_tflite
 # TODO: Surely there's a better way to set Emscripten flags.
 if (Halide_TARGET MATCHES "wasm")
     foreach (t IN ITEMS benchmark compare_vs_tflite)
-        target_link_libraries(${t} PRIVATE
-                              "-s ALLOW_MEMORY_GROWTH=1"
-                              "-s ENVIRONMENT=node"
-                              "-s NODERAWFS"
-                              "$<$<CONFIG:Debug>:-s ASSERTIONS=1>"
-                              )
+        target_link_options(
+            ${t} PRIVATE
+            "SHELL:-s ALLOW_MEMORY_GROWTH=1"
+            "SHELL:-s ENVIRONMENT=node"
+            "SHELL:-s NODERAWFS"
+            "SHELL:$<$<CONFIG:Debug>:-s ASSERTIONS=1>"
+        )
     endforeach ()
 endif ()
 

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -72,6 +72,7 @@ target_include_directories(compare_vs_tflite
 # TODO: Surely there's a better way to set Emscripten flags.
 if (Halide_TARGET MATCHES "wasm")
     foreach (t IN ITEMS benchmark compare_vs_tflite)
+        # Note: "SHELL:" prevents de-duplication of the -s flag.
         target_link_options(
             ${t} PRIVATE
             "SHELL:-s ALLOW_MEMORY_GROWTH=1"

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -9,7 +9,7 @@ enable_testing()
 option(HANNK_BUILD_TFLITE "Build TFLite+Delegate for HANNK" ON)
 if (HANNK_BUILD_TFLITE AND (Halide_TARGET MATCHES "wasm"))
     message(FATAL_ERROR "HANNK_BUILD_TFLITE must be OFF when targeting wasm")
-endif()
+endif ()
 message(STATUS "HANNK_BUILD_TFLITE is ${HANNK_BUILD_TFLITE}")
 
 # -fPIC is necessary for .so builds (at least on Linux); not necessary for the non-delegate
@@ -73,17 +73,13 @@ target_include_directories(compare_vs_tflite
 if (Halide_TARGET MATCHES "wasm")
     foreach (t IN ITEMS benchmark compare_vs_tflite)
         target_link_libraries(${t} PRIVATE
-            "-s ALLOW_MEMORY_GROWTH=1"
-            "-s ENVIRONMENT=node"
-            "-s NODERAWFS"
-        )
-        if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-            target_link_libraries(${t} PRIVATE
-                "-s ASSERTIONS=1"
-            )
-        endif()
-    endforeach()
-endif()
+                              "-s ALLOW_MEMORY_GROWTH=1"
+                              "-s ENVIRONMENT=node"
+                              "-s NODERAWFS"
+                              "$<$<CONFIG:Debug>:-s ASSERTIONS=1>"
+                              )
+    endforeach ()
+endif ()
 
 # TODO: Replicated from Halide's wasm dependency code; we should move this
 # into a Helper file included in the install, perhaps?
@@ -121,6 +117,4 @@ foreach (t IN LISTS TEST_FILES)
     endif()
     set_tests_properties(${test_name} PROPERTIES
                          LABELS hannk_tests)
-endforeach()
-
-
+endforeach ()

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -6,6 +6,10 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 enable_testing()
 
+# ----------------------------
+
+option(HANNK_AOT_HOST_ONLY "Only build AOT host tools for cross-compiling" OFF)
+
 option(HANNK_BUILD_TFLITE "Build TFLite+Delegate for HANNK" ON)
 if (HANNK_BUILD_TFLITE AND (Halide_TARGET MATCHES "wasm"))
     message(FATAL_ERROR "HANNK_BUILD_TFLITE must be OFF when targeting wasm")
@@ -21,34 +25,42 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-# Find HalideHelpers -- this is just the Runtime headers, but no libraries
-find_package(HalideHelpers REQUIRED)
-
 # Set up the version of TFLite we expect
 # (We need to do this even if HANNK_BUILD_TFLITE is off,
 # so that the .tflite file parser can get the right schema)
 set(TFLITE_VERSION_MAJOR "2" CACHE STRING "Major version of TFLite to assume")
 set(TFLITE_VERSION_MINOR "6" CACHE STRING "Minor version of TFLite to assume")
 set(TFLITE_VERSION_PATCH "0" CACHE STRING "Patch version of TFLite to assume")
+set(TFLITE_VERSION "${TFLITE_VERSION_MAJOR}.${TFLITE_VERSION_MINOR}.${TFLITE_VERSION_PATCH}")
+
+# ----------------------------
 
 add_compile_definitions(TFLITE_VERSION_MAJOR=${TFLITE_VERSION_MAJOR})
 add_compile_definitions(TFLITE_VERSION_MINOR=${TFLITE_VERSION_MINOR})
 add_compile_definitions(TFLITE_VERSION_PATCH=${TFLITE_VERSION_PATCH})
-if (HANNK_BUILD_TFLITE)
-    add_compile_definitions(HANNK_BUILD_TFLITE=1)
-else ()
-    add_compile_definitions(HANNK_BUILD_TFLITE=0)
-endif ()
+add_compile_definitions(HANNK_BUILD_TFLITE=$<BOOL:${HANNK_BUILD_TFLITE}>)
 
-set(TFLITE_VERSION "${TFLITE_VERSION_MAJOR}.${TFLITE_VERSION_MINOR}.${TFLITE_VERSION_PATCH}")
+# ----------------------------
+
+# Find HalideHelpers -- this is just the Runtime headers and CMake functions, but no libraries
+find_package(HalideHelpers REQUIRED)
+
+# ----------------------------
 
 add_subdirectory(halide)
+if (HANNK_AOT_HOST_ONLY)
+    # Don't add anything else to the build... everything for AOT is in the halide subdirectory
+    return()
+endif ()
+
 add_subdirectory(interpreter)
 add_subdirectory(tflite)
 add_subdirectory(util)
 if (HANNK_BUILD_TFLITE)
     add_subdirectory(delegate)
 endif ()
+
+# ----------------------------
 
 # Benchmarking executable
 add_executable(benchmark benchmark.cpp)

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -111,6 +111,8 @@ file(GLOB TEST_FILES CONFIGURE_DEPENDS "test/*/*")
 foreach (t IN LISTS TEST_FILES)
     file(RELATIVE_PATH test_name ${hannk_SOURCE_DIR} ${t})
 
+    # Emscripten sets CMAKE_CROSSCOMPILING_TOOLCHAIN to NODE_JS_EXECUTABLE,
+    # which ensures these tests will run in Node.
     add_test(NAME ${test_name}
              COMMAND compare_vs_tflite ${t} --benchmark 0)
 

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -82,15 +82,7 @@ if (Halide_TARGET MATCHES "wasm")
     endforeach ()
 endif ()
 
-# TODO: Replicated from Halide's wasm dependency code; we should move this
-# into a Helper file included in the install, perhaps?
-function(_find_node_js)
-    find_program(NODE_JS_EXECUTABLE node nodejs)
-
-    if (NOT NODE_JS_EXECUTABLE)
-        message(FATAL_ERROR "Could not find nodejs. Please set NODE_JS_EXECUTABLE on the CMake command line.")
-    endif ()
-
+if (Halide_TARGET MATCHES "wasm" AND NODE_JS_EXECUTABLE)
     execute_process(COMMAND "${NODE_JS_EXECUTABLE}" --version
                     OUTPUT_VARIABLE NODE_JS_VERSION_RAW
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -99,8 +91,7 @@ function(_find_node_js)
     if (NODE_JS_VERSION VERSION_LESS "16.13")
         message(FATAL_ERROR "Halide requires Node v16.13 or later, but found ${NODE_JS_VERSION_RAW} at ${NODE_JS_EXECUTABLE}. Please set NODE_JS_EXECUTABLE on the CMake command line.")
     endif ()
-endfunction()
-
+endif ()
 
 # Tests
 file(GLOB TEST_FILES CONFIGURE_DEPENDS "test/*/*")

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -98,15 +98,9 @@ file(GLOB TEST_FILES CONFIGURE_DEPENDS "test/*/*")
 foreach (t IN LISTS TEST_FILES)
     file(RELATIVE_PATH test_name ${hannk_SOURCE_DIR} ${t})
 
-    set(LAUNCHER "")
-    if (Halide_TARGET MATCHES "wasm")
-        _find_node_js()
-        add_test(NAME ${test_name}
-                 COMMAND ${NODE_JS_EXECUTABLE} compare_vs_tflite.js ${t} --benchmark 0)
-    else()
-        add_test(NAME ${test_name}
-                 COMMAND compare_vs_tflite ${t} --benchmark 0)
-    endif()
+    add_test(NAME ${test_name}
+             COMMAND compare_vs_tflite ${t} --benchmark 0)
+
     set_tests_properties(${test_name} PROPERTIES
                          LABELS hannk_tests)
 endforeach ()

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -107,7 +107,7 @@ if (Halide_TARGET MATCHES "wasm" AND NODE_JS_EXECUTABLE)
 endif ()
 
 # Tests
-file(GLOB TEST_FILES CONFIGURE_DEPENDS "test/*/*")
+file(GLOB TEST_FILES CONFIGURE_DEPENDS "test/*/*.tflite")
 foreach (t IN LISTS TEST_FILES)
     file(RELATIVE_PATH test_name ${hannk_SOURCE_DIR} ${t})
 

--- a/apps/hannk/Makefile
+++ b/apps/hannk/Makefile
@@ -37,12 +37,12 @@ build: \
 	$(BIN)/$(HL_TARGET)/compare_vs_tflite
 
 test: compare_vs_tflite
-	$(foreach test_model, $(shell ls -1 test/*/*), $(BIN)/$(HL_TARGET)/compare_vs_tflite $(test_model) --benchmark 0;)
+	$(foreach test_model, $(shell ls -1 test/*/*.tflite), $(BIN)/$(HL_TARGET)/compare_vs_tflite $(test_model) --benchmark 0;)
 
 test-hexagon-sim: $(BIN)/$(HL_TARGET)/$(BENCHMARK_OUT)
 	@mkdir -p $@
 	echo "Benchmarking tests..."
-	$(foreach test_model, $(shell ls -1 test/*/*), BIN=$(BIN) ./run_benchmark_on_hexagon_sim.sh $(test_model);)
+	$(foreach test_model, $(shell ls -1 test/*/*.tflite), BIN=$(BIN) ./run_benchmark_on_hexagon_sim.sh $(test_model);)
 
 test-hexagon-device: $(BIN)/$(HL_TARGET)/$(BENCHMARK_OUT)
 	echo "Benchmarking tests..."
@@ -51,7 +51,7 @@ test-hexagon-device: $(BIN)/$(HL_TARGET)/$(BENCHMARK_OUT)
 	adb push test/. /vendor/bin/hannk-test
 	adb push $(HEXAGON_SDK_ROOT)/libs/run_main_on_hexagon/ship/android_aarch64/run_main_on_hexagon /vendor/bin/run_main_on_hexagon
 	adb push $(HEXAGON_SDK_ROOT)/libs/run_main_on_hexagon/ship/hexagon_toolv84_v65/librun_main_on_hexagon_skel.so /vendor/lib/rfsa/adsp/
-	$(foreach test_model, $(shell ls -1 test/*/*), adb shell 'cd /vendor/bin; touch /vendor/lib/rfsa/adsp/run_main_on_hexagon.farf; ./run_main_on_hexagon 3 /vendor/bin/$(BENCHMARK_OUT) --verbose hannk-$(test_model)';)
+	$(foreach test_model, $(shell ls -1 test/*/*.tflite), adb shell 'cd /vendor/bin; touch /vendor/lib/rfsa/adsp/run_main_on_hexagon.farf; ./run_main_on_hexagon 3 /vendor/bin/$(BENCHMARK_OUT) --verbose hannk-$(test_model)';)
 
 clean:
 	rm -rf $(BIN)

--- a/apps/hannk/configure_cmake.sh
+++ b/apps/hannk/configure_cmake.sh
@@ -2,79 +2,106 @@
 
 set -e
 
-HANNK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+HANNK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-if [ -z ${BUILD_DIR} ]; then
-BUILD_DIR="${HANNK_DIR}/build"
+if [ -z "${BUILD_DIR}" ]; then
+  BUILD_DIR="${HANNK_DIR}/build"
 fi
 
-if [ -z ${HALIDE_INSTALL_PATH} ]; then
-HALIDE_INSTALL_PATH=${HOME}/halide-14-install/
+if [ -z "${HALIDE_INSTALL_PATH}" ]; then
+  HALIDE_INSTALL_PATH="${HOME}/halide-14-install/"
 fi
 
-if [ -z ${HL_TARGET} ]; then
-HL_TARGET=host
+if [ -z "${HL_TARGET}" ]; then
+  HL_TARGET=host
 fi
 
 if [ -z "${CMAKE_GENERATOR}" ]; then
-CMAKE_GENERATOR=Ninja
+  CMAKE_GENERATOR=Ninja
 fi
 
 if [ -z "${CMAKE_BUILD_TYPE}" ]; then
-CMAKE_BUILD_TYPE=Release
+  CMAKE_BUILD_TYPE=Release
+fi
+
+if [ -z "${ANDROID_PLATFORM}" ]; then
+  ANDROID_PLATFORM=21
 fi
 
 if [ -z "${HANNK_BUILD_TFLITE}" ]; then
-HANNK_BUILD_TFLITE=ON
+  HANNK_BUILD_TFLITE=ON
 else
-HANNK_BUILD_TFLITE=OFF
+  HANNK_BUILD_TFLITE=OFF
 fi
 
-PREFIX=
-EXTRAS=
+## In a cross-compiling scenario, use a separate host and build dir
 
 if [[ "${HL_TARGET}" =~ ^arm-64-android.* ]]; then
-
-  # TODO: this doesn't work (yet); crosscompiling in CMake is painful.
-  echo Configuring for Android arm64-v8a build...
-  echo Using ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT}
-  echo Using CMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake
-
-  EXTRAS="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} -DANDROID_ABI=arm64-v8a"
-
+  HOST_BUILD_DIR="${BUILD_DIR}/_host"
+  HOST_BUILD_TARGET=(--target hannk_tools)
+  HL_HOST_TARGET=host
 elif [[ "${HL_TARGET}" =~ ^wasm-32-wasmrt.* ]]; then
-
-    PREFIX=emcmake
-    HANNK_BUILD_TFLITE=OFF
-
+  HOST_BUILD_DIR="${BUILD_DIR}/_host"
+  HOST_BUILD_TARGET=(--target hannk_tools)
+  HL_HOST_TARGET=host
 else
-
-  echo Assuming host build...
-
+  HOST_BUILD_DIR="${BUILD_DIR}"
+  HOST_BUILD_TARGET=()
+  HL_HOST_TARGET="${HL_TARGET}"
 fi
 
-if [ -n "${NODE_JS_EXECUTABLE}" ]; then
-EXTRAS="${EXTRAS} -DNODE_JS_EXECUTABLE=${NODE_JS_EXECUTABLE}"
-echo Using NODE_JS_EXECUTABLE=${NODE_JS_EXECUTABLE}
-fi
+## Build HANNK for the host no matter what
 
-echo Using HalideInstall=${HALIDE_INSTALL_PATH}
-echo Using BUILD_DIR=${BUILD_DIR}
-echo Using build tool=${CMAKE_GENERATOR}
-echo Using CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-echo Using HL_TARGET=${HL_TARGET}
-echo Using HANNK_BUILD_TFLITE=${HANNK_BUILD_TFLITE}
-
-mkdir -p "${BUILD_DIR}"
-cd "${BUILD_DIR}"
-
-${PREFIX} cmake \
-  ${EXTRAS} \
+echo "Configuring HANNK for ${HL_HOST_TARGET}"
+cmake \
   -G "${CMAKE_GENERATOR}" \
+  -S "${HANNK_DIR}" \
+  -B "${HOST_BUILD_DIR}" \
   -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
   -DHalide_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/Halide" \
   -DHalideHelpers_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/HalideHelpers" \
-  -DHalide_TARGET=${HL_TARGET} \
-  -DHANNK_BUILD_TFLITE=${HANNK_BUILD_TFLITE} \
+  -DHalide_TARGET="${HL_HOST_TARGET}" \
+  -DHANNK_BUILD_TFLITE=${HANNK_BUILD_TFLITE}
+
+echo "Building HANNK for ${HL_HOST_TARGET}"
+cmake --build "${HOST_BUILD_DIR}" "${HOST_BUILD_TARGET[@]}"
+
+## Now if we're cross-compiling for Android or WASM, set up the build
+## for that, using the platform-provided CMake toolchain files.
+
+if [[ "${HL_TARGET}" =~ ^arm-64-android.* ]]; then
+  # TODO: this doesn't work (yet); crosscompiling in CMake is painful.
+  echo "Using ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT}"
+  echo "Using CMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake"
+  CROSS_OPTIONS=(
+    -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake"
+    -DANDROID_ABI=arm64-v8a
+    "-DANDROID_PLATFORM=${ANDROID_PLATFORM}"
+    # Required because TFLite's internal Eigen tries to compile an unnecessary BLAS with the system Fortran compiler.
+    "-DCMAKE_Fortran_COMPILER=NO"
+  )
+elif [[ "${HL_TARGET}" =~ ^wasm-32-wasmrt.* ]]; then
+  echo "Using NODE_JS_EXECUTABLE=${NODE_JS_EXECUTABLE}"
+  CROSS_OPTIONS=(
+    -DCMAKE_TOOLCHAIN_FILE="${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+    -DNODE_JS_EXECUTABLE="${NODE_JS_EXECUTABLE}"
+  )
+else
+  # Not cross-compiling, so we're done.
+  exit
+fi
+
+echo "Configuring HANNK for ${HL_TARGET}"
+cmake \
+  -G "${CMAKE_GENERATOR}" \
   -S "${HANNK_DIR}" \
-  -B "${BUILD_DIR}"
+  -B "${BUILD_DIR}" \
+  "${CROSS_OPTIONS[@]}" \
+  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
+  -DHANNK_BUILD_TFLITE=OFF \
+  -DHalide_TARGET="${HL_TARGET}" \
+  -DHalideHelpers_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/HalideHelpers" \
+  -Dhannk_tools_ROOT="${HOST_BUILD_DIR}"
+
+echo "Building HANNK for ${HL_TARGET}"
+cmake --build "${BUILD_DIR}"

--- a/apps/hannk/configure_cmake.sh
+++ b/apps/hannk/configure_cmake.sh
@@ -39,12 +39,12 @@ fi
 
 if [[ "${HL_TARGET}" =~ ^arm-64-android.* ]]; then
   HOST_BUILD_DIR="${BUILD_DIR}/_host"
-  HOST_BUILD_TARGET=(--target hannk_tools)
+  HOST_BUILD_TARGET=(--target hannk-halide_generators)
   HOST_HL_TARGET=host
   HOST_CMAKE_DEFS=(-DHANNK_AOT_HOST_ONLY=ON)
 elif [[ "${HL_TARGET}" =~ ^wasm-32-wasmrt.* ]]; then
   HOST_BUILD_DIR="${BUILD_DIR}/_host"
-  HOST_BUILD_TARGET=(--target hannk_tools)
+  HOST_BUILD_TARGET=(--target hannk-halide_generators)
   HOST_HL_TARGET=host
   HOST_CMAKE_DEFS=(-DHANNK_AOT_HOST_ONLY=ON)
 else
@@ -109,7 +109,7 @@ cmake \
   -DHANNK_BUILD_TFLITE=OFF \
   -DHalide_TARGET="${HL_TARGET}" \
   -DHalideHelpers_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/HalideHelpers" \
-  -Dhannk_tools_ROOT="${HOST_BUILD_DIR}"
+  -Dhannk-halide_generators_ROOT="${HOST_BUILD_DIR}"
 
 echo "Building cross-build HANNK for ${HL_TARGET}"
 cmake --build "${BUILD_DIR}"

--- a/apps/hannk/halide/CMakeLists.txt
+++ b/apps/hannk/halide/CMakeLists.txt
@@ -1,37 +1,37 @@
-add_custom_target(hannk_tools)
+add_custom_target(hannk-halide_generators)
 
-function(_export_hannk_tool TARGET)
-    add_dependencies(hannk_tools ${TARGET})
+function(_export_host_target TARGET)
+    add_dependencies(hannk-halide_generators ${TARGET})
     export(TARGETS ${TARGET}
-           NAMESPACE hannk::tools::
-           APPEND FILE "${hannk_BINARY_DIR}/hannk_tools-config.cmake")
+           NAMESPACE hannk::halide_generators::
+           APPEND FILE "${hannk_BINARY_DIR}/hannk-halide_generators-config.cmake")
 endfunction()
 
 # Emscripten tries to disable finding packages outside its sysroot,
 # but we need our native generators. Setting CMAKE_FIND_ROOT_PATH_BOTH
 # here overrides Emscripten's search preference.
-find_package(hannk_tools QUIET CMAKE_FIND_ROOT_PATH_BOTH)
+find_package(hannk-halide_generators QUIET CMAKE_FIND_ROOT_PATH_BOTH)
 
-if (hannk_tools_FOUND)
-    message(STATUS "Using hannk_tools from ${hannk_tools_DIR}")
+if (hannk-halide_generators_FOUND)
+    message(STATUS "Using hannk-halide_generators from ${hannk-halide_generators_DIR}")
 else ()
     if (CMAKE_CROSSCOMPILING)
         message(WARNING
-                "hannk_tools were not found and it looks like you are cross-compiling. "
-                "This is likely to fail. Please set -Dhannk_tools_ROOT=... at the CMake "
+                "hannk-halide_generators were not found and it looks like you are cross-compiling. "
+                "This is likely to fail. Please set -Dhannk-halide_generators_ROOT=... at the CMake "
                 "command line to the build directory of a host-built hannk.")
     endif ()
     find_package(Halide REQUIRED)
 endif ()
 
-if (NOT TARGET hannk::tools::common_halide)
+if (NOT TARGET hannk::halide_generators::common_halide)
     add_library(common_halide STATIC common_halide.cpp)
-    add_library(hannk::tools::common_halide ALIAS common_halide)
+    add_library(hannk::halide_generators::common_halide ALIAS common_halide)
 
     target_link_libraries(common_halide PRIVATE Halide::Halide)
     target_include_directories(common_halide PUBLIC $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
 
-    _export_hannk_tool(common_halide)
+    _export_host_target(common_halide)
 endif ()
 
 # ----------------------------
@@ -49,7 +49,7 @@ function(_add_halide_library_set LIBRARY_SET)
     set(multiValueArgs SRCS GENERATOR_ARGS GENERATOR_DEPS FEATURES)
     cmake_parse_arguments(args "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(gen hannk::tools::${args_TARGET}.generator)
+    set(gen hannk::halide_generators::${args_TARGET}.generator)
 
     if (NOT TARGET ${gen})
         add_executable(${args_TARGET}.generator ${args_SRCS})
@@ -58,7 +58,7 @@ function(_add_halide_library_set LIBRARY_SET)
         target_link_libraries(${args_TARGET}.generator PRIVATE ${args_GENERATOR_DEPS} common_halide Halide::Generator)
         target_include_directories(${args_TARGET}.generator PUBLIC $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
 
-        _export_hannk_tool(${args_TARGET}.generator)
+        _export_host_target(${args_TARGET}.generator)
     endif ()
 
     add_halide_library(${args_TARGET} FROM ${gen}

--- a/apps/hannk/halide/CMakeLists.txt
+++ b/apps/hannk/halide/CMakeLists.txt
@@ -8,49 +8,49 @@ set(CMAKE_CXX_EXTENSIONS NO)
 
 # ----------------------------
 
-if (NOT CMAKE_CROSSCOMPILING)
+add_custom_target(hannk_tools)
+
+function(_export_hannk_tool TARGET)
+    add_dependencies(hannk_tools ${TARGET})
+    export(TARGETS ${TARGET}
+           NAMESPACE hannk::tools::
+           APPEND FILE "${hannk_BINARY_DIR}/hannk_tools-config.cmake")
+endfunction()
+
+# Emscripten tries to disable finding packages outside its sysroot,
+# but we need our native generators. Setting CMAKE_FIND_ROOT_PATH_BOTH
+# here overrides Emscripten's search preference.
+find_package(hannk_tools QUIET CMAKE_FIND_ROOT_PATH_BOTH)
+
+if (hannk_tools_FOUND)
+    message(STATUS "Using hannk_tools from ${hannk_tools_DIR}")
+else ()
+    if (CMAKE_CROSSCOMPILING)
+        message(WARNING
+                "hannk_tools were not found and it looks like you are cross-compiling. "
+                "This is likely to fail. Please set -Dhannk_tools_ROOT=... at the CMake "
+                "command line to the build directory of a host-built hannk.")
+    endif ()
     find_package(Halide REQUIRED)
+endif ()
+
+if (NOT TARGET hannk::tools::common_halide)
     add_library(common_halide STATIC common_halide.cpp)
+    add_library(hannk::tools::common_halide ALIAS common_halide)
+
     target_link_libraries(common_halide PRIVATE Halide::Halide)
     target_include_directories(common_halide PUBLIC $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
-endif()
+
+    _export_hannk_tool(common_halide)
+endif ()
 
 # ----------------------------
 
 function(_begin_halide_library_set LIBRARY_SET)
-    set(${LIBRARY_SET}_CMAKE_LIB_LIST "" PARENT_SCOPE)
-    if (CMAKE_CROSSCOMPILING)
-        # Make a subdir to put all the forced-host-mode stuff.
-        # Make it a double-subdir so that include paths of the form "halide/foo.h" can work as-is.
-        set(GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/host_build_dir/halide")
-        set(${LIBRARY_SET}_GEN_DIR "${GEN_DIR}" PARENT_SCOPE)
+    add_library(${LIBRARY_SET} INTERFACE)
+    target_include_directories(${LIBRARY_SET} INTERFACE "$<BUILD_INTERFACE:${hannk_BINARY_DIR}>")
 
-        file(MAKE_DIRECTORY ${GEN_DIR})
-
-        # Unset CC, CXX, etc so that the sub-cmake file picks up host defaults, rather than (e.g.) emcc
-        set(CC_SAVE "$ENV{CC}")
-        set(CXX_SAVE "$ENV{CXX}")
-        set(ENV{CC} "")
-        set(ENV{CXX} "")
-        execute_process(
-            COMMAND "${CMAKE_COMMAND}"
-                    "-DCMAKE_GENERATOR=${CMAKE_GENERATOR}"
-                    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-                    "-DHalide_DIR=${Halide_DIR}"
-                    "-DHalideHelpers_DIR=${HalideHelpers_DIR}"
-                    "-Dhannk_SOURCE_DIR=${hannk_SOURCE_DIR}"
-                    "${CMAKE_CURRENT_SOURCE_DIR}"
-            WORKING_DIRECTORY ${GEN_DIR}
-        )
-        set(ENV{CC} "${CC_SAVE}")
-        set(ENV{CXX} "${CXX_SAVE}")
-    else()
-        find_package(Halide REQUIRED)
-        # TODO: when crosscompiling, the "runtime.a" files don't get produced;
-        # create a fake target that we can add them to as depdendencies, then
-        # pass the fake target to the sub-build.
-        add_custom_target("${LIBRARY_SET}.build_all")
-    endif()
+    add_custom_target(${LIBRARY_SET}.build_all)
 endfunction()
 
 function(_add_halide_library_set LIBRARY_SET)
@@ -59,63 +59,30 @@ function(_add_halide_library_set LIBRARY_SET)
     set(multiValueArgs SRCS GENERATOR_ARGS GENERATOR_DEPS FEATURES)
     cmake_parse_arguments(args "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if (CMAKE_CROSSCOMPILING)
-        set(GEN_DIR "${${LIBRARY_SET}_GEN_DIR}")
-        foreach (t IN ITEMS "${args_TARGET}" "${args_TARGET}.runtime")
-            add_library("${t}" STATIC IMPORTED GLOBAL)
-            add_dependencies("${t}" ${LIBRARY_SET}.crosscompile)
-            set_target_properties("${t}" PROPERTIES
-                                  IMPORTED_LOCATION "${GEN_DIR}/${t}.a")
-        endforeach()
-    else()
+    set(gen hannk::tools::${args_TARGET}.generator)
+
+    if (NOT TARGET ${gen})
         add_executable(${args_TARGET}.generator ${args_SRCS})
+        add_executable(${gen} ALIAS ${args_TARGET}.generator)
+
         target_link_libraries(${args_TARGET}.generator PRIVATE ${args_GENERATOR_DEPS} common_halide Halide::Generator)
         target_include_directories(${args_TARGET}.generator PUBLIC $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
 
-        add_halide_library(${args_TARGET} FROM ${args_TARGET}.generator
-                           NAMESPACE hannk
-                           GENERATOR ${args_GENERATOR_NAME}
-                           FEATURES c_plus_plus_name_mangling ${args_FEATURES}
-                           PARAMS ${args_GENERATOR_ARGS})
+        _export_hannk_tool(${args_TARGET}.generator)
+    endif ()
 
-        add_dependencies("${LIBRARY_SET}.build_all" "${args_TARGET}" "${args_TARGET}.runtime")
-    endif()
-    set(${LIBRARY_SET}_CMAKE_LIB_LIST ${${LIBRARY_SET}_CMAKE_LIB_LIST} "${args_TARGET}" PARENT_SCOPE)
+    add_halide_library(${args_TARGET} FROM ${gen}
+                       NAMESPACE hannk
+                       GENERATOR ${args_GENERATOR_NAME}
+                       FEATURES c_plus_plus_name_mangling ${args_FEATURES}
+                       PARAMS ${args_GENERATOR_ARGS})
+
+    add_dependencies("${LIBRARY_SET}.build_all" "${args_TARGET}" "${args_TARGET}.runtime")
+    target_link_libraries(${LIBRARY_SET} INTERFACE ${args_TARGET})
 endfunction()
 
 function(_finish_halide_library_set LIBRARY_SET)
-    if (CMAKE_CROSSCOMPILING)
-        set(GEN_DIR "${${LIBRARY_SET}_GEN_DIR}")
-
-        set(BYPRODUCTS "")
-        set(LIB_LIST "")
-        foreach (t IN LISTS ${LIBRARY_SET}_CMAKE_LIB_LIST)
-            set(BYPRODUCTS ${BYPRODUCTS} "${GEN_DIR}/${t}.a" "${GEN_DIR}/${t}.runtime.a" "${GEN_DIR}/${t}.h")
-            set(LIB_LIST ${LIB_LIST} "${t}" "${t}.runtime")
-        endforeach()
-
-        # TODO: set --parallel here, is this the best way?
-        cmake_host_system_information(RESULT NUMCORES QUERY NUMBER_OF_LOGICAL_CORES)
-        add_custom_target(${LIBRARY_SET}.crosscompile
-            COMMAND "${CMAKE_COMMAND}"
-                    --build "${GEN_DIR}"
-                    --parallel ${NUMCORES}
-                    --config $<CONFIG>
-                    --target "${LIBRARY_SET}.build_all"
-            BYPRODUCTS "${BYPRODUCTS}"
-            WORKING_DIRECTORY "${GEN_DIR}"
-            USES_TERMINAL
-        )
-
-        set(INCLUDE_PATH "${GEN_DIR}/..")
-    else ()
-        set(INCLUDE_PATH $<BUILD_INTERFACE:${hannk_BINARY_DIR}>)
-        set(LIB_LIST ${${LIBRARY_SET}_CMAKE_LIB_LIST})
-    endif ()
-
-    add_library(${LIBRARY_SET} INTERFACE)
-    target_link_libraries(${LIBRARY_SET} INTERFACE ${LIB_LIST})
-    target_include_directories(${LIBRARY_SET} INTERFACE ${INCLUDE_PATH})
+    # Nothing to do for now.
 endfunction()
 
 # ---------------------------
@@ -143,7 +110,6 @@ _add_halide_library_set(halide_op_implementations
         GENERATOR_NAME Conv
         GENERATOR_ARGS output.type=uint8
         GENERATOR_DEPS)
-
 
 _add_halide_library_set(halide_op_implementations
         TARGET conv_u8_u8_i16

--- a/apps/hannk/halide/CMakeLists.txt
+++ b/apps/hannk/halide/CMakeLists.txt
@@ -1,13 +1,3 @@
-cmake_minimum_required(VERSION 3.16)
-project(hannk_halide)
-
-# Set up language settings
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-set(CMAKE_CXX_EXTENSIONS NO)
-
-# ----------------------------
-
 add_custom_target(hannk_tools)
 
 function(_export_hannk_tool TARGET)

--- a/apps/hannk/halide/CMakeLists.txt
+++ b/apps/hannk/halide/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_custom_target(hannk-halide_generators)
 
+# This function adds the target ${TARGET} to the hannk-halide_generators
+# CMake package that exists in the build-tree of a host build. It also adds
+# it to the target of the same name that can be used as a convenience for
+# just building the host targets.
 function(_export_host_target TARGET)
     add_dependencies(hannk-halide_generators ${TARGET})
     export(TARGETS ${TARGET}

--- a/apps/hannk/util/CMakeLists.txt
+++ b/apps/hannk/util/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(hannk_log_stderr STATIC EXCLUDE_FROM_ALL
             hannk_log_stderr.cpp)
 target_include_directories(hannk_log_stderr PUBLIC
                            $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
+target_link_libraries(hannk_log_stderr PUBLIC "$<$<PLATFORM_ID:Android>:log>")
 
 add_library(hannk_log_tflite STATIC EXCLUDE_FROM_ALL
             hannk_log_tflite.cpp)

--- a/cmake/HalideTargetHelpers.cmake
+++ b/cmake/HalideTargetHelpers.cmake
@@ -17,6 +17,12 @@ function(_Halide_cmake_target OUTVAR)
     # Get OS from CMake
     string(TOLOWER "${CMAKE_SYSTEM_NAME}" os)
     list(TRANSFORM os REPLACE "^darwin$" "osx")
+    list(TRANSFORM os REPLACE "^emscripten$" "wasmrt")
+
+    # Fix up emscripten usage
+    if (os STREQUAL "wasmrt" AND arch STREQUAL "x86")
+        set(arch "wasm")
+    endif ()
 
     set(${OUTVAR} "${arch}-${bits}-${os}" PARENT_SCOPE)
 endfunction()

--- a/cmake/HalideTargetHelpers.cmake
+++ b/cmake/HalideTargetHelpers.cmake
@@ -60,8 +60,10 @@ unset(_default_target)
 # Print the active values of all special target triples.
 ##
 
-if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY)
+get_property(${CMAKE_FIND_PACKAGE_NAME}_MESSAGE_PRINTED GLOBAL PROPERTY ${CMAKE_FIND_PACKAGE_NAME}_MESSAGE_PRINTED)
+if (NOT ${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY AND NOT ${CMAKE_FIND_PACKAGE_NAME}_MESSAGE_PRINTED)
     message(STATUS "Halide 'host' platform triple:   ${Halide_HOST_TARGET}")
     message(STATUS "Halide 'cmake' platform triple:  ${Halide_CMAKE_TARGET}")
     message(STATUS "Halide default AOT target:       ${Halide_TARGET}")
+    set_property(GLOBAL PROPERTY ${CMAKE_FIND_PACKAGE_NAME}_MESSAGE_PRINTED 1)
 endif ()


### PR DESCRIPTION
There's a bunch of changes in here, and I thought it would be better to review them here, rather than just pushing to your branch. I took some care to make each commit self-contained and easy to interpret. The big changes are in the last two:

First, the cross-compiling strategy changed significantly. Rather than shelling out via execute_process and potentially guessing the toolchain options wrong, expect to find our host tools (i.e. generators) in a package called "hannk_tools".

The package is created by the host build via the CMake export() command. Importing this package in the cross build creates IMPORTED targets with the same names as our generators. We then use these generators rather than creating generators for the target build.

Second, the `configure_cmake.sh` script now takes charge of creating a host build when cross compiling for Android or WASM.

Oh yeah, Android NDK cross compiling works now, too!

Overall, the code for this is _much_ smaller and more robust to unknown environments.