### PR TITLE
Revert "Make random faster by putting the innermost var last"

### DIFF
--- a/src/Simplify_Mul.cpp
+++ b/src/Simplify_Mul.cpp
@@ -69,16 +69,12 @@ Expr Simplify::visit(const Mul *op, ExprInfo *bounds) {
         }
 
         if (rewrite(c0 * c1, fold(c0 * c1)) ||
-            rewrite((x + c0) * (x + c1), x * (x + fold(c0 + c1)) + fold(c0 * c1)) ||
-            rewrite((x * c0 + c1) * (x + c2), x * (x * c0 + fold(c1 + c0 * c2)) + fold(c1 * c2)) ||
-            rewrite((x + c2) * (x * c0 + c1), x * (x * c0 + fold(c1 + c0 * c2)) + fold(c1 * c2)) ||
-            rewrite((x * c0 + c1) * (x * c2 + c3), x * (x * fold(c0 * c2) + fold(c0 * c3 + c1 * c2)) + fold(c1 * c3)) ||
-            rewrite((x + c0) * c1, x * c1 + fold(c0 * c1)) ||
-            rewrite((c0 - x) * c1, x * fold(-c1) + fold(c0 * c1)) ||
+            rewrite((x + c0) * c1, x * c1 + fold(c0 * c1), !overflows(c0 * c1)) ||
+            rewrite((c0 - x) * c1, x * fold(-c1) + fold(c0 * c1), !overflows(c0 * c1)) ||
             rewrite((0 - x) * y, 0 - x * y) ||
             rewrite(x * (0 - y), 0 - x * y) ||
             rewrite((x - y) * c0, (y - x) * fold(-c0), c0 < 0 && -c0 > 0) ||
-            rewrite((x * c0) * c1, x * fold(c0 * c1)) ||
+            rewrite((x * c0) * c1, x * fold(c0 * c1), !overflows(c0 * c1)) ||
             rewrite((x * c0) * y, (x * y) * c0, !is_const(y)) ||
             rewrite(x * (y * c0), (x * y) * c0) ||
             rewrite(max(x, y) * min(x, y), x * y) ||

--- a/test/correctness/async_device_copy.cpp
+++ b/test/correctness/async_device_copy.cpp
@@ -9,9 +9,9 @@ Expr expensive_zero(Expr x, Expr y, Expr t, int n) {
     RDom r(0, n);
     Func a, b, c;
     Var z;
-    a(x, y, t, z) = random_int() % 1024 + 5;
-    b(x, y, t, z) = random_int() % 1024 + 5;
-    c(x, y, t, z) = random_int() % 1024 + 5;
+    a(x, y, t, z) = random_int() % 1024;
+    b(x, y, t, z) = random_int() % 1024;
+    c(x, y, t, z) = random_int() % 1024;
     return sum(select(pow(a(x, y, t, r), 3) + pow(b(x, y, t, r), 3) == pow(c(x, y, t, r), 3), 1, 0));
 }
 

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -130,7 +130,7 @@ void check_casts() {
 
     check(cast(Float(64), 0.5f), Expr(0.5));
     check((x - cast(Float(64), 0.5f)) * (x - cast(Float(64), 0.5f)),
-          (cast(Float(64), x) + Expr(-1.0)) * cast(Float(64), x) + Expr(0.25));
+          (x + Expr(-0.5)) * (x + Expr(-0.5)));
 
     check(cast(Int(64, 3), ramp(5.5f, 2.0f, 3)),
           cast(Int(64, 3), ramp(5.5f, 2.0f, 3)));


### PR DESCRIPTION
Reverts halide/Halide#6504 -- the new simplifier rules introduce `Signed integer overflow occurred during constant-folding` errors in downstream code that hasn't failed before; I'll need some time to figure out the right fix and this change isn't urgent IIUC