### PR TITLE
HexagonOffload needs to call inject_hvx_lock_unlock() before lower_parallel_tasks()

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -451,7 +451,7 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
     body = sloppy_unpredicate_loads_and_stores(body);
 
     debug(2) << "Lowering after unpredicating loads/stores:\n"
-    //          << body << "\n\n";
+             << body << "\n\n";
 
     if (is_hvx_v65_or_later()) {
         // Generate vscatter-vgathers before optimize_hexagon_shuffles.
@@ -464,7 +464,7 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
     const int lut_alignment = 64;
     body = optimize_hexagon_shuffles(body, lut_alignment);
     debug(2) << "Lowering after optimizing shuffles:\n"
-    //          << body << "\n\n";
+             << body << "\n\n";
 
     debug(1) << "Aligning loads for HVX....\n";
     body = align_loads(body, target.natural_vector_size(Int(8)), 8);
@@ -472,14 +472,14 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
     // Don't simplify here, otherwise it will re-collapse the loads we
     // want to carry across loop iterations.
     debug(2) << "Lowering after aligning loads:\n"
-    //          << body << "\n\n";
+             << body << "\n\n";
 
     debug(1) << "Carrying values across loop iterations...\n";
     // Use at most 16 vector registers for carrying values.
     body = loop_carry(body, 16);
     body = simplify(body);
     debug(2) << "Lowering after forwarding stores:\n"
-    //          << body << "\n\n";
+             << body << "\n\n";
 
     // Optimize the IR for Hexagon.
     debug(1) << "Optimizing Hexagon instructions...\n";
@@ -2259,7 +2259,6 @@ Stmt inject_hvx_lock_unlock(Stmt body, const Target &target) {
     user_error << "hexagon not enabled for this build of Halide.\n";
     return Stmt();
 }
-
 
 #endif  // WITH_HEXAGON
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -3,6 +3,7 @@
 
 #include "AlignLoads.h"
 #include "CSE.h"
+#include "CodeGen_Hexagon.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_Posix.h"
 #include "Debug.h"
@@ -437,17 +438,6 @@ private:
     Target target;
 };
 
-Stmt inject_hvx_lock_unlock(Stmt body, const Target &target) {
-    InjectHVXLocks i(target);
-    body = i.mutate(body);
-    if (i.uses_hvx) {
-        body = acquire_hvx_context(body, target);
-    }
-    body = substitute("uses_hvx", i.uses_hvx, body);
-    body = simplify(body);
-    return body;
-}
-
 void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
                                    const string &simple_name,
                                    const string &extern_name) {
@@ -455,46 +445,48 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
 
     Stmt body = f.body;
 
-    debug(1) << "Unpredicating loads and stores...\n";
+    // debug(1) << "Unpredicating loads and stores...\n";
     // Replace dense vector predicated loads with sloppy scalarized
     // predicates, and scalarize predicated stores
     body = sloppy_unpredicate_loads_and_stores(body);
 
-    debug(2) << "Lowering after unpredicating loads/stores:\n"
-             << body << "\n\n";
+    // debug(2) << "Lowering after unpredicating loads/stores:\n"
+    //          << body << "\n\n";
 
     if (is_hvx_v65_or_later()) {
         // Generate vscatter-vgathers before optimize_hexagon_shuffles.
-        debug(1) << "Looking for vscatter-vgather...\n";
+        // debug(1) << "Looking for vscatter-vgather...\n";
         body = scatter_gather_generator(body);
     }
 
-    debug(1) << "Optimizing shuffles...\n";
+    // debug(1) << "Optimizing shuffles...\n";
     // vlut always indexes 64 bytes of the LUT at a time, even in 128 byte mode.
     const int lut_alignment = 64;
     body = optimize_hexagon_shuffles(body, lut_alignment);
-    debug(2) << "Lowering after optimizing shuffles:\n"
-             << body << "\n\n";
+    // debug(2) << "Lowering after optimizing shuffles:\n"
+    //          << body << "\n\n";
 
-    debug(1) << "Aligning loads for HVX....\n";
+    // debug(1) << "Aligning loads for HVX....\n";
     body = align_loads(body, target.natural_vector_size(Int(8)), 8);
     body = common_subexpression_elimination(body);
     // Don't simplify here, otherwise it will re-collapse the loads we
     // want to carry across loop iterations.
-    debug(2) << "Lowering after aligning loads:\n"
-             << body << "\n\n";
+    // debug(2) << "Lowering after aligning loads:\n"
+    //          << body << "\n\n";
 
-    debug(1) << "Carrying values across loop iterations...\n";
+    // debug(1) << "Carrying values across loop iterations...\n";
     // Use at most 16 vector registers for carrying values.
     body = loop_carry(body, 16);
     body = simplify(body);
-    debug(2) << "Lowering after forwarding stores:\n"
-             << body << "\n\n";
+    // debug(2) << "Lowering after forwarding stores:\n"
+    //          << body << "\n\n";
 
     // Optimize the IR for Hexagon.
-    debug(1) << "Optimizing Hexagon instructions...\n";
+    // debug(1) << "Optimizing Hexagon instructions...\n";
     body = optimize_hexagon_instructions(body, target);
 
+    debug(1) << "Before qurt_hvx_lock:\n";
+    debug(1) << body << "\n";
     debug(1) << "Adding calls to qurt_hvx_lock, if necessary...\n";
     body = inject_hvx_lock_unlock(body, target);
 
@@ -2245,12 +2237,29 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
     return std::make_unique<CodeGen_Hexagon>(target);
 }
 
