### PR TITLE
Add super-build for cross-compiling HANNK

### DIFF
--- a/apps/hannk/cmake/superbuild/CMakeLists.txt
+++ b/apps/hannk/cmake/superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.16...3.21)
 project(hannk_superbuild LANGUAGES NONE)
 
 ##
@@ -40,6 +40,20 @@ foreach (entry IN LISTS cache)
 endforeach ()
 
 ##
+# Common ExternalProject options
+
+set(ep_opts
+    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.."
+    INSTALL_COMMAND ""  # Disables install stage
+    BUILD_ALWAYS YES
+    USES_TERMINAL_CONFIGURE YES
+    USES_TERMINAL_BUILD YES)
+
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+    list(APPEND ep_opts CONFIGURE_HANDLED_BY_BUILD TRUE)
+endif ()
+
+##
 # Define host and target builds
 
 include(ExternalProject)
@@ -50,15 +64,8 @@ foreach (entry IN LISTS host_args)
     message(STATUS "\t${entry}")
 endforeach ()
 
-ExternalProject_Add(
-        hannk_host
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
-        CMAKE_ARGS ${host_args}
-        INSTALL_COMMAND ""  # Disables install stage
-        CONFIGURE_HANDLED_BY_BUILD TRUE  # Requires CMake 3.20+
-        BUILD_ALWAYS YES
-        USES_TERMINAL YES
-)
+ExternalProject_Add(hannk_host ${ep_opts}
+                    CMAKE_ARGS ${host_args})
 
 ExternalProject_Get_Property(hannk_host BINARY_DIR)
 list(APPEND cross_args "-Dhannk-halide_generators_ROOT:FILEPATH=${BINARY_DIR}")
@@ -69,15 +76,8 @@ foreach (entry IN LISTS cross_args)
     message(STATUS "\t${entry}")
 endforeach ()
 
-ExternalProject_Add(
-        hannk
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
-        CMAKE_ARGS ${cross_args}
-        INSTALL_COMMAND ""
-        CONFIGURE_HANDLED_BY_BUILD TRUE
-        BUILD_ALWAYS YES
-        USES_TERMINAL YES
-)
+ExternalProject_Add(hannk ${ep_opts}
+                    CMAKE_ARGS ${cross_args})
 
 ExternalProject_Add_StepDependencies(hannk configure hannk_host)
 

