### PR TITLE
Allow third parties to externally override SOVERSION

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -385,10 +385,14 @@ target_export_script(Halide
                      APPLE_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.osx"
                      GNU_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.ldscript")
 
+set(Halide_SOVERSION_OVERRIDE "${Halide_VERSION_MAJOR}"
+    CACHE STRING "SOVERSION to set for custom Halide packaging")
+mark_as_advanced(Halide_SOVERSION_OVERRIDE)
+
 set_target_properties(Halide PROPERTIES
                       POSITION_INDEPENDENT_CODE ON
                       VERSION ${Halide_VERSION}
-                      SOVERSION ${Halide_VERSION_MAJOR})
+                      SOVERSION ${Halide_SOVERSION_OVERRIDE})
 
 target_include_directories(Halide INTERFACE "$<BUILD_INTERFACE:${Halide_BINARY_DIR}/include>")
 add_dependencies(Halide HalideIncludes)


### PR DESCRIPTION
Debian and other third-party packagers might need or want to patch our sources for a variety of reasons. In those cases, they might also need to override the SOVERSION.

See here for a practical example:

https://salsa.debian.org/pkg-llvm-team/halide/-/blob/f881de70cd83095053e13047b63f61faf6bc7a36/debian/patches/0006-Fixup-libhalide-version-soversion-for-debian-package.patch

ATTN @LebedevRI 