### PR TITLE
Trim code size for Printer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -801,6 +801,7 @@ RUNTIME_CPP_COMPONENTS = \
   posix_threads_tsan \
   powerpc_cpu_features \
   prefetch \
+  printer \
   profiler \
   profiler_inlined \
   pseudostack \

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -125,6 +125,7 @@ DECLARE_CPP_INITMOD(posix_print)
 DECLARE_CPP_INITMOD(posix_threads)
 DECLARE_CPP_INITMOD(posix_threads_tsan)
 DECLARE_CPP_INITMOD(prefetch)
+DECLARE_CPP_INITMOD(printer)
 DECLARE_CPP_INITMOD(profiler)
 DECLARE_CPP_INITMOD(profiler_inlined)
 DECLARE_CPP_INITMOD(pseudostack)
@@ -1111,8 +1112,10 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
 
     if (module_type == ModuleJITShared || module_type == ModuleGPU) {
         modules.push_back(get_initmod_module_jit_ref_count(c, bits_64, debug));
+        modules.push_back(get_initmod_printer(c, bits_64, debug));
     } else if (module_type == ModuleAOT) {
         modules.push_back(get_initmod_module_aot_ref_count(c, bits_64, debug));
+        modules.push_back(get_initmod_printer(c, bits_64, debug));
     }
 
     if (module_type == ModuleAOT || module_type == ModuleGPU) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -711,9 +711,10 @@ std::map<Output, std::string> compile_standalone_runtime(const std::map<Output, 
 
     Module empty("standalone_runtime", t.without_feature(Target::NoRuntime).without_feature(Target::JIT));
     // For runtime, it only makes sense to output object files or static_library, so ignore
-    // everything else.
+    // everything else. (Well, LLVM IR and actual assembly can be useful for debugging and optimzation
+    // as well, so let's allow that, too.)
     std::map<Output, std::string> actual_outputs;
-    for (auto key : {Output::object, Output::static_library}) {
+    for (auto key : {Output::object, Output::static_library, Output::llvm_assembly, Output::assembly}) {
         auto it = output_files.find(key);
         if (it != output_files.end()) {
             actual_outputs[key] = it->second;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -65,6 +65,7 @@ set(RUNTIME_CPP
     posix_threads_tsan
     powerpc_cpu_features
     prefetch
+    printer
     profiler
     profiler_inlined
     pseudostack

--- a/src/runtime/printer.cpp
+++ b/src/runtime/printer.cpp
@@ -1,0 +1,134 @@
+#include "printer.h"
+#include "HalideRuntime.h"
+
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+
+static const char *const kAllocationError = "Printer buffer allocation failed.\n";
+
+WEAK PrinterBase::PrinterBase(void *ctx, char *mem, uint64_t length)
+    : user_context(ctx), length(length) {
+
+    if (mem == nullptr) {
+        mem = (char *)malloc(length);
+        mem_to_free = mem;
+    } else {
+        mem_to_free = nullptr;
+    }
+
+    dst = buf = mem;
+    if (dst) {
+        end = buf + length - 1;
+        *end = 0;
+    } else {
+        end = dst;
+    }
+}
+
+WEAK PrinterBase::PrinterBase(void *ctx)
+    : PrinterBase(ctx, nullptr, default_printer_buffer_length) {
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(const char *arg) {
+    dst = halide_string_to_string(dst, end, arg);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(int64_t arg) {
+    dst = halide_int64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(int32_t arg) {
+    dst = halide_int64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(uint64_t arg) {
+    dst = halide_uint64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(uint32_t arg) {
+    dst = halide_uint64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(double arg) {
+    dst = halide_double_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(float arg) {
+    dst = halide_double_to_string(dst, end, arg, 0);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(const void *arg) {
+    dst = halide_pointer_to_string(dst, end, arg);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::write_float16_from_bits(const uint16_t arg) {
+    double value = halide_float16_bits_to_double(arg);
+    dst = halide_double_to_string(dst, end, value, 1);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(const halide_type_t &t) {
+    dst = halide_type_to_string(dst, end, &t);
+    return *this;
+}
+
+WEAK PrinterBase &PrinterBase::operator<<(const halide_buffer_t &buf) {
+    dst = halide_buffer_to_string(dst, end, &buf);
+    return *this;
+}
+
+// Use it like a stringstream.
+WEAK const char *PrinterBase::str() {
+    if (!buf) {
+        return kAllocationError;
+    }
+
+    // This is really only needed for StringStreamPrinter, but is easier to do unconditionally
+    halide_msan_annotate_memory_is_initialized(user_context, buf, dst - buf + 1);
+    return buf;
+}
+
+// Clear it. Useful for reusing a stringstream.
+WEAK void PrinterBase::clear() {
+    dst = buf;
+    if (dst) {
+        dst[0] = 0;
+    }
+}
+
+// Delete the last N characters
+WEAK void PrinterBase::erase(int n) {
+    if (dst) {
+        dst -= n;
+        if (dst < buf) {
+            dst = buf;
+        }
+        dst[0] = 0;
+    }
+}
+
+WEAK PrinterBase::~PrinterBase() {
+    // free() is fine to call on a nullptr
+    free(mem_to_free);
+}
+
+WEAK void PrinterBase::finish_error() {
+    halide_error(user_context, str());
+}
+
+WEAK void PrinterBase::finish_print() {
+    halide_print(user_context, str());
+}
+
+}  // namespace Internal
+}  // namespace Runtime
+}  // namespace Halide

--- a/src/runtime/printer.cpp
+++ b/src/runtime/printer.cpp
@@ -7,7 +7,7 @@ namespace Internal {
 
 static const char *const kAllocationError = "Printer buffer allocation failed.\n";
 
-WEAK PrinterBase::PrinterBase(void *ctx, char *mem, uint64_t length)
+PrinterBase::PrinterBase(void *ctx, char *mem, uint64_t length)
     : user_context(ctx), length(length) {
 
     if (mem == nullptr) {
@@ -26,68 +26,68 @@ WEAK PrinterBase::PrinterBase(void *ctx, char *mem, uint64_t length)
     }
 }
 
-WEAK PrinterBase::PrinterBase(void *ctx)
+PrinterBase::PrinterBase(void *ctx)
     : PrinterBase(ctx, nullptr, default_printer_buffer_length) {
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(const char *arg) {
+PrinterBase &PrinterBase::operator<<(const char *arg) {
     dst = halide_string_to_string(dst, end, arg);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(int64_t arg) {
+PrinterBase &PrinterBase::operator<<(int64_t arg) {
     dst = halide_int64_to_string(dst, end, arg, 1);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(int32_t arg) {
+PrinterBase &PrinterBase::operator<<(int32_t arg) {
     dst = halide_int64_to_string(dst, end, arg, 1);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(uint64_t arg) {
+PrinterBase &PrinterBase::operator<<(uint64_t arg) {
     dst = halide_uint64_to_string(dst, end, arg, 1);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(uint32_t arg) {
+PrinterBase &PrinterBase::operator<<(uint32_t arg) {
     dst = halide_uint64_to_string(dst, end, arg, 1);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(double arg) {
+PrinterBase &PrinterBase::operator<<(double arg) {
     dst = halide_double_to_string(dst, end, arg, 1);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(float arg) {
+PrinterBase &PrinterBase::operator<<(float arg) {
     dst = halide_double_to_string(dst, end, arg, 0);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(const void *arg) {
+PrinterBase &PrinterBase::operator<<(const void *arg) {
     dst = halide_pointer_to_string(dst, end, arg);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::write_float16_from_bits(const uint16_t arg) {
+PrinterBase &PrinterBase::write_float16_from_bits(const uint16_t arg) {
     double value = halide_float16_bits_to_double(arg);
     dst = halide_double_to_string(dst, end, value, 1);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(const halide_type_t &t) {
+PrinterBase &PrinterBase::operator<<(const halide_type_t &t) {
     dst = halide_type_to_string(dst, end, &t);
     return *this;
 }
 
-WEAK PrinterBase &PrinterBase::operator<<(const halide_buffer_t &buf) {
+PrinterBase &PrinterBase::operator<<(const halide_buffer_t &buf) {
     dst = halide_buffer_to_string(dst, end, &buf);
     return *this;
 }
 
 // Use it like a stringstream.
-WEAK const char *PrinterBase::str() {
+const char *PrinterBase::str() {
     if (!buf) {
         return kAllocationError;
     }
@@ -98,7 +98,7 @@ WEAK const char *PrinterBase::str() {
 }
 
 // Clear it. Useful for reusing a stringstream.
-WEAK void PrinterBase::clear() {
+void PrinterBase::clear() {
     dst = buf;
     if (dst) {
         dst[0] = 0;
@@ -106,7 +106,7 @@ WEAK void PrinterBase::clear() {
 }
 
 // Delete the last N characters
-WEAK void PrinterBase::erase(int n) {
+void PrinterBase::erase(int n) {
     if (dst) {
         dst -= n;
         if (dst < buf) {
@@ -116,16 +116,16 @@ WEAK void PrinterBase::erase(int n) {
     }
 }
 
-WEAK PrinterBase::~PrinterBase() {
+PrinterBase::~PrinterBase() {
     // free() is fine to call on a nullptr
     free(mem_to_free);
 }
 
-WEAK void PrinterBase::finish_error() {
+void PrinterBase::finish_error() {
     halide_error(user_context, str());
 }
 
-WEAK void PrinterBase::finish_print() {
+void PrinterBase::finish_print() {
     halide_print(user_context, str());
 }
 


### PR DESCRIPTION
This builds on top of https://github.com/halide/Halide/pull/6472 to de-inline as much of Printer as possible, moving things into a new 'printer' runtime module using a PrinterBase class.

This is, admittedly, a pretty small improvement: comparing before-and-after on OSX for target=host shows only a ~4k reduction in object size (115k -> 111k for `runtime.o`) but adding ~~targets~~ features with more verbose error reporting and such increases the benefit (eg host-opencl gives a 179k -> 164k reduction for runtime.o).

Since ~all of the usages of Printer in runtime are for error handling, debugging, profiling, or tracing, any possible reduction in performance seems unlikely to be significant.