### PR TITLE
free shape storage last

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -995,8 +995,8 @@ public:
      * this is the last reference to it. Will assert fail if there are
      * weak references to this Buffer outstanding. */
     ~Buffer() {
-        free_shape_storage();
         decref();
+        free_shape_storage();
     }
 
     /** Get a pointer to the raw halide_buffer_t this wraps. */


### PR DESCRIPTION
Some decref-triggered runtime methods need the shape

Fixes #6509