### PR TITLE
Make random faster by putting the innermost var last

### DIFF
--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -82,6 +82,10 @@ Expr random_int(const vector<Expr> &e) {
                                rng32(Variable::make(UInt(32), name)));
         }
     }
+    // The low bytes of this have a poor period, so mix in the high bytes for
+    // two additional instructions.
+    result = result ^ (result >> 16);
+
     return result;
 }
 

--- a/src/Random.cpp
+++ b/src/Random.cpp
@@ -101,7 +101,9 @@ class LowerRandom : public IRMutator {
     Expr visit(const Call *op) override {
         if (op->is_intrinsic(Call::random)) {
             vector<Expr> args = op->args;
-            args.insert(args.end(), extra_args.begin(), extra_args.end());
+            // Insert the free vars in reverse, so innermost vars typically end
+            // up last.
+            args.insert(args.end(), extra_args.rbegin(), extra_args.rend());
             if (op->type == Float(32)) {
                 return random_float(args);
             } else if (op->type == Int(32)) {
@@ -121,7 +123,6 @@ class LowerRandom : public IRMutator {
 
 public:
     LowerRandom(const vector<VarOrRVar> &free_vars, int tag) {
-        extra_args.emplace_back(tag);
         for (const VarOrRVar &v : free_vars) {
             if (v.is_rvar) {
                 extra_args.push_back(v.rvar);
@@ -129,6 +130,7 @@ public:
                 extra_args.push_back(v.var);
             }
         }
+        extra_args.emplace_back(tag);
     }
 };
 

--- a/src/Simplify_Mul.cpp
+++ b/src/Simplify_Mul.cpp
@@ -69,12 +69,16 @@ Expr Simplify::visit(const Mul *op, ExprInfo *bounds) {
         }
 
         if (rewrite(c0 * c1, fold(c0 * c1)) ||
-            rewrite((x + c0) * c1, x * c1 + fold(c0 * c1), !overflows(c0 * c1)) ||
-            rewrite((c0 - x) * c1, x * fold(-c1) + fold(c0 * c1), !overflows(c0 * c1)) ||
+            rewrite((x + c0) * (x + c1), x * (x + fold(c0 + c1)) + fold(c0 * c1)) ||
+            rewrite((x * c0 + c1) * (x + c2), x * (x * c0 + fold(c1 + c0 * c2)) + fold(c1 * c2)) ||
+            rewrite((x + c2) * (x * c0 + c1), x * (x * c0 + fold(c1 + c0 * c2)) + fold(c1 * c2)) ||
+            rewrite((x * c0 + c1) * (x * c2 + c3), x * (x * fold(c0 * c2) + fold(c0 * c3 + c1 * c2)) + fold(c1 * c3)) ||
+            rewrite((x + c0) * c1, x * c1 + fold(c0 * c1)) ||
+            rewrite((c0 - x) * c1, x * fold(-c1) + fold(c0 * c1)) ||
             rewrite((0 - x) * y, 0 - x * y) ||
             rewrite(x * (0 - y), 0 - x * y) ||
             rewrite((x - y) * c0, (y - x) * fold(-c0), c0 < 0 && -c0 > 0) ||
-            rewrite((x * c0) * c1, x * fold(c0 * c1), !overflows(c0 * c1)) ||
+            rewrite((x * c0) * c1, x * fold(c0 * c1)) ||
             rewrite((x * c0) * y, (x * y) * c0, !is_const(y)) ||
             rewrite(x * (y * c0), (x * y) * c0) ||
             rewrite(max(x, y) * min(x, y), x * y) ||

--- a/test/correctness/async_device_copy.cpp
+++ b/test/correctness/async_device_copy.cpp
@@ -9,9 +9,9 @@ Expr expensive_zero(Expr x, Expr y, Expr t, int n) {
     RDom r(0, n);
     Func a, b, c;
     Var z;
-    a(x, y, t, z) = random_int() % 1024;
-    b(x, y, t, z) = random_int() % 1024;
-    c(x, y, t, z) = random_int() % 1024;
+    a(x, y, t, z) = random_int() % 1024 + 5;
+    b(x, y, t, z) = random_int() % 1024 + 5;
+    c(x, y, t, z) = random_int() % 1024 + 5;
     return sum(select(pow(a(x, y, t, r), 3) + pow(b(x, y, t, r), 3) == pow(c(x, y, t, r), 3), 1, 0));
 }
 

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -130,7 +130,7 @@ void check_casts() {
 
     check(cast(Float(64), 0.5f), Expr(0.5));
     check((x - cast(Float(64), 0.5f)) * (x - cast(Float(64), 0.5f)),
-          (x + Expr(-0.5)) * (x + Expr(-0.5)));
+          (cast(Float(64), x) + Expr(-1.0)) * cast(Float(64), x) + Expr(0.25));
 
     check(cast(Int(64, 3), ramp(5.5f, 2.0f, 3)),
           cast(Int(64, 3), ramp(5.5f, 2.0f, 3)));


### PR DESCRIPTION
40% faster, and I fixed the issue where the low bits of our noise have a low period. This combined with #6506 makes it possible to generate low-bit-width-noise very cheaply for things like dithering.