### PR TITLE
Bump version to Halide 14.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.20)
 project(Halide
-        VERSION 13.0.0
+        VERSION 14.0.0
         DESCRIPTION "Halide compiler and libraries"
         HOMEPAGE_URL "https://halide-lang.org")
 


### PR DESCRIPTION
Bumps version to Halide 14.0.0. Release branch for 13.x has been cut.