### PR TITLE
If cmake built a python module, teach cmake to install the python module

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -46,6 +46,18 @@ foreach (dep IN ITEMS Halide_LLVM Halide_wabt)
 endforeach ()
 
 ##
+# Python bindings
+##
+
+if (WITH_PYTHON_BINDINGS)
+    set(Halide_INSTALL_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}/python3/site-packages"
+        CACHE STRING "Path to Halide Python bindings folder")
+    install(TARGETS Halide_Python
+            LIBRARY DESTINATION ${Halide_INSTALL_PYTHONDIR} COMPONENT Halide_Python
+            NAMELINK_COMPONENT Halide_Python)
+endif ()
+
+##
 # Library-type-agnostic interface targets
 ##
 


### PR DESCRIPTION
CMake can build the python module, but it's ignored during `make install`.  This teaches cmake to install it, if it was built.

The cmake `FindPython3` module makes some distutils calls to figure out where modules should go, and exposes those as cmake vars.  Specifically, [Python3_STDLIB, Python3_STDARCH, Python3_SITELIB, Python3_SITEARCH](https://cmake.org/cmake/help/v3.15/module/FindPython3.html#result-variables) give us the various cases of "python3/" vs "python3.x", and "dist-modules" vs "site-modules".

This patch uses `Python3_SITEARCH` by default, which maps to `/usr/lib/python3.9/site-packages/` for me on debian linux.  The var `Halide_INSTALL_PYTHONDIR` can be used to override that.  The intention is for distro packaging to point that wherever it needs to go.
