### PR TITLE
Add LinkageType::ExternalPlusArgv (#6452)

### DIFF
--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -22,6 +22,7 @@ void define_enums(py::module &m) {
     py::enum_<LinkageType>(m, "LinkageType")
         .value("External", LinkageType::External)
         .value("ExternalPlusMetadata", LinkageType::ExternalPlusMetadata)
+        .value("ExternalPlusArgv", LinkageType::ExternalPlusArgv)
         .value("Internal", LinkageType::Internal);
 
     py::enum_<LoopAlignStrategy>(m, "LoopAlignStrategy")

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1888,11 +1888,13 @@ void CodeGen_C::compile(const LoweredFunc &f, const std::map<std::string, std::s
         stream << "}\n";
     }
 
-    if (f.linkage == LinkageType::ExternalPlusMetadata) {
+    if (f.linkage == LinkageType::ExternalPlusArgv || f.linkage == LinkageType::ExternalPlusMetadata) {
         // Emit the argv version
         emit_argv_wrapper(simple_name, args);
+    }
 
-        // And also the metadata.
+    if (f.linkage == LinkageType::ExternalPlusMetadata) {
+        // Emit the metadata.
         emit_metadata_getter(simple_name, args, metadata_name_map);
     }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -168,6 +168,7 @@ llvm::GlobalValue::LinkageTypes llvm_linkage(LinkageType t) {
     return llvm::GlobalValue::ExternalLinkage;
 
     // switch (t) {
+    // case LinkageType::ExternalPlusArgv:
     // case LinkageType::ExternalPlusMetadata:
     // case LinkageType::External:
     //     return llvm::GlobalValue::ExternalLinkage;
@@ -511,13 +512,15 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
 
         // If the Func is externally visible, also create the argv wrapper and metadata.
         // (useful for calling from JIT and other machine interfaces).
-        if (f.linkage == LinkageType::ExternalPlusMetadata) {
+        if (f.linkage == LinkageType::ExternalPlusArgv || f.linkage == LinkageType::ExternalPlusMetadata) {
             llvm::Function *wrapper = add_argv_wrapper(function, names.argv_name);
-            llvm::Function *metadata_getter = embed_metadata_getter(names.metadata_name,
-                                                                    names.simple_name, f.args, input.get_metadata_name_map());
+            if (f.linkage == LinkageType::ExternalPlusMetadata) {
+                llvm::Function *metadata_getter = embed_metadata_getter(names.metadata_name,
+                                                                        names.simple_name, f.args, input.get_metadata_name_map());
 
-            if (target.has_feature(Target::Matlab)) {
-                define_matlab_wrapper(module.get(), wrapper, metadata_getter);
+                if (target.has_feature(Target::Matlab)) {
+                    define_matlab_wrapper(module.get(), wrapper, metadata_getter);
+                }
             }
         }
     }

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -846,7 +846,8 @@ class InjectHexagonRpc : public IRMutator {
             LoweredArgument arg(i.first, Argument::InputScalar, i.second, 0, ArgumentEstimates{});
             args.push_back(arg);
         }
-        device_code.append(LoweredFunc(hex_name, args, body, LinkageType::ExternalPlusMetadata));
+        // We need the _argv function but not the _metadata.
+        device_code.append(LoweredFunc(hex_name, args, body, LinkageType::ExternalPlusArgv));
 
         // Generate a call to hexagon_device_run.
         std::vector<Expr> arg_sizes;

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -365,6 +365,9 @@ ostream &operator<<(ostream &stream, const LoweredFunc &function) {
 
 std::ostream &operator<<(std::ostream &stream, const LinkageType &type) {
     switch (type) {
+    case LinkageType::ExternalPlusArgv:
+        stream << "external_plus_argv";
+        break;
     case LinkageType::ExternalPlusMetadata:
         stream << "external_plus_metadata";
         break;

--- a/src/Module.h
+++ b/src/Module.h
@@ -48,6 +48,7 @@ enum class Output {
 enum class LinkageType {
     External,              ///< Visible externally.
     ExternalPlusMetadata,  ///< Visible externally. Argument metadata and an argv wrapper are also generated.
+    ExternalPlusArgv,      ///< Visible externally. Argv wrapper is generated but *not* argument metadata.
     Internal,              ///< Not visible externally, similar to 'static' linkage in C.
 };
 


### PR DESCRIPTION
Allows us to skip generating metadata for offloaded hexagon funcs, which will never use it.