### PR TITLE
Move null check from Printer to halide_string_to_string()

### DIFF
--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -55,12 +55,7 @@ public:
     }
 
     Printer &operator<<(const char *arg) {
-        // Crashing on nullptr here is a big debugging time sink.
-        if (arg == nullptr) {
-            dst = halide_string_to_string(dst, end, "<nullptr>");
-        } else {
-            dst = halide_string_to_string(dst, end, arg);
-        }
+        dst = halide_string_to_string(dst, end, arg);
         return *this;
     }
 

--- a/src/runtime/to_string.cpp
+++ b/src/runtime/to_string.cpp
@@ -6,6 +6,10 @@ WEAK char *halide_string_to_string(char *dst, char *end, const char *arg) {
     if (dst >= end) {
         return dst;
     }
+    if (!arg) {
+        // Crashing on nullptr here is a big debugging time sink.
+        arg = "<nullptr>";
+    }
     while (true) {
         if (dst == end) {
             dst[-1] = 0;


### PR DESCRIPTION
The Printer is (currently) usually inlined into every module, so this check is repeated in multiple chunks of code. Since the goal is to avoid crashing when debugging, let's move it to halide_string_to_string() (which will catch all these, and possibly more) and save some code size.

(Further improvements in Printer code size on the way; this change seems worthy of considering separately.)