--- a/apps/hannk/cmake/superbuild/CMakeLists.txt
+++ b/apps/hannk/cmake/superbuild/CMakeLists.txt
@@ -1,0 +1,99 @@
+cmake_minimum_required(VERSION 3.20)
+project(hannk_superbuild LANGUAGES NONE)
+
+##
+# Derive settings for the host and cross builds from the super-build cache.
+# Any cache variable matching HANNK_(HOST|CROSS)_VAR will set VAR
+# in the corresponding build. All other non-INTERNAL or STATIC cache
+# variables are set in the cross build, too.
+
+set(host_args
+    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+    -DHANNK_AOT_HOST_ONLY:BOOL=ON)
+
+set(cross_args
+    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+    -DHANNK_BUILD_TFLITE:BOOL=OFF)
+
+get_property(cache DIRECTORY PROPERTY CACHE_VARIABLES)
+foreach (entry IN LISTS cache)
+    get_property(type CACHE ${entry} PROPERTY TYPE)
+
+    # Uninitialized cache entries sometimes behave oddly on the first versus
+    # second invocation of CMake on versions prior to 3.21. See the docs for
+    # more detail: https://cmake.org/cmake/help/latest/policy/CMP0126.html
+    if (type STREQUAL "UNINITIALIZED")
+        set(type "STRING")
+    endif ()
+
+    # Don't copy over CMake internal variables
+    if (NOT type MATCHES "STATIC|INTERNAL")
+        string(REPLACE ";" "$<SEMICOLON>" value "${${entry}}")
+        if (entry MATCHES "^HANNK_HOST_(.+)$")
+            list(APPEND host_args "-D${CMAKE_MATCH_1}:${type}=${value}")
+        elseif (entry MATCHES "^HANNK_CROSS_(.+)$")
+            list(APPEND cross_args "-D${CMAKE_MATCH_1}:${type}=${value}")
+        else ()
+            list(APPEND cross_args "-D${entry}:${type}=${value}")
+        endif ()
+    endif ()
+endforeach ()
+
+##
+# Define host and target builds
+
+include(ExternalProject)
+
+message(STATUS "Using the following settings for host build: ")
+foreach (entry IN LISTS host_args)
+    string(REPLACE "$<SEMICOLON>" ";" entry "${entry}")
+    message(STATUS "\t${entry}")
+endforeach ()
+
+ExternalProject_Add(
+        hannk_host
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
+        CMAKE_ARGS ${host_args}
+        INSTALL_COMMAND ""  # Disables install stage
+        CONFIGURE_HANDLED_BY_BUILD TRUE  # Requires CMake 3.20+
+        BUILD_ALWAYS YES
+        USES_TERMINAL YES
+)
+
+ExternalProject_Get_Property(hannk_host BINARY_DIR)
+list(APPEND cross_args "-Dhannk-halide_generators_ROOT:FILEPATH=${BINARY_DIR}")
+
+message(STATUS "Using the following settings for cross build: ")
+foreach (entry IN LISTS cross_args)
+    string(REPLACE "$<SEMICOLON>" ";" entry "${entry}")
+    message(STATUS "\t${entry}")
+endforeach ()
+
+ExternalProject_Add(
+        hannk
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
+        CMAKE_ARGS ${cross_args}
+        INSTALL_COMMAND ""
+        CONFIGURE_HANDLED_BY_BUILD TRUE
+        BUILD_ALWAYS YES
+        USES_TERMINAL YES
+)
+
+ExternalProject_Add_StepDependencies(hannk configure hannk_host)
+
+##
+# Create shims to make the super-build directory behave like the cross-build directory
+
+# Don't let CMake generate a cmake_install.cmake file
+set(CMAKE_SKIP_INSTALL_RULES YES)
+
+ExternalProject_Get_Property(hannk BINARY_DIR)
+file(CONFIGURE OUTPUT "cmake_install.cmake"
+     CONTENT [[include("${BINARY_DIR}/cmake_install.cmake")]])
+
+# Don't let CMake generate a CTestTestfile.cmake file (don't uncomment!)
+# enable_testing()
+
+file(RELATIVE_PATH ctest_dir "${CMAKE_CURRENT_BINARY_DIR}" "${BINARY_DIR}")
+file(CONFIGURE OUTPUT "CTestTestfile.cmake"
+     CONTENT [[subdirs("${ctest_dir}")]])

--- a/apps/hannk/configure_cmake.sh
+++ b/apps/hannk/configure_cmake.sh
@@ -2,114 +2,74 @@
 
 set -e
 
+die() {
+  echo "$@"
+  exit 1
+}
+
 HANNK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-if [ -z "${BUILD_DIR}" ]; then