+Stmt inject_hvx_lock_unlock(Stmt body, const Target &target) {
+    InjectHVXLocks i(target);
+    body = i.mutate(body);
+    if (i.uses_hvx) {
+        body = acquire_hvx_context(body, target);
+    }
+    body = substitute("uses_hvx", i.uses_hvx, body);
+    body = simplify(body);
+    return body;
+}
+
 #else  // WITH_HEXAGON
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
     user_error << "hexagon not enabled for this build of Halide.\n";
     return nullptr;
 }
+
+Stmt inject_hvx_lock_unlock(Stmt body, const Target &target) {
+    user_error << "hexagon not enabled for this build of Halide.\n";
+    return Stmt();
+}
+
 
 #endif  // WITH_HEXAGON
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -445,44 +445,44 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
 
     Stmt body = f.body;
 
-    // debug(1) << "Unpredicating loads and stores...\n";
+    debug(1) << "Unpredicating loads and stores...\n";
     // Replace dense vector predicated loads with sloppy scalarized
     // predicates, and scalarize predicated stores
     body = sloppy_unpredicate_loads_and_stores(body);
 
-    // debug(2) << "Lowering after unpredicating loads/stores:\n"
+    debug(2) << "Lowering after unpredicating loads/stores:\n"
     //          << body << "\n\n";
 
     if (is_hvx_v65_or_later()) {
         // Generate vscatter-vgathers before optimize_hexagon_shuffles.
-        // debug(1) << "Looking for vscatter-vgather...\n";
+        debug(1) << "Looking for vscatter-vgather...\n";
         body = scatter_gather_generator(body);
     }
 
-    // debug(1) << "Optimizing shuffles...\n";
+    debug(1) << "Optimizing shuffles...\n";
     // vlut always indexes 64 bytes of the LUT at a time, even in 128 byte mode.
     const int lut_alignment = 64;
     body = optimize_hexagon_shuffles(body, lut_alignment);
-    // debug(2) << "Lowering after optimizing shuffles:\n"
+    debug(2) << "Lowering after optimizing shuffles:\n"
     //          << body << "\n\n";
 
-    // debug(1) << "Aligning loads for HVX....\n";
+    debug(1) << "Aligning loads for HVX....\n";
     body = align_loads(body, target.natural_vector_size(Int(8)), 8);
     body = common_subexpression_elimination(body);
     // Don't simplify here, otherwise it will re-collapse the loads we
     // want to carry across loop iterations.
-    // debug(2) << "Lowering after aligning loads:\n"
+    debug(2) << "Lowering after aligning loads:\n"
     //          << body << "\n\n";
 
-    // debug(1) << "Carrying values across loop iterations...\n";
+    debug(1) << "Carrying values across loop iterations...\n";
     // Use at most 16 vector registers for carrying values.
     body = loop_carry(body, 16);
     body = simplify(body);
-    // debug(2) << "Lowering after forwarding stores:\n"
+    debug(2) << "Lowering after forwarding stores:\n"
     //          << body << "\n\n";
 
     // Optimize the IR for Hexagon.
-    // debug(1) << "Optimizing Hexagon instructions...\n";
+    debug(1) << "Optimizing Hexagon instructions...\n";
     body = optimize_hexagon_instructions(body, target);
 
     debug(1) << "Before qurt_hvx_lock:\n";

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -1,0 +1,17 @@
+#ifndef HALIDE_CODEGEN_HEXAGON_H
+#define HALIDE_CODEGEN_HEXAGON_H
+
+#include "Expr.h"
+
+namespace Halide {
+
+class Target;
+
+namespace Internal {
+
+Stmt inject_hvx_lock_unlock(Stmt body, const Target &target);
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/src/CodeGen_Hexagon.h
+++ b/src/CodeGen_Hexagon.h
@@ -5,7 +5,7 @@
 
 namespace Halide {
 
-class Target;
+struct Target;
 
 namespace Internal {
 

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -760,6 +760,14 @@ class InjectHexagonRpc : public IRMutator {
         debug(2) << "After inject_hvx_lock_unlock:\n"
                  << body << "\n";
 
+        // Build a closure for the device code.
+        // Note that we must do this *before* calling lower_parallel_tasks();
+        // otherwise the Closure may fail to find buffers that are referenced
+        // only in the closure.
+        // TODO: Should this move the body of the loop to Hexagon,
+        // or the loop itself? Currently, this moves the loop itself.
+        Closure c(body);
+
         std::vector<LoweredFunc> closure_implementations;
         body = lower_parallel_tasks(body, closure_implementations, hex_name, device_code.target());
         for (auto &lowered_func : closure_implementations) {


### PR DESCRIPTION
Not 100% sure this is the proper fix, but it's definitely the issue we are seeing with correctness_parallel_nested_1; the qurt_hvx_lock stuff only got injected for parallel For loops, but with the changes in factor_parallel_codegen, those are all gone by the time we hit that code. Solution here is to explicitly call inject_hvx_lock_unlock() on blocks that we are lowering as parallel tasks in HexagonOffload, but I need to convince myself we aren't inserting duplicate locks or unlocks now (or just getting lucky).