### PR TITLE
Add support for wasm-simd ops for integer-integer widening

### DIFF
--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -109,6 +109,9 @@ const WasmIntrinsic intrinsic_defs[] = {
 
     {"llvm.wasm.dot", Int(32, 4), "dot_product", {Int(16, 8), Int(16, 8)}, Target::WasmSimd128},
 
+    // TODO: LLVM should be able to handle this on its own, but doesn't at top-of-tree as of Jan 2022;
+    // if/when https://github.com/llvm/llvm-project/issues/53278 gets addressed, it may be possible to remove
+    // these.
     {"extend_i8x16_to_i16x8", Int(16, 16), "widen_integer", {Int(8, 16)}, Target::WasmSimd128},
     {"extend_u8x16_to_u16x8", UInt(16, 16), "widen_integer", {UInt(8, 16)}, Target::WasmSimd128},
     {"extend_i16x8_to_i32x8", Int(32, 8), "widen_integer", {Int(16, 8)}, Target::WasmSimd128},

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -108,6 +108,13 @@ const WasmIntrinsic intrinsic_defs[] = {
     {"saturating_narrow_i32x8_to_u16x8", UInt(16, 8), "saturating_narrow", {Int(32, 8)}, Target::WasmSimd128},
 
     {"llvm.wasm.dot", Int(32, 4), "dot_product", {Int(16, 8), Int(16, 8)}, Target::WasmSimd128},
+
+    {"extend_i8x16_to_i16x8", Int(16, 16), "widen_integer", {Int(8, 16)}, Target::WasmSimd128},
+    {"extend_u8x16_to_u16x8", UInt(16, 16), "widen_integer", {UInt(8, 16)}, Target::WasmSimd128},
+    {"extend_i16x8_to_i32x8", Int(32, 8), "widen_integer", {Int(16, 8)}, Target::WasmSimd128},
+    {"extend_u16x8_to_u32x8", UInt(32, 8), "widen_integer", {UInt(16, 8)}, Target::WasmSimd128},
+    {"extend_i32x4_to_i64x4", Int(64, 4), "widen_integer", {Int(32, 4)}, Target::WasmSimd128},
+    {"extend_u32x4_to_u64x4", UInt(64, 4), "widen_integer", {UInt(32, 4)}, Target::WasmSimd128},
 #endif
 };
 // clang-format on
@@ -156,6 +163,12 @@ void CodeGen_WebAssembly::visit(const Cast *op) {
 #if LLVM_VERSION == 130
         {"float_to_double", f64(wild_f32x_), Target::WasmSimd128},
 #endif
+        {"widen_integer", i16(wild_i8x_), Target::WasmSimd128},
+        {"widen_integer", u16(wild_u8x_), Target::WasmSimd128},
+        {"widen_integer", i32(wild_i16x_), Target::WasmSimd128},
+        {"widen_integer", u32(wild_u16x_), Target::WasmSimd128},
+        {"widen_integer", i64(wild_i32x_), Target::WasmSimd128},
+        {"widen_integer", u64(wild_u32x_), Target::WasmSimd128},
     };
     // clang-format on
 

--- a/src/runtime/wasm_math.ll
+++ b/src/runtime/wasm_math.ll
@@ -239,3 +239,74 @@ define weak_odr <4 x double> @float_to_double(<4 x float> %x) nounwind alwaysinl
   %1 = fpext <4 x float> %x to <4 x double>
   ret <4 x double> %1
 }
