### PR TITLE
[hannk] tests should only process .tflite files

### DIFF
--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(compare_vs_tflite
                            PUBLIC $<BUILD_INTERFACE:${hannk_SOURCE_DIR}>)
 
 # Tests
-file(GLOB TEST_FILES CONFIGURE_DEPENDS "test/*/*")
+file(GLOB TEST_FILES CONFIGURE_DEPENDS "test/*/*.tflite")
 foreach (t IN LISTS TEST_FILES)
     file(RELATIVE_PATH test_name ${hannk_SOURCE_DIR} ${t})
     add_test(NAME ${test_name} COMMAND compare_vs_tflite ${t} --benchmark 0)

--- a/apps/hannk/Makefile
+++ b/apps/hannk/Makefile
@@ -37,12 +37,12 @@ build: \
 	$(BIN)/$(HL_TARGET)/compare_vs_tflite
 
 test: compare_vs_tflite
-	$(foreach test_model, $(shell ls -1 test/*/*), $(BIN)/$(HL_TARGET)/compare_vs_tflite $(test_model) --benchmark 0;)
+	$(foreach test_model, $(shell ls -1 test/*/*.tflite), $(BIN)/$(HL_TARGET)/compare_vs_tflite $(test_model) --benchmark 0;)
 
 test-hexagon-sim: $(BIN)/$(HL_TARGET)/$(BENCHMARK_OUT)
 	@mkdir -p $@
 	echo "Benchmarking tests..."
-	$(foreach test_model, $(shell ls -1 test/*/*), BIN=$(BIN) ./run_benchmark_on_hexagon_sim.sh $(test_model);)
+	$(foreach test_model, $(shell ls -1 test/*/*.tflite), BIN=$(BIN) ./run_benchmark_on_hexagon_sim.sh $(test_model);)
 
 test-hexagon-device: $(BIN)/$(HL_TARGET)/$(BENCHMARK_OUT)
 	echo "Benchmarking tests..."
@@ -51,7 +51,7 @@ test-hexagon-device: $(BIN)/$(HL_TARGET)/$(BENCHMARK_OUT)
 	adb push test/. /vendor/bin/hannk-test
 	adb push $(HEXAGON_SDK_ROOT)/libs/run_main_on_hexagon/ship/android_aarch64/run_main_on_hexagon /vendor/bin/run_main_on_hexagon
 	adb push $(HEXAGON_SDK_ROOT)/libs/run_main_on_hexagon/ship/hexagon_toolv84_v65/librun_main_on_hexagon_skel.so /vendor/lib/rfsa/adsp/
-	$(foreach test_model, $(shell ls -1 test/*/*), adb shell 'cd /vendor/bin; touch /vendor/lib/rfsa/adsp/run_main_on_hexagon.farf; ./run_main_on_hexagon 3 /vendor/bin/$(BENCHMARK_OUT) --verbose hannk-$(test_model)';)
+	$(foreach test_model, $(shell ls -1 test/*/*.tflite), adb shell 'cd /vendor/bin; touch /vendor/lib/rfsa/adsp/run_main_on_hexagon.farf; ./run_main_on_hexagon 3 /vendor/bin/$(BENCHMARK_OUT) --verbose hannk-$(test_model)';)
 
 clean:
 	rm -rf $(BIN)


### PR DESCRIPTION
currently, random dotfiles (e.g. .DS_Store on OSX) can creep in, causing bogus failures