### PR TITLE
Backport build and stability changes to v13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 
 # Build Halide with ccache if the package is present
 option(Halide_CCACHE_BUILD "Set to ON for a ccache enabled build" OFF)
+mark_as_advanced(Halide_CCACHE_BUILD)
 if (Halide_CCACHE_BUILD)
     find_program(CCACHE_PROGRAM ccache)
     if (CCACHE_PROGRAM)
@@ -58,6 +59,7 @@ if (Halide_CCACHE_BUILD)
         # if issues occur (but we don't use any of the time macros so should be irrelevant).
         set(Halide_CCACHE_PARAMS CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines
             CACHE STRING "Parameters to pass through to ccache")
+        mark_as_advanced(Halide_CCACHE_PARAMS)
         set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})
         set(CMAKE_CXX_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env ${Halide_CCACHE_PARAMS} ${CCACHE_PROGRAM})
         message(STATUS "Enabling ccache usage for building.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.20)
 project(Halide
-        VERSION 13.0.2
+        VERSION 13.0.3
         DESCRIPTION "Halide compiler and libraries"
         HOMEPAGE_URL "https://halide-lang.org")
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you've acquired a full source distribution and want to build Halide, see the
 
 ## Binary tarballs
 
-The latest version of Halide is **Halide 13.0.2**. We provide binary releases
+The latest version of Halide is **Halide 13.0.3**. We provide binary releases
 for many popular platforms and architectures, including 32/64-bit x86 Windows,
 64-bit macOS, and 32/64-bit x86/ARM Ubuntu Linux. See the releases tab on the
 right (or click [here](https://github.com/halide/Halide/releases/tag/v13.0.1)).

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -30,6 +30,7 @@ The following sections cover each in detail.
     - [Imported targets](#imported-targets)
     - [Functions](#functions)
       - [`add_halide_library`](#add_halide_library)
+      - [`add_halide_generator`](#add_halide_generator)
 - [Contributing CMake code to Halide](#contributing-cmake-code-to-halide)
   - [General guidelines and best practices](#general-guidelines-and-best-practices)
     - [Prohibited commands list](#prohibited-commands-list)
@@ -358,35 +359,42 @@ following are the most consequential and control how Halide is actually
 compiled.
 
 | Option                                   | Default               | Description                                                                                                      |
-| ---------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+|------------------------------------------|-----------------------|------------------------------------------------------------------------------------------------------------------|
 | [`BUILD_SHARED_LIBS`][build_shared_libs] | `ON`                  | Standard CMake variable that chooses whether to build as a static or shared library.                             |
 | `Halide_BUNDLE_LLVM`                     | `OFF`                 | When building Halide as a static library, unpack the LLVM static libraries and add those objects to libHalide.a. |
 | `Halide_SHARED_LLVM`                     | `OFF`                 | Link to the shared version of LLVM. Not available on Windows.                                                    |
 | `Halide_ENABLE_RTTI`                     | _inherited from LLVM_ | Enable RTTI when building Halide. Recommended to be set to `ON`                                                  |
-| `Halide_CLANG_TIDY_BUILD`                | `OFF`                 | Used internally to generate fake compile jobs for runtime files when running clang-tidy.                         |
 | `Halide_ENABLE_EXCEPTIONS`               | `ON`                  | Enable exceptions when building Halide                                                                           |
-| `Halide_USE_CODEMODEL_LARGE`             | `OFF`                 | Use the Large LLVM codemodel                                                                                     |
 | `Halide_TARGET`                          | _empty_               | The default target triple to use for `add_halide_library` (and the generator tests, by extension)                |
-| `Halide_CCACHE_BUILD`                    | `OFF`                 | Use ccache to accelerate rebuilds.                                                                               |
+
+The following options are _advanced_ and should not be required in typical workflows. Generally, these are used by
+Halide's own CI infrastructure, or as escape hatches for third-party packagers.
+
+| Option                      | Default                                                            | Description                                                                              |
+|-----------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| `Halide_CLANG_TIDY_BUILD`   | `OFF`                                                              | Used internally to generate fake compile jobs for runtime files when running clang-tidy. |
+| `Halide_CCACHE_BUILD`       | `OFF`                                                              | Use ccache with Halide-recommended settings to accelerate rebuilds.                      |
+| `Halide_CCACHE_PARAMS`      | `CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines` | Options to pass to `ccache` when using `Halide_CCACHE_BUILD`.                            | 
+| `Halide_SOVERSION_OVERRIDE` | `${Halide_VERSION_MAJOR}`                                          | Override the SOVERSION for libHalide. Expects a positive integer (i.e. not a version).   |
 
 The following options are only available when building Halide directly, ie. not
 through the [`add_subdirectory`][add_subdirectory] or
 [`FetchContent`][fetchcontent] mechanisms. They control whether non-essential
 targets (like tests and documentation) are built.
 
-| Option                 | Default              | Description                                                                              |
-| ---------------------- | -------------------- | ---------------------------------------------------------------------------------------- |
-| `WITH_TESTS`           | `ON`                 | Enable building unit and integration tests                                               |
-| `WITH_PYTHON_BINDINGS` | `ON` if Python found | Enable building Python 3.x bindings                                                      |
-| `WITH_DOCS`            | `OFF`                | Enable building the documentation via Doxygen                                            |
-| `WITH_UTILS`           | `ON`                 | Enable building various utilities including the trace visualizer                         |
-| `WITH_TUTORIALS`       | `ON`                 | Enable building the tutorials                                                            |
+| Option                 | Default              | Description                                                      |
+|------------------------|----------------------|------------------------------------------------------------------|
+| `WITH_TESTS`           | `ON`                 | Enable building unit and integration tests                       |
+| `WITH_PYTHON_BINDINGS` | `ON` if Python found | Enable building Python 3.x bindings                              |
+| `WITH_DOCS`            | `OFF`                | Enable building the documentation via Doxygen                    |
+| `WITH_UTILS`           | `ON`                 | Enable building various utilities including the trace visualizer |
+| `WITH_TUTORIALS`       | `ON`                 | Enable building the tutorials                                    |
 
 The following options control whether to build certain test subsets. They only
 apply when `WITH_TESTS=ON`:
 
 | Option                    | Default | Description                       |
-| ------------------------- | ------- | --------------------------------- |
+|---------------------------|---------|-----------------------------------|
 | `WITH_TEST_AUTO_SCHEDULE` | `ON`    | enable the auto-scheduling tests  |
 | `WITH_TEST_CORRECTNESS`   | `ON`    | enable the correctness tests      |
 | `WITH_TEST_ERROR`         | `ON`    | enable the expected-error tests   |
@@ -397,23 +405,23 @@ apply when `WITH_TESTS=ON`:
 The following options enable/disable various LLVM backends (they correspond to
 LLVM component names):
 
-| Option               | Default              | Description                                              |
-| -------------------- | -------------------- | -------------------------------------------------------- |
-| `TARGET_AARCH64`     | `ON`, _if available_ | Enable the AArch64 backend                               |
-| `TARGET_AMDGPU`      | `ON`, _if available_ | Enable the AMD GPU backend                               |
-| `TARGET_ARM`         | `ON`, _if available_ | Enable the ARM backend                                   |
-| `TARGET_HEXAGON`     | `ON`, _if available_ | Enable the Hexagon backend                               |
-| `TARGET_MIPS`        | `ON`, _if available_ | Enable the MIPS backend                                  |
-| `TARGET_NVPTX`       | `ON`, _if available_ | Enable the NVidia PTX backend                            |
-| `TARGET_POWERPC`     | `ON`, _if available_ | Enable the PowerPC backend                               |
-| `TARGET_RISCV`       | `ON`, _if available_ | Enable the RISC V backend                                |
-| `TARGET_WEBASSEMBLY` | `ON`, _if available_ | Enable the WebAssembly backend. Only valid for LLVM 11+. |
-| `TARGET_X86`         | `ON`, _if available_ | Enable the x86 (and x86_64) backend                      |
+| Option               | Default              | Description                         |
+|----------------------|----------------------|-------------------------------------|
+| `TARGET_AARCH64`     | `ON`, _if available_ | Enable the AArch64 backend          |
+| `TARGET_AMDGPU`      | `ON`, _if available_ | Enable the AMD GPU backend          |
+| `TARGET_ARM`         | `ON`, _if available_ | Enable the ARM backend              |
+| `TARGET_HEXAGON`     | `ON`, _if available_ | Enable the Hexagon backend          |
+| `TARGET_MIPS`        | `ON`, _if available_ | Enable the MIPS backend             |
+| `TARGET_NVPTX`       | `ON`, _if available_ | Enable the NVidia PTX backend       |
+| `TARGET_POWERPC`     | `ON`, _if available_ | Enable the PowerPC backend          |
+| `TARGET_RISCV`       | `ON`, _if available_ | Enable the RISC V backend           |
+| `TARGET_WEBASSEMBLY` | `ON`, _if available_ | Enable the WebAssembly backend.     |
+| `TARGET_X86`         | `ON`, _if available_ | Enable the x86 (and x86_64) backend |
 
 The following options enable/disable various Halide-specific backends:
 
 | Option                | Default | Description                            |
-| --------------------- | ------- | -------------------------------------- |
+|-----------------------|---------|----------------------------------------|
 | `TARGET_OPENCL`       | `ON`    | Enable the OpenCL-C backend            |
 | `TARGET_METAL`        | `ON`    | Enable the Metal backend               |
 | `TARGET_D3D12COMPUTE` | `ON`    | Enable the Direct3D 12 Compute backend |
@@ -422,7 +430,7 @@ The following options are WebAssembly-specific. They only apply when
 `TARGET_WEBASSEMBLY=ON`:
 
 | Option            | Default | Description                                                |
-| ----------------- | ------- | ---------------------------------------------------------- |
+|-------------------|---------|------------------------------------------------------------|
 | `WITH_WABT`       | `ON`    | Include WABT Interpreter for WASM testing                  |
 | `WITH_WASM_SHELL` | `ON`    | Download a wasm shell (e.g. d8) for testing AOT wasm code. |
 
@@ -441,7 +449,7 @@ First, Halide expects to find LLVM and Clang through the `CONFIG` mode of
 the corresponding `_DIR` variables:
 
 | Variable    | Description                                    |
-| ----------- | ---------------------------------------------- |
+|-------------|------------------------------------------------|
 | `LLVM_DIR`  | `$LLVM_ROOT/lib/cmake/LLVM/LLVMConfig.cmake`   |
 | `Clang_DIR` | `$LLVM_ROOT/lib/cmake/Clang/ClangConfig.cmake` |
 
@@ -456,7 +464,7 @@ using the [`FindCUDAToolkit`][findcudatoolkit] module. If it doesn't find your
 CUDA installation automatically, you can point it to it by setting:
 
 | Variable           | Description                                       |
-| ------------------ | ------------------------------------------------- |
+|--------------------|---------------------------------------------------|
 | `CUDAToolkit_ROOT` | Path to the directory containing `bin/nvcc[.exe]` |
 | `CUDA_PATH`        | _Environment_ variable, same as above.            |
 
@@ -471,7 +479,7 @@ modules will be used to link AOT generated binaries. These modules can be
 overridden by setting the following variables:
 
 | Variable                | Description                      |
-| ----------------------- | -------------------------------- |
+|-------------------------|----------------------------------|
 | `OPENGL_egl_LIBRARY`    | Path to the EGL library.         |
 | `OPENGL_glu_LIBRARY`    | Path to the GLU library.         |
 | `OPENGL_glx_LIBRARY`    | Path to the GLVND GLX library.   |
@@ -486,7 +494,7 @@ Halide also searches for `libpng` and `libjpeg-turbo` through the
 be overridden by setting the following variables.
 
 | Variable            | Description                                        |
-| ------------------- | -------------------------------------------------- |
+|---------------------|----------------------------------------------------|
 | `PNG_LIBRARIES`     | Paths to the libraries to link against to use PNG. |
 | `PNG_INCLUDE_DIRS`  | Path to `png.h`, etc.                              |
 | `JPEG_LIBRARIES`    | Paths to the libraries needed to use JPEG.         |
@@ -497,7 +505,7 @@ When `WITH_DOCS` is set to `ON`, Halide searches for Doxygen using the
 following variable.
 
 | Variable             | Description                     |
-| -------------------- | ------------------------------- |
+|----------------------|---------------------------------|
 | `DOXYGEN_EXECUTABLE` | Path to the Doxygen executable. |
 
 When compiling for an OpenCL target, Halide uses the [`FindOpenCL`][findopencl]
@@ -505,7 +513,7 @@ target to locate the libraries and include paths. These can be overridden by
 setting the following variables:
 
 | Variable              | Description                                           |
-| --------------------- | ----------------------------------------------------- |
+|-----------------------|-------------------------------------------------------|
 | `OpenCL_LIBRARIES`    | Paths to the libraries to link against to use OpenCL. |
 | `OpenCL_INCLUDE_DIRS` | Include directories for OpenCL.                       |
 
@@ -515,7 +523,7 @@ like other projects you might have encountered. You can select which Python
 installation to use by setting the following variable.
 
 | Variable           | Description                                           |
-| ------------------ | ----------------------------------------------------- |
+|--------------------|-------------------------------------------------------|
 | `Python3_ROOT_DIR` | Define the root directory of a Python 3 installation. |
 
 # Using Halide from your CMake build
@@ -745,28 +753,29 @@ try the static libs first then fall back to the shared libs.
 Variables that control package loading:
 
 | Variable             | Description                                                                                                                                                                   |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Halide_SHARED_LIBS` | override `BUILD_SHARED_LIBS` when loading the Halide package via `find_package`. Has no effect when using Halide via `add_subdirectory` as a Git or `FetchContent` submodule. |
 
 Variables set by the package:
 
-| Variable                   | Description                                                      |
-| -------------------------- | ---------------------------------------------------------------- |
-| `Halide_VERSION`           | The full version string of the loaded Halide package             |
-| `Halide_VERSION_MAJOR`     | The major version of the loaded Halide package                   |
-| `Halide_VERSION_MINOR`     | The minor version of the loaded Halide package                   |
-| `Halide_VERSION_PATCH`     | The patch version of the loaded Halide package                   |
-| `Halide_VERSION_TWEAK`     | The tweak version of the loaded Halide package                   |
-| `Halide_HOST_TARGET`       | The Halide target triple corresponding to "host" for this build. |
-| `Halide_ENABLE_EXCEPTIONS` | Whether Halide was compiled with exception support               |
-| `Halide_ENABLE_RTTI`       | Whether Halide was compiled with RTTI                            |
+| Variable                   | Description                                                        |
+|----------------------------|--------------------------------------------------------------------|
+| `Halide_VERSION`           | The full version string of the loaded Halide package               |
+| `Halide_VERSION_MAJOR`     | The major version of the loaded Halide package                     |
+| `Halide_VERSION_MINOR`     | The minor version of the loaded Halide package                     |
+| `Halide_VERSION_PATCH`     | The patch version of the loaded Halide package                     |
+| `Halide_VERSION_TWEAK`     | The tweak version of the loaded Halide package                     |
+| `Halide_HOST_TARGET`       | The Halide target triple corresponding to "host" for this build.   |
+| `Halide_CMAKE_TARGET`      | The Halide target triple corresponding to the active CMake target. |
+| `Halide_ENABLE_EXCEPTIONS` | Whether Halide was compiled with exception support                 |
+| `Halide_ENABLE_RTTI`       | Whether Halide was compiled with RTTI                              |
 
 ### Imported targets
 
 Halide defines the following targets that are available to users:
 
 | Imported target      | Description                                                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `Halide::Halide`     | this is the JIT-mode library to use when using Halide from C++.                                                                      |
 | `Halide::Generator`  | this is the target to use when defining a generator executable. It supplies a `main()` function.                                     |
 | `Halide::Runtime`    | adds include paths to the Halide runtime headers                                                                                     |
@@ -776,15 +785,16 @@ Halide defines the following targets that are available to users:
 
 The following targets are not guaranteed to be available:
 
-| Imported target   | Description                                                                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `Halide::Python`  | this is a Python 3 module that can be referenced as `$<TARGET_FILE:Halide::Python>` when setting up Python tests or the like from CMake. |
-| `Halide::Adams19` | the Adams et.al. 2019 autoscheduler (no GPU support)                                                                                     |
-| `Halide::Li18`    | the Li et.al. 2018 gradient autoscheduler (limited GPU support)                                                                          |
+| Imported target         | Description                                                                                                                              |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `Halide::Python`        | this is a Python 3 module that can be referenced as `$<TARGET_FILE:Halide::Python>` when setting up Python tests or the like from CMake. |
+| `Halide::Adams19`       | the Adams et.al. 2019 autoscheduler (no GPU support)                                                                                     |
+| `Halide::Li18`          | the Li et.al. 2018 gradient autoscheduler (limited GPU support)                                                                          |
+| `Halide::Mullapudi2016` | the Mullapudi et.al. 2016 autoscheduler (no GPU support)                                                                                 |
 
 ### Functions
 
-Currently, only one function is defined:
+Currently, only two functions are defined:
 
 #### `add_halide_library`
 
@@ -887,6 +897,42 @@ which a path (relative to
 [`CMAKE_CURRENT_BINARY_DIR`][cmake_current_binary_dir]) to the extra file will
 be written.
 
+#### `add_halide_generator`
+
+This function aids in creating cross-compilable builds that use Halide generators.
+
+```
+add_halide_generator(
+    target
+    [PACKAGE_NAME package-name]
+    [PACKAGE_NAMESPACE namespace]
+    [EXPORT_FILE export-file]
+    [[SOURCES] source1 ...]
+)
+```
+
+Every named argument is optional, and the function uses the following default arguments:
+
+* If `PACKAGE_NAME` is not provided, it defaults to `${PROJECT_NAME}-halide_generators`.
+* If `PACKAGE_NAMESPACE` is not provided, it defaults to `${PROJECT_NAME}::halide_generators::`.
+* If `EXPORT_FILE` is not provided, it defaults to `${PROJECT_BINARY_DIR}/cmake/${ARG_PACKAGE_NAME}-config.cmake`
+
+The `SOURCES` keyword marks the beginning of sources to be used to build `<target>`, if it is not loaded. All unparsed
+arguments will be interpreted as sources.
+
+This function guarantees that a Halide generator target named `<namespace><target>` is available. It will first search
+for a package named `<package-name>` using `find_package`; if it is found, it is assumed that it provides the target.
+Otherwise, it will create an executable target named `target` and an `ALIAS` target `<namespace><target>`. This function
+also creates a custom target named `<package-name>` if it does not exist and `<target>` would exist. In this case,
+`<package-name>` will depend on `<target>`, this enables easy building of _just_ the Halide generators managed by this
+function.
+
+After the call, `<PACKAGE_NAME>_FOUND` will be set to true if the host generators were imported (and hence won't be
+built). Otherwise, it will be set to false. This variable may be used to conditionally set properties on `<target>`.
+
+Please see [test/integration/xc](https://github.com/halide/Halide/tree/master/test/integration/xc) for a simple example
+and [apps/hannk](https://github.com/halide/Halide/tree/master/apps/hannk) for a complete app that uses it extensively.
+
 ## Cross compiling
 
 Cross-compiling in CMake can be tricky, since CMake doesn't easily support
@@ -895,6 +941,28 @@ build. Unfortunately, Halide generator executables are just about always
 designed to run on the host platform. Each project will be set up differently
 and have different requirements, but here are some suggestions for effective use
 of CMake in these scenarios.
+
+### Use `add_halide_generator`
+
+If you are writing new programs that use Halide, you might wish to use our
+helper, `add_halide_generator`. When using this helper, you are expected to
+build your project twice: once for your build host and again for your intended
+target.
+
+When building the host build, you can use the `<package-name>` (see the
+documentation above) target to build _just_ the generators. Then, in the
+target build, set `<package-name>_ROOT` to the host build directory.
+
+For example:
+
+```
+$ cmake -G Ninja -S . -B build-host -DCMAKE_BUILD_TYPE=Release
+$ cmake --build build-host --target <package-name>
+$ cmake -G Ninja -S . -B build-target -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=/path/to/target-tc.cmake \
+    -D<package-name>_ROOT:FILEPATH=$PWD/build-host
+$ cmake --build build-target
+```
 
 ### Use a super-build
 
@@ -909,6 +977,8 @@ project would be configured with the target [toolchain][cmake-toolchains] and
 would call `add_halide_library` with no `TARGETS` option and set `FROM` equal to
 the name of the imported generator executable. Obviously, this is a significant
 increase in complexity over a typical CMake project.
+
+This is very compatible with the `add_halide_generator` strategy above. 
 
 ### Use `ExternalProject` directly
 
@@ -996,7 +1066,7 @@ As mentioned above, using directory properties is brittle and they are therefore
 _not allowed_. The following functions may not appear in any new CMake code.
 
 | Command                             | Alternative                                                                                        |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------- |
+|-------------------------------------|----------------------------------------------------------------------------------------------------|
 | `add_compile_definitions`           | Use [`target_compile_definitions`][target_compile_definitions]                                     |
 | `add_compile_options`               | Use [`target_compile_options`][target_compile_options]                                             |
 | `add_definitions`                   | Use [`target_compile_definitions`][target_compile_definitions]                                     |
@@ -1043,7 +1113,7 @@ If common properties need to be grouped together, use an INTERFACE target
 disallowed for other reasons:
 
 | Command                         | Reason                                                                            | Alternative                                                                            |
-| ------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+|---------------------------------|-----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
 | `aux_source_directory`          | Interacts poorly with incremental builds and Git                                  | List source files explicitly                                                           |
 | `build_command`                 | CTest internal function                                                           | Use CTest build-and-test mode via [`CMAKE_CTEST_COMMAND`][cmake_ctest_command]         |
 | `cmake_host_system_information` | Usually misleading information.                                                   | Inspect [toolchain][cmake-toolchains] variables and use generator expressions.         |
@@ -1072,7 +1142,7 @@ or should not be overridden for our end-users. The following (non-exhaustive)
 list of variables shall not be used in code merged into master.
 
 | Variable                        | Reason                                        | Alternative                                                                                             |
-| ------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+|---------------------------------|-----------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | `CMAKE_ROOT`                    | Code smell                                    | Rely on `find_package` search options; include `HINTS` if necessary                                     |
 | `CMAKE_DEBUG_TARGET_PROPERTIES` | Debugging helper                              | None                                                                                                    |
 | `CMAKE_FIND_DEBUG_MODE`         | Debugging helper                              | None                                                                                                    |
@@ -1097,7 +1167,7 @@ remove them before review. Finally, the following variables are allowed, but
 their use must be motivated:
 
 | Variable                                       | Reason                                              | Alternative                                                                                  |
-| ---------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+|------------------------------------------------|-----------------------------------------------------|----------------------------------------------------------------------------------------------|
 | [`CMAKE_SOURCE_DIR`][cmake_source_dir]         | Points to global source root, not Halide's.         | [`Halide_SOURCE_DIR`][project-name_source_dir] or [`PROJECT_SOURCE_DIR`][project_source_dir] |
 | [`CMAKE_BINARY_DIR`][cmake_binary_dir]         | Points to global build root, not Halide's           | [`Halide_BINARY_DIR`][project-name_binary_dir] or [`PROJECT_BINARY_DIR`][project_binary_dir] |
 | [`CMAKE_MAKE_PROGRAM`][cmake_make_program]     | CMake abstracts over differences in the build tool. | Prefer CTest's build and test mode or CMake's `--build` mode                                 |

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -98,7 +98,7 @@ add_library(Halide_LLVM INTERFACE)
 add_library(Halide::LLVM ALIAS Halide_LLVM)
 
 set_target_properties(Halide_LLVM PROPERTIES EXPORT_NAME LLVM)
-target_include_directories(Halide_LLVM INTERFACE $<BUILD_INTERFACE:${LLVM_INCLUDE_DIRS}>)
+target_include_directories(Halide_LLVM INTERFACE "$<BUILD_INTERFACE:${LLVM_INCLUDE_DIRS}>")
 target_compile_definitions(Halide_LLVM INTERFACE ${Halide_LLVM_DEFS})
 
 # Link LLVM libraries to Halide_LLVM, depending on shared, static, or bundled selection.

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -46,6 +46,18 @@ foreach (dep IN ITEMS Halide_LLVM Halide_wabt)
 endforeach ()
 
 ##
+# Python bindings
+##
+
+if (WITH_PYTHON_BINDINGS)
+    set(Halide_INSTALL_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}/python3/site-packages"
+        CACHE STRING "Path to Halide Python bindings folder")
+    install(TARGETS Halide_Python
+            LIBRARY DESTINATION ${Halide_INSTALL_PYTHONDIR} COMPONENT Halide_Python
+            NAMELINK_COMPONENT Halide_Python)
+endif ()
+
+##
 # Library-type-agnostic interface targets
 ##
 

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -140,6 +140,13 @@ if (WITH_TUTORIALS)
             PATTERN "*.jpg"
             PATTERN "*.mp4"
             PATTERN "*.png")
+
+    if (WITH_PYTHON_BINDINGS)
+      install(DIRECTORY ${Halide_SOURCE_DIR}/python_bindings/tutorial/
+              DESTINATION ${CMAKE_INSTALL_DOCDIR}/tutorial-python
+              COMPONENT Halide_Documentation
+              FILES_MATCHING PATTERN "*.py")
+    endif ()
 endif ()
 
 ##

--- a/python_bindings/src/PyError.cpp
+++ b/python_bindings/src/PyError.cpp
@@ -10,6 +10,7 @@ void halide_python_error(void *, const char *msg) {
 }
 
 void halide_python_print(void *, const char *msg) {
+    py::gil_scoped_acquire acquire;
     py::print(msg, py::arg("end") = "");
 }
 

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -117,6 +117,7 @@ void define_func(py::module &m) {
             .def(
                 "realize",
                 [](Func &f, Buffer<> buffer, const Target &target) -> void {
+                    py::gil_scoped_release release;
                     f.realize(buffer, target);
                 },
                 py::arg("dst"), py::arg("target") = Target())
@@ -125,6 +126,7 @@ void define_func(py::module &m) {
             .def(
                 "realize",
                 [](Func &f, std::vector<Buffer<>> buffers, const Target &t) -> void {
+                    py::gil_scoped_release release;
                     f.realize(Realization(buffers), t);
                 },
                 py::arg("dst"), py::arg("target") = Target())
@@ -132,7 +134,12 @@ void define_func(py::module &m) {
             .def(
                 "realize",
                 [](Func &f, const std::vector<int32_t> &sizes, const Target &target) -> py::object {
-                    return realization_to_object(f.realize(sizes, target));
+                    std::optional<Realization> r;
+                    {
+                        py::gil_scoped_release release;
+                        r = std::move(f.realize(sizes, target));
+                    }
+                    return realization_to_object(*r);
                 },
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
 

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -137,7 +137,7 @@ void define_func(py::module &m) {
                     std::optional<Realization> r;
                     {
                         py::gil_scoped_release release;
-                        r = std::move(f.realize(sizes, target));
+                        r = f.realize(sizes, target);
                     }
                     return realization_to_object(*r);
                 },

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -96,6 +96,7 @@ void define_pipeline(py::module &m) {
 
             .def(
                 "realize", [](Pipeline &p, Buffer<> buffer, const Target &target) -> void {
+                    py::gil_scoped_release release;
                     p.realize(Realization(buffer), target);
                 },
                 py::arg("dst"), py::arg("target") = Target())
@@ -103,13 +104,19 @@ void define_pipeline(py::module &m) {
             // This will actually allow a list-of-buffers as well as a tuple-of-buffers, but that's OK.
             .def(
                 "realize", [](Pipeline &p, std::vector<Buffer<>> buffers, const Target &t) -> void {
+                    py::gil_scoped_release release;
                     p.realize(Realization(buffers), t);
                 },
                 py::arg("dst"), py::arg("target") = Target())
 
             .def(
                 "realize", [](Pipeline &p, std::vector<int32_t> sizes, const Target &target) -> py::object {
-                    return realization_to_object(p.realize(std::move(sizes), target));
+                    std::optional<Realization> r;
+                    {
+                        py::gil_scoped_release release;
+                        r = std::move(p.realize(std::move(sizes), target));
+                    }
+                    return realization_to_object(*r);
                 },
                 py::arg("sizes") = std::vector<int32_t>{}, py::arg("target") = Target())
 

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -114,7 +114,7 @@ void define_pipeline(py::module &m) {
                     std::optional<Realization> r;
                     {
                         py::gil_scoped_release release;
-                        r = std::move(p.realize(std::move(sizes), target));
+                        r = p.realize(std::move(sizes), target);
                     }
                     return realization_to_object(*r);
                 },

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -381,10 +381,14 @@ target_export_script(Halide
                      APPLE_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.osx"
                      GNU_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.ldscript")
 
+set(Halide_SOVERSION_OVERRIDE "${Halide_VERSION_MAJOR}"
+    CACHE STRING "SOVERSION to set for custom Halide packaging")
+mark_as_advanced(Halide_SOVERSION_OVERRIDE)
+
 set_target_properties(Halide PROPERTIES
                       POSITION_INDEPENDENT_CODE ON
                       VERSION ${Halide_VERSION}
-                      SOVERSION ${Halide_VERSION_MAJOR})
+                      SOVERSION ${Halide_SOVERSION_OVERRIDE})
 
 target_include_directories(Halide INTERFACE "$<BUILD_INTERFACE:${Halide_BINARY_DIR}/include>")
 add_dependencies(Halide HalideIncludes)

--- a/src/ClampUnsafeAccesses.cpp
+++ b/src/ClampUnsafeAccesses.cpp
@@ -50,7 +50,7 @@ protected:
             }
         }
 
-        ScopedValue s(is_inside_indexing, true);
+        ScopedValue<bool> s(is_inside_indexing, true);
         return IRMutator::visit(call);
     }
 
@@ -60,7 +60,7 @@ private:
         ScopedBinding<bool> binding(let_var_inside_indexing, let->name, false);
         Body body = mutate(let->body);
 
-        ScopedValue s(is_inside_indexing, is_inside_indexing || let_var_inside_indexing.get(let->name));
+        ScopedValue<bool> s(is_inside_indexing, is_inside_indexing || let_var_inside_indexing.get(let->name));
         Expr value = mutate(let->value);
 
         return L::make(let->name, std::move(value), std::move(body));

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1198,6 +1198,9 @@ void CodeGen_LLVM::optimize_module() {
 #endif
     }
 
+    // Target::MSAN handling is sprinkled throughout the codebase,
+    // there is no need to run MemorySanitizerPass here.
+
     if (get_target().has_feature(Target::TSAN)) {
         pb.registerOptimizerLastEPCallback(
             [](ModulePassManager &mpm, OptimizationLevel level) {
@@ -1209,6 +1212,9 @@ void CodeGen_LLVM::optimize_module() {
     for (auto &function : *module) {
         if (get_target().has_feature(Target::ASAN)) {
             function.addFnAttr(Attribute::SanitizeAddress);
+        }
+        if (get_target().has_feature(Target::MSAN)) {
+            function.addFnAttr(Attribute::SanitizeMemory);
         }
         if (get_target().has_feature(Target::TSAN)) {
             // Do not annotate any of Halide's low-level synchronization code as it has

--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -347,7 +347,9 @@ void PythonExtensionGen::compile(const LoweredFunc &f) {
             // Python already converted this.
         }
     }
-    dest << "    int result = " << f.name << "(";
+    dest << "    int result;\n";
+    dest << "    Py_BEGIN_ALLOW_THREADS\n";
+    dest << "    result = " << f.name << "(";
     for (size_t i = 0; i < args.size(); i++) {
         if (i > 0) {
             dest << ", ";
@@ -359,6 +361,7 @@ void PythonExtensionGen::compile(const LoweredFunc &f) {
         }
     }
     dest << ");\n";
+    dest << "    Py_END_ALLOW_THREADS\n";
     release_buffers();
     dest << R"INLINE_CODE(
     if (result != 0) {

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -197,8 +197,9 @@ class RollFunc : public IRMutator {
         if (loops_to_rebase.count(op->name)) {
             string new_name = op->name + ".rebased";
             Stmt body = substitute(op->name, Variable::make(Int(32), new_name) + op->min, op->body);
-            result = For::make(new_name, 0, op->extent, op->for_type, op->device_api, body);
+            // use op->name *before* the re-assignment of result, which will clobber it
             loops_to_rebase.erase(op->name);
+            result = For::make(new_name, 0, op->extent, op->for_type, op->device_api, body);
         }
         return result;
     }

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -78,7 +78,7 @@ Target calculate_host_target() {
     int bits = use_64_bits ? 64 : 32;
     std::vector<Target::Feature> initial_features;
 
-#if __riscv__
+#if __riscv
     Target::Arch arch = Target::RISCV;
 #else
 #if __mips__ || __mips || __MIPS__

--- a/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
+++ b/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
@@ -3377,9 +3377,6 @@ struct Mullapudi2016 {
         results.target = target;
         results.machine_params_string = arch_params.to_string();
 
-        user_assert(target.arch == Target::X86 || target.arch == Target::ARM ||
-                    target.arch == Target::POWERPC || target.arch == Target::MIPS)
-            << "The Mullapudi2016 autoscheduler is not supported for the target: " << target.to_string();
         results.scheduler_name = "Mullapudi2016";
         std::vector<Function> pipeline_outputs;
         for (const Func &f : pipeline.outputs()) {

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -165,6 +165,9 @@ set(RUNTIME_CXX_FLAGS
     -Wsign-compare
 )
 
+option(Halide_CLANG_TIDY_BUILD "Generate fake compile jobs for runtime files when running clang-tidy." OFF)
+mark_as_advanced(Halide_CLANG_TIDY_BUILD)
+
 foreach (i IN LISTS RUNTIME_CPP)
     foreach (j IN ITEMS 32 64)
         # -fpic needs special treatment; see below on windows 64bits

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -991,8 +991,8 @@ public:
      * this is the last reference to it. Will assert fail if there are
      * weak references to this Buffer outstanding. */
     ~Buffer() {
-        free_shape_storage();
         decref();
+        free_shape_storage();
     }
 
     /** Get a pointer to the raw halide_buffer_t this wraps. */

--- a/test/correctness/indexing_access_undef.cpp
+++ b/test/correctness/indexing_access_undef.cpp
@@ -8,33 +8,59 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Var x{"x"};
+    {
+        Func f{"f"}, g{"g"}, h{"h"}, out{"out"};
 
-    Func f{"f"}, g{"g"}, h{"h"}, out{"out"};
+        const int min = -10000000;
+        const int max = min + 20;
 
-    const int min = -10000000;
-    const int max = min + 20;
+        h(x) = clamp(x, min, max);
+        // Within its compute bounds, h's value will be within
+        // [min,max]. Outside that, it's uninitialized memory.
 
-    h(x) = clamp(x, min, max);
-    // Within its compute bounds, h's value will be within
-    // [min,max]. Outside that, it's uninitialized memory.
+        g(x) = sin(x);
+        // Halide thinks g will be accessed within [min,max], so its
+        // allocation bounds will be [min,max]
 
-    g(x) = sin(x);
-    // Halide thinks g will be accessed within [min,max], so its
-    // allocation bounds will be [min,max]
+        f(x) = g(h(x));
+        f.vectorize(x, 64, TailStrategy::RoundUp);
+        // f will access h at values outside its compute bounds, and get
+        // garbage, and then use that garbage to access g outside its
+        // allocation bounds.
 
-    f(x) = g(h(x));
-    f.vectorize(x, 64, TailStrategy::RoundUp);
-    // f will access h at values outside its compute bounds, and get
-    // garbage, and then use that garbage to access g outside its
-    // allocation bounds.
+        out(x) = f(x);
 
-    out(x) = f(x);
+        h.compute_root();
+        g.compute_root();
+        f.compute_root();
 
-    h.compute_root();
-    g.compute_root();
-    f.compute_root();
+        out.realize({1});
+    }
 
-    out.realize({1});
+    {
+        // A similar test, but with an input image, harvested from a real
+        // failure in the wild.
+        Buffer<uint8_t> input(1024);
+
+        Func f;
+        f(x) = clamp(12345234 / x, input.dim(0).min(), input.dim(0).max()) - 1234567890;
+
+        Func g;
+        // If f(x) is zero, this will read *way* outside of bounds.
+        g(x) = input(f(x) + 1234567890);
+
+        Func h;
+        h(x) = g(x);
+
+        f.compute_root();
+        h.vectorize(x, 8, TailStrategy::GuardWithIf);
+        // Massively over-compute g
+        g.compute_at(h, x).bound_extent(x, 1024);
+
+        h.realize({1024});
+    }
+
+    // No crash means success
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
Backport the following PRs:

* #6503 
* #6352 (dependency)
* #6508 
* #6520 
* #6519 
* #6527 
* #6511 
* #6516 
* #6530 
* #6525 
* #6523 
* #6537
* #6534
* #6535

These are the PRs requested by @LebedevRI for the sake of Debian packaging, plus a handful of small stability-related changes I thought would be nice to include.

Also bumps version number to v13.0.3