+
+; Integer to integer extension
+
+; i8 -> i16
+
+define weak_odr <16 x i16> @extend_i8x16_to_i16x8(<16 x i8> %x) nounwind alwaysinline {
+  %1 = shufflevector <16 x i8> %x, <16 x i8> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %2 = shufflevector <16 x i8> %x, <16 x i8> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %3 = sext <8 x i8> %1 to <8 x i16>
+  %4 = sext <8 x i8> %2 to <8 x i16>
+  %5 = shufflevector <8 x i16> %3, <8 x i16> %4, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  ret <16 x i16> %5
+}
+
+; u8 -> u16
+
+define weak_odr <16 x i16> @extend_u8x16_to_u16x8(<16 x i8> %x) nounwind alwaysinline {
+  %1 = shufflevector <16 x i8> %x, <16 x i8> undef, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  %2 = shufflevector <16 x i8> %x, <16 x i8> undef, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  %3 = zext <8 x i8> %1 to <8 x i16>
+  %4 = zext <8 x i8> %2 to <8 x i16>
+  %5 = shufflevector <8 x i16> %3, <8 x i16> %4, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  ret <16 x i16> %5
+}
+
+; i16 -> i32
+
+define weak_odr <8 x i32> @extend_i16x8_to_i32x8(<8 x i16> %x) nounwind alwaysinline {
+  %1 = shufflevector <8 x i16> %x, <8 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %2 = shufflevector <8 x i16> %x, <8 x i16> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %3 = sext <4 x i16> %1 to <4 x i32>
+  %4 = sext <4 x i16> %2 to <4 x i32>
+  %5 = shufflevector <4 x i32> %3, <4 x i32> %4, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  ret <8 x i32> %5
+}
+
+; u16 -> u32
+
+define weak_odr <8 x i32> @extend_u16x8_to_u32x8(<8 x i16> %x) nounwind alwaysinline {
+  %1 = shufflevector <8 x i16> %x, <8 x i16> undef, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %2 = shufflevector <8 x i16> %x, <8 x i16> undef, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %3 = zext <4 x i16> %1 to <4 x i32>
+  %4 = zext <4 x i16> %2 to <4 x i32>
+  %5 = shufflevector <4 x i32> %3, <4 x i32> %4, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  ret <8 x i32> %5
+}
+
+; i32 -> i64
+
+define weak_odr <4 x i64> @extend_i32x4_to_i64x4(<4 x i32> %x) nounwind alwaysinline {
+  %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <2 x i32> <i32 0, i32 1>
+  %2 = shufflevector <4 x i32> %x, <4 x i32> undef, <2 x i32> <i32 2, i32 3>
+  %3 = sext <2 x i32> %1 to <2 x i64>
+  %4 = sext <2 x i32> %2 to <2 x i64>
+  %5 = shufflevector <2 x i64> %3, <2 x i64> %4, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x i64> %5
+}
+
+; u32 -> u64
+
+define weak_odr <4 x i64> @extend_u32x4_to_u64x4(<4 x i32> %x) nounwind alwaysinline {
+  %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <2 x i32> <i32 0, i32 1>
+  %2 = shufflevector <4 x i32> %x, <4 x i32> undef, <2 x i32> <i32 2, i32 3>
+  %3 = zext <2 x i32> %1 to <2 x i64>
+  %4 = zext <2 x i32> %2 to <2 x i64>
+  %5 = shufflevector <2 x i64> %3, <2 x i64> %4, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  ret <4 x i64> %5
+}
+
+
+

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2235,7 +2235,6 @@ public:
                 }
 
                 // Integer to integer widening
-                // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK
                 check("i16x8.extend_low_i8x16_s", 16*w, i16(i8_1));
                 check("i16x8.extend_high_i8x16_s", 16*w, i16(i8_1));
                 check("i16x8.extend_low_i8x16_u", 16*w, u16(u8_1));

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2235,18 +2235,18 @@ public:
                 }
 
                 // Integer to integer widening
