### PR TITLE
Backport PR6409 and PR6405 for v13.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.20)
 project(Halide
-        VERSION 13.0.0
+        VERSION 13.0.1
         DESCRIPTION "Halide compiler and libraries"
         HOMEPAGE_URL "https://halide-lang.org")
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ If you've acquired a full source distribution and want to build Halide, see the
 
 ## Binary tarballs
 
-The latest version of Halide is **Halide 12.0.0**. We provide binary releases
+The latest version of Halide is **Halide 13.0.1**. We provide binary releases
 for many popular platforms and architectures, including 32/64-bit x86 Windows,
 64-bit macOS, and 32/64-bit x86/ARM Ubuntu Linux. See the releases tab on the
-right (or click [here](https://github.com/halide/Halide/releases/tag/v12.0.0)).
+right (or click [here](https://github.com/halide/Halide/releases/tag/v13.0.1)).
 
 ## Vcpkg
 

--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -670,7 +670,15 @@ class SubstituteInWideningLets : public IRMutator {
             } extractor(frames);
 
             if (should_replace) {
+                size_t start_of_new_lets = frames.size();
                 value = extractor.mutate(value);
+                // Mutate any subexpressions the extractor decided to
+                // leave behind, in case they in turn depend on lets
+                // we've decided to substitute in.
+                for (size_t i = start_of_new_lets; i < frames.size(); i++) {
+                    frames[i].new_value = mutate(frames[i].new_value);
+                }
+
                 // Check it wasn't lifted entirely
                 should_replace = !value.as<Variable>();
             }

--- a/src/runtime/x86.ll
+++ b/src/runtime/x86.ll
@@ -126,6 +126,11 @@ define weak_odr <4 x float> @fast_inverse_sqrt_f32x4(<4 x float> %x) nounwind uw
 ; and cause it to fail via running out of registers.
 define weak_odr void @x86_cpuid_halide(i32* %info) nounwind uwtable {
   call void asm sideeffect inteldialect "xchg ebx, esi\0A\09mov eax, dword ptr $$0 $0\0A\09mov ecx, dword ptr $$4 $0\0A\09cpuid\0A\09mov dword ptr $$0 $0, eax\0A\09mov dword ptr $$4 $0, ebx\0A\09mov dword ptr $$8 $0, ecx\0A\09mov dword ptr $$12 $0, edx\0A\09xchg ebx, esi", "=*m,~{eax},~{ebx},~{ecx},~{edx},~{esi},~{dirflag},~{fpsr},~{flags}"(i32* %info)
+  ret void
+}
 
+; Same, but ensure that we save/restore the full 64 bits of rbx/rsi.
+define weak_odr void @x64_cpuid_halide(i32* %info) nounwind uwtable {
+  call void asm sideeffect inteldialect "xchg rbx, rsi\0A\09mov eax, dword ptr $$0 $0\0A\09mov ecx, dword ptr $$4 $0\0A\09cpuid\0A\09mov dword ptr $$0 $0, eax\0A\09mov dword ptr $$4 $0, ebx\0A\09mov dword ptr $$8 $0, ecx\0A\09mov dword ptr $$12 $0, edx\0A\09xchg rbx, rsi", "=*m,~{eax},~{ebx},~{ecx},~{edx},~{esi},~{dirflag},~{fpsr},~{flags}"(i32* %info)
   ret void
 }

--- a/src/runtime/x86_cpu_features.cpp
+++ b/src/runtime/x86_cpu_features.cpp
@@ -6,13 +6,20 @@ namespace Runtime {
 namespace Internal {
 
 extern "C" void x86_cpuid_halide(int32_t *);
+extern "C" void x64_cpuid_halide(int32_t *);
 
 namespace {
+
+constexpr bool use_64_bits = (sizeof(size_t) == 8);
 
 ALWAYS_INLINE void cpuid(int32_t *info, int32_t fn_id, int32_t extra = 0) {
     info[0] = fn_id;
     info[1] = extra;
-    x86_cpuid_halide(info);
+    if (use_64_bits) {
+        x64_cpuid_halide(info);
+    } else {
+        x86_cpuid_halide(info);
+    }
 }
 
 }  // namespace
@@ -51,25 +58,24 @@ WEAK CpuFeatures halide_get_cpu_features() {
         features.set_available(halide_target_feature_fma);
     }
 
-    const bool use_64_bits = (sizeof(size_t) == 8);
     if (use_64_bits && have_avx && have_f16c && have_rdrand) {
         int info2[4];
         cpuid(info2, 7);
-        const uint32_t avx2 = 1U << 5;
-        const uint32_t avx512f = 1U << 16;
-        const uint32_t avx512dq = 1U << 17;
-        const uint32_t avx512pf = 1U << 26;
-        const uint32_t avx512er = 1U << 27;
-        const uint32_t avx512cd = 1U << 28;
-        const uint32_t avx512bw = 1U << 30;
-        const uint32_t avx512vl = 1U << 31;
-        const uint32_t avx512ifma = 1U << 21;
-        const uint32_t avx512vnni = 1U << 11;  // vnni result in ecx
-        const uint32_t avx512bf16 = 1U << 5;   // bf16 result in eax, cpuid(eax=7, ecx=1)
-        const uint32_t avx512 = avx512f | avx512cd;
-        const uint32_t avx512_knl = avx512 | avx512pf | avx512er;
-        const uint32_t avx512_skylake = avx512 | avx512vl | avx512bw | avx512dq;
-        const uint32_t avx512_cannonlake = avx512_skylake | avx512ifma;  // Assume ifma => vbmi
+        constexpr uint32_t avx2 = 1U << 5;
+        constexpr uint32_t avx512f = 1U << 16;
+        constexpr uint32_t avx512dq = 1U << 17;
+        constexpr uint32_t avx512pf = 1U << 26;
+        constexpr uint32_t avx512er = 1U << 27;
+        constexpr uint32_t avx512cd = 1U << 28;
+        constexpr uint32_t avx512bw = 1U << 30;
+        constexpr uint32_t avx512vl = 1U << 31;
+        constexpr uint32_t avx512ifma = 1U << 21;
+        constexpr uint32_t avx512vnni = 1U << 11;  // vnni result in ecx
+        constexpr uint32_t avx512bf16 = 1U << 5;   // bf16 result in eax, cpuid(eax=7, ecx=1)
+        constexpr uint32_t avx512 = avx512f | avx512cd;
+        constexpr uint32_t avx512_knl = avx512 | avx512pf | avx512er;
+        constexpr uint32_t avx512_skylake = avx512 | avx512vl | avx512bw | avx512dq;
+        constexpr uint32_t avx512_cannonlake = avx512_skylake | avx512ifma;  // Assume ifma => vbmi
         if ((info2[1] & avx2) == avx2) {
             features.set_available(halide_target_feature_avx2);
         }

--- a/test/correctness/intrinsics.cpp
+++ b/test/correctness/intrinsics.cpp
@@ -314,6 +314,39 @@ int main(int argc, char **argv) {
     check_intrinsics_over_range<int32_t>();
     check_intrinsics_over_range<uint32_t>();
 
+    // The intrinsics-matching pass substitutes in widening lets. At
+    // one point this caused a missing symbol bug for the code below
+    // due to a subexpression not getting mutated.
+    {
+        Func f, g;
+        Var x;
+        Param<uint8_t> d;
+
+        f(x) = cast<uint8_t>(x);
+        f.compute_root();
+
+        // We want a widening let that uses a load that uses a widening let
+
+        // Widen it, but in a way that won't result in the cast being
+        // substituted in by the simplifier. We want it to only be
+        // substituted when we reach the intrinsics-matching pass.
+        Expr widened = absd(cast<uint16_t>(f(x)), cast<uint16_t>(d));
+
+        // Now use it in a load, twice, so that CSE pulls it out as a let.
+        Expr lut = f(cast<int32_t>(widened * widened));
+
+        // Now use that in another widening op...
+        Expr widened2 = absd(cast<uint16_t>(lut), cast<uint16_t>(d));
+
+        // ...which we will use twice so that CSE makes it another let.
+        g(x) = widened2 * widened2;
+
+        g.vectorize(x, 8);
+
+        // This used to crash with a missing symbol error
+        g.compile_jit();
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
Added fixes for [6405](https://github.com/halide/Halide/pull/6405) and [6409](https://github.com/halide/Halide/pull/6409) to cut a v13.0.1 release.

[Fix obscure bug in widening let substitution #6405](https://github.com/halide/Halide/pull/6409)
[x86_cpuid_halide must preserve all 64 bits of rbx/rsi #6409](https://github.com/halide/Halide/pull/6409)

I've left the README.md alone since it seems like v13 wasn't advertised yet, so it still mentions v12.0.0 as the latest release (since that's what is in master right now).  

Please look things over and let me know if I've missed anything!