### PR TITLE
Use add_halide_generator() everywhere in apps/

### DIFF
--- a/apps/HelloWasm/CMakeLists.txt
+++ b/apps/HelloWasm/CMakeLists.txt
@@ -20,8 +20,7 @@ configure_file(index.html index.html COPYONLY)
 set(EMCC_FLAGS -s WASM=1 -s USE_SDL=2 -s TOTAL_MEMORY=512MB -O3)
 set(EMCC_FLAGS_threads -pthread -matomics)
 
-add_executable(reaction_diffusion_generator reaction_diffusion_generator.cpp)
-target_link_libraries(reaction_diffusion_generator PRIVATE Halide::Generator)
+add_halide_generator(reaction_diffusion_generator SOURCES reaction_diffusion_generator.cpp)
 
 set(features_simd -wasm_simd128)
 set(features_threads -wasm_threads)

--- a/apps/HelloWasm/CMakeLists.txt
+++ b/apps/HelloWasm/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach (simd IN ITEMS "" "_simd")
         set(target "wasm-32-wasmrt${features${simd}}${features${threads}}")
 
         foreach (gen IN ITEMS init update render)
-            add_halide_library(${config}_${gen} FROM HelloWasm::halide_generators::reaction_diffusion_generator
+            add_halide_library(${config}_${gen} FROM reaction_diffusion_generator
                                GENERATOR reaction_diffusion_${gen}
                                FUNCTION_NAME reaction_diffusion_${gen}
                                PARAMS ${params${threads}}
@@ -63,7 +63,7 @@ foreach (simd IN ITEMS "" "_simd")
 endforeach ()
 
 foreach (gen IN ITEMS init update render)
-    add_halide_library(reaction_diffusion_${gen} FROM HelloWasm::halide_generators::reaction_diffusion_generator
+    add_halide_library(reaction_diffusion_${gen} FROM reaction_diffusion_generator
                        REGISTRATION ${gen}_cpp
                        PARAMS threads=true)
 endforeach ()

--- a/apps/HelloWasm/CMakeLists.txt
+++ b/apps/HelloWasm/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach (simd IN ITEMS "" "_simd")
         set(target "wasm-32-wasmrt${features${simd}}${features${threads}}")
 
         foreach (gen IN ITEMS init update render)
-            add_halide_library(${config}_${gen} FROM reaction_diffusion_generator
+            add_halide_library(${config}_${gen} FROM HelloWasm::halide_generators::reaction_diffusion_generator
                                GENERATOR reaction_diffusion_${gen}
                                FUNCTION_NAME reaction_diffusion_${gen}
                                PARAMS ${params${threads}}
@@ -63,7 +63,7 @@ foreach (simd IN ITEMS "" "_simd")
 endforeach ()
 
 foreach (gen IN ITEMS init update render)
-    add_halide_library(reaction_diffusion_${gen} FROM reaction_diffusion_generator
+    add_halide_library(reaction_diffusion_${gen} FROM HelloWasm::halide_generators::reaction_diffusion_generator
                        REGISTRATION ${gen}_cpp
                        PARAMS threads=true)
 endforeach ()

--- a/apps/bgu/CMakeLists.txt
+++ b/apps/bgu/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(bgu.generator bgu_generator.cpp)
-target_link_libraries(bgu.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(bgu.generator SOURCES bgu_generator.cpp)
 
 # Filters
 add_halide_library(bgu FROM bgu.generator)

--- a/apps/bgu/CMakeLists.txt
+++ b/apps/bgu/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(bgu.generator SOURCES bgu_generator.cpp)
 
 # Filters
-add_halide_library(bgu FROM bgu::halide_generators::bgu.generator)
-add_halide_library(bgu_auto_schedule FROM bgu::halide_generators::bgu.generator
+add_halide_library(bgu FROM bgu.generator)
+add_halide_library(bgu_auto_schedule FROM bgu.generator
                    GENERATOR bgu
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/bgu/CMakeLists.txt
+++ b/apps/bgu/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(bgu.generator SOURCES bgu_generator.cpp)
 
 # Filters
-add_halide_library(bgu FROM bgu.generator)
-add_halide_library(bgu_auto_schedule FROM bgu.generator
+add_halide_library(bgu FROM bgu::halide_generators::bgu.generator)
+add_halide_library(bgu_auto_schedule FROM bgu::halide_generators::bgu.generator
                    GENERATOR bgu
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -16,11 +16,11 @@ add_halide_generator(bilateral_grid.generator SOURCES bilateral_grid_generator.c
 target_link_libraries(bilateral_grid.generator PRIVATE Halide::Tools)
 
 # Filters
-add_halide_library(bilateral_grid FROM bilateral_grid.generator
+add_halide_library(bilateral_grid FROM bilateral_grid::halide_generators::bilateral_grid.generator
                    STMT bilateral_grid_STMT
                    SCHEDULE bilateral_grid_SCHEDULE)
 
-add_halide_library(bilateral_grid_auto_schedule FROM bilateral_grid.generator
+add_halide_library(bilateral_grid_auto_schedule FROM bilateral_grid::halide_generators::bilateral_grid.generator
                    GENERATOR bilateral_grid
                    STMT bilateral_grid_auto_schedule_STMT
                    SCHEDULE bilateral_grid_auto_schedule_SCHEDULE

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -12,8 +12,9 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_halide_generator(bilateral_grid.generator SOURCES bilateral_grid_generator.cpp)
-target_link_libraries(bilateral_grid::halide_generators::bilateral_grid.generator PRIVATE Halide::Tools)
+add_halide_generator(bilateral_grid.generator
+                     SOURCES bilateral_grid_generator.cpp
+                     LINK_LIBRARIES Halide::Tools)
 
 # Filters
 add_halide_library(bilateral_grid FROM bilateral_grid::halide_generators::bilateral_grid.generator

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -17,11 +17,11 @@ add_halide_generator(bilateral_grid.generator
                      LINK_LIBRARIES Halide::Tools)
 
 # Filters
-add_halide_library(bilateral_grid FROM bilateral_grid::halide_generators::bilateral_grid.generator
+add_halide_library(bilateral_grid FROM bilateral_grid.generator
                    STMT bilateral_grid_STMT
                    SCHEDULE bilateral_grid_SCHEDULE)
 
-add_halide_library(bilateral_grid_auto_schedule FROM bilateral_grid::halide_generators::bilateral_grid.generator
+add_halide_library(bilateral_grid_auto_schedule FROM bilateral_grid.generator
                    GENERATOR bilateral_grid
                    STMT bilateral_grid_auto_schedule_STMT
                    SCHEDULE bilateral_grid_auto_schedule_SCHEDULE

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Halide REQUIRED)
 
 # Generator
 add_halide_generator(bilateral_grid.generator SOURCES bilateral_grid_generator.cpp)
+target_link_libraries(bilateral_grid.generator PRIVATE Halide::Tools)
 
 # Filters
 add_halide_library(bilateral_grid FROM bilateral_grid.generator

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Halide REQUIRED)
 
 # Generator
 add_halide_generator(bilateral_grid.generator SOURCES bilateral_grid_generator.cpp)
-target_link_libraries(bilateral_grid.generator PRIVATE Halide::Tools)
+target_link_libraries(bilateral_grid::halide_generators::bilateral_grid.generator PRIVATE Halide::Tools)
 
 # Filters
 add_halide_library(bilateral_grid FROM bilateral_grid::halide_generators::bilateral_grid.generator

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(bilateral_grid.generator bilateral_grid_generator.cpp)
-target_link_libraries(bilateral_grid.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(bilateral_grid.generator SOURCES bilateral_grid_generator.cpp)
 
 # Filters
 add_halide_library(bilateral_grid FROM bilateral_grid.generator

--- a/apps/blur/CMakeLists.txt
+++ b/apps/blur/CMakeLists.txt
@@ -13,8 +13,7 @@ find_package(Halide REQUIRED)
 find_package(OpenMP)
 
 # Generator
-add_executable(blur.generator halide_blur_generator.cpp)
-target_link_libraries(blur.generator PRIVATE Halide::Generator)
+add_halide_generator(blur.generator SOURCES halide_blur_generator.cpp)
 
 # Filters
 add_halide_library(halide_blur FROM blur.generator)

--- a/apps/blur/CMakeLists.txt
+++ b/apps/blur/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(OpenMP)
 add_halide_generator(blur.generator SOURCES halide_blur_generator.cpp)
 
 # Filters
-add_halide_library(halide_blur FROM blur.generator)
+add_halide_library(halide_blur FROM blur::halide_generators::blur.generator)
 
 # Main executable
 add_executable(blur_test test.cpp)

--- a/apps/blur/CMakeLists.txt
+++ b/apps/blur/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(OpenMP)
 add_halide_generator(blur.generator SOURCES halide_blur_generator.cpp)
 
 # Filters
-add_halide_library(halide_blur FROM blur::halide_generators::blur.generator)
+add_halide_library(halide_blur FROM blur.generator)
 
 # Main executable
 add_executable(blur_test test.cpp)

--- a/apps/c_backend/CMakeLists.txt
+++ b/apps/c_backend/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator(s)
-add_executable(pipeline.generator pipeline_generator.cpp)
-target_link_libraries(pipeline.generator PRIVATE Halide::Generator)
+add_halide_generator(pipeline.generator SOURCES pipeline_generator.cpp)
 
 add_halide_library(pipeline_c FROM pipeline.generator
                    C_BACKEND
@@ -21,8 +20,7 @@ add_halide_library(pipeline_c FROM pipeline.generator
 add_halide_library(pipeline_native FROM pipeline.generator
                    GENERATOR pipeline)
 
-add_executable(pipeline_cpp.generator pipeline_cpp_generator.cpp)
-target_link_libraries(pipeline_cpp.generator PRIVATE Halide::Generator)
+add_halide_generator(pipeline_cpp.generator SOURCES pipeline_cpp_generator.cpp)
 
 add_halide_library(pipeline_cpp_cpp FROM pipeline_cpp.generator
                    C_BACKEND

--- a/apps/c_backend/CMakeLists.txt
+++ b/apps/c_backend/CMakeLists.txt
@@ -14,19 +14,19 @@ find_package(Halide REQUIRED)
 # Generator(s)
 add_halide_generator(pipeline.generator SOURCES pipeline_generator.cpp)
 
-add_halide_library(pipeline_c FROM pipeline.generator
+add_halide_library(pipeline_c FROM c_backend::halide_generators::pipeline.generator
                    C_BACKEND
                    GENERATOR pipeline)
-add_halide_library(pipeline_native FROM pipeline.generator
+add_halide_library(pipeline_native FROM c_backend::halide_generators::pipeline.generator
                    GENERATOR pipeline)
 
 add_halide_generator(pipeline_cpp.generator SOURCES pipeline_cpp_generator.cpp)
 
-add_halide_library(pipeline_cpp_cpp FROM pipeline_cpp.generator
+add_halide_library(pipeline_cpp_cpp FROM c_backend::halide_generators::pipeline_cpp.generator
                    C_BACKEND
                    GENERATOR pipeline_cpp
                    FEATURES c_plus_plus_name_mangling)
-add_halide_library(pipeline_cpp_native FROM pipeline_cpp.generator
+add_halide_library(pipeline_cpp_native FROM c_backend::halide_generators::pipeline_cpp.generator
                    GENERATOR pipeline_cpp
                    FEATURES c_plus_plus_name_mangling)
 

--- a/apps/c_backend/CMakeLists.txt
+++ b/apps/c_backend/CMakeLists.txt
@@ -14,19 +14,19 @@ find_package(Halide REQUIRED)
 # Generator(s)
 add_halide_generator(pipeline.generator SOURCES pipeline_generator.cpp)
 
-add_halide_library(pipeline_c FROM c_backend::halide_generators::pipeline.generator
+add_halide_library(pipeline_c FROM pipeline.generator
                    C_BACKEND
                    GENERATOR pipeline)
-add_halide_library(pipeline_native FROM c_backend::halide_generators::pipeline.generator
+add_halide_library(pipeline_native FROM pipeline.generator
                    GENERATOR pipeline)
 
 add_halide_generator(pipeline_cpp.generator SOURCES pipeline_cpp_generator.cpp)
 
-add_halide_library(pipeline_cpp_cpp FROM c_backend::halide_generators::pipeline_cpp.generator
+add_halide_library(pipeline_cpp_cpp FROM pipeline_cpp.generator
                    C_BACKEND
                    GENERATOR pipeline_cpp
                    FEATURES c_plus_plus_name_mangling)
-add_halide_library(pipeline_cpp_native FROM c_backend::halide_generators::pipeline_cpp.generator
+add_halide_library(pipeline_cpp_native FROM pipeline_cpp.generator
                    GENERATOR pipeline_cpp
                    FEATURES c_plus_plus_name_mangling)
 

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -17,8 +17,8 @@ add_halide_generator(camera_pipe.generator
                      LINK_LIBRARIES Halide::Tools)
 
 # Filters
-add_halide_library(camera_pipe FROM camera_pipe::halide_generators::camera_pipe.generator)
-add_halide_library(camera_pipe_auto_schedule FROM camera_pipe::halide_generators::camera_pipe.generator
+add_halide_library(camera_pipe FROM camera_pipe.generator)
+add_halide_library(camera_pipe_auto_schedule FROM camera_pipe.generator
                    GENERATOR camera_pipe
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Halide REQUIRED)
 
 # Generator
 add_halide_generator(camera_pipe.generator SOURCES camera_pipe_generator.cpp)
+target_link_libraries(camera_pipe.generator PRIVATE Halide::Tools)
 
 # Filters
 add_halide_library(camera_pipe FROM camera_pipe.generator)

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -12,11 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(camera_pipe.generator camera_pipe_generator.cpp)
-target_link_libraries(camera_pipe.generator
-                      PRIVATE
-                      Halide::Generator
-                      Halide::Tools)
+add_halide_generator(camera_pipe.generator SOURCES camera_pipe_generator.cpp)
 
 # Filters
 add_halide_library(camera_pipe FROM camera_pipe.generator)

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -12,8 +12,9 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_halide_generator(camera_pipe.generator SOURCES camera_pipe_generator.cpp)
-target_link_libraries(camera_pipe::halide_generators::camera_pipe.generator PRIVATE Halide::Tools)
+add_halide_generator(camera_pipe.generator
+                     SOURCES camera_pipe_generator.cpp
+                     LINK_LIBRARIES Halide::Tools)
 
 # Filters
 add_halide_library(camera_pipe FROM camera_pipe::halide_generators::camera_pipe.generator)

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Halide REQUIRED)
 
 # Generator
 add_halide_generator(camera_pipe.generator SOURCES camera_pipe_generator.cpp)
-target_link_libraries(camera_pipe.generator PRIVATE Halide::Tools)
+target_link_libraries(camera_pipe::halide_generators::camera_pipe.generator PRIVATE Halide::Tools)
 
 # Filters
 add_halide_library(camera_pipe FROM camera_pipe::halide_generators::camera_pipe.generator)

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -16,8 +16,8 @@ add_halide_generator(camera_pipe.generator SOURCES camera_pipe_generator.cpp)
 target_link_libraries(camera_pipe.generator PRIVATE Halide::Tools)
 
 # Filters
-add_halide_library(camera_pipe FROM camera_pipe.generator)
-add_halide_library(camera_pipe_auto_schedule FROM camera_pipe.generator
+add_halide_library(camera_pipe FROM camera_pipe::halide_generators::camera_pipe.generator)
+add_halide_library(camera_pipe_auto_schedule FROM camera_pipe::halide_generators::camera_pipe.generator
                    GENERATOR camera_pipe
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/conv_layer/CMakeLists.txt
+++ b/apps/conv_layer/CMakeLists.txt
@@ -12,10 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(conv_layer.generator conv_layer_generator.cpp)
-target_link_libraries(conv_layer.generator
-                      PRIVATE
-                      Halide::Generator)
+add_halide_generator(conv_layer.generator SOURCES conv_layer_generator.cpp)
 
 # Filters
 add_halide_library(conv_layer FROM conv_layer.generator)

--- a/apps/conv_layer/CMakeLists.txt
+++ b/apps/conv_layer/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(conv_layer.generator SOURCES conv_layer_generator.cpp)
 
 # Filters
-add_halide_library(conv_layer FROM conv_layer.generator)
-add_halide_library(conv_layer_auto_schedule FROM conv_layer.generator
+add_halide_library(conv_layer FROM conv_layer::halide_generators::conv_layer.generator)
+add_halide_library(conv_layer_auto_schedule FROM conv_layer::halide_generators::conv_layer.generator
                    GENERATOR conv_layer
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/conv_layer/CMakeLists.txt
+++ b/apps/conv_layer/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(conv_layer.generator SOURCES conv_layer_generator.cpp)
 
 # Filters
-add_halide_library(conv_layer FROM conv_layer::halide_generators::conv_layer.generator)
-add_halide_library(conv_layer_auto_schedule FROM conv_layer::halide_generators::conv_layer.generator
+add_halide_library(conv_layer FROM conv_layer.generator)
+add_halide_library(conv_layer_auto_schedule FROM conv_layer.generator
                    GENERATOR conv_layer
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/cuda_mat_mul/CMakeLists.txt
+++ b/apps/cuda_mat_mul/CMakeLists.txt
@@ -25,8 +25,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(mat_mul.generator mat_mul_generator.cpp)
-target_link_libraries(mat_mul.generator PRIVATE Halide::Generator)
+add_halide_generator(mat_mul.generator SOURCES mat_mul_generator.cpp)
 
 # Filters
 add_halide_library(mat_mul FROM mat_mul.generator

--- a/apps/cuda_mat_mul/CMakeLists.txt
+++ b/apps/cuda_mat_mul/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Halide REQUIRED)
 add_halide_generator(mat_mul.generator SOURCES mat_mul_generator.cpp)
 
 # Filters
-add_halide_library(mat_mul FROM cuda_mat_mul::halide_generators::mat_mul.generator
+add_halide_library(mat_mul FROM mat_mul.generator
                    TARGETS host
                    FEATURES cuda cuda_capability_50
                    PARAMS size=1024)

--- a/apps/cuda_mat_mul/CMakeLists.txt
+++ b/apps/cuda_mat_mul/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Halide REQUIRED)
 add_halide_generator(mat_mul.generator SOURCES mat_mul_generator.cpp)
 
 # Filters
-add_halide_library(mat_mul FROM mat_mul::halide_generators::mat_mul.generator
+add_halide_library(mat_mul FROM cuda_mat_mul::halide_generators::mat_mul.generator
                    TARGETS host
                    FEATURES cuda cuda_capability_50
                    PARAMS size=1024)

--- a/apps/cuda_mat_mul/CMakeLists.txt
+++ b/apps/cuda_mat_mul/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Halide REQUIRED)
 add_halide_generator(mat_mul.generator SOURCES mat_mul_generator.cpp)
 
 # Filters
-add_halide_library(mat_mul FROM mat_mul.generator
+add_halide_library(mat_mul FROM mat_mul::halide_generators::mat_mul.generator
                    TARGETS host
                    FEATURES cuda cuda_capability_50
                    PARAMS size=1024)

--- a/apps/depthwise_separable_conv/CMakeLists.txt
+++ b/apps/depthwise_separable_conv/CMakeLists.txt
@@ -12,10 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(depthwise_separable_conv.generator depthwise_separable_conv_generator.cpp)
-target_link_libraries(depthwise_separable_conv.generator
-                      PRIVATE
-                      Halide::Generator)
+add_halide_generator(depthwise_separable_conv.generator SOURCES depthwise_separable_conv_generator.cpp)
 
 # Filters
 add_halide_library(depthwise_separable_conv FROM depthwise_separable_conv.generator)

--- a/apps/depthwise_separable_conv/CMakeLists.txt
+++ b/apps/depthwise_separable_conv/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(depthwise_separable_conv.generator SOURCES depthwise_separable_conv_generator.cpp)
 
 # Filters
-add_halide_library(depthwise_separable_conv FROM depthwise_separable_conv::halide_generators::depthwise_separable_conv.generator)
-add_halide_library(depthwise_separable_conv_auto_schedule FROM depthwise_separable_conv::halide_generators::depthwise_separable_conv.generator
+add_halide_library(depthwise_separable_conv FROM depthwise_separable_conv.generator)
+add_halide_library(depthwise_separable_conv_auto_schedule FROM depthwise_separable_conv.generator
                    GENERATOR depthwise_separable_conv
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/depthwise_separable_conv/CMakeLists.txt
+++ b/apps/depthwise_separable_conv/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(depthwise_separable_conv.generator SOURCES depthwise_separable_conv_generator.cpp)
 
 # Filters
-add_halide_library(depthwise_separable_conv FROM depthwise_separable_conv.generator)
-add_halide_library(depthwise_separable_conv_auto_schedule FROM depthwise_separable_conv.generator
+add_halide_library(depthwise_separable_conv FROM depthwise_separable_conv::halide_generators::depthwise_separable_conv.generator)
+add_halide_library(depthwise_separable_conv_auto_schedule FROM depthwise_separable_conv::halide_generators::depthwise_separable_conv.generator
                    GENERATOR depthwise_separable_conv
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(fft.generator fft_generator.cpp fft.cpp)
-target_link_libraries(fft.generator PRIVATE Halide::Generator)
+add_halide_generator(fft.generator SOURCES fft_generator.cpp fft.cpp)
 
 # Filters
 add_halide_library(fft_forward_r2c FROM fft.generator

--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -15,16 +15,16 @@ find_package(Halide REQUIRED)
 add_halide_generator(fft.generator SOURCES fft_generator.cpp fft.cpp)
 
 # Filters
-add_halide_library(fft_forward_r2c FROM fft::halide_generators::fft.generator
+add_halide_library(fft_forward_r2c FROM fft.generator
                    GENERATOR fft
                    PARAMS direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex)
-add_halide_library(fft_inverse_c2r FROM fft::halide_generators::fft.generator
+add_halide_library(fft_inverse_c2r FROM fft.generator
                    GENERATOR fft
                    PARAMS direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real)
-add_halide_library(fft_forward_c2c FROM fft::halide_generators::fft.generator
+add_halide_library(fft_forward_c2c FROM fft.generator
                    GENERATOR fft
                    PARAMS direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex)
-add_halide_library(fft_inverse_c2c FROM fft::halide_generators::fft.generator
+add_halide_library(fft_inverse_c2c FROM fft.generator
                    GENERATOR fft
                    PARAMS direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex)
 

--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -15,16 +15,16 @@ find_package(Halide REQUIRED)
 add_halide_generator(fft.generator SOURCES fft_generator.cpp fft.cpp)
 
 # Filters
-add_halide_library(fft_forward_r2c FROM fft.generator
+add_halide_library(fft_forward_r2c FROM fft::halide_generators::fft.generator
                    GENERATOR fft
                    PARAMS direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=real output_number_type=complex)
-add_halide_library(fft_inverse_c2r FROM fft.generator
+add_halide_library(fft_inverse_c2r FROM fft::halide_generators::fft.generator
                    GENERATOR fft
                    PARAMS direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=real)
-add_halide_library(fft_forward_c2c FROM fft.generator
+add_halide_library(fft_forward_c2c FROM fft::halide_generators::fft.generator
                    GENERATOR fft
                    PARAMS direction=samples_to_frequency size0=16 size1=16 gain=0.00390625 input_number_type=complex output_number_type=complex)
-add_halide_library(fft_inverse_c2c FROM fft.generator
+add_halide_library(fft_inverse_c2c FROM fft::halide_generators::fft.generator
                    GENERATOR fft
                    PARAMS direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex)
 

--- a/apps/harris/CMakeLists.txt
+++ b/apps/harris/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(harris.generator harris_generator.cpp)
-target_link_libraries(harris.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(harris.generator SOURCES harris_generator.cpp)
 
 # Filters
 add_halide_library(harris FROM harris.generator)

--- a/apps/harris/CMakeLists.txt
+++ b/apps/harris/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(harris.generator SOURCES harris_generator.cpp)
 
 # Filters
-add_halide_library(harris FROM harris.generator)
-add_halide_library(harris_auto_schedule FROM harris.generator
+add_halide_library(harris FROM harris::halide_generators::harris.generator)
+add_halide_library(harris_auto_schedule FROM harris::halide_generators::harris.generator
                    GENERATOR harris
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/harris/CMakeLists.txt
+++ b/apps/harris/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(harris.generator SOURCES harris_generator.cpp)
 
 # Filters
-add_halide_library(harris FROM harris::halide_generators::harris.generator)
-add_halide_library(harris_auto_schedule FROM harris::halide_generators::harris.generator
+add_halide_library(harris FROM harris.generator)
+add_halide_library(harris_auto_schedule FROM harris.generator
                    GENERATOR harris
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(hist.generator hist_generator.cpp)
-target_link_libraries(hist.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(hist.generator SOURCES hist_generator.cpp)
 
 # Filters
 add_halide_library(hist FROM hist.generator)

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(hist.generator SOURCES hist_generator.cpp)
 
 # Filters
-add_halide_library(hist FROM hist.generator)
-add_halide_library(hist_auto_schedule FROM hist.generator
+add_halide_library(hist FROM hist::halide_generators::hist.generator)
+add_halide_library(hist_auto_schedule FROM hist::halide_generators::hist.generator
                    GENERATOR hist
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(hist.generator SOURCES hist_generator.cpp)
 
 # Filters
-add_halide_library(hist FROM hist::halide_generators::hist.generator)
-add_halide_library(hist_auto_schedule FROM hist::halide_generators::hist.generator
+add_halide_library(hist FROM hist.generator)
+add_halide_library(hist_auto_schedule FROM hist.generator
                    GENERATOR hist
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/iir_blur/CMakeLists.txt
+++ b/apps/iir_blur/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(iir_blur.generator iir_blur_generator.cpp)
-target_link_libraries(iir_blur.generator PRIVATE Halide::Generator)
+add_halide_generator(iir_blur.generator SOURCES iir_blur_generator.cpp)
 
 # Filters
 add_halide_library(iir_blur FROM iir_blur.generator)

--- a/apps/iir_blur/CMakeLists.txt
+++ b/apps/iir_blur/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(iir_blur.generator SOURCES iir_blur_generator.cpp)
 
 # Filters
-add_halide_library(iir_blur FROM iir_blur.generator)
-add_halide_library(iir_blur_auto_schedule FROM iir_blur.generator
+add_halide_library(iir_blur FROM iir_blur::halide_generators::iir_blur.generator)
+add_halide_library(iir_blur_auto_schedule FROM iir_blur::halide_generators::iir_blur.generator
                    GENERATOR iir_blur
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/iir_blur/CMakeLists.txt
+++ b/apps/iir_blur/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(iir_blur.generator SOURCES iir_blur_generator.cpp)
 
 # Filters
-add_halide_library(iir_blur FROM iir_blur::halide_generators::iir_blur.generator)
-add_halide_library(iir_blur_auto_schedule FROM iir_blur::halide_generators::iir_blur.generator
+add_halide_library(iir_blur FROM iir_blur.generator)
+add_halide_library(iir_blur_auto_schedule FROM iir_blur.generator
                    GENERATOR iir_blur
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/interpolate/CMakeLists.txt
+++ b/apps/interpolate/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(interpolate.generator interpolate_generator.cpp)
-target_link_libraries(interpolate.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(interpolate.generator SOURCES interpolate_generator.cpp)
 
 # Filters
 add_halide_library(interpolate FROM interpolate.generator)

--- a/apps/interpolate/CMakeLists.txt
+++ b/apps/interpolate/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(interpolate.generator SOURCES interpolate_generator.cpp)
 
 # Filters
-add_halide_library(interpolate FROM interpolate.generator)
-add_halide_library(interpolate_auto_schedule FROM interpolate.generator
+add_halide_library(interpolate FROM interpolate::halide_generators::interpolate.generator)
+add_halide_library(interpolate_auto_schedule FROM interpolate::halide_generators::interpolate.generator
                    GENERATOR interpolate
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/interpolate/CMakeLists.txt
+++ b/apps/interpolate/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(interpolate.generator SOURCES interpolate_generator.cpp)
 
 # Filters
-add_halide_library(interpolate FROM interpolate::halide_generators::interpolate.generator)
-add_halide_library(interpolate_auto_schedule FROM interpolate::halide_generators::interpolate.generator
+add_halide_library(interpolate FROM interpolate.generator)
+add_halide_library(interpolate_auto_schedule FROM interpolate.generator
                    GENERATOR interpolate
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/lens_blur/CMakeLists.txt
+++ b/apps/lens_blur/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(lens_blur.generator lens_blur_generator.cpp)
-target_link_libraries(lens_blur.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(lens_blur.generator SOURCES lens_blur_generator.cpp)
 
 # Filters
 add_halide_library(lens_blur FROM lens_blur.generator)

--- a/apps/lens_blur/CMakeLists.txt
+++ b/apps/lens_blur/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(lens_blur.generator SOURCES lens_blur_generator.cpp)
 
 # Filters
-add_halide_library(lens_blur FROM lens_blur::halide_generators::lens_blur.generator)
-add_halide_library(lens_blur_auto_schedule FROM lens_blur::halide_generators::lens_blur.generator
+add_halide_library(lens_blur FROM lens_blur.generator)
+add_halide_library(lens_blur_auto_schedule FROM lens_blur.generator
                    GENERATOR lens_blur
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/lens_blur/CMakeLists.txt
+++ b/apps/lens_blur/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(lens_blur.generator SOURCES lens_blur_generator.cpp)
 
 # Filters
-add_halide_library(lens_blur FROM lens_blur.generator)
-add_halide_library(lens_blur_auto_schedule FROM lens_blur.generator
+add_halide_library(lens_blur FROM lens_blur::halide_generators::lens_blur.generator)
+add_halide_library(lens_blur_auto_schedule FROM lens_blur::halide_generators::lens_blur.generator
                    GENERATOR lens_blur
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/linear_algebra/src/CMakeLists.txt
+++ b/apps/linear_algebra/src/CMakeLists.txt
@@ -2,8 +2,7 @@ add_library(halide_blas halide_blas.cpp)
 target_include_directories(halide_blas PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Define all our generators
-add_executable(blas.generator blas_l1_generators.cpp blas_l2_generators.cpp blas_l3_generators.cpp)
-target_link_libraries(blas.generator PRIVATE Halide::Generator)
+add_halide_generator(blas.generator SOURCES blas_l1_generators.cpp blas_l2_generators.cpp blas_l3_generators.cpp)
 
 # Function to reduce boilerplate
 function(add_halide_blas_library)

--- a/apps/linear_algebra/src/CMakeLists.txt
+++ b/apps/linear_algebra/src/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_halide_blas_library)
     set(oneValueArgs TARGET NAME)
     set(multiValueArgs GENERATOR_ARGS FEATURES)
     cmake_parse_arguments(args "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    add_halide_library(${args_TARGET} FROM blas.generator
+    add_halide_library(${args_TARGET} FROM linear_algebra::halide_generators::blas.generator
                        GENERATOR ${args_NAME}
                        FEATURES no_bounds_query ${args_FEATURES}
                        PARAMS ${args_GENERATOR_ARGS})

--- a/apps/linear_algebra/src/CMakeLists.txt
+++ b/apps/linear_algebra/src/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_halide_blas_library)
     set(oneValueArgs TARGET NAME)
     set(multiValueArgs GENERATOR_ARGS FEATURES)
     cmake_parse_arguments(args "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    add_halide_library(${args_TARGET} FROM linear_algebra::halide_generators::blas.generator
+    add_halide_library(${args_TARGET} FROM blas.generator
                        GENERATOR ${args_NAME}
                        FEATURES no_bounds_query ${args_FEATURES}
                        PARAMS ${args_GENERATOR_ARGS})

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -16,8 +16,8 @@ add_halide_generator(local_laplacian.generator SOURCES local_laplacian_generator
 target_link_libraries(local_laplacian.generator PRIVATE Halide::Tools)
 
 # Filters
-add_halide_library(local_laplacian FROM local_laplacian.generator)
-add_halide_library(local_laplacian_auto_schedule FROM local_laplacian.generator
+add_halide_library(local_laplacian FROM local_laplacian::halide_generators::local_laplacian.generator)
+add_halide_library(local_laplacian_auto_schedule FROM local_laplacian::halide_generators::local_laplacian.generator
                    GENERATOR local_laplacian
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(Halide REQUIRED)
 
 # Generator
 add_halide_generator(local_laplacian.generator SOURCES local_laplacian_generator.cpp)
+target_link_libraries(local_laplacian.generator PRIVATE Halide::Tools)
 
 # Filters
 add_halide_library(local_laplacian FROM local_laplacian.generator)

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -17,8 +17,8 @@ add_halide_generator(local_laplacian.generator
                      LINK_LIBRARIES Halide::Tools)
 
 # Filters
-add_halide_library(local_laplacian FROM local_laplacian::halide_generators::local_laplacian.generator)
-add_halide_library(local_laplacian_auto_schedule FROM local_laplacian::halide_generators::local_laplacian.generator
+add_halide_library(local_laplacian FROM local_laplacian.generator)
+add_halide_library(local_laplacian_auto_schedule FROM local_laplacian.generator
                    GENERATOR local_laplacian
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -12,8 +12,9 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_halide_generator(local_laplacian.generator SOURCES local_laplacian_generator.cpp)
-target_link_libraries(local_laplacian::halide_generators::local_laplacian.generator PRIVATE Halide::Tools)
+add_halide_generator(local_laplacian.generator
+                     SOURCES local_laplacian_generator.cpp
+                     LINK_LIBRARIES Halide::Tools)
 
 # Filters
 add_halide_library(local_laplacian FROM local_laplacian::halide_generators::local_laplacian.generator)

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(local_laplacian.generator local_laplacian_generator.cpp)
-target_link_libraries(local_laplacian.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(local_laplacian.generator SOURCES local_laplacian_generator.cpp)
 
 # Filters
 add_halide_library(local_laplacian FROM local_laplacian.generator)

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Halide REQUIRED)
 
 # Generator
 add_halide_generator(local_laplacian.generator SOURCES local_laplacian_generator.cpp)
-target_link_libraries(local_laplacian.generator PRIVATE Halide::Tools)
+target_link_libraries(local_laplacian::halide_generators::local_laplacian.generator PRIVATE Halide::Tools)
 
 # Filters
 add_halide_library(local_laplacian FROM local_laplacian::halide_generators::local_laplacian.generator)

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(max_filter.generator max_filter_generator.cpp)
-target_link_libraries(max_filter.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(max_filter.generator SOURCES max_filter_generator.cpp)
 
 # Filters
 add_halide_library(max_filter FROM max_filter.generator)

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(max_filter.generator SOURCES max_filter_generator.cpp)
 
 # Filters
-add_halide_library(max_filter FROM max_filter.generator)
-add_halide_library(max_filter_auto_schedule FROM max_filter.generator
+add_halide_library(max_filter FROM max_filter::halide_generators::max_filter.generator)
+add_halide_library(max_filter_auto_schedule FROM max_filter::halide_generators::max_filter.generator
                    GENERATOR max_filter
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(max_filter.generator SOURCES max_filter_generator.cpp)
 
 # Filters
-add_halide_library(max_filter FROM max_filter::halide_generators::max_filter.generator)
-add_halide_library(max_filter_auto_schedule FROM max_filter::halide_generators::max_filter.generator
+add_halide_library(max_filter FROM max_filter.generator)
+add_halide_library(max_filter_auto_schedule FROM max_filter.generator
                    GENERATOR max_filter
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/nl_means/CMakeLists.txt
+++ b/apps/nl_means/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(nl_means.generator nl_means_generator.cpp)
-target_link_libraries(nl_means.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(nl_means.generator SOURCES nl_means_generator.cpp)
 
 # Filters
 add_halide_library(nl_means FROM nl_means.generator)

--- a/apps/nl_means/CMakeLists.txt
+++ b/apps/nl_means/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(nl_means.generator SOURCES nl_means_generator.cpp)
 
 # Filters
-add_halide_library(nl_means FROM nl_means.generator)
-add_halide_library(nl_means_auto_schedule FROM nl_means.generator
+add_halide_library(nl_means FROM nl_means::halide_generators::nl_means.generator)
+add_halide_library(nl_means_auto_schedule FROM nl_means::halide_generators::nl_means.generator
                    GENERATOR nl_means
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/nl_means/CMakeLists.txt
+++ b/apps/nl_means/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(nl_means.generator SOURCES nl_means_generator.cpp)
 
 # Filters
-add_halide_library(nl_means FROM nl_means::halide_generators::nl_means.generator)
-add_halide_library(nl_means_auto_schedule FROM nl_means::halide_generators::nl_means.generator
+add_halide_library(nl_means FROM nl_means.generator)
+add_halide_library(nl_means_auto_schedule FROM nl_means.generator
                    GENERATOR nl_means
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(resize.generator resize_generator.cpp)
-target_link_libraries(resize.generator PRIVATE Halide::Generator)
+add_halide_generator(resize.generator SOURCES resize_generator.cpp)
 
 # Filters
 list(APPEND VARIANTS

--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach (VARIANT IN LISTS VARIANTS)
     list(GET VLIST 2 DIR)
     string(REPLACE "up" "true" DIR ${DIR})
     string(REPLACE "down" "false" DIR ${DIR})
-    add_halide_library(resize_${VARIANT} FROM resize::halide_generators::resize.generator
+    add_halide_library(resize_${VARIANT} FROM resize.generator
                        GENERATOR resize
                        PARAMS interpolation_type=${INTERP} input.type=${TYPE} upsample=${DIR})
 endforeach ()

--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -48,7 +48,7 @@ foreach (VARIANT IN LISTS VARIANTS)
     list(GET VLIST 2 DIR)
     string(REPLACE "up" "true" DIR ${DIR})
     string(REPLACE "down" "false" DIR ${DIR})
-    add_halide_library(resize_${VARIANT} FROM resize.generator
+    add_halide_library(resize_${VARIANT} FROM resize::halide_generators::resize.generator
                        GENERATOR resize
                        PARAMS interpolation_type=${INTERP} input.type=${TYPE} upsample=${DIR})
 endforeach ()

--- a/apps/stencil_chain/CMakeLists.txt
+++ b/apps/stencil_chain/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(stencil_chain.generator stencil_chain_generator.cpp)
-target_link_libraries(stencil_chain.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(stencil_chain.generator SOURCES stencil_chain_generator.cpp)
 
 # Filters
 add_halide_library(stencil_chain FROM stencil_chain.generator)

--- a/apps/stencil_chain/CMakeLists.txt
+++ b/apps/stencil_chain/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(stencil_chain.generator SOURCES stencil_chain_generator.cpp)
 
 # Filters
-add_halide_library(stencil_chain FROM stencil_chain::halide_generators::stencil_chain.generator)
-add_halide_library(stencil_chain_auto_schedule FROM stencil_chain::halide_generators::stencil_chain.generator
+add_halide_library(stencil_chain FROM stencil_chain.generator)
+add_halide_library(stencil_chain_auto_schedule FROM stencil_chain.generator
                    GENERATOR stencil_chain
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/stencil_chain/CMakeLists.txt
+++ b/apps/stencil_chain/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(stencil_chain.generator SOURCES stencil_chain_generator.cpp)
 
 # Filters
-add_halide_library(stencil_chain FROM stencil_chain.generator)
-add_halide_library(stencil_chain_auto_schedule FROM stencil_chain.generator
+add_halide_library(stencil_chain FROM stencil_chain::halide_generators::stencil_chain.generator)
+add_halide_library(stencil_chain_auto_schedule FROM stencil_chain::halide_generators::stencil_chain.generator
                    GENERATOR stencil_chain
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/unsharp/CMakeLists.txt
+++ b/apps/unsharp/CMakeLists.txt
@@ -12,8 +12,7 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(unsharp.generator unsharp_generator.cpp)
-target_link_libraries(unsharp.generator PRIVATE Halide::Generator Halide::Tools)
+add_halide_generator(unsharp.generator SOURCES unsharp_generator.cpp)
 
 # Filters
 add_halide_library(unsharp FROM unsharp.generator)

--- a/apps/unsharp/CMakeLists.txt
+++ b/apps/unsharp/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(unsharp.generator SOURCES unsharp_generator.cpp)
 
 # Filters
-add_halide_library(unsharp FROM unsharp::halide_generators::unsharp.generator)
-add_halide_library(unsharp_auto_schedule FROM unsharp::halide_generators::unsharp.generator
+add_halide_library(unsharp FROM unsharp.generator)
+add_halide_library(unsharp_auto_schedule FROM unsharp.generator
                    GENERATOR unsharp
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/unsharp/CMakeLists.txt
+++ b/apps/unsharp/CMakeLists.txt
@@ -15,8 +15,8 @@ find_package(Halide REQUIRED)
 add_halide_generator(unsharp.generator SOURCES unsharp_generator.cpp)
 
 # Filters
-add_halide_library(unsharp FROM unsharp.generator)
-add_halide_library(unsharp_auto_schedule FROM unsharp.generator
+add_halide_library(unsharp FROM unsharp::halide_generators::unsharp.generator)
+add_halide_library(unsharp_auto_schedule FROM unsharp::halide_generators::unsharp.generator
                    GENERATOR unsharp
                    AUTOSCHEDULER Halide::Mullapudi2016)
 

--- a/apps/wavelet/CMakeLists.txt
+++ b/apps/wavelet/CMakeLists.txt
@@ -12,12 +12,12 @@ set(CMAKE_CXX_EXTENSIONS NO)
 find_package(Halide REQUIRED)
 
 # Generator
-add_executable(wavelet.generator
-               daubechies_x_generator.cpp
-               inverse_daubechies_x_generator.cpp
-               haar_x_generator.cpp
-               inverse_haar_x_generator.cpp)
-target_link_libraries(wavelet.generator PRIVATE Halide::Generator)
+add_halide_generator(wavelet.generator
+                     SOURCES
+                     daubechies_x_generator.cpp
+                     inverse_daubechies_x_generator.cpp
+                     haar_x_generator.cpp
+                     inverse_haar_x_generator.cpp)
 
 # Filters
 add_halide_library(daubechies_x FROM wavelet.generator)

--- a/apps/wavelet/CMakeLists.txt
+++ b/apps/wavelet/CMakeLists.txt
@@ -20,10 +20,10 @@ add_halide_generator(wavelet.generator
                      inverse_haar_x_generator.cpp)
 
 # Filters
-add_halide_library(daubechies_x FROM wavelet.generator)
-add_halide_library(inverse_daubechies_x FROM wavelet.generator)
-add_halide_library(haar_x FROM wavelet.generator)
-add_halide_library(inverse_haar_x FROM wavelet.generator)
+add_halide_library(daubechies_x FROM wavelet::halide_generators::wavelet.generator)
+add_halide_library(inverse_daubechies_x FROM wavelet::halide_generators::wavelet.generator)
+add_halide_library(haar_x FROM wavelet::halide_generators::wavelet.generator)
+add_halide_library(inverse_haar_x FROM wavelet::halide_generators::wavelet.generator)
 
 # Main executable
 add_executable(wavelet wavelet.cpp)

--- a/apps/wavelet/CMakeLists.txt
+++ b/apps/wavelet/CMakeLists.txt
@@ -20,10 +20,10 @@ add_halide_generator(wavelet.generator
                      inverse_haar_x_generator.cpp)
 
 # Filters
-add_halide_library(daubechies_x FROM wavelet::halide_generators::wavelet.generator)
-add_halide_library(inverse_daubechies_x FROM wavelet::halide_generators::wavelet.generator)
-add_halide_library(haar_x FROM wavelet::halide_generators::wavelet.generator)
-add_halide_library(inverse_haar_x FROM wavelet::halide_generators::wavelet.generator)
+add_halide_library(daubechies_x FROM wavelet.generator)
+add_halide_library(inverse_daubechies_x FROM wavelet.generator)
+add_halide_library(haar_x FROM wavelet.generator)
+add_halide_library(inverse_haar_x FROM wavelet.generator)
 
 # Main executable
 add_executable(wavelet wavelet.cpp)

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -18,7 +18,7 @@ define_property(TARGET PROPERTY Halide_GENERATOR_HAS_POST_BUILD
 function(add_halide_generator TARGET)
     set(options "")
     set(oneValueArgs PACKAGE_NAME PACKAGE_NAMESPACE EXPORT_FILE)
-    set(multiValueArgs SOURCES)
+    set(multiValueArgs SOURCES LINK_LIBRARIES)
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (NOT ARG_PACKAGE_NAME)
@@ -55,7 +55,7 @@ function(add_halide_generator TARGET)
 
         add_executable(${TARGET} ${ARG_SOURCES})
         add_executable(${gen} ALIAS ${TARGET})
-        target_link_libraries(${TARGET} PRIVATE Halide::Generator)
+        target_link_libraries(${TARGET} PRIVATE Halide::Generator ${ARG_LINK_LIBRARIES})
 
         add_dependencies("${ARG_PACKAGE_NAME}" ${TARGET})
         export(TARGETS ${TARGET}

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -148,6 +148,16 @@ function(add_halide_library TARGET)
         message(FATAL_ERROR "Missing FROM argument specifying a Halide generator target")
     endif ()
 
+    if (NOT TARGET ${ARG_FROM})
+        # FROM is usually an unqualified name; if we are crosscompiling, we might need a
+        # fully-qualified name, so add the default package name and retry
+        set(FQ_ARG_FROM "${PROJECT_NAME}::halide_generators::${ARG_FROM}")
+        if (NOT TARGET ${FQ_ARG_FROM})
+            message(FATAL_ERROR "Unable to local FROM as either ${ARG_FROM} or ${FQ_ARG_FROM}")
+        endif ()
+        set(ARG_FROM "${FQ_ARG_FROM}")
+    endif ()
+
     _Halide_place_dll(${ARG_FROM})
 
     if (ARG_C_BACKEND)

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -153,7 +153,7 @@ function(add_halide_library TARGET)
         # fully-qualified name, so add the default package name and retry
         set(FQ_ARG_FROM "${PROJECT_NAME}::halide_generators::${ARG_FROM}")
         if (NOT TARGET ${FQ_ARG_FROM})
-            message(FATAL_ERROR "Unable to local FROM as either ${ARG_FROM} or ${FQ_ARG_FROM}")
+            message(FATAL_ERROR "Unable to locate FROM as either ${ARG_FROM} or ${FQ_ARG_FROM}")
         endif ()
         set(ARG_FROM "${FQ_ARG_FROM}")
     endif ()


### PR DESCRIPTION
Existing CMake code uses add_executable + target_link_libraries to create a Generator, but the somewhat-recently-added add_halide_generator() helper is a cleaner way to do this. Move to using it everywhere in apps/ instead.

(Note that add_halide_generator()) doesn't yet work for in-tree builds, unfortunately.)