-  BUILD_DIR="${HANNK_DIR}/build"
+# Set variable default values
+: "${BUILD_DIR:=${HANNK_DIR}/build}"
+: "${HALIDE_INSTALL_PATH:=${HOME}/halide-14-install}"
+: "${HL_TARGET:=host}"
+: "${CMAKE_GENERATOR:=Ninja}"
+: "${CMAKE_BUILD_TYPE:=Release}"
+
+# Validate HALIDE_INSTALL_PATH (too brittle without the check)
+[ -d "${HALIDE_INSTALL_PATH}" ] || die "HALIDE_INSTALL_PATH must point to a directory"
+
+# Default options for host-only build.
+SOURCE_DIR="${HANNK_DIR}"
+CMAKE_DEFS=(
+  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+  -DHalide_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/Halide"
+  -DHalideHelpers_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/HalideHelpers"
+  -DHalide_TARGET="${HL_TARGET}"
+)
+
+# Ask the provided Halide install for the host target
+HL_HOST_TARGET="host"
+get_host_target="${HALIDE_INSTALL_PATH}/bin/get_host_target"
+[ -x "${get_host_target}" ] && HL_HOST_TARGET="$("${get_host_target}" | cut -d- -f1-3)"
+
+# Cross compile when HL_TARGET does not match the host target.
+if [[ ! "${HL_TARGET}" =~ ^host*|${HL_HOST_TARGET}* ]]; then
+  SOURCE_DIR="${HANNK_DIR}/cmake/superbuild"
+  CMAKE_DEFS=(
+    "${CMAKE_DEFS[@]}"
+    -DHANNK_HOST_Halide_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/Halide"
+    -DHANNK_HOST_HalideHelpers_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/HalideHelpers"
+  )
+
+  # Special settings for cross-compiling targets with known quirks
+  if [[ "${HL_TARGET}" =~ ^arm-64-android.* ]]; then
+    : "${ANDROID_PLATFORM:=21}"
+    [ -d "${ANDROID_NDK_ROOT}" ] || die "Must set ANDROID_NDK_ROOT"
+
+    CMAKE_DEFS=(
+      "${CMAKE_DEFS[@]}"
+      -DHANNK_CROSS_CMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake"
+      -DANDROID_ABI=arm64-v8a
+      -DANDROID_PLATFORM="${ANDROID_PLATFORM}"
+      # Required because TFLite's internal Eigen tries to compile an unnecessary BLAS with the system Fortran compiler.
+      -DCMAKE_Fortran_COMPILER=NO
+    )
+  elif [[ "${HL_TARGET}" =~ ^wasm-32-wasmrt.* ]]; then
+    [ -d "${EMSDK}" ] || die "Must set EMSDK"
+    [ -x "${NODE_JS_EXECUTABLE}" ] || die "Must set NODE_JS_EXECUTABLE (version 16.13+ required)"
+
+    CMAKE_DEFS=(
+      "${CMAKE_DEFS[@]}"
+      -DHANNK_CROSS_CMAKE_TOOLCHAIN_FILE="${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
+      -DNODE_JS_EXECUTABLE="${NODE_JS_EXECUTABLE}"
+    )
+  fi
 fi
 
-if [ -z "${HALIDE_INSTALL_PATH}" ]; then
-  HALIDE_INSTALL_PATH="${HOME}/halide-14-install/"
-fi
-
-if [ -z "${HL_TARGET}" ]; then
-  HL_TARGET=host
-fi
-
-if [ -z "${CMAKE_GENERATOR}" ]; then
-  CMAKE_GENERATOR=Ninja
-fi
-
-if [ -z "${CMAKE_BUILD_TYPE}" ]; then
-  CMAKE_BUILD_TYPE=Release
-fi
-
-if [ -z "${ANDROID_PLATFORM}" ]; then
-  ANDROID_PLATFORM=21
-fi
-
-if [ -z "${HANNK_BUILD_TFLITE}" ]; then
-  HANNK_BUILD_TFLITE=ON
-else
-  HANNK_BUILD_TFLITE=OFF
-fi
-
-## In a cross-compiling scenario, use a separate host and build dir
-# TODO: figure out if there's a way to generalize "is this crosscompiling or not", and just make this a single if-else
-
-if [[ "${HL_TARGET}" =~ ^arm-64-android.* ]]; then
-  HOST_BUILD_DIR="${BUILD_DIR}/_host"
-  HOST_BUILD_TARGET=(--target hannk-halide_generators)
-  HOST_HL_TARGET=host
-  HOST_CMAKE_DEFS=(-DHANNK_AOT_HOST_ONLY=ON)
-elif [[ "${HL_TARGET}" =~ ^wasm-32-wasmrt.* ]]; then
-  HOST_BUILD_DIR="${BUILD_DIR}/_host"
-  HOST_BUILD_TARGET=(--target hannk-halide_generators)
-  HOST_HL_TARGET=host
-  HOST_CMAKE_DEFS=(-DHANNK_AOT_HOST_ONLY=ON)
-else
-  HOST_BUILD_DIR="${BUILD_DIR}"
-  HOST_BUILD_TARGET=()
-  HOST_HL_TARGET="${HL_TARGET}"
-  HOST_CMAKE_DEFS=()
-fi
-
-## Build HANNK for the host no matter what
-
-echo "Configuring HANNK for ${HOST_HL_TARGET}"
 cmake \
   -G "${CMAKE_GENERATOR}" \
