### PR TITLE
Ensure that halide_start_clock() is called before halide_current_time…

### DIFF
--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -253,6 +253,7 @@ WEAK int halide_hexagon_initialize_kernels(void *user_context, void **state_ptr,
     halide_abort_if_false(user_context, state_ptr != nullptr);
 
 #ifdef DEBUG_RUNTIME
+    halide_start_clock(user_context);
     uint64_t t_before = halide_current_time_ns(user_context);
 #endif
 


### PR DESCRIPTION
…_ns() in hexagon_host.cpp

This oversight was causing an assert with the -debug feature flag enabled (with presumably-misleading timing results as well)