### PR TITLE
Support vectorized Select in OpenGLCompute backend

### DIFF
--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -615,11 +615,21 @@ void CodeGen_OpenGLCompute_C::visit(const Select *op) {
     string true_val = print_expr(op->true_value);
     string false_val = print_expr(op->false_value);
     string cond = print_expr(op->condition);
-    rhs << print_type(op->type)
-        << "(" << cond
-        << " ? " << true_val
-        << " : " << false_val
-        << ")";
+    if (op->type.is_scalar()) {
+        rhs << cond << " ? " << true_val << " : " << false_val;
+    } else {
+        rhs << print_type(op->type) << "(";
+        for (int i = 0; i < op->type.lanes(); i++) {
+            string index = "[" + std::to_string(i) + "]";
+            rhs << cond << index << " ? "
+                << true_val << index << " : "
+                << false_val << index;
+            if (i != op->type.lanes() - 1) {
+                rhs << ", ";
+            }
+        }
+        rhs << ")";
+    }
     print_assignment(op->type, rhs.str());
 }
 


### PR DESCRIPTION
The ternary operator in GLSL does not work with vector types. While the
mix function have overloads to boolean vectors, it is only supported in
version 4.5, so it is not exactly portable. To work around this, we use
the ternary operator on all elements of the vector type.

Necessary for #6348.