### PR TITLE
Sketch of AOT-compiled performance tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,11 @@ if (WITH_TEST_PERFORMANCE)
     add_subdirectory(performance)
 endif ()
 
+option(WITH_TEST_PERFORMANCE_AOT "Build performance_aot tests" ON)
+if (WITH_TEST_PERFORMANCE_AOT)
+    add_subdirectory(performance_aot)
+endif ()
+
 option(WITH_TEST_GENERATOR "Build generator tests" ON)
 if (WITH_TEST_GENERATOR)
     add_subdirectory(generator)

--- a/test/performance_aot/CMakeLists.txt
+++ b/test/performance_aot/CMakeLists.txt
@@ -1,0 +1,62 @@
+function(_define_peformance_aot NAME)
+    set(options )
+    set(oneValueArgs )
+    set(multiValueArgs GENERATORS GEN_DEPS ENABLE_IF FEATURES)
+    cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (args_ENABLE_IF AND NOT (${args_ENABLE_IF}))
+        return()
+    endif ()
+
+    # add_halide_generator(${NAME}.generator
+    #                      SOURCES ${NAME}.cpp)
+    add_executable("${NAME}.generator" "${NAME}.cpp")
+    target_compile_definitions("${NAME}.generator" PRIVATE HALIDE_COMPILING_GENERATOR)
+    target_link_libraries("${NAME}.generator" PRIVATE Halide::Generator ${args_GEN_DEPS})
+
+    set(TARGET "performance_aot_${NAME}")
+    set(DEPS )
+    foreach(G IN ITEMS ${args_GENERATORS})
+        add_halide_library(${G}
+                           FROM "${NAME}.generator"
+                           GENERATOR "${G}"
+                           FEATURES "${args_FEATURES}")
+        list(APPEND DEPS ${G} ${G}.runtime)
+    endforeach()
+
+    if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
+        add_wasm_executable("${TARGET}"
+                            SRCS "${NAME}.cpp"
+                            DEPS "${DEPS}"
+                            INCLUDES
+                            "${Halide_BINARY_DIR}/include"
+                            "${Halide_SOURCE_DIR}/test/common"
+                            "${Halide_SOURCE_DIR}/tools"
+                            "${CMAKE_CURRENT_BINARY_DIR}")
+
+        add_wasm_halide_test("${TARGET}" GROUPS performance_aot)
+    else ()
+        add_executable("${TARGET}" "${NAME}.cpp")
+        target_include_directories("${TARGET}"
+                                   PRIVATE
+                                   "${Halide_SOURCE_DIR}/test/common"
+                                   "${Halide_SOURCE_DIR}/tools")
+        target_link_libraries(${TARGET} PRIVATE ${DEPS})
+
+        # TODO(#4938): remove need for these definitions
+        if ("${Halide_TARGET}" MATCHES "opencl")
+            target_compile_definitions("${TARGET}" PRIVATE TEST_OPENCL)
+        endif ()
+        if ("${Halide_TARGET}" MATCHES "metal")
+            target_compile_definitions("${TARGET}" PRIVATE TEST_METAL)
+        endif ()
+        if ("${Halide_TARGET}" MATCHES "cuda")
+            target_compile_definitions("${TARGET}" PRIVATE TEST_CUDA)
+        endif ()
+        add_halide_test("${TARGET}" GROUPS performance_aot)
+    endif ()
+endfunction()
+
+_define_peformance_aot(async_gpu
+                       GENERATORS with_async without_async)
+

