### PR TITLE
Document the usage of llvm::legacy::PassManager

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -639,7 +639,7 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
 
     // NOTE: use of the "legacy" PassManager here is still required; it is deprecated
     // for optimization, but is still the only complete API for codegen as of work-in-progress
-    // LLVM14. At the time of this comment, there is no firm plan as to when codegen will
+    // LLVM14. At the time of this comment (Dec 2021), there is no firm plan as to when codegen will
     // be fully available in the new PassManager, so don't worry about this 'legacy'
     // tag until there's any indication that the old APIs start breaking.
     //

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -637,6 +637,16 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     raw_svector_ostream ostream(outstr);
     ostream.SetUnbuffered();
 
+    // NOTE: use of the "legacy" PassManager here is still required; it is deprecated
+    // for optimization, but is still the only complete API for codegen as of work-in-progress
+    // LLVM14. At the time of this comment, there is no firm plan as to when codegen will
+    // be fully available in the new PassManager, so don't worry about this 'legacy'
+    // tag until there's any indication that the old APIs start breaking.
+    //
+    // See:
+    // https://lists.llvm.org/pipermail/llvm-dev/2021-April/150100.html
+    // https://releases.llvm.org/13.0.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir
+    // https://groups.google.com/g/llvm-dev/c/HoS07gXx0p8
     legacy::FunctionPassManager function_pass_manager(module.get());
     legacy::PassManager module_pass_manager;
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -363,7 +363,7 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
 
     // NOTE: use of the "legacy" PassManager here is still required; it is deprecated
     // for optimization, but is still the only complete API for codegen as of work-in-progress
-    // LLVM14. At the time of this comment, there is no firm plan as to when codegen will
+    // LLVM14. At the time of this comment (Dec 2021), there is no firm plan as to when codegen will
     // be fully available in the new PassManager, so don't worry about this 'legacy'
     // tag until there's any indication that the old APIs start breaking.
     //

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -360,6 +360,17 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
     }
 
     // Build up all of the passes that we want to do to the module.
+
+    // NOTE: use of the "legacy" PassManager here is still required; it is deprecated
+    // for optimization, but is still the only complete API for codegen as of work-in-progress
+    // LLVM14. At the time of this comment, there is no firm plan as to when codegen will
+    // be fully available in the new PassManager, so don't worry about this 'legacy'
+    // tag until there's any indication that the old APIs start breaking.
+    //
+    // See:
+    // https://lists.llvm.org/pipermail/llvm-dev/2021-April/150100.html
+    // https://releases.llvm.org/13.0.0/docs/ReleaseNotes.html#changes-to-the-llvm-ir
+    // https://groups.google.com/g/llvm-dev/c/HoS07gXx0p8
     llvm::legacy::PassManager pass_manager;
 
     pass_manager.add(new llvm::TargetLibraryInfoWrapperPass(llvm::Triple(module->getTargetTriple())));


### PR DESCRIPTION
There is some confusion about whether this usage is acceptable. TL;DR: it's not just acceptable, it's required for the forseeable future. Add comments to capture this to avoid future such questions. (With great thanks to Alina for pointing me at the relevant LLVM discussion links!)