### PR TITLE
Remove unnecessary `std::move` calls

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -137,7 +137,7 @@ void define_func(py::module &m) {
                     std::optional<Realization> r;
                     {
                         py::gil_scoped_release release;
-                        r = std::move(f.realize(sizes, target));
+                        r = f.realize(sizes, target);
                     }
                     return realization_to_object(*r);
                 },

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -114,7 +114,7 @@ void define_pipeline(py::module &m) {
                     std::optional<Realization> r;
                     {
                         py::gil_scoped_release release;
-                        r = std::move(p.realize(std::move(sizes), target));
+                        r = p.realize(std::move(sizes), target);
                     }
                     return realization_to_object(*r);
                 },


### PR DESCRIPTION
Compilers with `-Werror` will fail with `error: moving a temporary object prevents copy elision`