### PR TITLE
Drop support for LLVM11

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -7,7 +7,7 @@ jobs:
     env:
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
       CMAKE_C_COMPILER_LAUNCHER: ccache
-      LLVM_ROOT: /usr/lib/llvm-11
+      LLVM_ROOT: /usr/lib/llvm-12
     steps:
       - name: Install dependencies
         run: |
@@ -16,7 +16,7 @@ jobs:
           sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
           sudo apt update
           sudo apt install cmake ninja-build doxygen ccache
-          sudo apt install llvm-11-dev liblld-11-dev clang-11 libclang-11-dev libjpeg-dev libpng-dev
+          sudo apt install llvm-12-dev liblld-12-dev clang-12 libclang-12-dev libjpeg-dev libpng-dev
           sudo apt install lintian dpkg-dev
       - name: Check out sources
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -840,15 +840,11 @@ RUNTIME_LL_COMPONENTS = \
   wasm_math \
   win32_math \
   x86 \
+  x86_amx \
   x86_avx \
   x86_avx2 \
   x86_avx512 \
   x86_sse41
-
-ifeq (,$(findstring $(LLVM_VERSION_TIMES_10), 110 111))
-# x86_amx.ll won't compile under LLVM11, but we don't need it there, either
-RUNTIME_LL_COMPONENTS += x86_amx
-endif
 
 RUNTIME_EXPORTED_INCLUDES = $(INCLUDE_DIR)/HalideRuntime.h \
                             $(INCLUDE_DIR)/HalideRuntimeD3D12Compute.h \
@@ -2151,7 +2147,7 @@ $(BUILD_DIR)/clang_ok:
 	@exit 1
 endif
 
-ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 110 111 120 130 140))
+ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 120 130 140))
 LLVM_OK=yes
 endif
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ issue.
 
 ### TL;DR
 
-Have llvm-11.0 (or greater) installed and run `make` in the root directory of
+Have llvm-12.0 (or greater) installed and run `make` in the root directory of
 the repository (where this README is).
 
 ### Acquiring LLVM
 
 At any point in time, building Halide requires either the latest stable version
 of LLVM, the previous stable version of LLVM, and trunk. At the time of writing,
-this means versions 12.0 and 11.0 are supported, but 10.0 is not. The commands
+this means versions 13.0 and 12.0 are supported, but 11.0 is not. The commands
 `llvm-config` and `clang` must be somewhere in the path.
 
 If your OS does not have packages for LLVM, you can find binaries for it at
