### PR TITLE
Fix empty INSTALL_COMMAND in hannk super-build

### DIFF
--- a/apps/hannk/cmake/superbuild/CMakeLists.txt
+++ b/apps/hannk/cmake/superbuild/CMakeLists.txt
@@ -44,7 +44,6 @@ endforeach ()
 
 set(ep_opts
     SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../.."
-    INSTALL_COMMAND ""  # Disables install stage
     BUILD_ALWAYS YES
     USES_TERMINAL_CONFIGURE YES
     USES_TERMINAL_BUILD YES)
@@ -65,6 +64,7 @@ foreach (entry IN LISTS host_args)
 endforeach ()
 
 ExternalProject_Add(hannk_host ${ep_opts}
+                    INSTALL_COMMAND ""  # Disables install stage
                     CMAKE_ARGS ${host_args})
 
 ExternalProject_Get_Property(hannk_host BINARY_DIR)
@@ -77,6 +77,7 @@ foreach (entry IN LISTS cross_args)
 endforeach ()
 
 ExternalProject_Add(hannk ${ep_opts}
+                    INSTALL_COMMAND ""  # Disables install stage
                     CMAKE_ARGS ${cross_args})
 
 ExternalProject_Add_StepDependencies(hannk configure hannk_host)

--- a/apps/hannk/cmake/superbuild/CMakeLists.txt
+++ b/apps/hannk/cmake/superbuild/CMakeLists.txt
@@ -89,10 +89,14 @@ ExternalProject_Add_StepDependencies(hannk configure hannk_host)
 set(CMAKE_SKIP_INSTALL_RULES YES)
 
 ExternalProject_Get_Property(hannk BINARY_DIR)
-file(WRITE "cmake_install.cmake" "include(\"${BINARY_DIR}/cmake_install.cmake\")")
+file(GENERATE OUTPUT "cmake_install.cmake"
+     CONTENT "include(\"${BINARY_DIR}/cmake_install.cmake\")")
+
 
 # Don't let CMake generate a CTestTestfile.cmake file (don't uncomment!)
 # enable_testing()
 
 file(RELATIVE_PATH ctest_dir "${CMAKE_CURRENT_BINARY_DIR}" "${BINARY_DIR}")
-file(WRITE "CTestTestfile.cmake" "subdirs(\"${ctest_dir}\")")
+file(GENERATE OUTPUT "CTestTestfile.cmake"
+     CONTENT "subdirs(\"${ctest_dir}\")")
+

--- a/apps/hannk/cmake/superbuild/CMakeLists.txt
+++ b/apps/hannk/cmake/superbuild/CMakeLists.txt
@@ -89,12 +89,10 @@ ExternalProject_Add_StepDependencies(hannk configure hannk_host)
 set(CMAKE_SKIP_INSTALL_RULES YES)
 
 ExternalProject_Get_Property(hannk BINARY_DIR)
-file(CONFIGURE OUTPUT "cmake_install.cmake"
-     CONTENT [[include("${BINARY_DIR}/cmake_install.cmake")]])
+file(WRITE "cmake_install.cmake" "include(\"${BINARY_DIR}/cmake_install.cmake\")")
 
 # Don't let CMake generate a CTestTestfile.cmake file (don't uncomment!)
 # enable_testing()
 
 file(RELATIVE_PATH ctest_dir "${CMAKE_CURRENT_BINARY_DIR}" "${BINARY_DIR}")
-file(CONFIGURE OUTPUT "CTestTestfile.cmake"
-     CONTENT [[subdirs("${ctest_dir}")]])
+file(WRITE "CTestTestfile.cmake" "subdirs(\"${ctest_dir}\")")


### PR DESCRIPTION
Not sure why this broke, but I can confirm it works locally, now.