### PR TITLE
Do target-specific lowering of lerp

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2306,7 +2306,7 @@ void CodeGen_C::visit(const Call *op) {
         }
     } else if (op->is_intrinsic(Call::lerp)) {
         internal_assert(op->args.size() == 3);
-        Expr e = lower_lerp(op->args[0], op->args[1], op->args[2]);
+        Expr e = lower_lerp(op->args[0], op->args[1], op->args[2], target);
         rhs << print_expr(e);
     } else if (op->is_intrinsic(Call::absd)) {
         internal_assert(op->args.size() == 2);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2697,7 +2697,8 @@ void CodeGen_LLVM::visit(const Call *op) {
         Type wt = upgrade_type_for_arithmetic(op->args[2].type());
         Expr e = lower_lerp(cast(t, op->args[0]),
                             cast(t, op->args[1]),
-                            cast(wt, op->args[2]));
+                            cast(wt, op->args[2]),
+                            target);
         e = cast(op->type, e);
         codegen(e);
     } else if (op->is_intrinsic(Call::popcount)) {

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -991,7 +991,7 @@ private:
             // We need to lower lerps now to optimize the arithmetic
             // that they generate.
             internal_assert(op->args.size() == 3);
-            return mutate(lower_lerp(op->args[0], op->args[1], op->args[2]));
+            return mutate(lower_lerp(op->args[0], op->args[1], op->args[2], target));
         } else if ((op->is_intrinsic(Call::div_round_to_zero) ||
                     op->is_intrinsic(Call::mod_round_to_zero)) &&
                    !op->type.is_float() && op->type.is_vector()) {

--- a/src/Lerp.h
+++ b/src/Lerp.h
@@ -9,7 +9,7 @@
 
 namespace Halide {
 
-class Target;
+struct Target;
 
 namespace Internal {
 

--- a/src/Lerp.h
+++ b/src/Lerp.h
@@ -8,11 +8,14 @@
 #include "Expr.h"
 
 namespace Halide {
+
+class Target;
+
 namespace Internal {
 
 /** Build Halide IR that computes a lerp. Use by codegen targets that
  * don't have a native lerp. */
-Expr lower_lerp(Expr zero_val, Expr one_val, const Expr &weight);
+Expr lower_lerp(Expr zero_val, Expr one_val, const Expr &weight, const Target &target);
 
 }  // namespace Internal
 }  // namespace Halide


### PR DESCRIPTION
Saves instructions on x86. For the division by 255 in an 8-bit lerp we get:

Before #6426

	vpaddw	%ymm0, %ymm1, %ymm1
	vpsrlw	$8, %ymm1, %ymm2
	vpaddw	%ymm2, %ymm1, %ymm1
	vpsrlw	$8, %ymm1, %ymm1

After #6426

	vpsrlw	$7, %ymm2, %ymm3
	vpand	%ymm0, %ymm3, %ymm3
	vpsrlw	$8, %ymm2, %ymm4
	vpaddw	%ymm2, %ymm4, %ymm2
	vpaddw	%ymm3, %ymm2, %ymm2
	vpsrlw	$7, %ymm2, %ymm3
	vpand	%ymm0, %ymm3, %ymm3
	vpsrlw	$8, %ymm2, %ymm2
	vpaddw	%ymm2, %ymm3, %ymm2
	vpand	%ymm1, %ymm2, %ymm2

This PR:

        vpaddw  %ymm0, %ymm3, %ymm3
        vpmulhuw        %ymm1, %ymm3, %ymm3
        vpsrlw  $7, %ymm3, %ymm3