### PR TITLE
Add halide_debug_assert() macro

### DIFF
--- a/src/runtime/gpu_context_common.h
+++ b/src/runtime/gpu_context_common.h
@@ -66,7 +66,7 @@ public:
         }
         // This is a logic error that should never occur. It means the table is
         // full, but it should have been resized.
-        halide_assert(nullptr, false);
+        halide_debug_assert(nullptr, false);
         return false;
     }
 
@@ -124,7 +124,8 @@ public:
                     if (old_table[i].kernel_id != kInvalidId &&
                         old_table[i].kernel_id != kDeletedId) {
                         bool result = insert(old_table[i]);
-                        halide_assert(nullptr, result);  // Resizing the table while resizing the table is a logic error.
+                        halide_debug_assert(nullptr, result);  // Resizing the table while resizing the table is a logic error.
+                        (void)result;
                     }
                 }
             }
@@ -212,7 +213,8 @@ public:
         ModuleStateT *mod;
         uint32_t id = (uint32_t)(uintptr_t)state_ptr;
         bool result = find_internal(context, id, mod, -1);
-        halide_assert(user_context, result);  // Value must be in cache to be released
+        halide_debug_assert(user_context, result);  // Value must be in cache to be released
+        (void)result;
     }
 };
 

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -248,12 +248,12 @@ using namespace Halide::Runtime::Internal;
 /** halide_debug_assert() is like halide_assert(), but only expands into a check when
  * DEBUG_RUNTIME is defined. It is what you want to use in almost all cases. */
 #ifdef DEBUG_RUNTIME
-#define halide_debug_assert(user_context, cond)                                                                                                 \
-    do {                                                                                                                                        \
-        if (!(cond)) {                                                                                                                          \
+#define halide_debug_assert(user_context, cond)                                                                                           \
+    do {                                                                                                                                  \
+        if (!(cond)) {                                                                                                                    \
             halide_print(user_context, __FILE__ ":" _halide_expand_and_stringify(__LINE__) " halide_debug_assert() failed: " #cond "\n"); \
-            abort();                                                                                                                            \
-        }                                                                                                                                       \
+            abort();                                                                                                                      \
+        }                                                                                                                                 \
     } while (0)
 #else
 #define halide_debug_assert(user_context, cond)

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -227,7 +227,14 @@ using namespace Halide::Runtime::Internal;
 
 /** A macro that calls halide_print if the supplied condition is
  * false, then aborts. Used for unrecoverable errors, or
- * should-never-happen errors. */
+ * should-never-happen errors.
+ *
+ * Note that this is *NOT* a debug-only macro;
+ * the condition will be checked (and abort() possibly called) in *all* build modes!
+ *
+ * It should be used very rarely in new code, and only when the condition
+ * is truly unrecoverable.
+ */
 #define _halide_stringify(x) #x
 #define _halide_expand_and_stringify(x) _halide_stringify(x)
 #define halide_assert(user_context, cond)                                                                                  \
@@ -238,4 +245,18 @@ using namespace Halide::Runtime::Internal;
         }                                                                                                                  \
     } while (0)
 
+/** halide_debug_assert() is like halide_assert(), but only expands into a check when
+ * DEBUG_RUNTIME is defined. It is what you want to use in almost all cases. */
+#ifdef DEBUG_RUNTIME
+#define halide_debug_assert(user_context, cond)                                                                                                 \
+    do {                                                                                                                                        \
+        if (!(cond)) {                                                                                                                          \
+            halide_print(user_context, __FILE__ ":" _halide_expand_and_stringify(__LINE__) " halide_debug_assert() failed: " #cond "\n"); \
+            abort();                                                                                                                            \
+        }                                                                                                                                       \
+    } while (0)
+#else
+#define halide_debug_assert(user_context, cond)
 #endif
+
+#endif  // HALIDE_RUNTIME_INTERNAL_H


### PR DESCRIPTION
Also convert usage of halide_assert()/HALIDE_CHECK() in hashmap.h and gpu_context_common.h to halide_debug_assert(), as all the usages looked to be appropriate for debug-mode only.

(Rebased version of #6385, which this replaces)