### PR TITLE
Fix OGLC debug builds

### DIFF
--- a/src/runtime/fuchsia_clock.cpp
+++ b/src/runtime/fuchsia_clock.cpp
@@ -24,6 +24,9 @@ WEAK int halide_start_clock(void *user_context) {
 }
 
 WEAK int64_t halide_current_time_ns(void *user_context) {
+    // It is an error to call halide_current_time_ns() if halide_start_clock() has never been called
+    halide_debug_assert(user_context, halide_reference_clock_inited);
+
     return zx_clock_get_monotonic() - halide_reference_clock;
 }
 

--- a/src/runtime/linux_clock.cpp
+++ b/src/runtime/linux_clock.cpp
@@ -1,4 +1,5 @@
 #include "HalideRuntime.h"
+#include "runtime_internal.h"
 
 #ifndef __clockid_t_defined
 #define __clockid_t_defined 1
@@ -62,6 +63,9 @@ WEAK int halide_start_clock(void *user_context) {
 }
 
 WEAK int64_t halide_current_time_ns(void *user_context) {
+    // It is an error to call halide_current_time_ns() if halide_start_clock() has never been called
+    halide_debug_assert(user_context, halide_reference_clock_inited);
+
     timespec now;
     // To avoid requiring people to link -lrt, we just make the syscall directly.
 

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -755,6 +755,7 @@ WEAK char *get_kernel_name(const char *start, const char *end) {
 WEAK int halide_openglcompute_initialize_kernels(void *user_context, void **state_ptr,
                                                  const char *src, int size) {
 #ifdef DEBUG_RUNTIME
+    halide_start_clock(user_context);
     uint64_t t_before = halide_current_time_ns(user_context);
 #endif
 

--- a/src/runtime/osx_clock.cpp
+++ b/src/runtime/osx_clock.cpp
@@ -37,6 +37,9 @@ WEAK int halide_start_clock(void *user_context) {
 }
 
 WEAK int64_t halide_current_time_ns(void *user_context) {
+    // It is an error to call halide_current_time_ns() if halide_start_clock() has never been called
+    halide_debug_assert(user_context, halide_reference_clock_inited);
+
     uint64_t now = mach_absolute_time();
     return (now - halide_reference_clock) * halide_timebase_info.numer / halide_timebase_info.denom;
 }

--- a/src/runtime/posix_clock.cpp
+++ b/src/runtime/posix_clock.cpp
@@ -41,6 +41,9 @@ WEAK int halide_start_clock(void *user_context) {
 // doesn't provide the former. (Use linux_clock.cpp to use clock_gettime(),
 // which will provide actual nanosecond accuracy.)
 WEAK int64_t halide_current_time_ns(void *user_context) {
+    // It is an error to call halide_current_time_ns() if halide_start_clock() has never been called
+    halide_debug_assert(user_context, halide_reference_clock_inited);
+
     timeval now;
     gettimeofday(&now, nullptr);
     int64_t d = int64_t(now.tv_sec - halide_reference_clock.tv_sec) * 1000000;

--- a/src/runtime/windows_clock.cpp
+++ b/src/runtime/windows_clock.cpp
@@ -27,6 +27,9 @@ WEAK int halide_start_clock(void *user_context) {
 }
 
 WEAK int64_t halide_current_time_ns(void *user_context) {
+    // It is an error to call halide_current_time_ns() if halide_start_clock() has never been called
+    halide_debug_assert(user_context, halide_reference_clock_inited);
+
     int64_t clock;
     QueryPerformanceCounter(&clock);
     clock -= halide_reference_clock;


### PR DESCRIPTION
If you try to build and run something with `openglcompute` and `debug`, you may crash with a div-by-zero, because the openglcompute runtime never calls `halide_start_clock()`, and all implementations of `halide_current_time_ns()` assume that it has been called. On (e.g.) OSX, this results in div by zero. This fixes it by inserting the correct call into openglruntime.cpp, and also adding debug-only asserts to all the `halide_current_time_ns()` implementations.

(I was tempted to fix this by removing `halide_start_clock()` entirely and just lazily initing the initial value in `halide_current_time_ns()`, but I figured that would likely get pushback...)