### PR TITLE
Tweak type-comparing code for Xtensa

### DIFF
--- a/src/CodeGen_Xtensa.cpp
+++ b/src/CodeGen_Xtensa.cpp
@@ -1909,19 +1909,19 @@ class ScopedDmaInitializer {
         stream << std::flush;
 
         std::set<Type> native_vector_types = {
-            Type(Type::Int, 8, 64),
-            Type(Type::UInt, 8, 64),
-            Type(Type::Int, 16, 32),
-            Type(Type::UInt, 16, 32),
-            Type(Type::Int, 32, 16),
-            Type(Type::UInt, 32, 16),
-            Type(Type::Int, 24, 64),
-            Type(Type::UInt, 24, 64),
-            Type(Type::Int, 48, 32),
-            Type(Type::UInt, 48, 32),
-            Type(Type::Int, 64, 16),
-            Type(Type::Float, 16, 32),
-            Type(Type::Float, 32, 16),
+            Int(8, 64),
+            UInt(8, 64),
+            Int(16, 32),
+            UInt(16, 32),
+            Int(32, 16),
+            UInt(32, 16),
+            Int(24, 64),
+            UInt(24, 64),
+            Int(48, 32),
+            UInt(48, 32),
+            Int(64, 16),
+            Float(16, 32),
+            Float(32, 16),
         };
 
         std::set<Type> predefined_vectors = {

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -23,67 +23,24 @@ using std::vector;
 
 using namespace Halide::ConciseCasts;
 
-template<>
-bool is_native_xtensa_vector<int8_t>(const Type &t) {
-    return t.is_int() && (t.bits() == 8) && (t.lanes() == 64);
-}
-
-template<>
-bool is_native_xtensa_vector<uint8_t>(const Type &t) {
-    return t.is_uint() && (t.bits() == 8) && (t.lanes() == 64);
-}
-
-template<>
-bool is_native_xtensa_vector<int16_t>(const Type &t) {
-    return t.is_int() && (t.bits() == 16) && (t.lanes() == 32);
-}
-
-template<>
-bool is_native_xtensa_vector<uint16_t>(const Type &t) {
-    return t.is_uint() && (t.bits() == 16) && (t.lanes() == 32);
-}
-
-template<>
-bool is_native_xtensa_vector<int32_t>(const Type &t) {
-    return t.is_int() && (t.bits() == 32) && (t.lanes() == 16);
-}
-
-template<>
-bool is_native_xtensa_vector<uint32_t>(const Type &t) {
-    return t.is_uint() && (t.bits() == 32) && (t.lanes() == 16);
-}
-
-template<>
-bool is_native_xtensa_vector<float>(const Type &t) {
-    return t.is_float() && (t.bits() == 32) && (t.lanes() == 16);
-}
-
 bool is_native_vector_type(const Type &t) {
-    if (t.is_int_or_uint() && (t.lanes() == 64) && (t.bits() == 8)) {
+    switch (((halide_type_t)t).as_u32()) {
+    case halide_type_t(halide_type_int, 8, 64).as_u32():
+    case halide_type_t(halide_type_uint, 8, 64).as_u32():
+    case halide_type_t(halide_type_int, 16, 32).as_u32():
+    case halide_type_t(halide_type_uint, 16, 32).as_u32():
+    case halide_type_t(halide_type_int, 32, 16).as_u32():
+    case halide_type_t(halide_type_uint, 32, 16).as_u32():
+    case halide_type_t(halide_type_float, 32, 16).as_u32():
+    // 24 and 48-bit integers?
+    case halide_type_t(halide_type_int, 24, 64).as_u32():
+    case halide_type_t(halide_type_uint, 24, 64).as_u32():
+    case halide_type_t(halide_type_int, 48, 32).as_u32():
+    case halide_type_t(halide_type_uint, 48, 32).as_u32():
         return true;
+    default:
+        return false;
     }
-
-    if (t.is_int_or_uint() && (t.lanes() == 64) && (t.bits() == 24)) {
-        return true;
-    }
-
-    if (t.is_int_or_uint() && (t.lanes() == 32) && (t.bits() == 16)) {
-        return true;
-    }
-
-    if (t.is_int_or_uint() && (t.lanes() == 32) && (t.bits() == 48)) {
-        return true;
-    }
-
-    if (t.is_int_or_uint() && (t.lanes() == 16) && (t.bits() == 32)) {
-        return true;
-    }
-
-    if (t.is_float() && (t.lanes() == 16) && (t.bits() == 32)) {
-        return true;
-    }
-
-    return false;
 }
 
 bool is_double_native_vector_type(const Type &t) {
@@ -99,27 +56,28 @@ Type get_native_xtensa_vector(const Type &t) {
 }
 
 std::string suffix_for_type(Type t) {
-    if (t.is_bool()) {
+    switch (((halide_type_t)t).element_of().as_u32()) {
+    case halide_type_t(halide_type_uint, 1).as_u32():
         return "_u1";
-    } else if (t.is_int() && (t.bits() == 8)) {
+    case halide_type_t(halide_type_int, 8).as_u32():
         return "_i8";
-    } else if (t.is_uint() && (t.bits() == 8)) {
+    case halide_type_t(halide_type_uint, 8).as_u32():
         return "_u8";
-    } else if (t.is_int() && (t.bits() == 16)) {
+    case halide_type_t(halide_type_int, 16).as_u32():
         return "_i16";
-    } else if (t.is_uint() && (t.bits() == 16)) {
+    case halide_type_t(halide_type_uint, 16).as_u32():
         return "_u16";
-    } else if (t.is_int() && (t.bits() == 32)) {
+    case halide_type_t(halide_type_int, 32).as_u32():
         return "_i32";
-    } else if (t.is_uint() && (t.bits() == 32)) {
+    case halide_type_t(halide_type_uint, 32).as_u32():
         return "_u32";
-    } else if (t.is_float() && (t.bits() == 32)) {
-        return "_f32";
-    } else if (t.is_float() && (t.bits() == 16)) {
+    case halide_type_t(halide_type_float, 16).as_u32():
         return "_f16";
+    case halide_type_t(halide_type_float, 32).as_u32():
+        return "_f32";
+    default:
+        return "";
     }
-
-    return "";
 }
 
 struct Pattern {

--- a/src/XtensaOptimize.h
+++ b/src/XtensaOptimize.h
@@ -10,30 +10,45 @@ struct Target;
 namespace Internal {
 
 template<typename T>
-bool is_native_xtensa_vector(const Type &t) {
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector(const Type &t) {
     return false;
 }
 
+// halide_type_t::operator== should inline as a single load-and-compare of u32 values
 template<>
-bool is_native_xtensa_vector<int8_t>(const Type &t);
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector<int8_t>(const Type &t) {
+    return t == (halide_type_t)Int(8, 64);
+}
 
 template<>
-bool is_native_xtensa_vector<uint8_t>(const Type &t);
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector<uint8_t>(const Type &t) {
+    return t == (halide_type_t)UInt(8, 64);
+}
 
 template<>
-bool is_native_xtensa_vector<int16_t>(const Type &t);
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector<int16_t>(const Type &t) {
+    return t == (halide_type_t)Int(16, 32);
+}
 
 template<>
-bool is_native_xtensa_vector<uint16_t>(const Type &t);
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector<uint16_t>(const Type &t) {
+    return t == (halide_type_t)UInt(16, 32);
+}
 
 template<>
-bool is_native_xtensa_vector<int32_t>(const Type &t);
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector<int32_t>(const Type &t) {
+    return t == (halide_type_t)Int(32, 16);
+}
 
 template<>
-bool is_native_xtensa_vector<uint32_t>(const Type &t);
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector<uint32_t>(const Type &t) {
+    return t == (halide_type_t)UInt(32, 16);
+}
 
 template<>
-bool is_native_xtensa_vector<float>(const Type &t);
+HALIDE_ALWAYS_INLINE bool is_native_xtensa_vector<float>(const Type &t) {
+    return t == (halide_type_t)Float(32, 16);
+}
 
 bool is_native_vector_type(const Type &t);
 bool is_double_native_vector_type(const Type &t);


### PR DESCRIPTION
This is an untested, just-fyi PR, which is full of premature optimization, but still, FYI:

`halide_type_t::as_u32()` is a constexpr method that returns a unique value for a given type (including lanes). This allows us to do a couple of things:

(1) by forcing `is_native_xtensa_vector()` to  use this operator, we can (in theory) get more efficient code for this frequently-used helper by inlining it as essentially a single compare-two-u32 instruction. (I haven't actually tested this. Maybe it's less efficient.)

(2) since it's a constexpr function, you can also use it to construct `switch` statements as I've done here (both with and without the lanes); the syntax is suboptimal (I'm open for suggestions) but may produce cleaner code. (Again, untested?)

(2a) aside from switch, we could also use this approach to build tables of static+constant data (since the method is `constexpr`).