### PR TITLE
Fix broken ASAN code

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1148,7 +1148,8 @@ void CodeGen_LLVM::optimize_module() {
         });
         pb.registerPipelineStartEPCallback([](ModulePassManager &mpm, OptimizationLevel) {
 #if LLVM_VERSION >= 140
-            AddressSanitizerOptions asan_options;  // default values are good
+            AddressSanitizerOptions asan_options;  // default values are good...
+            asan_options.UseAfterScope = true;     // ...except this one
             constexpr bool use_global_gc = true;
             constexpr bool use_odr_indicator = true;
             constexpr auto destructor_kind = AsanDtorKind::Global;


### PR DESCRIPTION
Various changes and merges ended up with us using multiple ASAN passes, which was pretty crashy (we just didn't notice because it isn't tested well enough on our buildbots, but is elsewhere).

I think we really only want to use the ModuleAddressSanitizerPass (not the non-Module version), which is what Clang does.