### PR TITLE
Install Python tutorials

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -141,6 +141,14 @@ if (WITH_TUTORIALS)
             PATTERN "*.jpg"
             PATTERN "*.mp4"
             PATTERN "*.png")
+
+    if (WITH_PYTHON_BINDINGS)
+      install(DIRECTORY ${Halide_SOURCE_DIR}/python_bindings/tutorial/
+              DESTINATION ${CMAKE_INSTALL_DOCDIR}/tutorial-python
+              COMPONENT Halide_Documentation
+              FILES_MATCHING
+              PATTERN "*.py")
+    endif ()
 endif ()
 
 ##

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -146,8 +146,7 @@ if (WITH_TUTORIALS)
       install(DIRECTORY ${Halide_SOURCE_DIR}/python_bindings/tutorial/
               DESTINATION ${CMAKE_INSTALL_DOCDIR}/tutorial-python
               COMPONENT Halide_Documentation
-              FILES_MATCHING
-              PATTERN "*.py")
+              FILES_MATCHING PATTERN "*.py")
     endif ()
 endif ()
 


### PR DESCRIPTION
I know we have previously discussed that `TYPE DOC` should be used,
but unfortunately i'm not sure that will work here,
because doc/tutorial directory is already occupied by C++ tutorials,
and i don't think they should be mixed.
I'm open to alternative suggestions.