### PR TITLE
Vectorize Ramp in OpenGLCompute backend

### DIFF
--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -550,20 +550,24 @@ void CodeGen_OpenGLCompute_C::visit(const For *loop) {
 }
 
 void CodeGen_OpenGLCompute_C::visit(const Ramp *op) {
-    ostringstream rhs;
-    rhs << print_type(op->type) << "(";
-
     if (op->lanes > 4) {
         internal_error << "GLSL: ramp lanes " << op->lanes << " is not supported\n";
     }
 
-    rhs << print_expr(op->base);
-
-    for (int i = 1; i < op->lanes; ++i) {
-        rhs << ", " << print_expr(Add::make(op->base, Mul::make(i, op->stride)));
+    ostringstream rhs;
+    // Print the sequence vec(0, 1, 2, ...).
+    rhs << print_type(op->type) << "(";
+    for (int i = 0; i < op->type.lanes(); i++) {
+        rhs << i;
+        if (i != op->type.lanes() - 1) {
+            rhs << ", ";
+        }
     }
-
     rhs << ")";
+
+    // Multiply by the stride and add the base.
+    rhs << " * " << print_expr(op->stride) << " + " << print_expr(op->base);
+
     print_assignment(op->type, rhs.str());
 }
 


### PR DESCRIPTION
Currently, ramps are generated as a number of independent scalar
expressions that are finally gathered into a vector. For instance,
indexing in vectorized code is filled with ramps like the following:

```
int _11 = int(1) * int(1);
int _12 = _10 + _11;
int _13 = int(2) * int(1);
int _14 = _10 + _13;
int _15 = int(3) * int(1);
int _16 = _10 + _15;
ivec4 _17 = ivec4(_10, _12, _14, _16);
```

This patch simplifies the generated code using a multiply add expression
on a vector containing an arithmetic sequence, such that the code is
as follows:

```
ivec4 _11 = ivec4(0, 1, 2, 3) * int(1) + _10;
```

This is more performant due to vectorization, more compact, and more
readable because the base and the stride are easily identifiable.