### PR TITLE
rounding shift rights should use rounding halving add

### DIFF
--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -174,6 +174,7 @@ protected:
     IRMatcher::Wild<1> y;
     IRMatcher::Wild<2> z;
     IRMatcher::WildConst<0> c0;
+    IRMatcher::WildConst<1> c1;
 
     Expr visit(const Add *op) override {
         if (!find_intrinsics_for_type(op->type)) {
@@ -383,43 +384,129 @@ protected:
             auto is_x_same_int = op->type.is_int() && is_int(x, bits);
             auto is_x_same_uint = op->type.is_uint() && is_uint(x, bits);
             auto is_x_same_int_or_uint = is_x_same_int || is_x_same_uint;
-            // clang-format off
-            if (rewrite(max(min(widening_add(x, y), upper), lower), saturating_add(x, y), is_x_same_int_or_uint) ||
-                rewrite(max(min(widening_sub(x, y), upper), lower), saturating_sub(x, y), is_x_same_int_or_uint) ||
-                rewrite(min(cast(signed_type_wide, widening_add(x, y)), upper), saturating_add(x, y), is_x_same_uint) ||
-                rewrite(min(widening_add(x, y), upper), saturating_add(x, y), op->type.is_uint() && is_x_same_uint) ||
-                rewrite(max(widening_sub(x, y), lower), saturating_sub(x, y), op->type.is_uint() && is_x_same_uint) ||
+            if (
+                // Saturating patterns
+                rewrite(max(min(widening_add(x, y), upper), lower),
+                        saturating_add(x, y),
+                        is_x_same_int_or_uint) ||
 
-                rewrite(shift_right(widening_add(x, y), 1), halving_add(x, y), is_x_same_int_or_uint) ||
-                rewrite(shift_right(widening_sub(x, y), 1), halving_sub(x, y), is_x_same_int_or_uint) ||
+                rewrite(max(min(widening_sub(x, y), upper), lower),
+                        saturating_sub(x, y),
+                        is_x_same_int_or_uint) ||
 
-                rewrite(halving_add(widening_add(x, y), 1), rounding_halving_add(x, y), is_x_same_int_or_uint) ||
-                rewrite(halving_add(widening_add(x, 1), y), rounding_halving_add(x, y), is_x_same_int_or_uint) ||
-                rewrite(halving_add(widening_sub(x, y), 1), rounding_halving_sub(x, y), is_x_same_int_or_uint) ||
-                rewrite(rounding_shift_right(widening_add(x, y), 1), rounding_halving_add(x, y), is_x_same_int_or_uint) ||
-                rewrite(rounding_shift_right(widening_sub(x, y), 1), rounding_halving_sub(x, y), is_x_same_int_or_uint) ||
+                rewrite(min(cast(signed_type_wide, widening_add(x, y)), upper),
+                        saturating_add(x, y),
+                        is_x_same_uint) ||
 
-                rewrite(max(min(shift_right(widening_mul(x, y), z), upper), lower), mul_shift_right(x, y, cast(unsigned_type, z)), is_x_same_int_or_uint && is_uint(z)) ||
-                rewrite(max(min(rounding_shift_right(widening_mul(x, y), z), upper), lower), rounding_mul_shift_right(x, y, cast(unsigned_type, z)), is_x_same_int_or_uint && is_uint(z)) ||
-                rewrite(min(shift_right(widening_mul(x, y), z), upper), mul_shift_right(x, y, cast(unsigned_type, z)), is_x_same_uint && is_uint(z)) ||
-                rewrite(min(rounding_shift_right(widening_mul(x, y), z), upper), rounding_mul_shift_right(x, y, cast(unsigned_type, z)), is_x_same_uint && is_uint(z)) ||
+                rewrite(min(widening_add(x, y), upper),
+                        saturating_add(x, y),
+                        op->type.is_uint() && is_x_same_uint) ||
+
+                rewrite(max(widening_sub(x, y), lower),
+                        saturating_sub(x, y),
+                        op->type.is_uint() && is_x_same_uint) ||
+
+                // Averaging patterns
+                //
+                // We have a slight preference for rounding_halving_add over
+                // using halving_add when unsigned, because x86 supports it.
+
+                rewrite(shift_right(widening_add(x, c0), 1),
+                        rounding_halving_add(x, c0 - 1),
+                        c0 > 0 && is_x_same_uint) ||
+
+                rewrite(shift_right(widening_add(x, y), 1),
+                        halving_add(x, y),
+                        is_x_same_int_or_uint) ||
+
+                rewrite(shift_right(widening_add(x, c0), c1),
+                        rounding_shift_right(x, cast(op->type, c1)),
+                        c0 == shift_left(1, c1 - 1) && is_x_same_int_or_uint) ||
+
+                rewrite(shift_right(widening_add(x, c0), c1),
+                        shift_right(rounding_halving_add(x, cast(op->type, fold(c0 - 1))), cast(op->type, fold(c1 - 1))),
+                        c0 > 0 && c1 > 0 && is_x_same_uint) ||
+
+                rewrite(shift_right(widening_add(x, y), c0),
+                        shift_right(halving_add(x, y), cast(op->type, fold(c0 - 1))),
+                        c0 > 0 && is_x_same_int_or_uint) ||
+
+                rewrite(shift_right(widening_sub(x, y), 1),
+                        halving_sub(x, y),
+                        is_x_same_int_or_uint) ||
+
+                rewrite(halving_add(widening_add(x, y), 1),
+                        rounding_halving_add(x, y),
+                        is_x_same_int_or_uint) ||
+
+                rewrite(halving_add(widening_add(x, 1), y),
+                        rounding_halving_add(x, y),
+                        is_x_same_int_or_uint) ||
+
+                rewrite(halving_add(widening_sub(x, y), 1),
+                        rounding_halving_sub(x, y),
+                        is_x_same_int_or_uint) ||
+
+                rewrite(rounding_shift_right(widening_add(x, y), 1),
+                        rounding_halving_add(x, y),
+                        is_x_same_int_or_uint) ||
+
+                rewrite(rounding_shift_right(widening_sub(x, y), 1),
+                        rounding_halving_sub(x, y),
+                        is_x_same_int_or_uint) ||
+
+                // Multiply-keep-high-bits patterns.
+
+                rewrite(max(min(shift_right(widening_mul(x, y), z), upper), lower),
+                        mul_shift_right(x, y, cast(unsigned_type, z)),
+                        is_x_same_int_or_uint && is_uint(z)) ||
+
+                rewrite(max(min(rounding_shift_right(widening_mul(x, y), z), upper), lower),
+                        rounding_mul_shift_right(x, y, cast(unsigned_type, z)),
+                        is_x_same_int_or_uint && is_uint(z)) ||
+
+                rewrite(min(shift_right(widening_mul(x, y), z), upper),
+                        mul_shift_right(x, y, cast(unsigned_type, z)),
+                        is_x_same_uint && is_uint(z)) ||
+
+                rewrite(min(rounding_shift_right(widening_mul(x, y), z), upper),
+                        rounding_mul_shift_right(x, y, cast(unsigned_type, z)),
+                        is_x_same_uint && is_uint(z)) ||
+
                 // We don't need saturation for the full upper half of a multiply.
                 // For signed integers, this is almost true, except for when x and y
                 // are both the most negative value. For these, we only need saturation
                 // at the upper bound.
-                rewrite(min(shift_right(widening_mul(x, y), c0), upper), mul_shift_right(x, y, cast(unsigned_type, c0)), is_x_same_int && c0 >= bits - 1) ||
-                rewrite(min(rounding_shift_right(widening_mul(x, y), c0), upper), rounding_mul_shift_right(x, y, cast(unsigned_type, c0)), is_x_same_int && c0 >= bits - 1) ||
-                rewrite(shift_right(widening_mul(x, y), c0), mul_shift_right(x, y, cast(unsigned_type, c0)), is_x_same_int_or_uint && c0 >= bits) ||
-                rewrite(rounding_shift_right(widening_mul(x, y), c0), rounding_mul_shift_right(x, y, cast(unsigned_type, c0)), is_x_same_int_or_uint && c0 >= bits) ||
+                rewrite(min(shift_right(widening_mul(x, y), c0), upper),
+                        mul_shift_right(x, y, cast(unsigned_type, c0)),
+                        is_x_same_int && c0 >= bits - 1) ||
 
-                // We can ignore the sign of the widening subtract for halving subtracts.
-                rewrite(shift_right(cast(op_type_wide, widening_sub(x, y)), 1), halving_sub(x, y), is_x_same_int_or_uint) ||
-                rewrite(rounding_shift_right(cast(op_type_wide, widening_sub(x, y)), 1), rounding_halving_sub(x, y), is_x_same_int_or_uint) ||
+                rewrite(min(rounding_shift_right(widening_mul(x, y), c0), upper),
+                        rounding_mul_shift_right(x, y, cast(unsigned_type, c0)),
+                        is_x_same_int && c0 >= bits - 1) ||
+
+                rewrite(shift_right(widening_mul(x, y), c0),
+                        mul_shift_right(x, y, cast(unsigned_type, c0)),
+                        is_x_same_int_or_uint && c0 >= bits) ||
+
+                rewrite(rounding_shift_right(widening_mul(x, y), c0),
+                        rounding_mul_shift_right(x, y, cast(unsigned_type, c0)),
+                        is_x_same_int_or_uint && c0 >= bits) ||
+
+                // Halving subtract patterns
+                rewrite(shift_right(cast(op_type_wide, widening_sub(x, y)), 1),
+                        halving_sub(x, y),
+                        is_x_same_int_or_uint) ||
+
+                rewrite(rounding_shift_right(cast(op_type_wide, widening_sub(x, y)), 1),
+                        rounding_halving_sub(x, y),
+                        is_x_same_int_or_uint) ||
 
                 false) {
+                internal_assert(rewrite.result.type() == op->type)
+                    << "Rewrite changed type: " << Expr(op) << " -> " << rewrite.result << "\n";
                 return mutate(rewrite.result);
             }
-            // clang-format on
 
             // When the argument is a widened rounding shift, we might not need the widening.
             // When there is saturation, we can only avoid the widening if we know the shift is
@@ -763,6 +850,14 @@ Expr lower_rounding_shift_left(const Expr &a, const Expr &b) {
 }
 
 Expr lower_rounding_shift_right(const Expr &a, const Expr &b) {
+    if (is_positive_const(b)) {
+        // We can handle the rounding with an averaging instruction. We prefer
+        // the rounding average instruction (we could use either), because the
+        // non-rounding one is missing on x86.
+        Expr shift = simplify(b - 1);
+        Expr round = simplify(cast(a.type(), (1 << shift) - 1));
+        return rounding_halving_add(a, round) >> shift;
+    }
     // Shift right, then add one to the result if bits were dropped
     // (because b > 0) and the most significant dropped bit was a one.
     Expr b_positive = select(b > 0, make_one(a.type()), make_zero(a.type()));

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1483,7 +1483,48 @@ struct Intrin {
         return Expr();
     }
 
-    constexpr static bool foldable = false;
+    constexpr static bool foldable = true;
+
+    HALIDE_ALWAYS_INLINE void make_folded_const(halide_scalar_value_t &val, halide_type_t &ty, MatcherState &state) const noexcept {
+        halide_scalar_value_t arg1;
+        // Assuming the args have the same type as the intrinsic is incorrect in
+        // general. But for the intrinsics we can fold (just shifts), the LHS
+        // has the same type as the intrinsic, and we can always treat the RHS
+        // as a signed int, because we're using 64 bits for it. (TODO: Dillon,
+        // is this legit?)
+        std::get<0>(args).make_folded_const(val, ty, state);
+        halide_type_t signed_ty = ty;
+        signed_ty.code = halide_type_int;
+        std::get<1>(args).make_folded_const(arg1, signed_ty, state);
+
+        if (intrin == Call::shift_left) {
+            if (arg1.u.i64 < 0) {
+                if (ty.code == halide_type_int) {
+                    // Arithmetic shift
+                    val.u.i64 >>= -arg1.u.i64;
+                } else {
+                    // Logical shift
+                    val.u.u64 >>= -arg1.u.i64;
+                }
+            } else {
+                val.u.u64 <<= arg1.u.i64;
+            }
+        } else if (intrin == Call::shift_right) {
+            if (arg1.u.i64 > 0) {
+                if (ty.code == halide_type_int) {
+                    // Arithmetic shift
+                    val.u.i64 >>= arg1.u.i64;
+                } else {
+                    // Logical shift
+                    val.u.u64 >>= arg1.u.i64;
+                }
+            } else {
+                val.u.u64 <<= -arg1.u.i64;
+            }
+        } else {
+            internal_error << "Folding not implemented for intrinsic: " << intrin;
+        }
+    }
 
     HALIDE_ALWAYS_INLINE
     Intrin(Call::IntrinsicOp intrin, Args... args) noexcept

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -138,7 +138,7 @@ public:
                 // fast-math on (instead it uses the approximate
                 // reciprocal, a newtown rhapson step, and a
                 // multiplication by the numerator).
-                //check("divps", 2*w, f32_1 / f32_2);
+                // check("divps", 2*w, f32_1 / f32_2);
             }
 
             check(use_avx512 ? "vrsqrt*ps" : "rsqrtps", 2 * w, fast_inverse_sqrt(f32_1));
@@ -150,6 +150,13 @@ public:
             check("pavgb", 8 * w, u8((u16(u8_1) + u16(u8_2) + 1) >> 1));
             check("pavgw", 4 * w, u16((u32(u16_1) + u32(u16_2) + 1) / 2));
             check("pavgw", 4 * w, u16((u32(u16_1) + u32(u16_2) + 1) >> 1));
+
+            // Rounding right shifts should also use pavg
+            check("pavgb", 8 * w, u8((u16(u8_1) + 15) >> 4));
+            check("pavgw", 4 * w, u16((u32(u16_1) + 15) >> 4));
+            check("pavgb", 8 * w, rounding_shift_right(u8_1, 2));
+            check("pavgw", 4 * w, rounding_shift_right(u16_1, 2));
+
             check("pmaxsw", 4 * w, max(i16_1, i16_2));
             check("pminsw", 4 * w, min(i16_1, i16_2));
             check("pmaxub", 8 * w, max(u8_1, u8_2));
@@ -166,8 +173,8 @@ public:
             check("cmpltps", 2 * w, select(f32_1 < f32_2, 1.0f, 2.0f));
 
             // These get normalized to not of eq, and not of lt with the args flipped
-            //check("cmpneqps", 2*w, cast<int32_t>(f32_1 != f32_2));
-            //check("cmpleps", 2*w, cast<int32_t>(f32_1 <= f32_2));
+            // check("cmpneqps", 2*w, cast<int32_t>(f32_1 != f32_2));
+            // check("cmpleps", 2*w, cast<int32_t>(f32_1 <= f32_2));
         }
 
         // These guys get normalized to the integer versions for widths
@@ -182,8 +189,8 @@ public:
         }
 
         // These ones are not necessary, because we just flip the args and cmpltps or cmpleps
-        //check("cmpnleps", 4, select(f32_1 > f32_2, 1.0f, 2.0f));
-        //check("cmpnltps", 4, select(f32_1 >= f32_2, 1.0f, 2.0f));
+        // check("cmpnleps", 4, select(f32_1 > f32_2, 1.0f, 2.0f));
+        // check("cmpnltps", 4, select(f32_1 >= f32_2, 1.0f, 2.0f));
 
         check("shufps", 4, in_f32(2 * x));
 
@@ -199,20 +206,20 @@ public:
             check("minpd", w, min(f64_1, f64_2));
 
             check("cmpeqpd", w, select(f64_1 == f64_2, 1.0f, 2.0f));
-            //check("cmpneqpd", w, select(f64_1 != f64_2, 1.0f, 2.0f));
-            //check("cmplepd", w, select(f64_1 <= f64_2, 1.0f, 2.0f));
+            // check("cmpneqpd", w, select(f64_1 != f64_2, 1.0f, 2.0f));
+            // check("cmplepd", w, select(f64_1 <= f64_2, 1.0f, 2.0f));
             check("cmpltpd", w, select(f64_1 < f64_2, 1.0f, 2.0f));
 
             // llvm is pretty inconsistent about which ops get generated
             // for casts. We don't intend to catch these for now, so skip
             // them.
 
-            //check("cvttpd2dq", 4, i32(f64_1));
-            //check("cvtdq2pd", 4, f64(i32_1));
-            //check("cvttps2dq", 4, i32(f32_1));
-            //check("cvtdq2ps", 4, f32(i32_1));
-            //check("cvtps2pd", 4, f64(f32_1));
-            //check("cvtpd2ps", 4, f32(f64_1));
+            // check("cvttpd2dq", 4, i32(f64_1));
+            // check("cvtdq2pd", 4, f64(i32_1));
+            // check("cvttps2dq", 4, i32(f32_1));
+            // check("cvtdq2ps", 4, f32(i32_1));
+            // check("cvtps2pd", 4, f64(f32_1));
+            // check("cvtpd2ps", 4, f32(f64_1));
 
             check("paddq", w, i64_1 + i64_2);
             check("psubq", w, i64_1 - i64_2);
@@ -309,7 +316,7 @@ public:
         }
 
         // llvm doesn't distinguish between signed and unsigned multiplies
