### PR TITLE
Update README for Halide 13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ If you've acquired a full source distribution and want to build Halide, see the
 
 ## Binary tarballs
 
-The latest version of Halide is **Halide 12.0.0**. We provide binary releases
+The latest version of Halide is **Halide 13.0.0**. We provide binary releases
 for many popular platforms and architectures, including 32/64-bit x86 Windows,
 64-bit macOS, and 32/64-bit x86/ARM Ubuntu Linux. See the releases tab on the
-right (or click [here](https://github.com/halide/Halide/releases/tag/v12.0.0)).
+right (or click [here](https://github.com/halide/Halide/releases)).
 
 ## Vcpkg
 
@@ -61,7 +61,7 @@ $ brew install halide
 
 ## Other package managers
 
-We are interested in bringing Halide 12 to other popular package managers and
+We are interested in bringing Halide to other popular package managers and
 Linux distribution repositories including, but not limited to, Conan,
 Debian, [Ubuntu (or PPA)](https://github.com/halide/Halide/issues/5285),
 CentOS/Fedora, and Arch. If you have experience publishing packages we would be
@@ -125,7 +125,7 @@ works well on OS X and Ubuntu.)
 If you want to build it yourself, first check it out from GitHub:
 
 ```
-% git clone --depth 1 --branch llvmorg-12.0.0 https://github.com/llvm/llvm-project.git
+% git clone --depth 1 --branch llvmorg-13.0.0 https://github.com/llvm/llvm-project.git
 ```
 
 (If you want to build LLVM 11.x, use branch `llvmorg-11.1.0`; for current trunk,
@@ -286,7 +286,7 @@ Follow these steps if you want to build LLVM yourself. First, download LLVM's
 sources (these instructions use the latest 12.0 release)
 
 ```
-D:\> git clone --depth 1 --branch llvmorg-12.0.0 https://github.com/llvm/llvm-project.git
+D:\> git clone --depth 1 --branch llvmorg-13.0.0 https://github.com/llvm/llvm-project.git
 ```
 
 For a 64-bit build, run:


### PR DESCRIPTION
I just realized we forgot to bump the version number in the README... better to fix that now than never. I've added it to the [release instructions](https://github.com/halide/Halide/wiki/Cutting-a-release) for next time so we hopefully won't forget.

I also removed version number references where they aren't helpful (fewer places to patch).

I don't want to re-do the whole release process for a README typo :stuck_out_tongue: