### PR TITLE
Sketch of partial fix for #6474

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1177,6 +1177,9 @@ enum halide_error_code_t {
     /** An explicit storage bound provided is too small to store
      * all the values produced by the function. */
     halide_error_code_storage_bound_too_small = -45,
+
+    /** Catch-all internal error code used by the runtime. */
+    halide_error_code_runtime_internal = -46,
 };
 
 /** Halide calls the functions below on various error conditions. The
@@ -1251,6 +1254,8 @@ extern int halide_error_device_dirty_with_no_device_support(void *user_context, 
 extern int halide_error_storage_bound_too_small(void *user_context, const char *func_name, const char *var_name,
                                                 int provided_size, int required_size);
 extern int halide_error_device_crop_failed(void *user_context);
+extern int halide_error_runtime_internal(void *user_context);
+extern int halide_error_runtime_internal_verbose(void *user_context, const char *msg);
 // @}
 
 /** Optional features a compilation Target can have.

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -65,7 +65,7 @@ ALWAYS_INLINE T get_cuda_symbol(void *user_context, const char *name, bool optio
     T s = (T)halide_cuda_get_symbol(user_context, name);
     if (!optional && !s) {
         (void)_halide_runtime_error(user_context, "CUDA API not found: ", name);
-        return (T)0;
+        // fall thru and return s, which is nullptr
     }
     return s;
 }
@@ -367,7 +367,7 @@ WEAK CUresult create_cuda_context(void *user_context, CUcontext *ctx) {
         debug(user_context) << "      " << name << "\n";
 
         if (err != CUDA_SUCCESS) {
-            (void) _halide_runtime_error(user_context, "CUDA: cuDeviceGetName failed: ", get_error_name(err));
+            (void)_halide_runtime_error(user_context, "CUDA: cuDeviceGetName failed: ", get_error_name(err));
             return err;
         }
 
@@ -376,7 +376,7 @@ WEAK CUresult create_cuda_context(void *user_context, CUcontext *ctx) {
         debug(user_context) << "      total memory: " << (int)(memory >> 20) << " MB\n";
 
         if (err != CUDA_SUCCESS) {
-            (void) _halide_runtime_error(user_context, "CUDA: cuDeviceTotalMem failed: ", get_error_name(err));
+            (void)_halide_runtime_error(user_context, "CUDA: cuDeviceTotalMem failed: ", get_error_name(err));
             return err;
         }
 
@@ -774,6 +774,7 @@ WEAK int halide_cuda_device_malloc(void *user_context, halide_buffer_t *buf) {
     halide_abort_if_false(user_context, size != 0);
     if (buf->device) {
         // This buffer already has a device allocation
+        // TODO: should we really abort here? Can't we just return an error?
         halide_abort_if_false(user_context, validate_device_pointer(user_context, buf, size));
         return 0;
     }

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -291,4 +291,14 @@ WEAK int halide_error_device_crop_failed(void *user_context) {
     return halide_error_code_device_crop_failed;
 }
 
+WEAK int halide_error_runtime_internal(void *user_context) {
+    error(user_context) << "Halide Runtime Error.\n";
+    return halide_error_code_runtime_internal;
+}
+
+WEAK int halide_error_runtime_internal_verbose(void *user_context, const char *msg) {
+    error(user_context) << "Halide Runtime Error: " << msg << ".\n";
+    return halide_error_code_runtime_internal;
+}
+
 }  // extern "C"

--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -237,6 +237,22 @@ using StackErrorPrinter = StackPrinter<ErrorPrinterType, buffer_length>;
 template<uint64_t buffer_length = default_printer_buffer_length>
 using StackStringStreamPrinter = StackPrinter<StringStreamPrinterType, buffer_length>;
 
+#ifdef DEBUG_RUNTIME
+
+template<typename... Args>
+inline int _halide_runtime_error_impl(void *user_context, Args &&...args) {
+    stringstream s(user_context);
+    (s << ... << args);  // C++17 right fold
+    return halide_error_runtime_internal_verbose(user_context, s.str());
+}
+#define _halide_runtime_error(user_context, ...) (_halide_runtime_error_impl((user_context), __VA_ARGS__))
+
+#else
+
+#define _halide_runtime_error(user_context, ...) (halide_error_runtime_internal((user_context)))
+
+#endif
+
 }  // namespace Internal
 }  // namespace Runtime
 }  // namespace Halide

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -81,6 +81,8 @@ WEAK void halide_print(void *user_context, const char *msg);
 WEAK void halide_error(void *user_context, const char *msg);
 WEAK void (*halide_set_custom_print(void (*print)(void *, const char *)))(void *, const char *);
 WEAK void (*halide_set_error_handler(void (*handler)(void *, const char *)))(void *, const char *);
+WEAK int halide_error_runtime_internal(void *user_context);
+WEAK int halide_error_runtime_internal_verbose(void *user_context, const char *msg);
 
 char *getenv(const char *);
 void free(void *);


### PR DESCRIPTION
This makes an assumption that ~all of the calls to `error()` in the runtime have descriptive text that is generally only useful for developers, and leaving this text in release builds is of limited-to-no-use. On that assumption:
-Add a new "runtime internal" error code that is a catch-all for these cases
- Add a new `_halide_runtime_error()` error function, which is a smart wrapper that discards all its arguments in non-debug runtimes
- Convert runtime/cuda.cpp as a proof-of-concept of possible code savings. On My OSX box, `bin/host-cuda/runtime.a` is 174128 bytes at current top-of-tree, 163160 bytes with this PR in place. Extending this to the rest of runtime would likely get us down to ~140k if the estimates in #6474 are correct.

Note #1: You could achieve (nearly) the same thing by just changing `error()` to be special-case for DEBUG_RUNTIME, but this formulation is (IMHO) slightly cleaner, since it also allows us to return the error result directly, rather than requiring two statements. It also provides a good excuse to do a once-over of all existing usage, which is probably worthwhile.

- As mentioned above, it basically drops useful text on the floor for release builds, on the assumption that developers can use a debug-runtime build for more details; this may be a terrible assumption. Thoughts?

- This PR makes no attempt to address the really-quite-loose bounds on what can be returned; e.g. there are lots of places we just return a Cuda error where (technically) a halide_error_code_t is expected; this doesn't seem to ever have been a real problem in practice, but it makes my spidey-sense tingle.