-        //check("pmuldq", 4, i64(i32_1) * i64(i32_2));
+        // check("pmuldq", 4, i64(i32_1) * i64(i32_2));
 
         if (use_sse41) {
             for (int w = 2; w <= 4; w++) {
@@ -375,8 +382,8 @@ public:
             check("vsubps*ymm", 8, f32_1 - f32_2);
             check("vsubpd*ymm", 4, f64_1 - f64_2);
             // LLVM no longer generates division instruction when fast-math is on
-            //check("vdivps", 8, f32_1 / f32_2);
-            //check("vdivpd", 4, f64_1 / f64_2);
+            // check("vdivps", 8, f32_1 / f32_2);
+            // check("vdivpd", 4, f64_1 / f64_2);
             check("vminps*ymm", 8, min(f32_1, f32_2));
             check("vminpd*ymm", 4, min(f64_1, f64_2));
             check("vmaxps*ymm", 8, max(f32_1, f32_2));
@@ -385,12 +392,12 @@ public:
             check("vroundpd*ymm", 4, round(f64_1));
 
             check("vcmpeqpd*ymm", 4, select(f64_1 == f64_2, 1.0f, 2.0f));
-            //check("vcmpneqpd", 4, select(f64_1 != f64_2, 1.0f, 2.0f));
-            //check("vcmplepd", 4, select(f64_1 <= f64_2, 1.0f, 2.0f));
+            // check("vcmpneqpd", 4, select(f64_1 != f64_2, 1.0f, 2.0f));
+            // check("vcmplepd", 4, select(f64_1 <= f64_2, 1.0f, 2.0f));
             check("vcmpltpd*ymm", 4, select(f64_1 < f64_2, 1.0f, 2.0f));
             check("vcmpeqps*ymm", 8, select(f32_1 == f32_2, 1.0f, 2.0f));
-            //check("vcmpneqps", 8, select(f32_1 != f32_2, 1.0f, 2.0f));
-            //check("vcmpleps", 8, select(f32_1 <= f32_2, 1.0f, 2.0f));
+            // check("vcmpneqps", 8, select(f32_1 != f32_2, 1.0f, 2.0f));
+            // check("vcmpleps", 8, select(f32_1 <= f32_2, 1.0f, 2.0f));
             check("vcmpltps*ymm", 8, select(f32_1 < f32_2, 1.0f, 2.0f));
 
             // avx512 can do predicated mov ops instead of blends
@@ -1223,7 +1230,7 @@ public:
             check(arm32 ? "vqrshrun.s64" : "sqrshrun", 2 * w, u32_sat((i64_1 + 8) / 16));
             check(arm32 ? "vqrshrn.u16" : "uqrshrn", 8 * w, u8(min((u32(u16_1) + 8) / 16, max_u8)));
             check(arm32 ? "vqrshrn.u32" : "uqrshrn", 4 * w, u16(min((u64(u32_1) + 8) / 16, max_u16)));
-            //check(arm32 ? "vqrshrn.u64" : "uqrshrn", 2 * w, u32(min((u64_1 + 8) / 16, max_u32)));
+            // check(arm32 ? "vqrshrn.u64" : "uqrshrn", 2 * w, u32(min((u64_1 + 8) / 16, max_u32)));
 
             // VQSHL    I       -       Saturating Shift Left
             check(arm32 ? "vqshl.s8" : "sqshl", 8 * w, i8_sat(i16(i8_1) * 16));
@@ -1266,7 +1273,7 @@ public:
             check(arm32 ? "vraddhn.i32" : "raddhn", 4 * w, i16((i32_1 + i32_2 + 32768) >> 16));
             check(arm32 ? "vraddhn.i32" : "raddhn", 4 * w, u16((u64(u32_1 + u32_2) + 32768) >> 16));
             check(arm32 ? "vraddhn.i64" : "raddhn", 2 * w, i32((i64_1 + i64_2 + (Expr(int64_t(1)) << 31)) >> 32));
-            //check(arm32 ? "vraddhn.i64" : "raddhn", 2 * w, u32((u128(u64_1) + u64_2 + (Expr(uint64_t(1)) << 31)) >> 32));
+            // check(arm32 ? "vraddhn.i64" : "raddhn", 2 * w, u32((u128(u64_1) + u64_2 + (Expr(uint64_t(1)) << 31)) >> 32));
 
             // VRECPE   I, F    -       Reciprocal Estimate
             check(arm32 ? "vrecpe.f32" : "frecpe", 2 * w, fast_inverse(f32_1));
@@ -1335,7 +1342,7 @@ public:
             check(arm32 ? "vrshrn.i64" : "rshrn", 2 * w, i32((i64_1 + 8) >> 4));
             check(arm32 ? "vrshrn.i16" : "rshrn", 8 * w, u8((u32(u16_1) + 128) >> 8));
             check(arm32 ? "vrshrn.i32" : "rshrn", 4 * w, u16((u64(u32_1) + 1024) >> 11));
-            //check(arm32 ? "vrshrn.i64" : "rshrn", 2 * w, u32((u64_1 + 64) >> 7));
+            // check(arm32 ? "vrshrn.i64" : "rshrn", 2 * w, u32((u64_1 + 64) >> 7));
 
             // VRSQRTE  I, F    -       Reciprocal Square Root Estimate
             check(arm32 ? "vrsqrte.f32" : "frsqrte", 4 * w, fast_inverse_sqrt(f32_1));
@@ -1357,7 +1364,7 @@ public:
             check(arm32 ? "vrsubhn.i32" : "rsubhn", 4 * w, i16((i32_1 - i32_2 + 32768) >> 16));
             check(arm32 ? "vrsubhn.i32" : "rsubhn", 4 * w, u16((u64(u32_1 - u32_2) + 32768) >> 16));
             check(arm32 ? "vrsubhn.i64" : "rsubhn", 2 * w, i32((i64_1 - i64_2 + (Expr(int64_t(1)) << 31)) >> 32));
-            //check(arm32 ? "vrsubhn.i64" : "rsubhn", 2 * w, u32((u64_1 - u64_2 + (Expr(uint64_t(1)) << 31)) >> 32));
+            // check(arm32 ? "vrsubhn.i64" : "rsubhn", 2 * w, u32((u64_1 - u64_2 + (Expr(uint64_t(1)) << 31)) >> 32));
 
             // VSHL     I       -       Shift Left
             check(arm32 ? "vshl.i8" : "shl", 8 * w, i8_1 * 16);
@@ -1592,7 +1599,7 @@ public:
         Expr u32_1 = in_u32(x), u32_2 = in_u32(x + 16), u32_3 = in_u32(x + 32);
         Expr i64_1 = in_i64(x), i64_2 = in_i64(x + 16), i64_3 = in_i64(x + 32);
         Expr u64_1 = in_u64(x), u64_2 = in_u64(x + 16), u64_3 = in_u64(x + 32);
-        //Expr bool_1 = (f32_1 > 0.3f), bool_2 = (f32_1 < -0.3f), bool_3 = (f32_1 != -0.34f);
+        // Expr bool_1 = (f32_1 > 0.3f), bool_2 = (f32_1 < -0.3f), bool_3 = (f32_1 != -0.34f);
 
         // Basic AltiVec SIMD instructions.
         for (int w = 1; w <= 4; w++) {


### PR DESCRIPTION
On x86 currently we lower cast<uint8_t>((cast<uint16_t>(x) + 8) / 16)
to:

cast<uint8_t>(shift_right(widening_add(x, 8), 4))

This compiles to 8 instructions on x86: Widen each half of the input
vector, add 8 to each half-vector, shift each half-vector, then narrow
each half-vector.

First, this should have been a rounding_shift_right. Some patterns were
missing in FindIntrinsics.

Second, rounding_shift_right had suboptimal codegen in the case where
the second arg is a positive const. On archs without a rounding shift
right instruction you can further rewrite this to:

shift_right(rounding_halving_add(x, 7), 3)

which is just two instructions on x86.