### PR TITLE
Don't remap the function name or the target in the metadata

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1042,8 +1042,8 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
         /* version */ version,
         /* num_arguments */ ConstantInt::get(i32_t, num_args),
         /* arguments */ ConstantExpr::getInBoundsGetElementPtr(arguments_array, arguments_array_storage, zeros),
-        /* target */ create_string_constant(map_string(target.to_string())),
-        /* name */ create_string_constant(map_string(function_name))};
+        /* target */ create_string_constant(target.to_string()),
+        /* name */ create_string_constant(function_name)};
 
     GlobalVariable *metadata_storage = new GlobalVariable(
         *module,


### PR DESCRIPTION
The remapping is only intended to be used for output argument(s), not the function name; if you have an output with the same name as the function, you can get the metadata emitted with incorrect information. (And remapping the target string is just silly.)

This is almost impossible to do currently, but if you construct a Generator just right, you can make it happen.