### PR TITLE
[NFC-ish] Finish MSAN handling (Refs. #6513)

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1171,6 +1171,9 @@ void CodeGen_LLVM::optimize_module() {
         });
     }
 
+    // Target::MSAN handling is sprinkled throughout the codebase,
+    // there is no need to run MemorySanitizerPass here.
+
     if (get_target().has_feature(Target::TSAN)) {
         pb.registerOptimizerLastEPCallback(
             [](ModulePassManager &mpm, OptimizationLevel level) {
@@ -1182,6 +1185,9 @@ void CodeGen_LLVM::optimize_module() {
     for (auto &function : *module) {
         if (get_target().has_feature(Target::ASAN)) {
             function.addFnAttr(Attribute::SanitizeAddress);
+        }
+        if (get_target().has_feature(Target::MSAN)) {
+            function.addFnAttr(Attribute::SanitizeMemory);
         }
         if (get_target().has_feature(Target::TSAN)) {
             // Do not annotate any of Halide's low-level synchronization code as it has


### PR DESCRIPTION
Somehow, initially i missed that there was MSan support,
so it might be good to actually mention that we don't need to run
any MSan passes here, and that we didn't forget to run them.

Secondly, it seems inconsistent not annotate the functions
with `Attribute::SanitizeMemory`, like we do for others.

I suppose it isn't strictly required, since they are used
to actually drive the instrumentation passes, and we don't
run MSan pass, but they are also used to disable some LLVM optimizations,
and that //might// be important. Or not, but then i suppose
there should be a comment about it?

Let me know if i should replace the second change with a comment too.