### PR TITLE
Better default lowering of absd

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2709,7 +2709,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         Expr b_var = Variable::make(op->args[1].type(), b_name);
         codegen(Let::make(a_name, op->args[0],
                           Let::make(b_name, op->args[1],
-                                    Max::make(a_var, b_var) - Min::make(a_var, b_var))));
+                                    Select::make(a_var < b_var, b_var - a_var, a_var - b_var))));
     } else if (op->is_intrinsic(Call::div_round_to_zero)) {
         // See if we can rewrite it to something faster (e.g. a shift)
         Expr e = lower_int_uint_div(op->args[0], op->args[1], /** round to zero */ true);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2709,7 +2709,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         Expr b_var = Variable::make(op->args[1].type(), b_name);
         codegen(Let::make(a_name, op->args[0],
                           Let::make(b_name, op->args[1],
-                                    Select::make(a_var < b_var, b_var - a_var, a_var - b_var))));
+                                    Max::make(a_var, b_var) - Min::make(a_var, b_var))));
     } else if (op->is_intrinsic(Call::div_round_to_zero)) {
         // See if we can rewrite it to something faster (e.g. a shift)
         Expr e = lower_int_uint_div(op->args[0], op->args[1], /** round to zero */ true);

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -519,14 +519,15 @@ void CodeGen_X86::visit(const Call *op) {
             }
         }
     } else if (op->is_intrinsic(Call::absd)) {
-        if (op->type.is_uint()) {
+        if (op->args[0].type().is_uint()) {
             // On x86, there are many 3-instruction sequences to compute absd of
             // unsigned integers. This one consists solely of instructions with
             // throughput of 3 ops per cycle on Cannon Lake.
-            codegen(saturating_sub(op->args[0], op->args[1]) | saturating_sub(op->args[0], op->args[1]));
+            codegen(saturating_sub(op->args[0], op->args[1]) | saturating_sub(op->args[1], op->args[0]));
             return;
         } else if (op->type.is_int()) {
             codegen(Max::make(op->args[0], op->args[1]) - Min::make(op->args[0], op->args[1]));
+            return;
         }
     }
 

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -519,13 +519,17 @@ void CodeGen_X86::visit(const Call *op) {
             }
         }
     } else if (op->is_intrinsic(Call::absd)) {
+        internal_assert(op->args.size() == 2);
         if (op->args[0].type().is_uint()) {
             // On x86, there are many 3-instruction sequences to compute absd of
             // unsigned integers. This one consists solely of instructions with
             // throughput of 3 ops per cycle on Cannon Lake.
+            //
+            // Solution due to Wolciech Mula:
+            // http://0x80.pl/notesen/2018-03-11-sse-abs-unsigned.html
             codegen(saturating_sub(op->args[0], op->args[1]) | saturating_sub(op->args[1], op->args[0]));
             return;
-        } else if (op->type.is_int()) {
+        } else if (op->args[0].type().is_int()) {
             codegen(Max::make(op->args[0], op->args[1]) - Min::make(op->args[0], op->args[1]));
             return;
         }

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -525,7 +525,7 @@ void CodeGen_X86::visit(const Call *op) {
             // unsigned integers. This one consists solely of instructions with
             // throughput of 3 ops per cycle on Cannon Lake.
             //
-            // Solution due to Wolciech Mula:
+            // Solution due to Wojciech Mula:
             // http://0x80.pl/notesen/2018-03-11-sse-abs-unsigned.html
             codegen(saturating_sub(op->args[0], op->args[1]) | saturating_sub(op->args[1], op->args[0]));
             return;

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -518,6 +518,16 @@ void CodeGen_X86::visit(const Call *op) {
                 return;
             }
         }
+    } else if (op->is_intrinsic(Call::absd)) {
+        if (op->type.is_uint()) {
+            // On x86, there are many 3-instruction sequences to compute absd of
+            // unsigned integers. This one consists solely of instructions with
+            // throughput of 3 ops per cycle on Cannon Lake.
+            codegen(saturating_sub(op->args[0], op->args[1]) | saturating_sub(op->args[0], op->args[1]));
+            return;
+        } else if (op->type.is_int()) {
+            codegen(Max::make(op->args[0], op->args[1]) - Min::make(op->args[0], op->args[1]));
+        }
     }
 
     struct Pattern {
@@ -612,11 +622,15 @@ void CodeGen_X86::codegen_vector_reduce(const VectorReduce *op, const Expr &init
                 a = lossless_cast(p.narrow_type.with_lanes(a.type().lanes()), a);
                 b = lossless_cast(p.narrow_type.with_lanes(b.type().lanes()), b);
             }
-            if (!a.defined() || !b.defined()) { continue; }
+            if (!a.defined() || !b.defined()) {
+                continue;
+            }
 
             if (init.defined() && (p.flags & Pattern::CombineInit)) {
                 value = call_overloaded_intrin(op->type, p.intrin, {init, a, b});
-                if (value) { return; }
+                if (value) {
+                    return;
+                }
             } else {
                 value = call_overloaded_intrin(op->type, p.intrin, {a, b});
                 if (value) {

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -1649,6 +1649,9 @@ public:
             check("vsububs", 16 * w, u8(max(i16(u8_1) - i16(u8_2), 0)));
             check("vsubuhs", 8 * w, u16(max(i32(u16_1) - i32(u16_2), 0)));
             check("vsubuws", 4 * w, u32(max(i64(u32_1) - i64(u32_2), 0)));
+            check("vsububs", 16 * w, absd(i8_1, i8_2));
+            check("vsubuhs", 16 * w, absd(i16_1, i16_2));
+            check("vsubuws", 16 * w, absd(i32_1, i32_2));
 
             // Vector Integer Average Instructions.
             check("vavgsb", 16 * w, i8((i16(i8_1) + i16(i8_2) + 1) / 2));


### PR DESCRIPTION
This produces 3 instructions on x86, whereas the previous version
produced 5.