### PR TITLE
Fix weird CMake issue with custom LLVM

### DIFF
--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -101,7 +101,7 @@ add_library(Halide_LLVM INTERFACE)
 add_library(Halide::LLVM ALIAS Halide_LLVM)
 
 set_target_properties(Halide_LLVM PROPERTIES EXPORT_NAME LLVM)
-target_include_directories(Halide_LLVM INTERFACE $<BUILD_INTERFACE:${LLVM_INCLUDE_DIRS}>)
+target_include_directories(Halide_LLVM INTERFACE "$<BUILD_INTERFACE:${LLVM_INCLUDE_DIRS}>")
 target_compile_definitions(Halide_LLVM INTERFACE ${Halide_LLVM_DEFS})
 
 # Link LLVM libraries to Halide_LLVM, depending on shared, static, or bundled selection.


### PR DESCRIPTION
Without this, cmake fails with:
```
CMake Error in dependencies/llvm/CMakeLists.txt:
  Target "Halide_LLVM" INTERFACE_INCLUDE_DIRECTORIES property contains path:

    "/repositories/halide/dependencies/llvm/"

  which is prefixed in the source directory.
```

`LLVM_INCLUDE_DIRS` there is `/repositories/llvm-project/llvm/include;/builddirs/llvm-project/build-Clang13/include`,
and `INTERFACE_INCLUDE_DIRECTORIES`'s property beforehand is `` (empty),
but after this line it suddenly becomes `/repositories/halide/dependencies/llvm/$<BUILD_INTERFACE:/repositories/llvm-project/llvm/include;/builddirs/llvm-project/build-Clang13/include>`.

This is quite obscure. I don't really understand what is going on,
but with the patch it builds fine.