-  -S "${HANNK_DIR}" \
-  -B "${HOST_BUILD_DIR}" \
-  "${HOST_CMAKE_DEFS[@]}" \
-  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-  -DHalide_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/Halide" \
-  -DHalideHelpers_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/HalideHelpers" \
-  -DHalide_TARGET="${HOST_HL_TARGET}" \
-  -DHANNK_BUILD_TFLITE=${HANNK_BUILD_TFLITE}
-
-if [ -z "${HOST_BUILD_TARGET[*]}" ]; then
-  echo "Building HANNK for ${HOST_HL_TARGET}"
-else
-  echo "Building HANNK host generator executables"
-fi
-cmake --build "${HOST_BUILD_DIR}" "${HOST_BUILD_TARGET[@]}"
-
-## Now if we're cross-compiling for Android or WASM, set up the build
-## for that, using the platform-provided CMake toolchain files.
-
-if [[ "${HL_TARGET}" =~ ^arm-64-android.* ]]; then
-  echo "Using ANDROID_NDK_ROOT=${ANDROID_NDK_ROOT}"
-  echo "Using CMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake"
-  CROSS_CMAKE_DEFS=(
-    -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake"
-    -DANDROID_ABI=arm64-v8a
-    "-DANDROID_PLATFORM=${ANDROID_PLATFORM}"
-    # Required because TFLite's internal Eigen tries to compile an unnecessary BLAS with the system Fortran compiler.
-    "-DCMAKE_Fortran_COMPILER=NO"
-  )
-elif [[ "${HL_TARGET}" =~ ^wasm-32-wasmrt.* ]]; then
-  echo "Using NODE_JS_EXECUTABLE=${NODE_JS_EXECUTABLE}"
-  CROSS_CMAKE_DEFS=(
-    -DCMAKE_TOOLCHAIN_FILE="${EMSDK}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake"
-    -DNODE_JS_EXECUTABLE="${NODE_JS_EXECUTABLE}"
-  )
-else
-  # Not cross-compiling, so we're done.
-  exit
-fi
-
-echo "Configuring cross-build HANNK for ${HL_TARGET}"
-cmake \
-  -G "${CMAKE_GENERATOR}" \
-  -S "${HANNK_DIR}" \
+  -S "${SOURCE_DIR}" \
   -B "${BUILD_DIR}" \
-  "${CROSS_CMAKE_DEFS[@]}" \
-  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-  -DHANNK_BUILD_TFLITE=OFF \
-  -DHalide_TARGET="${HL_TARGET}" \
-  -DHalideHelpers_DIR="${HALIDE_INSTALL_PATH}/lib/cmake/HalideHelpers" \
-  -Dhannk-halide_generators_ROOT="${HOST_BUILD_DIR}"
-
-echo "Building cross-build HANNK for ${HL_TARGET}"
-cmake --build "${BUILD_DIR}"
+  "${CMAKE_DEFS[@]}" \
+  "$@"


### PR DESCRIPTION
After #6361 the cross-compiling workflow requires building HANNK twice: once for the host-run generators (with a host toolchain) and again with the cross toolchain. This PR adds an opt-in _superbuild_ that orchestrates running both builds and correctly updates the world with a single call to Ninja.

The `configure_cmake.sh` script learned how to call `get_host_target` to determine whether the given `HL_TARGET` requires cross compiling. When not cross-compiling, it invokes the build directly. When cross compiling, it invokes the super-build. It doesn't actually run the build (it's called "configure", after all) in either case. It checks a few basic sanity conditions on the env-vars it reads, now, too.

The superbuild has a few special features to make using it more convenient:

* Variables matching `HANNK_HOST_<VAR>` are forwarded to the host build as `<VAR>`
* Variables matching `HANNK_CROSS_<VAR>` are forwarded to the cross build as `<VAR>`
* All other cache variables that are explicitly set by either the user or the superbuild toolchain are forwarded to the **cross** build
* The super-build writes shims to make `cmake --install` and `ctest` work from the top-level build directory.