### PR TITLE
Remove halide_assert() from halide_default_device_wrap_native

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -409,7 +409,15 @@ WEAK int halide_device_detach_native(void *user_context, struct halide_buffer_t 
 }
 
 WEAK int halide_default_device_wrap_native(void *user_context, struct halide_buffer_t *buf, uint64_t handle) {
-    halide_assert(user_context, buf->device == 0);
+    // No: this can return halide_error_no_device_interface for OGLC and HVX,
+    // since `device_interface` may be set but `device` may not be. Instead,
+    // just return halide_error_code_device_wrap_native_failed if buf->device isn't set.
+    // (And *don't* halide_assert() here, as that will abort. Just return an error and let the caller handle it.)
+    //
+    // int result = debug_log_and_validate_buf(user_context, buf, "halide_default_device_wrap_native");
+    // if (result != 0) {
+    //     return result;
+    // }
     if (buf->device != 0) {
         return halide_error_code_device_wrap_native_failed;
     }


### PR DESCRIPTION
This was inserted in https://github.com/halide/Halide/pull/6310, probably mistakenly, since `halide_assert()` in the Halide runtime is *not* a debug-only assertion). Instead of a controlled runtime failure, we just abort, which is not OK.