### PR TITLE
Include GPU source kernels in Stmt and StmtHtml file.

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -8,6 +8,7 @@
 #include "IROperator.h"
 #include "Module.h"
 #include "Target.h"
+#include "Util.h"
 
 namespace Halide {
 
@@ -58,7 +59,17 @@ ostream &operator<<(ostream &stream, const Expr &ir) {
 }
 
 ostream &operator<<(ostream &stream, const Buffer<> &buffer) {
-    return stream << "buffer " << buffer.name() << " = {...}\n";
+    bool include_data = Internal::ends_with(buffer.name(), "_gpu_source_kernels");
+    stream << "buffer " << buffer.name() << " = {";
+    if (include_data) {
+        std::string str((const char *)buffer.data(), buffer.size_in_bytes());
+        stream << "\n"
+               << str << "\n";
+    } else {
+        stream << "...";
+    }
+    stream << "}\n";
+    return stream;
 }
 
 ostream &operator<<(ostream &stream, const Module &m) {

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -3,6 +3,7 @@
 #include "IRVisitor.h"
 #include "Module.h"
 #include "Scope.h"
+#include "Util.h"
 
 #include <cstdio>
 #include <fstream>
@@ -762,8 +763,29 @@ public:
     }
 
     void print(const Buffer<> &op) {
+        bool include_data = ends_with(op.name(), "_gpu_source_kernels");
+        int id = 0;
+        if (include_data) {
+            id = unique_id();
+            stream << open_expand_button(id);
+            stream << open_span("Matched");
+        }
         stream << open_div("Buffer<>");
         stream << keyword("buffer ") << var(op.name());
+        if (include_data) {
+            stream << " = ";
+            stream << matched("{");
+            stream << close_expand_button();
+
+            stream << open_div("BufferData", id);
+            stream << "<pre>\n";
+            std::string str((const char *)op.data(), op.size_in_bytes());
+            stream << str;
+            stream << "</pre>\n";
+            stream << close_div();
+
+            stream << " " << matched("}");
+        }
         stream << close_div();
     }
 


### PR DESCRIPTION
This works for me nicely with CUDA, OpenCL, OpenGLCompute, Direct3D12Compute, and Metal as backends. I tried collapsing the code for all of them and it works nicely. I put everything in a `<pre>` for the HTML output. Not sure if any of the backends produce non-compatible characters that might break the HTML, but for my kernels, it didn't.