@@ -128,7 +128,7 @@ If you want to build it yourself, first check it out from GitHub:
 % git clone --depth 1 --branch llvmorg-13.0.0 https://github.com/llvm/llvm-project.git
 ```
 
-(If you want to build LLVM 11.x, use branch `llvmorg-11.1.0`; for current trunk,
+(If you want to build LLVM 12.x, use branch `release/12.x`; for current trunk,
 use `main`)
 
 Then build it like so:

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -407,7 +407,7 @@ LLVM component names):
 | `TARGET_NVPTX`       | `ON`, _if available_ | Enable the NVidia PTX backend                            |
 | `TARGET_POWERPC`     | `ON`, _if available_ | Enable the PowerPC backend                               |
 | `TARGET_RISCV`       | `ON`, _if available_ | Enable the RISC V backend                                |
-| `TARGET_WEBASSEMBLY` | `ON`, _if available_ | Enable the WebAssembly backend. Only valid for LLVM 11+. |
+| `TARGET_WEBASSEMBLY` | `ON`, _if available_ | Enable the WebAssembly backend.                          |
 | `TARGET_X86`         | `ON`, _if available_ | Enable the x86 (and x86_64) backend                      |
 
 The following options enable/disable various Halide-specific backends:

--- a/README_webassembly.md
+++ b/README_webassembly.md
@@ -6,8 +6,6 @@ backend.
 As WebAssembly itself is still under active development, Halide's support has
 some limitations. Some of the most important:
 
--   We require using LLVM 11 or later for Wasm codegen; earlier versions of LLVM
-    will not work.
 -   Fixed-width SIMD (128 bit) can be enabled via Target::WasmSimd128.
 -   Sign-extension operations can be enabled via Target::WasmSignExt.
 -   Non-trapping float-to-int conversions can be enabled via
@@ -19,9 +17,7 @@ some limitations. Some of the most important:
 
 # Additional Tooling Requirements:
 
--   In additional to the usual install of LLVM and clang, you'll need lld. All
-    should be at least v11 or later (codegen will be improved under LLVM
-    v12/trunk, at least as of July 2020).
+-   In additional to the usual install of LLVM and clang, you'll need lld.
 -   Locally-installed version of Emscripten, 1.39.19+
 
 Note that for all of the above, earlier versions might work, but have not been

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -23,8 +23,8 @@ message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 # LLVM_PACKAGE_VERSION does not propagate to higher scopes
 set(Halide_LLVM_VERSION ${LLVM_PACKAGE_VERSION} CACHE INTERNAL "Provided LLVM version")
 
-if (LLVM_PACKAGE_VERSION VERSION_LESS 11.0)
-    message(FATAL_ERROR "LLVM version must be 11.0 or newer")
+if (LLVM_PACKAGE_VERSION VERSION_LESS 12.0)
+    message(FATAL_ERROR "LLVM version must be 12.0 or newer")
 endif ()
 
 if (LLVM_PACKAGE_VERSION VERSION_GREATER 14.0)

--- a/packaging/ubuntu/config.cmake
+++ b/packaging/ubuntu/config.cmake
@@ -62,8 +62,8 @@ set(CPACK_DEBIAN_HALIDE_DOCUMENTATION_PACKAGE_ARCHITECTURE all)
 
 # Package dependencies.
 # TODO: figure out how to get LLVM major version piped in here.
-set(CPACK_DEBIAN_HALIDE_RUNTIME_PACKAGE_DEPENDS "llvm-11 (>= 11.0.0)")
-set(CPACK_DEBIAN_HALIDE_DEVELOPMENT_PACKAGE_DEPENDS "llvm-11-dev (>= 11.0.0), liblld-11-dev (>= 11.0.0)")
+set(CPACK_DEBIAN_HALIDE_RUNTIME_PACKAGE_DEPENDS "llvm-12 (>= 12.0.0)")
+set(CPACK_DEBIAN_HALIDE_DEVELOPMENT_PACKAGE_DEPENDS "llvm-12-dev (>= 12.0.0), liblld-12-dev (>= 12.0.0)")
 set(CPACK_DEBIAN_HALIDE_DOCUMENTATION_PACKAGE_DEPENDS "")
 
 # Sets up package dependencies based on CPack component dependencies

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -137,7 +137,6 @@ llvm::Type *llvm_type_of(LLVMContext *c, Halide::Type t) {
     }
 }
 
-#if LLVM_VERSION >= 120
 int get_vector_num_elements(llvm::Type *t) {
     if (t->isVectorTy()) {
         auto *vt = dyn_cast<llvm::FixedVectorType>(t);
@@ -147,15 +146,6 @@ int get_vector_num_elements(llvm::Type *t) {
         return 1;
     }
 }
-#else
-int get_vector_num_elements(llvm::Type *t) {
-    if (t->isVectorTy()) {
-        return dyn_cast<llvm::VectorType>(t)->getNumElements();
-    } else {
-        return 1;
-    }
-}
-#endif
 
 llvm::Type *get_vector_element_type(llvm::Type *t) {
     if (t->isVectorTy()) {
@@ -165,15 +155,9 @@ llvm::Type *get_vector_element_type(llvm::Type *t) {
     }
 }
 
-#if LLVM_VERSION >= 120
 llvm::ElementCount element_count(int e) {
     return llvm::ElementCount::getFixed(e);
 }
-#else
-llvm::ElementCount element_count(int e) {
-    return llvm::ElementCount(e, /*scalable*/ false);
-}
-#endif
 
 llvm::Type *get_vector_type(llvm::Type *t, int n) {
     return VectorType::get(t, element_count(n));

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1101,10 +1101,8 @@ void CodeGen_LLVM::optimize_module() {
 
 #if LLVM_VERSION >= 130
     llvm::PassBuilder pb(tm.get(), pto);
-#elif LLVM_VERSION >= 120
-    llvm::PassBuilder pb(/*DebugLogging*/ false, tm.get(), pto);
 #else
-    llvm::PassBuilder pb(tm.get(), pto);
+    llvm::PassBuilder pb(/*DebugLogging*/ false, tm.get(), pto);
 #endif
 
     bool debug_pass_manager = false;
@@ -1145,18 +1143,11 @@ void CodeGen_LLVM::optimize_module() {
     OptimizationLevel level = OptimizationLevel::O3;
 
     if (get_target().has_feature(Target::ASAN)) {
-#if LLVM_VERSION >= 120
         pb.registerPipelineStartEPCallback([&](ModulePassManager &mpm,
                                                OptimizationLevel) {
             mpm.addPass(
                 RequireAnalysisPass<ASanGlobalsMetadataAnalysis, llvm::Module>());
         });
-#else
-        pb.registerPipelineStartEPCallback([&](ModulePassManager &mpm) {
-            mpm.addPass(
-                RequireAnalysisPass<ASanGlobalsMetadataAnalysis, llvm::Module>());
-        });
-#endif
         pb.registerOptimizerLastEPCallback(
             [](ModulePassManager &mpm, OptimizationLevel level) {
 #if LLVM_VERSION >= 140
@@ -1182,20 +1173,9 @@ void CodeGen_LLVM::optimize_module() {
                     asan_options, use_global_gc,
                     use_odr_indicator, destructor_kind));
             });
-#elif LLVM_VERSION >= 120
-        pb.registerPipelineStartEPCallback(
-            [](ModulePassManager &mpm, OptimizationLevel) {
-                constexpr bool compile_kernel = false;
-                constexpr bool recover = false;
-                constexpr bool module_use_after_scope = false;
-                constexpr bool use_odr_indicator = true;
-                mpm.addPass(ModuleAddressSanitizerPass(
-                    compile_kernel, recover, module_use_after_scope,
-                    use_odr_indicator));
-            });
 #else
         pb.registerPipelineStartEPCallback(
-            [](ModulePassManager &mpm) {
+            [](ModulePassManager &mpm, OptimizationLevel) {
                 constexpr bool compile_kernel = false;
                 constexpr bool recover = false;
                 constexpr bool module_use_after_scope = false;
@@ -1239,7 +1219,7 @@ void CodeGen_LLVM::optimize_module() {
     if (tm) {
         tm->registerPassBuilderCallbacks(pb);
     }
-#elif LLVM_VERSION >= 120
+#else
     if (tm) {
         tm->registerPassBuilderCallbacks(pb, debug_pass_manager);
     }
@@ -4508,33 +4488,21 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
 
         if (llvm_has_intrinsic) {
             std::stringstream name;
-#if LLVM_VERSION >= 120
             name << "llvm.vector.reduce.";
-#else
-            name << "llvm.experimental.vector.reduce.";
-#endif
             const int bits = op->type.bits();
             bool takes_initial_value = false;
             Expr initial_value = init;
             if (op->type.is_float()) {
                 switch (op->op) {
                 case VectorReduce::Add:
-#if LLVM_VERSION >= 120
                     name << "fadd";
-#else
-                    name << "v2.fadd.f" << bits;
-#endif
                     takes_initial_value = true;
                     if (!initial_value.defined()) {
                         initial_value = make_zero(op->type);
                     }
                     break;
                 case VectorReduce::Mul:
-#if LLVM_VERSION >= 120
                     name << "fmul";
-#else
-                    name << "v2.fmul.f" << bits;
-#endif
                     takes_initial_value = true;
                     if (!initial_value.defined()) {
                         initial_value = make_one(op->type);

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -608,9 +608,6 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     internal_assert(llvm_target) << err_str << "\n";
 
     TargetOptions options;
-#if LLVM_VERSION < 120
-    options.PrintMachineCode = false;
-#endif
     options.AllowFPOpFusion = FPOpFusion::Fast;
     options.UnsafeFPMath = true;
     options.NoInfsFPMath = true;

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -643,12 +643,7 @@ void CodeGen_X86::visit(const Store *op) {
 
 string CodeGen_X86::mcpu() const {
     if (target.has_feature(Target::AVX512_SapphireRapids)) {
-#if LLVM_VERSION >= 120
         return "sapphirerapids";
-#else
-        user_error << "AVX512 SapphireRapids requires LLVM 12 or later.";
-        return "";
-#endif
     } else if (target.has_feature(Target::AVX512_Cannonlake)) {
         return "cannonlake";
     } else if (target.has_feature(Target::AVX512_Skylake)) {
@@ -700,11 +695,7 @@ string CodeGen_X86::mattrs() const {
             features += ",+avx512ifma,+avx512vbmi";
         }
         if (target.has_feature(Target::AVX512_SapphireRapids)) {
-#if LLVM_VERSION >= 120
             features += ",+avx512bf16,+avx512vnni,+amx-int8,+amx-bf16";
-#else
-            user_error << "AVX512 SapphireRapids requires LLVM 12 or later.";
-#endif
         }
     }
     return features;

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -1,10 +1,10 @@
 #ifndef HALIDE_LLVM_HEADERS_H
 #define HALIDE_LLVM_HEADERS_H
 
-#if LLVM_VERSION >= 110
+#if LLVM_VERSION >= 120
 // We're good to go
 #else
-#error "Compiling Halide requires LLVM 11.0 or newer"
+#error "Compiling Halide requires LLVM 12.0 or newer"
 #endif
 
 // No msvc warnings from llvm headers please
@@ -30,9 +30,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/ADT/Triple.h>
 #include <llvm/ADT/Twine.h>
-#if LLVM_VERSION >= 120
 #include <llvm/Analysis/AliasAnalysis.h>
-#endif
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Bitcode/BitcodeReader.h>
@@ -69,9 +67,7 @@
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/CodeGen.h>
-#if LLVM_VERSION >= 120
 #include <llvm/Support/CommandLine.h>
-#endif
 #include <llvm/Support/DataExtractor.h>
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/ErrorHandling.h>
@@ -130,11 +126,7 @@ inline std::string get_llvm_function_name(const llvm::Function &f) {
 }
 
 inline llvm::StructType *get_llvm_struct_type_by_name(llvm::Module *module, const char *name) {
-#if LLVM_VERSION >= 120
     return llvm::StructType::getTypeByName(module->getContext(), name);
-#else
-    return module->getTypeByName(name);
-#endif
 }
 
 }  // namespace Internal

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -1066,11 +1066,9 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             if (t.has_feature(Target::AVX512)) {
                 modules.push_back(get_initmod_x86_avx512_ll(c));
             }
-#if LLVM_VERSION >= 120
             if (t.has_feature(Target::AVX512_SapphireRapids)) {
                 modules.push_back(get_initmod_x86_amx_ll(c));
             }
-#endif
             if (t.has_feature(Target::Profile)) {
                 user_assert(t.os != Target::WebAssemblyRuntime) << "The profiler cannot be used in a threadless environment.";
                 modules.push_back(get_initmod_profiler_inlined(c, bits_64, debug));

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -383,13 +383,11 @@ void lower_impl(const vector<Function> &output_funcs,
     s = lower_unsafe_promises(s, t);
     log("Lowering after lowering unsafe promises:", s);
 
-#if LLVM_VERSION >= 120
     if (t.has_feature(Target::AVX512_SapphireRapids)) {
         debug(1) << "Extracting tile operations...\n";
         s = extract_tile_operations(s);
         log("Lowering after extracting tile operations:", s);
     }
-#endif
 
     debug(1) << "Flattening nested ramps...\n";
     s = flatten_nested_ramps(s);

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -173,8 +173,6 @@ Target calculate_host_target() {
             if ((info2[1] & avx512_cannonlake) == avx512_cannonlake) {
                 initial_features.push_back(Target::AVX512_Cannonlake);
 
-#if LLVM_VERSION >= 120
-                // Sapphire Rapids support was added in LLVM 12, so earlier versions cannot support this CPU's features.
                 const uint32_t avx512vnni = 1U << 11;  // vnni result in ecx
                 const uint32_t avx512bf16 = 1U << 5;   // bf16 result in eax, with cpuid(eax=7, ecx=1)
                 int info3[4];
@@ -183,7 +181,6 @@ Target calculate_host_target() {
                     (info3[0] & avx512bf16) == avx512bf16) {
                     initial_features.push_back(Target::AVX512_SapphireRapids);
                 }
-#endif
             }
         }
     }
@@ -1044,11 +1041,6 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // We merge the bits via bitwise or.
     Target output = Target{os, arch, bits};
     output.features = ((features | other.features) & union_mask) | ((features | other.features) & matching_mask) | ((features & other.features) & intersection_mask);
-
-#if LLVM_VERSION < 120
-    // We require LLVM 12+ to compile SapphireRapids features.
-    output.features.reset(AVX512_SapphireRapids);
-#endif
 
     // Pick tight lower bound for CUDA capability. Use fall-through to clear redundant features
     int cuda_a = get_cuda_capability_lower_bound();

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -107,16 +107,12 @@ set(RUNTIME_LL
     wasm_math
     win32_math
     x86
+    x86_amx
     x86_avx
     x86_avx2
     x86_avx512
     x86_sse41
     )
-
-if (Halide_LLVM_VERSION VERSION_GREATER_EQUAL 12.0)
-  # AMX instructions require LLVM 12 or newer
-  list(APPEND RUNTIME_LL x86_amx)
-endif ()
 
 set(RUNTIME_BC
     compute_20

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1746,13 +1746,8 @@ public:
                     check("v128.const", 8 * w, f32_1 * f32(42));
                     check("v128.const", 4 * w, f64_1 * f64(42));
                 } else {
-                    if (Halide::Internal::get_llvm_version() == 120) {
-                        check("i64x2.splat", 8 * w, u16_1 * u16(42));
-                        check("i64x2.splat", 4 * w, u32_1 * u32(42));
-                    } else {
-                        check("i16x8.splat", 8 * w, u16_1 * u16(42));
-                        check("i32x4.splat", 4 * w, u32_1 * u32(42));
-                    }
+                    check("i64x2.splat", 8 * w, u16_1 * u16(42));
+                    check("i64x2.splat", 4 * w, u32_1 * u32(42));
                     check("i64x2.splat", 2 * w, u64_1 * u64(42));
                     check("f32x4.splat", 8 * w, f32_1 * f32(42));
                     check("f64x2.splat", 4 * w, f64_1 * f64(42));
@@ -1764,16 +1759,9 @@ public:
                 // to be used explicitly
 
                 // Shuffling using immediate indices
-                if (Halide::Internal::get_llvm_version() >= 120) {
-                    check("i8x16.shuffle", 16 * w, in_u8(2 * x));
-                    check("i8x16.shuffle", 8 * w, in_u16(2 * x));
-                    check("i8x16.shuffle", 4 * w, in_u32(2 * x));
-                } else {
-                    // older mnemonics
-                    check("v8x16.shuffle", 16 * w, in_u8(2 * x));
-                    check("v8x16.shuffle", 8 * w, in_u16(2 * x));
-                    check("v8x16.shuffle", 4 * w, in_u32(2 * x));
-                }
+                check("i8x16.shuffle", 16 * w, in_u8(2 * x));
+                check("i8x16.shuffle", 8 * w, in_u16(2 * x));
+                check("i8x16.shuffle", 4 * w, in_u32(2 * x));
 
                 // Swizzling using variable indices
                 // (This fails to generate, but that's not entirely surprising -- I don't
@@ -1994,12 +1982,10 @@ public:
 
                 check("v128.bitselect", 16 * w, select(bool_1, u8_1, u8_2));
                 check("v128.bitselect", 8 * w, select(bool_1, u16_1, u16_2));
-                if (Halide::Internal::get_llvm_version() >= 120) {
-                    check("v128.bitselect", 4 * w, select(bool_1, u32_1, u32_2));
-                    check("v128.bitselect", 2 * w, select(bool_1, u64_1, u64_2));
-                    check("v128.bitselect", 4 * w, select(bool_1, f32_1, f32_2));
-                    check("v128.bitselect", 2 * w, select(bool_1, f64_1, f64_2));
-                }
+                check("v128.bitselect", 4 * w, select(bool_1, u32_1, u32_2));
+                check("v128.bitselect", 2 * w, select(bool_1, u64_1, u64_2));
+                check("v128.bitselect", 4 * w, select(bool_1, f32_1, f32_2));
+                check("v128.bitselect", 2 * w, select(bool_1, f64_1, f64_2));
 
                 // Lane-wise Population Count
                 // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK
@@ -2091,18 +2077,10 @@ public:
                 // check("v128.load64_zero", 2 * w, in_u64(0));
 
                 // Load vector with identical lanes
-                if (Halide::Internal::get_llvm_version() >= 120) {
-                    check("v128.load8_splat", 16 * w, in_u8(0));
-                    check("v128.load16_splat", 8 * w, in_u16(0));
-                    check("v128.load32_splat", 4 * w, in_u32(0));
-                    check("v128.load64_splat", 2 * w, in_u64(0));
-                } else {
-                    // older mnemonics
-                    check("v8x16.load_splat", 16 * w, in_u8(0));
-                    check("v16x8.load_splat", 8 * w, in_u16(0));
-                    check("v32x4.load_splat", 4 * w, in_u32(0));
-                    check("v64x2.load_splat", 2 * w, in_u64(0));
-                }
+                check("v128.load8_splat", 16 * w, in_u8(0));
+                check("v128.load16_splat", 8 * w, in_u16(0));
+                check("v128.load32_splat", 4 * w, in_u32(0));
+                check("v128.load64_splat", 2 * w, in_u64(0));
 
                 // Load Lane
                 // TODO: does Halide have any idiom that obviously generates these?


### PR DESCRIPTION
With Halide 13 released, we should drop support for LLVM11 in Halide trunk, since we only promise to support LLVM trunk + two releases.