--- a/test/performance_aot/async_gpu.cpp
+++ b/test/performance_aot/async_gpu.cpp
@@ -1,0 +1,121 @@
+#ifdef HALIDE_COMPILING_GENERATOR
+
+#include "Halide.h"
+
+namespace {
+
+Halide::Expr expensive(Halide::Expr x, int c) {
+    if (c <= 0) {
+        return x;
+    } else {
+        return expensive(Halide::fast_pow(x, x + 1), c - 1);
+    }
+}
+
+class AsyncGpu : public Halide::Generator<AsyncGpu> {
+public:
+    GeneratorParam<bool> use_async{"use_async", true};
+    Input<Buffer<float>> input{"input", 3};
+    Output<Buffer<float>> output{"output", 3};
+
+    void generate() {
+        Var x, y, t, xi, yi;
+
+        Func cpu, gpu;
+
+        // We have a two-stage pipeline that processes frames. We want
+        // to run the first stage on the GPU and the second stage on
+        // the CPU. We'd like to get the CPU and GPU running at the
+        // same time using async. The amount of math we do here
+        // doesn't matter much - the important thing is that we
+        // overlap CPU computation with the GPU buffer copies.
+        gpu(x, y, t) = expensive(input(x, y, t), 16);
+        cpu(x, y, t) = expensive(gpu(x, y, t), 16);
+
+        cpu.parallel(y, 16).vectorize(x, 8);
+
+        if (get_target().has_gpu_feature()) {
+            // Assume GPU memory is limited, and compute the GPU stage one
+            // frame at a time. Hoist the allocation to the top level.
+            gpu.compute_at(cpu, t).store_root().gpu_tile(x, y, xi, yi, 8, 8);
+
+            // Stage the copy-back of the GPU result into a host-side
+            // double-buffer.
+            gpu.in().copy_to_host().compute_at(cpu, t).store_root().fold_storage(t, 2);
+
+            if (use_async) {
+                gpu.in().async();
+                gpu.async();
+            }
+        } else {
+            // Just quietly compile (we'll skip usage at runtime)
+            gpu.compute_root();
+        }
+
+        output = cpu;
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(AsyncGpu, with_async)
+HALIDE_REGISTER_GENERATOR_ALIAS(without_async, with_async, {{"use_async", "false"}})
+
+#else
+
+#include "HalideBuffer.h"
+#include "HalideRuntime.h"
+#include "halide_benchmark.h"
+#include "with_async.h"
+#include "without_async.h"
+
+#include <stdio.h>
+
+static bool has_gpu_feature(const char *t) {
+    return (strstr(t, "cuda") ||
+            strstr(t, "opencl") ||
+            strstr(t, "metal") ||
+            strstr(t, "d3d12compute") ||
+            strstr(t, "openglcompute"));
+}
+
+int main(int argc, char **argv) {
+    const char *const target = with_async_metadata()->target;
+    printf("Compiled with target: %s\n", target);
+
+    if (!has_gpu_feature(target)) {
+        printf("[SKIP] No GPU target enabled.\n");
+        return 0;
+    }
+
+    // Issue https://github.com/halide/Halide/issues/3586 -- failing
+    // on Windows; disabling pending a fix
+    if (strstr(target, "d3d12compute")) {
+        printf("[SKIP] D3D12Compute broken; see https://github.com/halide/Halide/issues/3586\n");
+        return 0;
+    }
+
+    Halide::Runtime::Buffer<float> in(800, 800, 16), out(800, 800, 16);
+    in.fill(0);
+
+    double times[2];
+    for (int use_async = 0; use_async < 2; use_async++) {
+        auto f = use_async ? with_async : without_async;
+        times[use_async] = Halide::Tools::benchmark(10, 1, [&]() {
+            f(in, out);
+        });
+
+        printf("%s: %f\n",
+               use_async ? "with async" : "without async",
+               times[use_async]);
+    }
+
+    if (times[1] > 1.2 * times[0]) {
+        printf("Using async should have been faster\n");
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}
+#endif


### PR DESCRIPTION
This is a sketch of a clunky-but-effective way to make some (simple) tests AOT-compiled without having to greatly increase number of source files or add lots of complex build rules. Not sure if it's a win or not -- opinions wanted. Basically, this puts a Generator and a 'main' test harness into the same file, separated by an ifdef; the CMake build rules know how to build the file multiple ways and connect them together.

I'm honestly torn as to whether the icky, please-don't-use-this-in-real-code approach here is outweighed by the convenience factor of having self-contained tests that will AOT-compile properly.

(BTW, this approach produces results that will build-and-run just fine under Wasm! Although the one example I've provided in this PR doesn't do so usefully, because it requires GPU support...)

Also note that I haven't provided build rules for Make (only CMake), and I don't intend to do so, because doing this in Make is a big mess of ugly special cases. Someone else can add new features to Make if they like.