-                check("i16x8.extend_low_i8x16_s", 16*w, i16(i8_1));
-                check("i16x8.extend_high_i8x16_s", 16*w, i16(i8_1));
-                check("i16x8.extend_low_i8x16_u", 16*w, u16(u8_1));
-                check("i16x8.extend_high_i8x16_u", 16*w, u16(u8_1));
-                check("i32x4.extend_low_i16x8_s", 8*w, i32(i16_1));
-                check("i32x4.extend_high_i16x8_s", 8*w, i32(i16_1));
-                check("i32x4.extend_low_i16x8_u", 8*w, u32(u16_1));
-                check("i32x4.extend_high_i16x8_u", 8*w, u32(u16_1));
-                check("i64x2.extend_low_i32x4_s", 4*w, i64(i32_1));
-                check("i64x2.extend_high_i32x4_s", 4*w, i64(i32_1));
-                check("i64x2.extend_low_i32x4_u", 4*w, u64(u32_1));
-                check("i64x2.extend_high_i32x4_u", 4*w, u64(u32_1));
+                check("i16x8.extend_low_i8x16_s", 16 * w, i16(i8_1));
+                check("i16x8.extend_high_i8x16_s", 16 * w, i16(i8_1));
+                check("i16x8.extend_low_i8x16_u", 16 * w, u16(u8_1));
+                check("i16x8.extend_high_i8x16_u", 16 * w, u16(u8_1));
+                check("i32x4.extend_low_i16x8_s", 8 * w, i32(i16_1));
+                check("i32x4.extend_high_i16x8_s", 8 * w, i32(i16_1));
+                check("i32x4.extend_low_i16x8_u", 8 * w, u32(u16_1));
+                check("i32x4.extend_high_i16x8_u", 8 * w, u32(u16_1));
+                check("i64x2.extend_low_i32x4_s", 4 * w, i64(i32_1));
+                check("i64x2.extend_high_i32x4_s", 4 * w, i64(i32_1));
+                check("i64x2.extend_low_i32x4_u", 4 * w, u64(u32_1));
+                check("i64x2.extend_high_i32x4_u", 4 * w, u64(u32_1));
             }
         }
     }

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2236,18 +2236,18 @@ public:
 
                 // Integer to integer widening
                 // TODO(https://github.com/halide/Halide/issues/5130): NOT BEING GENERATED AT TRUNK
-                // check("i16x8.extend_low_i8x16_s", 8*w, i8(x) * 2);
-                // check("i16x8.extend_high_i8x16_s", 8*w, i16(i8_1));
-                // check("i16x8.extend_low_i8x16_u", 8*w, u8(x) * 2);
-                // check("i16x8.extend_high_i8x16_u", 8*w, u16(u8_1));
-                // check("i32x4.extend_low_i16x8_s", 4*w, i32(i16_1));
-                // check("i32x4.extend_high_i16x8_s", 4*w, i32(i16_1));
-                // check("i32x4.extend_low_i16x8_u", 4*w, u32(u16_1));
-                // check("i32x4.extend_high_i16x8_u", 4*w, u32(u16_1));
-                // check("i64x2.extend_low_i32x4_s", 2*w, i64(i32_1));
-                // check("i64x2.extend_high_i32x4_s", 2*w, i64(i32_1));
-                // check("i64x2.extend_low_i32x4_u", 2*w, u64(u32_1));
-                // check("i64x2.extend_high_i32x4_u", 2*w, u64(u32_1));
+                check("i16x8.extend_low_i8x16_s", 16*w, i16(i8_1));
+                check("i16x8.extend_high_i8x16_s", 16*w, i16(i8_1));
+                check("i16x8.extend_low_i8x16_u", 16*w, u16(u8_1));
+                check("i16x8.extend_high_i8x16_u", 16*w, u16(u8_1));
+                check("i32x4.extend_low_i16x8_s", 8*w, i32(i16_1));
+                check("i32x4.extend_high_i16x8_s", 8*w, i32(i16_1));
+                check("i32x4.extend_low_i16x8_u", 8*w, u32(u16_1));
+                check("i32x4.extend_high_i16x8_u", 8*w, u32(u16_1));
+                check("i64x2.extend_low_i32x4_s", 4*w, i64(i32_1));
+                check("i64x2.extend_high_i32x4_s", 4*w, i64(i32_1));
+                check("i64x2.extend_low_i32x4_u", 4*w, u64(u32_1));
+                check("i64x2.extend_high_i32x4_u", 4*w, u64(u32_1));
             }
         }
     }


### PR DESCRIPTION
For reasons that are still under investigation, the WebAssembly simd128 instructions to do integer widening aren't getting emitted by LLVM14. This adds explicit pattern-matching code to generate them for typical cases as a temporary workaround pending more detailed investigation.

