### PR TITLE
[APP] Fix `hexagon_benchmarks` build (use two-var prefetch)

### DIFF
--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -52,7 +52,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-	        output.prefetch(input, y, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -52,7 +52,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+	        output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -45,7 +45,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -52,7 +52,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -56,7 +56,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -50,7 +50,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;


### PR DESCRIPTION
Fix the following error when compiling `hexgaon_benchmarks` app:
```
Halide/distrib/include/Halide.h:24829:77: error: ‘Halide::Func& Halide::Func::prefetch(const T&, Halide::VarOrRVar, int, Halide::PrefetchBoundStrategy) [with T = Halide::GeneratorInput<Halide::Buffer<unsigned char> >]’ is deprecated: Call prefetch() with the two-var form instead. [-Werror=deprecated-declarations]
24829 |         return this->template as<Class>().Method(std::forward<Args>(args)...)
```