### PR TITLE
wasm simd cleanup

### DIFF
--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -76,6 +76,10 @@ const WasmIntrinsic intrinsic_defs[] = {
     {"llvm.wasm.avgr.unsigned.v16i8", UInt(8, 16), "rounding_halving_add", {UInt(8, 16), UInt(8, 16)}, Target::WasmSimd128},
     {"llvm.wasm.avgr.unsigned.v8i16", UInt(16, 8), "rounding_halving_add", {UInt(16, 8), UInt(16, 8)}, Target::WasmSimd128},
 
+#if LLVM_VERSION == 130
+    {"float_to_double", Float(64, 4), "float_to_double", {Float(32, 4)}, Target::WasmSimd128},
+#endif
+
 #if LLVM_VERSION >= 130
     // With some work, some of these could possibly be adapted to work under earlier versions of LLVM.
     {"widening_mul_i8x16", Int(16, 16), "widening_mul", {Int(8, 16), Int(8, 16)}, Target::WasmSimd128},
@@ -93,14 +97,6 @@ const WasmIntrinsic intrinsic_defs[] = {
     // since the result will be the same for our purposes here
     {"llvm.wasm.extadd.pairwise.unsigned.v8i16", Int(16, 8), "pairwise_widening_add", {UInt(8, 16)}, Target::WasmSimd128},
     {"llvm.wasm.extadd.pairwise.unsigned.v4i32", Int(32, 4), "pairwise_widening_add", {UInt(16, 8)}, Target::WasmSimd128},
-
-    // TODO: these instructions are no longer available at LLVM top of tree,
-    // but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions;
-    // investigation needed.
-    // {"i32_to_double_s", Float(64, 4), "int_to_double", {Int(32, 4)}, Target::WasmSimd128},
-    // {"i32_to_double_u", Float(64, 4), "int_to_double", {UInt(32, 4)}, Target::WasmSimd128},
-
-    {"float_to_double", Float(64, 4), "float_to_double", {Float(32, 4)}, Target::WasmSimd128},
 
     // Basically like ARM's SQRDMULH
     {"llvm.wasm.q15mulr.sat.signed", Int(16, 8), "q15mulr_sat_s", {Int(16, 8), Int(16, 8)}, Target::WasmSimd128},
@@ -157,7 +153,9 @@ void CodeGen_WebAssembly::visit(const Cast *op) {
         {"saturating_narrow", u16_sat(wild_i32x_), Target::WasmSimd128},
         {"int_to_double", f64(wild_i32x_), Target::WasmSimd128},
         {"int_to_double", f64(wild_u32x_), Target::WasmSimd128},
+#if LLVM_VERSION == 130
         {"float_to_double", f64(wild_f32x_), Target::WasmSimd128},
+#endif
     };
     // clang-format on
 

--- a/src/runtime/wasm_math.ll
+++ b/src/runtime/wasm_math.ll
@@ -234,31 +234,7 @@ define weak_odr <8 x i16> @saturating_narrow_i32x8_to_u16x8(<8 x i32> %x) nounwi
   ret <8 x i16> %3
 }
 
-; Integer to double-precision floating point
-
-; COMMENTED OUT AT TOP OF TREE; llvm.wasm.convert.low.[un]signed is no longer
-; available, but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions
-; that we'd expect, so investigation needs to be done.
-;   declare <2 x double> @llvm.wasm.convert.low.signed(<4 x i32>)
-;   declare <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32>)
-;
-;   define weak_odr <4 x double> @i32_to_double_s(<4 x i32> %x) nounwind alwaysinline {
-;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-;     %2 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %x)
-;     %3 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %1)
-;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-;     ret <4 x double> %4
-;   }
-;
-;   define weak_odr <4 x double> @i32_to_double_u(<4 x i32> %x) nounwind alwaysinline {
-;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-;     %2 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %x)
-;     %3 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %1)
-;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-;     ret <4 x double> %4
-;   }
-
-; single to double-precision floating point
+; single to double-precision floating point (only needed for LLVM_VERSION == 13)
 define weak_odr <4 x double> @float_to_double(<4 x float> %x) nounwind alwaysinline {
   %1 = fpext <4 x float> %x to <4 x double>
   ret <4 x double> %1


### PR DESCRIPTION
- f64x2.convert_low_i32x4_s/u  is handled properly by LLVM 14, so remove the TODO stuff and leave the test special-cased for that version (don't bother trying to make it work in LLVM13)
- our `float_to_double` glue is only needed for LLVM13, so update comments and ifdefs appropriately