### PR TITLE
x86_cpuid_halide must preserve all 64 bits of rbx/rsi

### DIFF
--- a/src/runtime/x86.ll
+++ b/src/runtime/x86.ll
@@ -126,6 +126,11 @@ define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind uw
 ; and cause it to fail via running out of registers.
 define weak_odr void @x86_cpuid_halide(i32* %info) nounwind uwtable {
   call void asm sideeffect inteldialect "xchg ebx, esi\0A\09mov eax, dword ptr $$0 $0\0A\09mov ecx, dword ptr $$4 $0\0A\09cpuid\0A\09mov dword ptr $$0 $0, eax\0A\09mov dword ptr $$4 $0, ebx\0A\09mov dword ptr $$8 $0, ecx\0A\09mov dword ptr $$12 $0, edx\0A\09xchg ebx, esi", "=*m,~{eax},~{ebx},~{ecx},~{edx},~{esi},~{dirflag},~{fpsr},~{flags}"(i32* %info)
+  ret void
+}
 
+; Same, but ensure that we save/restore the full 64 bits of rbx/rsi.
+define weak_odr void @x64_cpuid_halide(i32* %info) nounwind uwtable {
+  call void asm sideeffect inteldialect "xchg rbx, rsi\0A\09mov eax, dword ptr $$0 $0\0A\09mov ecx, dword ptr $$4 $0\0A\09cpuid\0A\09mov dword ptr $$0 $0, eax\0A\09mov dword ptr $$4 $0, ebx\0A\09mov dword ptr $$8 $0, ecx\0A\09mov dword ptr $$12 $0, edx\0A\09xchg rbx, rsi", "=*m,~{eax},~{ebx},~{ecx},~{edx},~{esi},~{dirflag},~{fpsr},~{flags}"(i32* %info)
   ret void
 }

--- a/src/runtime/x86_cpu_features.cpp
+++ b/src/runtime/x86_cpu_features.cpp
@@ -6,13 +6,20 @@ namespace Runtime {
 namespace Internal {
 
 extern "C" void x86_cpuid_halide(int32_t *);
+extern "C" void x64_cpuid_halide(int32_t *);
 
 namespace {
+
+constexpr bool use_64_bits = (sizeof(size_t) == 8);
 
 ALWAYS_INLINE void cpuid(int32_t *info, int32_t fn_id, int32_t extra = 0) {
     info[0] = fn_id;
     info[1] = extra;
-    x86_cpuid_halide(info);
+    if (use_64_bits) {
+        x64_cpuid_halide(info);
+    } else {
+        x86_cpuid_halide(info);
+    }
 }
 
 }  // namespace
@@ -51,25 +58,24 @@ WEAK CpuFeatures halide_get_cpu_features() {
         features.set_available(halide_target_feature_fma);
     }
 
-    const bool use_64_bits = (sizeof(size_t) == 8);
     if (use_64_bits && have_avx && have_f16c && have_rdrand) {
         int info2[4];
         cpuid(info2, 7);
-        const uint32_t avx2 = 1U << 5;
-        const uint32_t avx512f = 1U << 16;
-        const uint32_t avx512dq = 1U << 17;
-        const uint32_t avx512pf = 1U << 26;
-        const uint32_t avx512er = 1U << 27;
-        const uint32_t avx512cd = 1U << 28;
-        const uint32_t avx512bw = 1U << 30;
-        const uint32_t avx512vl = 1U << 31;
-        const uint32_t avx512ifma = 1U << 21;
-        const uint32_t avx512vnni = 1U << 11;  // vnni result in ecx
-        const uint32_t avx512bf16 = 1U << 5;   // bf16 result in eax, cpuid(eax=7, ecx=1)
-        const uint32_t avx512 = avx512f | avx512cd;
-        const uint32_t avx512_knl = avx512 | avx512pf | avx512er;
-        const uint32_t avx512_skylake = avx512 | avx512vl | avx512bw | avx512dq;
-        const uint32_t avx512_cannonlake = avx512_skylake | avx512ifma;  // Assume ifma => vbmi
+        constexpr uint32_t avx2 = 1U << 5;
+        constexpr uint32_t avx512f = 1U << 16;
+        constexpr uint32_t avx512dq = 1U << 17;
+        constexpr uint32_t avx512pf = 1U << 26;
+        constexpr uint32_t avx512er = 1U << 27;
+        constexpr uint32_t avx512cd = 1U << 28;
+        constexpr uint32_t avx512bw = 1U << 30;
+        constexpr uint32_t avx512vl = 1U << 31;
+        constexpr uint32_t avx512ifma = 1U << 21;
+        constexpr uint32_t avx512vnni = 1U << 11;  // vnni result in ecx
+        constexpr uint32_t avx512bf16 = 1U << 5;   // bf16 result in eax, cpuid(eax=7, ecx=1)
+        constexpr uint32_t avx512 = avx512f | avx512cd;
+        constexpr uint32_t avx512_knl = avx512 | avx512pf | avx512er;
+        constexpr uint32_t avx512_skylake = avx512 | avx512vl | avx512bw | avx512dq;
+        constexpr uint32_t avx512_cannonlake = avx512_skylake | avx512ifma;  // Assume ifma => vbmi
         if ((info2[1] & avx2) == avx2) {
             features.set_available(halide_target_feature_avx2);
         }


### PR DESCRIPTION
The existing code attempts to preserve ebx (since the cpuid instruction can trash it), but it only preserves the lower 32 bits; on 64-bit systems, this (amazingly) usually works OK unless you are compiling in (e.g.) ASAN mode, which can subtly change codegen such that the full 32 bits of rbx must be preserved.

I'm genuinely astonished this hasn't bitten us before now!