### PR TITLE
`apps/linear_algebra/benchmarks/macros.h`: don't forget SSE guard

### DIFF
--- a/apps/linear_algebra/benchmarks/macros.h
+++ b/apps/linear_algebra/benchmarks/macros.h
@@ -1,16 +1,16 @@
 #include "halide_benchmark.h"
 
 #ifdef ENABLE_FTZ_DAZ
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__i386__) || defined(__x86_64__)) && defined(__SSE__)
 #include <pmmintrin.h>
 #include <xmmintrin.h>
-#endif  // defined(__i386__) || defined(__x86_64__)
+#endif  // (defined(__i386__) || defined(__x86_64__)) && defined(__SSE__)
 #endif
 
 inline void set_math_flags() {
 #ifdef ENABLE_FTZ_DAZ
 
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__i386__) || defined(__x86_64__)) && defined(__SSE__)
     // Flush denormals to zero (the FTZ flag).
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
     // Interpret denormal inputs as zero (the DAZ flag).


### PR DESCRIPTION
This is breaking i386 build:
https://buildd.debian.org/status/fetch.php?pkg=halide&arch=i386&ver=13.0.1-3&stamp=1638786518&raw=0