### PR TITLE
Fix description of rounding_shift_left/rounding_shift_right

### DIFF
--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -355,12 +355,12 @@ Expr widening_shift_left(Expr a, int b);
 Expr widening_shift_right(Expr a, Expr b);
 Expr widening_shift_right(Expr a, int b);
 
-/** Compute saturating_add(a, (1 >> min(b, 0)) / 2) << b. When b is positive
- * indicating a left shift, the rounding term is zero. */
+/** Compute saturating_narrow(widening_add(a, (1 >> min(b, 0)) / 2) << b).
+ * When b is positive indicating a left shift, the rounding term is zero. */
 Expr rounding_shift_left(Expr a, Expr b);
 Expr rounding_shift_left(Expr a, int b);
-/** Compute saturating_add(a, (1 << max(b, 0)) / 2) >> b. When b is negative
- * indicating a left shift, the rounding term is zero. */
+/** Compute saturating_narrow(widening_add(a, (1 << max(b, 0)) / 2) >> b).
+ * When b is negative indicating a left shift, the rounding term is zero. */
 Expr rounding_shift_right(Expr a, Expr b);
 Expr rounding_shift_right(Expr a, int b);
 


### PR DESCRIPTION
The comment refers to an older understanding which is incorrect for saturating cases, e.g. `rounding_shift_right(255, 1)` = 128 (new definition) and not 127 (old definition).