### PR TITLE
Rename Output to OutputFileType and deprecated Output

### DIFF
--- a/python_bindings/correctness/compile_to.py
+++ b/python_bindings/correctness/compile_to.py
@@ -43,7 +43,7 @@ def main():
             assert os.path.isfile(os.path.join(tmpdir, "f_all.o"))
 
         p = os.path.join(tmpdir, "f.html")
-        f.compile_to({hl.Output.stmt_html: p}, args, "f")
+        f.compile_to({hl.OutputFileType.stmt_html: p}, args, "f")
         assert os.path.isfile(p)
 
     finally:

--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -163,23 +163,23 @@ void define_enums(py::module &m) {
         .value("Float", Type::Float)
         .value("Handle", Type::Handle);
 
-    py::enum_<Output>(m, "Output")
-        .value("assembly", Output::assembly)
-        .value("bitcode", Output::bitcode)
-        .value("c_header", Output::c_header)
-        .value("c_source", Output::c_source)
-        .value("cpp_stub", Output::cpp_stub)
-        .value("featurization", Output::featurization)
-        .value("llvm_assembly", Output::llvm_assembly)
-        .value("object", Output::object)
-        .value("python_extension", Output::python_extension)
-        .value("pytorch_wrapper", Output::pytorch_wrapper)
-        .value("registration", Output::registration)
-        .value("schedule", Output::schedule)
-        .value("static_library", Output::static_library)
-        .value("stmt", Output::stmt)
-        .value("stmt_html", Output::stmt_html)
-        .value("compiler_log", Output::compiler_log);
+    py::enum_<OutputType>(m, "OutputType")
+        .value("assembly", OutputType::assembly)
+        .value("bitcode", OutputType::bitcode)
+        .value("c_header", OutputType::c_header)
+        .value("c_source", OutputType::c_source)
+        .value("cpp_stub", OutputType::cpp_stub)
+        .value("featurization", OutputType::featurization)
+        .value("llvm_assembly", OutputType::llvm_assembly)
+        .value("object", OutputType::object)
+        .value("python_extension", OutputType::python_extension)
+        .value("pytorch_wrapper", OutputType::pytorch_wrapper)
+        .value("registration", OutputType::registration)
+        .value("schedule", OutputType::schedule)
+        .value("static_library", OutputType::static_library)
+        .value("stmt", OutputType::stmt)
+        .value("stmt_html", OutputType::stmt_html)
+        .value("compiler_log", OutputType::compiler_log);
 }
 
 }  // namespace PythonBindings

--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -163,23 +163,23 @@ void define_enums(py::module &m) {
         .value("Float", Type::Float)
         .value("Handle", Type::Handle);
 
-    py::enum_<OutputType>(m, "OutputType")
-        .value("assembly", OutputType::assembly)
-        .value("bitcode", OutputType::bitcode)
-        .value("c_header", OutputType::c_header)
-        .value("c_source", OutputType::c_source)
-        .value("cpp_stub", OutputType::cpp_stub)
-        .value("featurization", OutputType::featurization)
-        .value("llvm_assembly", OutputType::llvm_assembly)
-        .value("object", OutputType::object)
-        .value("python_extension", OutputType::python_extension)
-        .value("pytorch_wrapper", OutputType::pytorch_wrapper)
-        .value("registration", OutputType::registration)
-        .value("schedule", OutputType::schedule)
-        .value("static_library", OutputType::static_library)
-        .value("stmt", OutputType::stmt)
-        .value("stmt_html", OutputType::stmt_html)
-        .value("compiler_log", OutputType::compiler_log);
+    py::enum_<OutputFileType>(m, "OutputFileType")
+        .value("assembly", OutputFileType::assembly)
+        .value("bitcode", OutputFileType::bitcode)
+        .value("c_header", OutputFileType::c_header)
+        .value("c_source", OutputFileType::c_source)
+        .value("cpp_stub", OutputFileType::cpp_stub)
+        .value("featurization", OutputFileType::featurization)
+        .value("llvm_assembly", OutputFileType::llvm_assembly)
+        .value("object", OutputFileType::object)
+        .value("python_extension", OutputFileType::python_extension)
+        .value("pytorch_wrapper", OutputFileType::pytorch_wrapper)
+        .value("registration", OutputFileType::registration)
+        .value("schedule", OutputFileType::schedule)
+        .value("static_library", OutputFileType::static_library)
+        .value("stmt", OutputFileType::stmt)
+        .value("stmt_html", OutputFileType::stmt_html)
+        .value("compiler_log", OutputFileType::compiler_log);
 }
 
 }  // namespace PythonBindings

--- a/python_bindings/src/PyModule.cpp
+++ b/python_bindings/src/PyModule.cpp
@@ -31,8 +31,8 @@ void define_module(py::module &m) {
             .def("buffers", &Module::buffers)
             .def("submodules", &Module::submodules)
 
-            .def("append", (void (Module::*)(const Buffer<> &)) & Module::append, py::arg("buffer"))
-            .def("append", (void (Module::*)(const Module &)) & Module::append, py::arg("module"))
+            .def("append", (void(Module::*)(const Buffer<> &)) & Module::append, py::arg("buffer"))
+            .def("append", (void(Module::*)(const Module &)) & Module::append, py::arg("module"))
 
             .def("compile", &Module::compile, py::arg("outputs"))
 
@@ -62,7 +62,7 @@ void define_module(py::module &m) {
 
     m.def("link_modules", &link_modules, py::arg("name"), py::arg("modules"));
     m.def("compile_standalone_runtime", (void (*)(const std::string &, const Target &)) & compile_standalone_runtime, py::arg("filename"), py::arg("target"));
-    using OutputMap = std::map<Output, std::string>;
+    using OutputMap = std::map<OutputType, std::string>;
     m.def("compile_standalone_runtime", (OutputMap(*)(const OutputMap &, const Target &)) & compile_standalone_runtime, py::arg("outputs"), py::arg("target"));
 
     // TODO: compile_multitarget() deliberately skipped for now.

--- a/python_bindings/src/PyModule.cpp
+++ b/python_bindings/src/PyModule.cpp
@@ -62,7 +62,7 @@ void define_module(py::module &m) {
 
     m.def("link_modules", &link_modules, py::arg("name"), py::arg("modules"));
     m.def("compile_standalone_runtime", (void (*)(const std::string &, const Target &)) & compile_standalone_runtime, py::arg("filename"), py::arg("target"));
-    using OutputMap = std::map<OutputType, std::string>;
+    using OutputMap = std::map<OutputFileType, std::string>;
     m.def("compile_standalone_runtime", (OutputMap(*)(const OutputMap &, const Target &)) & compile_standalone_runtime, py::arg("outputs"), py::arg("target"));
 
     // TODO: compile_multitarget() deliberately skipped for now.

--- a/python_bindings/src/PyModule.cpp
+++ b/python_bindings/src/PyModule.cpp
@@ -31,8 +31,8 @@ void define_module(py::module &m) {
             .def("buffers", &Module::buffers)
             .def("submodules", &Module::submodules)
 
-            .def("append", (void(Module::*)(const Buffer<> &)) & Module::append, py::arg("buffer"))
-            .def("append", (void(Module::*)(const Module &)) & Module::append, py::arg("module"))
+            .def("append", (void (Module::*)(const Buffer<> &)) & Module::append, py::arg("buffer"))
+            .def("append", (void (Module::*)(const Module &)) & Module::append, py::arg("module"))
 
             .def("compile", &Module::compile, py::arg("outputs"))
 

--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -64,8 +64,8 @@ def main():
     # arguments to the routine. This routine takes two. Arguments are
     # usually Params or ImageParams.
     fname = "lesson_10_halide"
-    brighter.compile_to({hl.Output.object: "lesson_10_halide.o",
-                         hl.Output.python_extension: "lesson_10_halide.py.cpp"},
+    brighter.compile_to({hl.OutputFileType.object: "lesson_10_halide.o",
+                         hl.OutputFileType.python_extension: "lesson_10_halide.py.cpp"},
                         [input, offset], "lesson_10_halide")
 
     print("Halide pipeline compiled, but not yet run.")

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3179,7 +3179,7 @@ Module Func::compile_to_module(const vector<Argument> &args, const std::string &
     return pipeline().compile_to_module(args, fn_name, target);
 }
 
-void Func::compile_to(const map<OutputType, string> &output_files,
+void Func::compile_to(const map<OutputFileType, string> &output_files,
                       const vector<Argument> &args,
                       const string &fn_name,
                       const Target &target) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3179,7 +3179,7 @@ Module Func::compile_to_module(const vector<Argument> &args, const std::string &
     return pipeline().compile_to_module(args, fn_name, target);
 }
 
-void Func::compile_to(const map<Output, string> &output_files,
+void Func::compile_to(const map<OutputFile, string> &output_files,
                       const vector<Argument> &args,
                       const string &fn_name,
                       const Target &target) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3179,7 +3179,7 @@ Module Func::compile_to_module(const vector<Argument> &args, const std::string &
     return pipeline().compile_to_module(args, fn_name, target);
 }
 
-void Func::compile_to(const map<OutputFile, string> &output_files,
+void Func::compile_to(const map<OutputType, string> &output_files,
                       const vector<Argument> &args,
                       const string &fn_name,
                       const Target &target) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -1034,7 +1034,7 @@ public:
      * Deduces target files based on filenames specified in
      * output_files map.
      */
-    void compile_to(const std::map<OutputType, std::string> &output_files,
+    void compile_to(const std::map<OutputFileType, std::string> &output_files,
                     const std::vector<Argument> &args,
                     const std::string &fn_name,
                     const Target &target = get_target_from_environment());

--- a/src/Func.h
+++ b/src/Func.h
@@ -1034,7 +1034,7 @@ public:
      * Deduces target files based on filenames specified in
      * output_files map.
      */
-    void compile_to(const std::map<Output, std::string> &output_files,
+    void compile_to(const std::map<OutputFile, std::string> &output_files,
                     const std::vector<Argument> &args,
                     const std::string &fn_name,
                     const Target &target = get_target_from_environment());
@@ -2301,9 +2301,9 @@ public:
     Func &async();
 
     /** Bound the extent of a Func's storage, but not extent of its
-     * compute. This can be useful for forcing a function's allocation 
-     * to be a fixed size, which often means it can go on the stack. 
-     * If bounds inference decides that it requires more storage for 
+     * compute. This can be useful for forcing a function's allocation
+     * to be a fixed size, which often means it can go on the stack.
+     * If bounds inference decides that it requires more storage for
      * this function than the allocation size you have stated, a runtime
      * error will occur when you try to run the pipeline. */
     Func &bound_storage(const Var &dim, const Expr &bound);

--- a/src/Func.h
+++ b/src/Func.h
@@ -1034,7 +1034,7 @@ public:
      * Deduces target files based on filenames specified in
      * output_files map.
      */
-    void compile_to(const std::map<OutputFile, std::string> &output_files,
+    void compile_to(const std::map<OutputType, std::string> &output_files,
                     const std::vector<Argument> &args,
                     const std::string &fn_name,
                     const Target &target = get_target_from_environment());

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -82,12 +82,12 @@ std::string compute_base_path(const std::string &output_dir,
     return base_path;
 }
 
-std::map<OutputType, std::string> compute_output_files(const Target &target,
-                                                       const std::string &base_path,
-                                                       const std::set<OutputType> &outputs) {
-    std::map<OutputType, const OutputInfo> output_info = get_output_info(target);
+std::map<OutputFileType, std::string> compute_output_files(const Target &target,
+                                                           const std::string &base_path,
+                                                           const std::set<OutputFileType> &outputs) {
+    std::map<OutputFileType, const OutputInfo> output_info = get_output_info(target);
 
-    std::map<OutputType, std::string> output_files;
+    std::map<OutputFileType, std::string> output_files;
     for (auto o : outputs) {
         output_files[o] = base_path + output_info.at(o).extension;
     }
@@ -912,23 +912,23 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output
     }
 
     // extensions won't vary across multitarget output
-    std::map<OutputType, const OutputInfo> output_info = get_output_info(targets[0]);
+    std::map<OutputFileType, const OutputInfo> output_info = get_output_info(targets[0]);
 
-    std::set<OutputType> outputs;
+    std::set<OutputFileType> outputs;
     if (emit_flags.empty() || (emit_flags.size() == 1 && emit_flags[0].empty())) {
         // If omitted or empty, assume .a and .h and registration.cpp
-        outputs.insert(OutputType::c_header);
-        outputs.insert(OutputType::registration);
-        outputs.insert(OutputType::static_library);
+        outputs.insert(OutputFileType::c_header);
+        outputs.insert(OutputFileType::registration);
+        outputs.insert(OutputFileType::static_library);
     } else {
         // Build a reverse lookup table. Allow some legacy aliases on the command line,
         // to allow legacy build systems to work more easily.
-        std::map<std::string, OutputType> output_name_to_enum = {
-            {"cpp", OutputType::c_source},
-            {"h", OutputType::c_header},
-            {"html", OutputType::stmt_html},
-            {"o", OutputType::object},
-            {"py.c", OutputType::python_extension},
+        std::map<std::string, OutputFileType> output_name_to_enum = {
+            {"cpp", OutputFileType::c_source},
+            {"h", OutputFileType::c_header},
+            {"html", OutputFileType::stmt_html},
+            {"o", OutputFileType::object},
+            {"py.c", OutputFileType::python_extension},
         };
         for (const auto &it : output_info) {
             output_name_to_enum[it.second.name] = it.first;
@@ -955,7 +955,7 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output
     }
 
     // Allow quick-n-dirty use of compiler logging via HL_DEBUG_COMPILER_LOGGER env var
-    const bool do_compiler_logging = outputs.count(OutputType::compiler_log) ||
+    const bool do_compiler_logging = outputs.count(OutputFileType::compiler_log) ||
                                      (get_env_variable("HL_DEBUG_COMPILER_LOGGER") == "1");
 
     const bool obfuscate_compiler_logging = get_env_variable("HL_OBFUSCATE_COMPILER_LOGGER") == "1";
@@ -1055,11 +1055,11 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output
     if (!generator_name.empty()) {
         std::string base_path = compute_base_path(output_dir, function_name, file_base_name);
         debug(1) << "Generator " << generator_name << " has base_path " << base_path << "\n";
-        if (outputs.count(OutputType::cpp_stub)) {
+        if (outputs.count(OutputFileType::cpp_stub)) {
             // When generating cpp_stub, we ignore all generator args passed in, and supply a fake Target.
             // (CompilerLogger is never enabled for cpp_stub, for now anyway.)
             auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(Target()));
-            auto stub_file_path = base_path + output_info[OutputType::cpp_stub].extension;
+            auto stub_file_path = base_path + output_info[OutputFileType::cpp_stub].extension;
             gen->emit_cpp_stub(stub_file_path);
         }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -82,12 +82,12 @@ std::string compute_base_path(const std::string &output_dir,
     return base_path;
 }
 
-std::map<OutputFile, std::string> compute_output_files(const Target &target,
+std::map<OutputType, std::string> compute_output_files(const Target &target,
                                                        const std::string &base_path,
-                                                       const std::set<OutputFile> &outputs) {
-    std::map<OutputFile, const OutputInfo> output_info = get_output_info(target);
+                                                       const std::set<OutputType> &outputs) {
+    std::map<OutputType, const OutputInfo> output_info = get_output_info(target);
 
-    std::map<OutputFile, std::string> output_files;
+    std::map<OutputType, std::string> output_files;
     for (auto o : outputs) {
         output_files[o] = base_path + output_info.at(o).extension;
     }
@@ -912,23 +912,23 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output
     }
 
     // extensions won't vary across multitarget output
-    std::map<OutputFile, const OutputInfo> output_info = get_output_info(targets[0]);
+    std::map<OutputType, const OutputInfo> output_info = get_output_info(targets[0]);
 
-    std::set<OutputFile> outputs;
+    std::set<OutputType> outputs;
     if (emit_flags.empty() || (emit_flags.size() == 1 && emit_flags[0].empty())) {
         // If omitted or empty, assume .a and .h and registration.cpp
-        outputs.insert(OutputFile::c_header);
-        outputs.insert(OutputFile::registration);
-        outputs.insert(OutputFile::static_library);
+        outputs.insert(OutputType::c_header);
+        outputs.insert(OutputType::registration);
+        outputs.insert(OutputType::static_library);
     } else {
         // Build a reverse lookup table. Allow some legacy aliases on the command line,
         // to allow legacy build systems to work more easily.
-        std::map<std::string, OutputFile> output_name_to_enum = {
-            {"cpp", OutputFile::c_source},
-            {"h", OutputFile::c_header},
-            {"html", OutputFile::stmt_html},
-            {"o", OutputFile::object},
-            {"py.c", OutputFile::python_extension},
+        std::map<std::string, OutputType> output_name_to_enum = {
+            {"cpp", OutputType::c_source},
+            {"h", OutputType::c_header},
+            {"html", OutputType::stmt_html},
+            {"o", OutputType::object},
+            {"py.c", OutputType::python_extension},
         };
         for (const auto &it : output_info) {
             output_name_to_enum[it.second.name] = it.first;
@@ -955,7 +955,7 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output
     }
 
     // Allow quick-n-dirty use of compiler logging via HL_DEBUG_COMPILER_LOGGER env var
-    const bool do_compiler_logging = outputs.count(OutputFile::compiler_log) ||
+    const bool do_compiler_logging = outputs.count(OutputType::compiler_log) ||
                                      (get_env_variable("HL_DEBUG_COMPILER_LOGGER") == "1");
 
     const bool obfuscate_compiler_logging = get_env_variable("HL_OBFUSCATE_COMPILER_LOGGER") == "1";
@@ -1055,11 +1055,11 @@ int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output
     if (!generator_name.empty()) {
         std::string base_path = compute_base_path(output_dir, function_name, file_base_name);
         debug(1) << "Generator " << generator_name << " has base_path " << base_path << "\n";
-        if (outputs.count(OutputFile::cpp_stub)) {
+        if (outputs.count(OutputType::cpp_stub)) {
             // When generating cpp_stub, we ignore all generator args passed in, and supply a fake Target.
             // (CompilerLogger is never enabled for cpp_stub, for now anyway.)
             auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(Target()));
-            auto stub_file_path = base_path + output_info[OutputFile::cpp_stub].extension;
+            auto stub_file_path = base_path + output_info[OutputType::cpp_stub].extension;
             gen->emit_cpp_stub(stub_file_path);
         }
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -37,27 +37,27 @@ namespace Internal {
 // We really don't want to vary the file extensions based on target flags,
 // and in practice, it's extremely unlikely that anyone needs to rely on this
 // being pure C output (vs possibly C++).
-std::map<Output, const OutputInfo> get_output_info(const Target &target) {
+std::map<OutputFile, const OutputInfo> get_output_info(const Target &target) {
     constexpr bool IsMulti = true;
     constexpr bool IsSingle = false;
     const bool is_windows_coff = target.os == Target::Windows;
-    std::map<Output, const OutputInfo> ext = {
-        {Output::assembly, {"assembly", ".s", IsMulti}},
-        {Output::bitcode, {"bitcode", ".bc", IsMulti}},
-        {Output::c_header, {"c_header", ".h", IsSingle}},
-        {Output::c_source, {"c_source", ".halide_generated.cpp", IsSingle}},
-        {Output::compiler_log, {"compiler_log", ".halide_compiler_log", IsSingle}},
-        {Output::cpp_stub, {"cpp_stub", ".stub.h", IsSingle}},
-        {Output::featurization, {"featurization", ".featurization", IsMulti}},
-        {Output::llvm_assembly, {"llvm_assembly", ".ll", IsMulti}},
-        {Output::object, {"object", is_windows_coff ? ".obj" : ".o", IsMulti}},
-        {Output::python_extension, {"python_extension", ".py.cpp", IsSingle}},
-        {Output::pytorch_wrapper, {"pytorch_wrapper", ".pytorch.h", IsSingle}},
-        {Output::registration, {"registration", ".registration.cpp", IsSingle}},
-        {Output::schedule, {"schedule", ".schedule.h", IsSingle}},
-        {Output::static_library, {"static_library", is_windows_coff ? ".lib" : ".a", IsSingle}},
-        {Output::stmt, {"stmt", ".stmt", IsMulti}},
-        {Output::stmt_html, {"stmt_html", ".stmt.html", IsMulti}},
+    std::map<OutputFile, const OutputInfo> ext = {
+        {OutputFile::assembly, {"assembly", ".s", IsMulti}},
+        {OutputFile::bitcode, {"bitcode", ".bc", IsMulti}},
+        {OutputFile::c_header, {"c_header", ".h", IsSingle}},
+        {OutputFile::c_source, {"c_source", ".halide_generated.cpp", IsSingle}},
+        {OutputFile::compiler_log, {"compiler_log", ".halide_compiler_log", IsSingle}},
+        {OutputFile::cpp_stub, {"cpp_stub", ".stub.h", IsSingle}},
+        {OutputFile::featurization, {"featurization", ".featurization", IsMulti}},
+        {OutputFile::llvm_assembly, {"llvm_assembly", ".ll", IsMulti}},
+        {OutputFile::object, {"object", is_windows_coff ? ".obj" : ".o", IsMulti}},
+        {OutputFile::python_extension, {"python_extension", ".py.cpp", IsSingle}},
+        {OutputFile::pytorch_wrapper, {"pytorch_wrapper", ".pytorch.h", IsSingle}},
+        {OutputFile::registration, {"registration", ".registration.cpp", IsSingle}},
+        {OutputFile::schedule, {"schedule", ".schedule.h", IsSingle}},
+        {OutputFile::static_library, {"static_library", is_windows_coff ? ".lib" : ".a", IsSingle}},
+        {OutputFile::stmt, {"stmt", ".stmt", IsMulti}},
+        {OutputFile::stmt_html, {"stmt_html", ".stmt.html", IsMulti}},
     };
     return ext;
 }
@@ -141,7 +141,7 @@ std::string add_suffix(const std::string &path, const std::string &suffix) {
     }
 }
 
-void validate_outputs(const std::map<Output, std::string> &in) {
+void validate_outputs(const std::map<OutputFile, std::string> &in) {
     // We don't care about the extensions, so any Target will do
     auto known = get_output_info(Target());
     for (const auto &it : in) {
@@ -149,7 +149,7 @@ void validate_outputs(const std::map<Output, std::string> &in) {
     }
 }
 
-bool contains(const std::map<Output, std::string> &in, const Output &key) {
+bool contains(const std::map<OutputFile, std::string> &in, const OutputFile &key) {
     return in.find(key) != in.end();
 }
 
@@ -552,42 +552,42 @@ std::map<std::string, std::string> Module::get_metadata_name_map() const {
     return contents->metadata_name_map;
 }
 
-void Module::compile(const std::map<Output, std::string> &output_files) const {
+void Module::compile(const std::map<OutputFile, std::string> &output_files) const {
     validate_outputs(output_files);
 
     // output stmt and html prior to resolving submodules. We need to
     // clear the output after writing it, otherwise the output will
     // be overwritten by recursive calls after submodules are resolved.
-    if (contains(output_files, Output::stmt)) {
-        debug(1) << "Module.compile(): stmt " << output_files.at(Output::stmt) << "\n";
-        std::ofstream file(output_files.at(Output::stmt));
+    if (contains(output_files, OutputFile::stmt)) {
+        debug(1) << "Module.compile(): stmt " << output_files.at(OutputFile::stmt) << "\n";
+        std::ofstream file(output_files.at(OutputFile::stmt));
         file << *this;
     }
-    if (contains(output_files, Output::stmt_html)) {
-        debug(1) << "Module.compile(): stmt_html " << output_files.at(Output::stmt_html) << "\n";
-        Internal::print_to_html(output_files.at(Output::stmt_html), *this);
+    if (contains(output_files, OutputFile::stmt_html)) {
+        debug(1) << "Module.compile(): stmt_html " << output_files.at(OutputFile::stmt_html) << "\n";
+        Internal::print_to_html(output_files.at(OutputFile::stmt_html), *this);
     }
 
     // If there are submodules, recursively lower submodules to
     // buffers on a copy of the module being compiled, then compile
     // the copied module.
     if (!submodules().empty()) {
-        std::map<Output, std::string> output_files_copy = output_files;
-        output_files_copy.erase(Output::stmt);
-        output_files_copy.erase(Output::stmt_html);
+        std::map<OutputFile, std::string> output_files_copy = output_files;
+        output_files_copy.erase(OutputFile::stmt);
+        output_files_copy.erase(OutputFile::stmt_html);
         resolve_submodules().compile(output_files_copy);
         return;
     }
 
     auto *logger = get_compiler_logger();
-    if (contains(output_files, Output::object) || contains(output_files, Output::assembly) ||
-        contains(output_files, Output::bitcode) || contains(output_files, Output::llvm_assembly) ||
-        contains(output_files, Output::static_library)) {
+    if (contains(output_files, OutputFile::object) || contains(output_files, OutputFile::assembly) ||
+        contains(output_files, OutputFile::bitcode) || contains(output_files, OutputFile::llvm_assembly) ||
+        contains(output_files, OutputFile::static_library)) {
         llvm::LLVMContext context;
         std::unique_ptr<llvm::Module> llvm_module(compile_module_to_llvm_module(*this, context));
 
-        if (contains(output_files, Output::object)) {
-            const auto &f = output_files.at(Output::object);
+        if (contains(output_files, OutputFile::object)) {
+            const auto &f = output_files.at(OutputFile::object);
             debug(1) << "Module.compile(): object " << f << "\n";
             auto out = make_raw_fd_ostream(f);
             compile_llvm_module_to_object(*llvm_module, *out);
@@ -596,105 +596,105 @@ void Module::compile(const std::map<Output, std::string> &output_files) const {
                 logger->record_object_code_size(file_stat(f).file_size);
             }
         }
-        if (contains(output_files, Output::static_library)) {
+        if (contains(output_files, OutputFile::static_library)) {
             // To simplify the code, we always create a temporary object output
-            // here, even if output_files.at(Output::object) was also set: in practice,
+            // here, even if output_files.at(OutputFile::object) was also set: in practice,
             // no real-world code ever sets both object and static_library
             // at the same time, so there is no meaningful performance advantage
             // to be had.
             TemporaryObjectFileDir temp_dir;
             {
-                std::string object = temp_dir.add_temp_object_file(output_files.at(Output::static_library), "", target());
+                std::string object = temp_dir.add_temp_object_file(output_files.at(OutputFile::static_library), "", target());
                 debug(1) << "Module.compile(): temporary object " << object << "\n";
                 auto out = make_raw_fd_ostream(object);
                 compile_llvm_module_to_object(*llvm_module, *out);
                 out->flush();  // create_static_library() is happier if we do this
-                if (logger && !contains(output_files, Output::object)) {
+                if (logger && !contains(output_files, OutputFile::object)) {
                     // Don't double-record object-code size if we already recorded it for object
                     logger->record_object_code_size(file_stat(object).file_size);
                 }
             }
-            debug(1) << "Module.compile(): static_library " << output_files.at(Output::static_library) << "\n";
+            debug(1) << "Module.compile(): static_library " << output_files.at(OutputFile::static_library) << "\n";
             Target base_target(target().os, target().arch, target().bits);
-            create_static_library(temp_dir.files(), base_target, output_files.at(Output::static_library));
+            create_static_library(temp_dir.files(), base_target, output_files.at(OutputFile::static_library));
         }
-        if (contains(output_files, Output::assembly)) {
-            debug(1) << "Module.compile(): assembly " << output_files.at(Output::assembly) << "\n";
-            auto out = make_raw_fd_ostream(output_files.at(Output::assembly));
+        if (contains(output_files, OutputFile::assembly)) {
+            debug(1) << "Module.compile(): assembly " << output_files.at(OutputFile::assembly) << "\n";
+            auto out = make_raw_fd_ostream(output_files.at(OutputFile::assembly));
             compile_llvm_module_to_assembly(*llvm_module, *out);
         }
-        if (contains(output_files, Output::bitcode)) {
-            debug(1) << "Module.compile(): bitcode " << output_files.at(Output::bitcode) << "\n";
-            auto out = make_raw_fd_ostream(output_files.at(Output::bitcode));
+        if (contains(output_files, OutputFile::bitcode)) {
+            debug(1) << "Module.compile(): bitcode " << output_files.at(OutputFile::bitcode) << "\n";
+            auto out = make_raw_fd_ostream(output_files.at(OutputFile::bitcode));
             compile_llvm_module_to_llvm_bitcode(*llvm_module, *out);
         }
-        if (contains(output_files, Output::llvm_assembly)) {
-            debug(1) << "Module.compile(): llvm_assembly " << output_files.at(Output::llvm_assembly) << "\n";
-            auto out = make_raw_fd_ostream(output_files.at(Output::llvm_assembly));
+        if (contains(output_files, OutputFile::llvm_assembly)) {
+            debug(1) << "Module.compile(): llvm_assembly " << output_files.at(OutputFile::llvm_assembly) << "\n";
+            auto out = make_raw_fd_ostream(output_files.at(OutputFile::llvm_assembly));
             compile_llvm_module_to_llvm_assembly(*llvm_module, *out);
         }
     }
-    if (contains(output_files, Output::c_header)) {
-        debug(1) << "Module.compile(): c_header " << output_files.at(Output::c_header) << "\n";
-        std::ofstream file(output_files.at(Output::c_header));
+    if (contains(output_files, OutputFile::c_header)) {
+        debug(1) << "Module.compile(): c_header " << output_files.at(OutputFile::c_header) << "\n";
+        std::ofstream file(output_files.at(OutputFile::c_header));
         Internal::CodeGen_C cg(file,
                                target(),
                                target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusHeader : Internal::CodeGen_C::CHeader,
-                               output_files.at(Output::c_header));
+                               output_files.at(OutputFile::c_header));
         cg.compile(*this);
     }
-    if (contains(output_files, Output::c_source)) {
-        debug(1) << "Module.compile(): c_source " << output_files.at(Output::c_source) << "\n";
-        std::ofstream file(output_files.at(Output::c_source));
+    if (contains(output_files, OutputFile::c_source)) {
+        debug(1) << "Module.compile(): c_source " << output_files.at(OutputFile::c_source) << "\n";
+        std::ofstream file(output_files.at(OutputFile::c_source));
         Internal::CodeGen_C cg(file,
                                target(),
                                target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusImplementation : Internal::CodeGen_C::CImplementation);
         cg.compile(*this);
     }
-    if (contains(output_files, Output::python_extension)) {
-        debug(1) << "Module.compile(): python_extension " << output_files.at(Output::python_extension) << "\n";
-        std::ofstream file(output_files.at(Output::python_extension));
+    if (contains(output_files, OutputFile::python_extension)) {
+        debug(1) << "Module.compile(): python_extension " << output_files.at(OutputFile::python_extension) << "\n";
+        std::ofstream file(output_files.at(OutputFile::python_extension));
         Internal::PythonExtensionGen python_extension_gen(file);
         python_extension_gen.compile(*this);
     }
-    if (contains(output_files, Output::schedule)) {
-        debug(1) << "Module.compile(): schedule " << output_files.at(Output::schedule) << "\n";
-        std::ofstream file(output_files.at(Output::schedule));
+    if (contains(output_files, OutputFile::schedule)) {
+        debug(1) << "Module.compile(): schedule " << output_files.at(OutputFile::schedule) << "\n";
+        std::ofstream file(output_files.at(OutputFile::schedule));
         auto *r = contents->auto_scheduler_results.get();
         std::string scheduler = r ? r->scheduler_name : "(None)";
         std::string machine_params = r ? r->machine_params_string : "(None)";
         std::string body = r && !r->schedule_source.empty() ? r->schedule_source : "// No autoscheduler has been run for this Generator.\n";
         emit_schedule_file(name(), {target()}, scheduler, machine_params, body, file);
     }
-    if (contains(output_files, Output::featurization)) {
-        debug(1) << "Module.compile(): featurization " << output_files.at(Output::featurization) << "\n";
+    if (contains(output_files, OutputFile::featurization)) {
+        debug(1) << "Module.compile(): featurization " << output_files.at(OutputFile::featurization) << "\n";
         // If the featurization data is empty, just write an empty file
-        std::ofstream binfile(output_files.at(Output::featurization), std::ios::binary | std::ios_base::trunc);
+        std::ofstream binfile(output_files.at(OutputFile::featurization), std::ios::binary | std::ios_base::trunc);
         auto *r = contents->auto_scheduler_results.get();
         if (r) {
             binfile.write((const char *)r->featurization.data(), r->featurization.size());
         }
         binfile.close();
     }
-    if (contains(output_files, Output::registration)) {
-        debug(1) << "Module.compile(): registration " << output_files.at(Output::registration) << "\n";
-        std::ofstream file(output_files.at(Output::registration));
+    if (contains(output_files, OutputFile::registration)) {
+        debug(1) << "Module.compile(): registration " << output_files.at(OutputFile::registration) << "\n";
+        std::ofstream file(output_files.at(OutputFile::registration));
         emit_registration(*this, file);
         file.close();
         internal_assert(!file.fail());
     }
-    if (contains(output_files, Output::pytorch_wrapper)) {
-        debug(1) << "Module.compile(): pytorch_wrapper " << output_files.at(Output::pytorch_wrapper) << "\n";
+    if (contains(output_files, OutputFile::pytorch_wrapper)) {
+        debug(1) << "Module.compile(): pytorch_wrapper " << output_files.at(OutputFile::pytorch_wrapper) << "\n";
 
-        std::ofstream file(output_files.at(Output::pytorch_wrapper));
+        std::ofstream file(output_files.at(OutputFile::pytorch_wrapper));
         Internal::CodeGen_PyTorch cg(file);
         cg.compile(*this);
         file.close();
         internal_assert(!file.fail());
     }
-    if (contains(output_files, Output::compiler_log)) {
-        debug(1) << "Module.compile(): compiler_log " << output_files.at(Output::compiler_log) << "\n";
-        std::ofstream file(output_files.at(Output::compiler_log));
+    if (contains(output_files, OutputFile::compiler_log)) {
+        debug(1) << "Module.compile(): compiler_log " << output_files.at(OutputFile::compiler_log) << "\n";
+        std::ofstream file(output_files.at(OutputFile::compiler_log));
         internal_assert(get_compiler_logger() != nullptr);
         get_compiler_logger()->emit_to_stream(file);
         file.close();
@@ -706,14 +706,14 @@ void Module::compile(const std::map<Output, std::string> &output_files) const {
     }
 }
 
-std::map<Output, std::string> compile_standalone_runtime(const std::map<Output, std::string> &output_files, const Target &t) {
+std::map<OutputFile, std::string> compile_standalone_runtime(const std::map<OutputFile, std::string> &output_files, const Target &t) {
     validate_outputs(output_files);
 
     Module empty("standalone_runtime", t.without_feature(Target::NoRuntime).without_feature(Target::JIT));
     // For runtime, it only makes sense to output object files or static_library, so ignore
     // everything else.
-    std::map<Output, std::string> actual_outputs;
-    for (auto key : {Output::object, Output::static_library}) {
+    std::map<OutputFile, std::string> actual_outputs;
+    for (auto key : {OutputFile::object, OutputFile::static_library}) {
         auto it = output_files.find(key);
         if (it != output_files.end()) {
             actual_outputs[key] = it->second;
@@ -724,7 +724,7 @@ std::map<Output, std::string> compile_standalone_runtime(const std::map<Output, 
 }
 
 void compile_standalone_runtime(const std::string &object_filename, const Target &t) {
-    compile_standalone_runtime({{Output::object, object_filename}}, t);
+    compile_standalone_runtime({{OutputFile::object, object_filename}}, t);
 }
 
 namespace {
@@ -748,7 +748,7 @@ public:
 }  // namespace
 
 void compile_multitarget(const std::string &fn_name,
-                         const std::map<Output, std::string> &output_files,
+                         const std::map<OutputFile, std::string> &output_files,
                          const std::vector<Target> &targets,
                          const std::vector<std::string> &suffixes,
                          const ModuleFactory &module_factory,
@@ -772,10 +772,10 @@ void compile_multitarget(const std::string &fn_name,
         return "-" + (suffixes.empty() ? targets[i].to_string() : suffixes[i]);
     };
 
-    const auto add_suffixes = [&](const std::map<Output, std::string> &in, const std::string &suffix) -> std::map<Output, std::string> {
+    const auto add_suffixes = [&](const std::map<OutputFile, std::string> &in, const std::string &suffix) -> std::map<OutputFile, std::string> {
         // is_multi doesn't vary by Target, so we can pass an empty target here safely
         auto output_info = get_output_info(Target());
-        std::map<Output, std::string> out = in;
+        std::map<OutputFile, std::string> out = in;
         for (auto &it : out) {
             if (output_info[it.first].is_multi) {
                 out[it.first] = add_suffix(it.second, suffix);
@@ -803,7 +803,7 @@ void compile_multitarget(const std::string &fn_name,
         return;
     }
 
-    user_assert(((int)contains(output_files, Output::object) + (int)contains(output_files, Output::static_library)) == 1)
+    user_assert(((int)contains(output_files, OutputFile::object) + (int)contains(output_files, OutputFile::static_library)) == 1)
         << "compile_multitarget() expects exactly one of 'object' and 'static_library' to be specified when multiple targets are specified.\n";
 
     // For safety, the runtime must be built only with features common to all
@@ -875,17 +875,17 @@ void compile_multitarget(const std::string &fn_name,
             base_target_args = sub_module.get_function_by_name(sub_fn_name).args;
 
             auto sub_out = add_suffixes(output_files, suffix);
-            if (contains(output_files, Output::static_library)) {
-                sub_out[Output::object] = temp_obj_dir.add_temp_object_file(output_files.at(Output::static_library), suffix, target);
-                sub_out.erase(Output::static_library);
+            if (contains(output_files, OutputFile::static_library)) {
+                sub_out[OutputFile::object] = temp_obj_dir.add_temp_object_file(output_files.at(OutputFile::static_library), suffix, target);
+                sub_out.erase(OutputFile::static_library);
             }
-            sub_out.erase(Output::registration);
-            sub_out.erase(Output::schedule);
-            sub_out.erase(Output::c_header);
-            if (contains(sub_out, Output::compiler_log)) {
-                sub_out[Output::compiler_log] = temp_compiler_log_dir.add_temp_file(output_files.at(Output::compiler_log), suffix, target);
+            sub_out.erase(OutputFile::registration);
+            sub_out.erase(OutputFile::schedule);
+            sub_out.erase(OutputFile::c_header);
+            if (contains(sub_out, OutputFile::compiler_log)) {
+                sub_out[OutputFile::compiler_log] = temp_compiler_log_dir.add_temp_file(output_files.at(OutputFile::compiler_log), suffix, target);
             }
-            debug(1) << "compile_multitarget: compile_sub_target " << sub_out[Output::object] << "\n";
+            debug(1) << "compile_multitarget: compile_sub_target " << sub_out[OutputFile::object] << "\n";
             sub_module.compile(sub_out);
             const auto *r = sub_module.get_auto_scheduler_results();
             auto_scheduler_results.push_back(r ? *r : AutoSchedulerResults());
@@ -935,13 +935,13 @@ void compile_multitarget(const std::string &fn_name,
                 runtime_target.set_feature((Target::Feature)i);
             }
         }
-        std::string runtime_path = contains(output_files, Output::static_library) ?
-                                       temp_obj_dir.add_temp_object_file(output_files.at(Output::static_library), "_runtime", runtime_target) :
-                                       add_suffix(output_files.at(Output::object), "_runtime");
+        std::string runtime_path = contains(output_files, OutputFile::static_library) ?
+                                       temp_obj_dir.add_temp_object_file(output_files.at(OutputFile::static_library), "_runtime", runtime_target) :
+                                       add_suffix(output_files.at(OutputFile::object), "_runtime");
 
-        std::map<Output, std::string> runtime_out =
-            {{Output::object, runtime_path}};
-        debug(1) << "compile_multitarget: compile_standalone_runtime " << runtime_out.at(Output::object) << "\n";
+        std::map<OutputFile, std::string> runtime_out =
+            {{OutputFile::object, runtime_path}};
+        debug(1) << "compile_multitarget: compile_standalone_runtime " << runtime_out.at(OutputFile::object) << "\n";
         compile_standalone_runtime(runtime_out, runtime_target);
     }
 
@@ -972,34 +972,34 @@ void compile_multitarget(const std::string &fn_name,
         Module wrapper_module(fn_name, wrapper_target);
         wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LinkageType::ExternalPlusMetadata));
 
-        std::string wrapper_path = contains(output_files, Output::static_library) ?
-                                       temp_obj_dir.add_temp_object_file(output_files.at(Output::static_library), "_wrapper", base_target, /* in_front*/ true) :
-                                       add_suffix(output_files.at(Output::object), "_wrapper");
+        std::string wrapper_path = contains(output_files, OutputFile::static_library) ?
+                                       temp_obj_dir.add_temp_object_file(output_files.at(OutputFile::static_library), "_wrapper", base_target, /* in_front*/ true) :
+                                       add_suffix(output_files.at(OutputFile::object), "_wrapper");
 
-        std::map<Output, std::string> wrapper_out = {{Output::object, wrapper_path}};
-        debug(1) << "compile_multitarget: wrapper " << wrapper_out.at(Output::object) << "\n";
+        std::map<OutputFile, std::string> wrapper_out = {{OutputFile::object, wrapper_path}};
+        debug(1) << "compile_multitarget: wrapper " << wrapper_out.at(OutputFile::object) << "\n";
         wrapper_module.compile(wrapper_out);
     }
 
-    if (contains(output_files, Output::c_header)) {
+    if (contains(output_files, OutputFile::c_header)) {
         Module header_module(fn_name, base_target);
         header_module.append(LoweredFunc(fn_name, base_target_args, {}, LinkageType::ExternalPlusMetadata));
-        std::map<Output, std::string> header_out = {{Output::c_header, output_files.at(Output::c_header)}};
-        debug(1) << "compile_multitarget: c_header " << header_out.at(Output::c_header) << "\n";
+        std::map<OutputFile, std::string> header_out = {{OutputFile::c_header, output_files.at(OutputFile::c_header)}};
+        debug(1) << "compile_multitarget: c_header " << header_out.at(OutputFile::c_header) << "\n";
         header_module.compile(header_out);
     }
 
-    if (contains(output_files, Output::registration)) {
-        debug(1) << "compile_multitarget: registration " << output_files.at(Output::registration) << "\n";
+    if (contains(output_files, OutputFile::registration)) {
+        debug(1) << "compile_multitarget: registration " << output_files.at(OutputFile::registration) << "\n";
         Module registration_module(fn_name, base_target);
         registration_module.append(LoweredFunc(fn_name, base_target_args, {}, LinkageType::ExternalPlusMetadata));
-        std::map<Output, std::string> registration_out = {{Output::registration, output_files.at(Output::registration)}};
-        debug(1) << "compile_multitarget: registration " << registration_out.at(Output::registration) << "\n";
+        std::map<OutputFile, std::string> registration_out = {{OutputFile::registration, output_files.at(OutputFile::registration)}};
+        debug(1) << "compile_multitarget: registration " << registration_out.at(OutputFile::registration) << "\n";
         registration_module.compile(registration_out);
     }
 
-    if (contains(output_files, Output::schedule)) {
-        debug(1) << "compile_multitarget: schedule " << output_files.at(Output::schedule) << "\n";
+    if (contains(output_files, OutputFile::schedule)) {
+        debug(1) << "compile_multitarget: schedule " << output_files.at(OutputFile::schedule) << "\n";
         std::string scheduler = auto_scheduler_results.front().scheduler_name;
         if (scheduler.empty()) {
             scheduler = "(None)";
@@ -1048,19 +1048,21 @@ void compile_multitarget(const std::string &fn_name,
             }
         }
 
-        std::ofstream file(output_files.at(Output::schedule));
+        std::ofstream file(output_files.at(OutputFile::schedule));
         emit_schedule_file(fn_name, targets, scheduler, machine_params, body.str(), file);
     }
 
-    if (contains(output_files, Output::static_library)) {
-        debug(1) << "compile_multitarget: static_library " << output_files.at(Output::static_library) << "\n";
-        create_static_library(temp_obj_dir.files(), base_target, output_files.at(Output::static_library));
+    if (contains(output_files, OutputFile::static_library)) {
+        debug(1) << "compile_multitarget: static_library "
+                 << output_files.at(OutputFile::static_library) << "\n";
+        create_static_library(temp_obj_dir.files(), base_target, output_files.at(OutputFile::static_library));
     }
 
-    if (contains(output_files, Output::compiler_log)) {
-        debug(1) << "compile_multitarget: compiler_log " << output_files.at(Output::compiler_log) << "\n";
+    if (contains(output_files, OutputFile::compiler_log)) {
+        debug(1) << "compile_multitarget: compiler_log "
+                 << output_files.at(OutputFile::compiler_log) << "\n";
 
-        std::ofstream compiler_log_file(output_files.at(Output::compiler_log));
+        std::ofstream compiler_log_file(output_files.at(OutputFile::compiler_log));
         compiler_log_file << "[\n";
         const auto &f = temp_compiler_log_dir.files();
         for (size_t i = 0; i < f.size(); i++) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -37,27 +37,27 @@ namespace Internal {
 // We really don't want to vary the file extensions based on target flags,
 // and in practice, it's extremely unlikely that anyone needs to rely on this
 // being pure C output (vs possibly C++).
-std::map<OutputType, const OutputInfo> get_output_info(const Target &target) {
+std::map<OutputFileType, const OutputInfo> get_output_info(const Target &target) {
     constexpr bool IsMulti = true;
     constexpr bool IsSingle = false;
     const bool is_windows_coff = target.os == Target::Windows;
-    std::map<OutputType, const OutputInfo> ext = {
-        {OutputType::assembly, {"assembly", ".s", IsMulti}},
-        {OutputType::bitcode, {"bitcode", ".bc", IsMulti}},
-        {OutputType::c_header, {"c_header", ".h", IsSingle}},
-        {OutputType::c_source, {"c_source", ".halide_generated.cpp", IsSingle}},
-        {OutputType::compiler_log, {"compiler_log", ".halide_compiler_log", IsSingle}},
-        {OutputType::cpp_stub, {"cpp_stub", ".stub.h", IsSingle}},
-        {OutputType::featurization, {"featurization", ".featurization", IsMulti}},
-        {OutputType::llvm_assembly, {"llvm_assembly", ".ll", IsMulti}},
-        {OutputType::object, {"object", is_windows_coff ? ".obj" : ".o", IsMulti}},
-        {OutputType::python_extension, {"python_extension", ".py.cpp", IsSingle}},
-        {OutputType::pytorch_wrapper, {"pytorch_wrapper", ".pytorch.h", IsSingle}},
-        {OutputType::registration, {"registration", ".registration.cpp", IsSingle}},
-        {OutputType::schedule, {"schedule", ".schedule.h", IsSingle}},
-        {OutputType::static_library, {"static_library", is_windows_coff ? ".lib" : ".a", IsSingle}},
-        {OutputType::stmt, {"stmt", ".stmt", IsMulti}},
-        {OutputType::stmt_html, {"stmt_html", ".stmt.html", IsMulti}},
+    std::map<OutputFileType, const OutputInfo> ext = {
+        {OutputFileType::assembly, {"assembly", ".s", IsMulti}},
+        {OutputFileType::bitcode, {"bitcode", ".bc", IsMulti}},
+        {OutputFileType::c_header, {"c_header", ".h", IsSingle}},
+        {OutputFileType::c_source, {"c_source", ".halide_generated.cpp", IsSingle}},
+        {OutputFileType::compiler_log, {"compiler_log", ".halide_compiler_log", IsSingle}},
+        {OutputFileType::cpp_stub, {"cpp_stub", ".stub.h", IsSingle}},
+        {OutputFileType::featurization, {"featurization", ".featurization", IsMulti}},
+        {OutputFileType::llvm_assembly, {"llvm_assembly", ".ll", IsMulti}},
+        {OutputFileType::object, {"object", is_windows_coff ? ".obj" : ".o", IsMulti}},
+        {OutputFileType::python_extension, {"python_extension", ".py.cpp", IsSingle}},
+        {OutputFileType::pytorch_wrapper, {"pytorch_wrapper", ".pytorch.h", IsSingle}},
+        {OutputFileType::registration, {"registration", ".registration.cpp", IsSingle}},
+        {OutputFileType::schedule, {"schedule", ".schedule.h", IsSingle}},
+        {OutputFileType::static_library, {"static_library", is_windows_coff ? ".lib" : ".a", IsSingle}},
+        {OutputFileType::stmt, {"stmt", ".stmt", IsMulti}},
+        {OutputFileType::stmt_html, {"stmt_html", ".stmt.html", IsMulti}},
     };
     return ext;
 }
@@ -141,7 +141,7 @@ std::string add_suffix(const std::string &path, const std::string &suffix) {
     }
 }
 
-void validate_outputs(const std::map<OutputType, std::string> &in) {
+void validate_outputs(const std::map<OutputFileType, std::string> &in) {
     // We don't care about the extensions, so any Target will do
     auto known = get_output_info(Target());
     for (const auto &it : in) {
@@ -149,7 +149,7 @@ void validate_outputs(const std::map<OutputType, std::string> &in) {
     }
 }
 
-bool contains(const std::map<OutputType, std::string> &in, const OutputType &key) {
+bool contains(const std::map<OutputFileType, std::string> &in, const OutputFileType &key) {
     return in.find(key) != in.end();
 }
 
@@ -552,42 +552,42 @@ std::map<std::string, std::string> Module::get_metadata_name_map() const {
     return contents->metadata_name_map;
 }
 
-void Module::compile(const std::map<OutputType, std::string> &output_files) const {
+void Module::compile(const std::map<OutputFileType, std::string> &output_files) const {
     validate_outputs(output_files);
 
     // output stmt and html prior to resolving submodules. We need to
     // clear the output after writing it, otherwise the output will
     // be overwritten by recursive calls after submodules are resolved.
-    if (contains(output_files, OutputType::stmt)) {
-        debug(1) << "Module.compile(): stmt " << output_files.at(OutputType::stmt) << "\n";
-        std::ofstream file(output_files.at(OutputType::stmt));
+    if (contains(output_files, OutputFileType::stmt)) {
+        debug(1) << "Module.compile(): stmt " << output_files.at(OutputFileType::stmt) << "\n";
+        std::ofstream file(output_files.at(OutputFileType::stmt));
         file << *this;
     }
-    if (contains(output_files, OutputType::stmt_html)) {
-        debug(1) << "Module.compile(): stmt_html " << output_files.at(OutputType::stmt_html) << "\n";
-        Internal::print_to_html(output_files.at(OutputType::stmt_html), *this);
+    if (contains(output_files, OutputFileType::stmt_html)) {
+        debug(1) << "Module.compile(): stmt_html " << output_files.at(OutputFileType::stmt_html) << "\n";
+        Internal::print_to_html(output_files.at(OutputFileType::stmt_html), *this);
     }
 
     // If there are submodules, recursively lower submodules to
     // buffers on a copy of the module being compiled, then compile
     // the copied module.
     if (!submodules().empty()) {
-        std::map<OutputType, std::string> output_files_copy = output_files;
-        output_files_copy.erase(OutputType::stmt);
-        output_files_copy.erase(OutputType::stmt_html);
+        std::map<OutputFileType, std::string> output_files_copy = output_files;
+        output_files_copy.erase(OutputFileType::stmt);
+        output_files_copy.erase(OutputFileType::stmt_html);
         resolve_submodules().compile(output_files_copy);
         return;
     }
 
     auto *logger = get_compiler_logger();
-    if (contains(output_files, OutputType::object) || contains(output_files, OutputType::assembly) ||
-        contains(output_files, OutputType::bitcode) || contains(output_files, OutputType::llvm_assembly) ||
-        contains(output_files, OutputType::static_library)) {
+    if (contains(output_files, OutputFileType::object) || contains(output_files, OutputFileType::assembly) ||
+        contains(output_files, OutputFileType::bitcode) || contains(output_files, OutputFileType::llvm_assembly) ||
+        contains(output_files, OutputFileType::static_library)) {
         llvm::LLVMContext context;
         std::unique_ptr<llvm::Module> llvm_module(compile_module_to_llvm_module(*this, context));
 
-        if (contains(output_files, OutputType::object)) {
-            const auto &f = output_files.at(OutputType::object);
+        if (contains(output_files, OutputFileType::object)) {
+            const auto &f = output_files.at(OutputFileType::object);
             debug(1) << "Module.compile(): object " << f << "\n";
             auto out = make_raw_fd_ostream(f);
             compile_llvm_module_to_object(*llvm_module, *out);
@@ -596,105 +596,105 @@ void Module::compile(const std::map<OutputType, std::string> &output_files) cons
                 logger->record_object_code_size(file_stat(f).file_size);
             }
         }
-        if (contains(output_files, OutputType::static_library)) {
+        if (contains(output_files, OutputFileType::static_library)) {
             // To simplify the code, we always create a temporary object output
-            // here, even if output_files.at(OutputType::object) was also set: in practice,
+            // here, even if output_files.at(OutputFileType::object) was also set: in practice,
             // no real-world code ever sets both object and static_library
             // at the same time, so there is no meaningful performance advantage
             // to be had.
             TemporaryObjectFileDir temp_dir;
             {
-                std::string object = temp_dir.add_temp_object_file(output_files.at(OutputType::static_library), "", target());
+                std::string object = temp_dir.add_temp_object_file(output_files.at(OutputFileType::static_library), "", target());
                 debug(1) << "Module.compile(): temporary object " << object << "\n";
                 auto out = make_raw_fd_ostream(object);
                 compile_llvm_module_to_object(*llvm_module, *out);
                 out->flush();  // create_static_library() is happier if we do this
-                if (logger && !contains(output_files, OutputType::object)) {
+                if (logger && !contains(output_files, OutputFileType::object)) {
                     // Don't double-record object-code size if we already recorded it for object
                     logger->record_object_code_size(file_stat(object).file_size);
                 }
             }
-            debug(1) << "Module.compile(): static_library " << output_files.at(OutputType::static_library) << "\n";
+            debug(1) << "Module.compile(): static_library " << output_files.at(OutputFileType::static_library) << "\n";
             Target base_target(target().os, target().arch, target().bits);
-            create_static_library(temp_dir.files(), base_target, output_files.at(OutputType::static_library));
+            create_static_library(temp_dir.files(), base_target, output_files.at(OutputFileType::static_library));
         }
-        if (contains(output_files, OutputType::assembly)) {
-            debug(1) << "Module.compile(): assembly " << output_files.at(OutputType::assembly) << "\n";
-            auto out = make_raw_fd_ostream(output_files.at(OutputType::assembly));
+        if (contains(output_files, OutputFileType::assembly)) {
+            debug(1) << "Module.compile(): assembly " << output_files.at(OutputFileType::assembly) << "\n";
+            auto out = make_raw_fd_ostream(output_files.at(OutputFileType::assembly));
             compile_llvm_module_to_assembly(*llvm_module, *out);
         }
-        if (contains(output_files, OutputType::bitcode)) {
-            debug(1) << "Module.compile(): bitcode " << output_files.at(OutputType::bitcode) << "\n";
-            auto out = make_raw_fd_ostream(output_files.at(OutputType::bitcode));
+        if (contains(output_files, OutputFileType::bitcode)) {
+            debug(1) << "Module.compile(): bitcode " << output_files.at(OutputFileType::bitcode) << "\n";
+            auto out = make_raw_fd_ostream(output_files.at(OutputFileType::bitcode));
             compile_llvm_module_to_llvm_bitcode(*llvm_module, *out);
         }
-        if (contains(output_files, OutputType::llvm_assembly)) {
-            debug(1) << "Module.compile(): llvm_assembly " << output_files.at(OutputType::llvm_assembly) << "\n";
-            auto out = make_raw_fd_ostream(output_files.at(OutputType::llvm_assembly));
+        if (contains(output_files, OutputFileType::llvm_assembly)) {
+            debug(1) << "Module.compile(): llvm_assembly " << output_files.at(OutputFileType::llvm_assembly) << "\n";
+            auto out = make_raw_fd_ostream(output_files.at(OutputFileType::llvm_assembly));
             compile_llvm_module_to_llvm_assembly(*llvm_module, *out);
         }
     }
-    if (contains(output_files, OutputType::c_header)) {
-        debug(1) << "Module.compile(): c_header " << output_files.at(OutputType::c_header) << "\n";
-        std::ofstream file(output_files.at(OutputType::c_header));
+    if (contains(output_files, OutputFileType::c_header)) {
+        debug(1) << "Module.compile(): c_header " << output_files.at(OutputFileType::c_header) << "\n";
+        std::ofstream file(output_files.at(OutputFileType::c_header));
         Internal::CodeGen_C cg(file,
                                target(),
                                target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusHeader : Internal::CodeGen_C::CHeader,
-                               output_files.at(OutputType::c_header));
+                               output_files.at(OutputFileType::c_header));
         cg.compile(*this);
     }
-    if (contains(output_files, OutputType::c_source)) {
-        debug(1) << "Module.compile(): c_source " << output_files.at(OutputType::c_source) << "\n";
-        std::ofstream file(output_files.at(OutputType::c_source));
+    if (contains(output_files, OutputFileType::c_source)) {
+        debug(1) << "Module.compile(): c_source " << output_files.at(OutputFileType::c_source) << "\n";
+        std::ofstream file(output_files.at(OutputFileType::c_source));
         Internal::CodeGen_C cg(file,
                                target(),
                                target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusImplementation : Internal::CodeGen_C::CImplementation);
         cg.compile(*this);
     }
-    if (contains(output_files, OutputType::python_extension)) {
-        debug(1) << "Module.compile(): python_extension " << output_files.at(OutputType::python_extension) << "\n";
-        std::ofstream file(output_files.at(OutputType::python_extension));
+    if (contains(output_files, OutputFileType::python_extension)) {
+        debug(1) << "Module.compile(): python_extension " << output_files.at(OutputFileType::python_extension) << "\n";
+        std::ofstream file(output_files.at(OutputFileType::python_extension));
         Internal::PythonExtensionGen python_extension_gen(file);
         python_extension_gen.compile(*this);
     }
-    if (contains(output_files, OutputType::schedule)) {
-        debug(1) << "Module.compile(): schedule " << output_files.at(OutputType::schedule) << "\n";
-        std::ofstream file(output_files.at(OutputType::schedule));
+    if (contains(output_files, OutputFileType::schedule)) {
+        debug(1) << "Module.compile(): schedule " << output_files.at(OutputFileType::schedule) << "\n";
+        std::ofstream file(output_files.at(OutputFileType::schedule));
         auto *r = contents->auto_scheduler_results.get();
         std::string scheduler = r ? r->scheduler_name : "(None)";
         std::string machine_params = r ? r->machine_params_string : "(None)";
         std::string body = r && !r->schedule_source.empty() ? r->schedule_source : "// No autoscheduler has been run for this Generator.\n";
         emit_schedule_file(name(), {target()}, scheduler, machine_params, body, file);
     }
-    if (contains(output_files, OutputType::featurization)) {
-        debug(1) << "Module.compile(): featurization " << output_files.at(OutputType::featurization) << "\n";
+    if (contains(output_files, OutputFileType::featurization)) {
+        debug(1) << "Module.compile(): featurization " << output_files.at(OutputFileType::featurization) << "\n";
         // If the featurization data is empty, just write an empty file
-        std::ofstream binfile(output_files.at(OutputType::featurization), std::ios::binary | std::ios_base::trunc);
+        std::ofstream binfile(output_files.at(OutputFileType::featurization), std::ios::binary | std::ios_base::trunc);
         auto *r = contents->auto_scheduler_results.get();
         if (r) {
             binfile.write((const char *)r->featurization.data(), r->featurization.size());
         }
         binfile.close();
     }
-    if (contains(output_files, OutputType::registration)) {
-        debug(1) << "Module.compile(): registration " << output_files.at(OutputType::registration) << "\n";
-        std::ofstream file(output_files.at(OutputType::registration));
+    if (contains(output_files, OutputFileType::registration)) {
+        debug(1) << "Module.compile(): registration " << output_files.at(OutputFileType::registration) << "\n";
+        std::ofstream file(output_files.at(OutputFileType::registration));
         emit_registration(*this, file);
         file.close();
         internal_assert(!file.fail());
     }
-    if (contains(output_files, OutputType::pytorch_wrapper)) {
-        debug(1) << "Module.compile(): pytorch_wrapper " << output_files.at(OutputType::pytorch_wrapper) << "\n";
+    if (contains(output_files, OutputFileType::pytorch_wrapper)) {
+        debug(1) << "Module.compile(): pytorch_wrapper " << output_files.at(OutputFileType::pytorch_wrapper) << "\n";
 
-        std::ofstream file(output_files.at(OutputType::pytorch_wrapper));
+        std::ofstream file(output_files.at(OutputFileType::pytorch_wrapper));
         Internal::CodeGen_PyTorch cg(file);
         cg.compile(*this);
         file.close();
         internal_assert(!file.fail());
     }
-    if (contains(output_files, OutputType::compiler_log)) {
-        debug(1) << "Module.compile(): compiler_log " << output_files.at(OutputType::compiler_log) << "\n";
-        std::ofstream file(output_files.at(OutputType::compiler_log));
+    if (contains(output_files, OutputFileType::compiler_log)) {
+        debug(1) << "Module.compile(): compiler_log " << output_files.at(OutputFileType::compiler_log) << "\n";
+        std::ofstream file(output_files.at(OutputFileType::compiler_log));
         internal_assert(get_compiler_logger() != nullptr);
         get_compiler_logger()->emit_to_stream(file);
         file.close();
@@ -706,14 +706,14 @@ void Module::compile(const std::map<OutputType, std::string> &output_files) cons
     }
 }
 
-std::map<OutputType, std::string> compile_standalone_runtime(const std::map<OutputType, std::string> &output_files, const Target &t) {
+std::map<OutputFileType, std::string> compile_standalone_runtime(const std::map<OutputFileType, std::string> &output_files, const Target &t) {
     validate_outputs(output_files);
 
     Module empty("standalone_runtime", t.without_feature(Target::NoRuntime).without_feature(Target::JIT));
     // For runtime, it only makes sense to output object files or static_library, so ignore
     // everything else.
-    std::map<OutputType, std::string> actual_outputs;
-    for (auto key : {OutputType::object, OutputType::static_library}) {
+    std::map<OutputFileType, std::string> actual_outputs;
+    for (auto key : {OutputFileType::object, OutputFileType::static_library}) {
         auto it = output_files.find(key);
         if (it != output_files.end()) {
             actual_outputs[key] = it->second;
@@ -724,7 +724,7 @@ std::map<OutputType, std::string> compile_standalone_runtime(const std::map<Outp
 }
 
 void compile_standalone_runtime(const std::string &object_filename, const Target &t) {
-    compile_standalone_runtime({{OutputType::object, object_filename}}, t);
+    compile_standalone_runtime({{OutputFileType::object, object_filename}}, t);
 }
 
 namespace {
@@ -748,7 +748,7 @@ public:
 }  // namespace
 
 void compile_multitarget(const std::string &fn_name,
-                         const std::map<OutputType, std::string> &output_files,
+                         const std::map<OutputFileType, std::string> &output_files,
                          const std::vector<Target> &targets,
                          const std::vector<std::string> &suffixes,
                          const ModuleFactory &module_factory,
@@ -772,10 +772,10 @@ void compile_multitarget(const std::string &fn_name,
         return "-" + (suffixes.empty() ? targets[i].to_string() : suffixes[i]);
     };
 
-    const auto add_suffixes = [&](const std::map<OutputType, std::string> &in, const std::string &suffix) -> std::map<OutputType, std::string> {
+    const auto add_suffixes = [&](const std::map<OutputFileType, std::string> &in, const std::string &suffix) -> std::map<OutputFileType, std::string> {
         // is_multi doesn't vary by Target, so we can pass an empty target here safely
         auto output_info = get_output_info(Target());
-        std::map<OutputType, std::string> out = in;
+        std::map<OutputFileType, std::string> out = in;
         for (auto &it : out) {
             if (output_info[it.first].is_multi) {
                 out[it.first] = add_suffix(it.second, suffix);
@@ -803,7 +803,7 @@ void compile_multitarget(const std::string &fn_name,
         return;
     }
 
-    user_assert(((int)contains(output_files, OutputType::object) + (int)contains(output_files, OutputType::static_library)) == 1)
+    user_assert(((int)contains(output_files, OutputFileType::object) + (int)contains(output_files, OutputFileType::static_library)) == 1)
         << "compile_multitarget() expects exactly one of 'object' and 'static_library' to be specified when multiple targets are specified.\n";
 
     // For safety, the runtime must be built only with features common to all
@@ -875,17 +875,17 @@ void compile_multitarget(const std::string &fn_name,
             base_target_args = sub_module.get_function_by_name(sub_fn_name).args;
 
             auto sub_out = add_suffixes(output_files, suffix);
-            if (contains(output_files, OutputType::static_library)) {
-                sub_out[OutputType::object] = temp_obj_dir.add_temp_object_file(output_files.at(OutputType::static_library), suffix, target);
-                sub_out.erase(OutputType::static_library);
+            if (contains(output_files, OutputFileType::static_library)) {
+                sub_out[OutputFileType::object] = temp_obj_dir.add_temp_object_file(output_files.at(OutputFileType::static_library), suffix, target);
+                sub_out.erase(OutputFileType::static_library);
             }
-            sub_out.erase(OutputType::registration);
-            sub_out.erase(OutputType::schedule);
-            sub_out.erase(OutputType::c_header);
-            if (contains(sub_out, OutputType::compiler_log)) {
-                sub_out[OutputType::compiler_log] = temp_compiler_log_dir.add_temp_file(output_files.at(OutputType::compiler_log), suffix, target);
+            sub_out.erase(OutputFileType::registration);
+            sub_out.erase(OutputFileType::schedule);
+            sub_out.erase(OutputFileType::c_header);
+            if (contains(sub_out, OutputFileType::compiler_log)) {
+                sub_out[OutputFileType::compiler_log] = temp_compiler_log_dir.add_temp_file(output_files.at(OutputFileType::compiler_log), suffix, target);
             }
-            debug(1) << "compile_multitarget: compile_sub_target " << sub_out[OutputType::object] << "\n";
+            debug(1) << "compile_multitarget: compile_sub_target " << sub_out[OutputFileType::object] << "\n";
             sub_module.compile(sub_out);
             const auto *r = sub_module.get_auto_scheduler_results();
             auto_scheduler_results.push_back(r ? *r : AutoSchedulerResults());
@@ -935,13 +935,13 @@ void compile_multitarget(const std::string &fn_name,
                 runtime_target.set_feature((Target::Feature)i);
             }
         }
-        std::string runtime_path = contains(output_files, OutputType::static_library) ?
-                                       temp_obj_dir.add_temp_object_file(output_files.at(OutputType::static_library), "_runtime", runtime_target) :
-                                       add_suffix(output_files.at(OutputType::object), "_runtime");
+        std::string runtime_path = contains(output_files, OutputFileType::static_library) ?
+                                       temp_obj_dir.add_temp_object_file(output_files.at(OutputFileType::static_library), "_runtime", runtime_target) :
+                                       add_suffix(output_files.at(OutputFileType::object), "_runtime");
 
-        std::map<OutputType, std::string> runtime_out =
-            {{OutputType::object, runtime_path}};
-        debug(1) << "compile_multitarget: compile_standalone_runtime " << runtime_out.at(OutputType::object) << "\n";
+        std::map<OutputFileType, std::string> runtime_out =
+            {{OutputFileType::object, runtime_path}};
+        debug(1) << "compile_multitarget: compile_standalone_runtime " << runtime_out.at(OutputFileType::object) << "\n";
         compile_standalone_runtime(runtime_out, runtime_target);
     }
 
@@ -972,34 +972,34 @@ void compile_multitarget(const std::string &fn_name,
         Module wrapper_module(fn_name, wrapper_target);
         wrapper_module.append(LoweredFunc(fn_name, base_target_args, wrapper_body, LinkageType::ExternalPlusMetadata));
 
-        std::string wrapper_path = contains(output_files, OutputType::static_library) ?
-                                       temp_obj_dir.add_temp_object_file(output_files.at(OutputType::static_library), "_wrapper", base_target, /* in_front*/ true) :
-                                       add_suffix(output_files.at(OutputType::object), "_wrapper");
+        std::string wrapper_path = contains(output_files, OutputFileType::static_library) ?
+                                       temp_obj_dir.add_temp_object_file(output_files.at(OutputFileType::static_library), "_wrapper", base_target, /* in_front*/ true) :
+                                       add_suffix(output_files.at(OutputFileType::object), "_wrapper");
 
-        std::map<OutputType, std::string> wrapper_out = {{OutputType::object, wrapper_path}};
-        debug(1) << "compile_multitarget: wrapper " << wrapper_out.at(OutputType::object) << "\n";
+        std::map<OutputFileType, std::string> wrapper_out = {{OutputFileType::object, wrapper_path}};
+        debug(1) << "compile_multitarget: wrapper " << wrapper_out.at(OutputFileType::object) << "\n";
         wrapper_module.compile(wrapper_out);
     }
 
-    if (contains(output_files, OutputType::c_header)) {
+    if (contains(output_files, OutputFileType::c_header)) {
         Module header_module(fn_name, base_target);
         header_module.append(LoweredFunc(fn_name, base_target_args, {}, LinkageType::ExternalPlusMetadata));
-        std::map<OutputType, std::string> header_out = {{OutputType::c_header, output_files.at(OutputType::c_header)}};
-        debug(1) << "compile_multitarget: c_header " << header_out.at(OutputType::c_header) << "\n";
+        std::map<OutputFileType, std::string> header_out = {{OutputFileType::c_header, output_files.at(OutputFileType::c_header)}};
+        debug(1) << "compile_multitarget: c_header " << header_out.at(OutputFileType::c_header) << "\n";
         header_module.compile(header_out);
     }
 
-    if (contains(output_files, OutputType::registration)) {
-        debug(1) << "compile_multitarget: registration " << output_files.at(OutputType::registration) << "\n";
+    if (contains(output_files, OutputFileType::registration)) {
+        debug(1) << "compile_multitarget: registration " << output_files.at(OutputFileType::registration) << "\n";
         Module registration_module(fn_name, base_target);
         registration_module.append(LoweredFunc(fn_name, base_target_args, {}, LinkageType::ExternalPlusMetadata));
-        std::map<OutputType, std::string> registration_out = {{OutputType::registration, output_files.at(OutputType::registration)}};
-        debug(1) << "compile_multitarget: registration " << registration_out.at(OutputType::registration) << "\n";
+        std::map<OutputFileType, std::string> registration_out = {{OutputFileType::registration, output_files.at(OutputFileType::registration)}};
+        debug(1) << "compile_multitarget: registration " << registration_out.at(OutputFileType::registration) << "\n";
         registration_module.compile(registration_out);
     }
 
-    if (contains(output_files, OutputType::schedule)) {
-        debug(1) << "compile_multitarget: schedule " << output_files.at(OutputType::schedule) << "\n";
+    if (contains(output_files, OutputFileType::schedule)) {
+        debug(1) << "compile_multitarget: schedule " << output_files.at(OutputFileType::schedule) << "\n";
         std::string scheduler = auto_scheduler_results.front().scheduler_name;
         if (scheduler.empty()) {
             scheduler = "(None)";
@@ -1048,21 +1048,21 @@ void compile_multitarget(const std::string &fn_name,
             }
         }
 
-        std::ofstream file(output_files.at(OutputType::schedule));
+        std::ofstream file(output_files.at(OutputFileType::schedule));
         emit_schedule_file(fn_name, targets, scheduler, machine_params, body.str(), file);
     }
 
-    if (contains(output_files, OutputType::static_library)) {
+    if (contains(output_files, OutputFileType::static_library)) {
         debug(1) << "compile_multitarget: static_library "
-                 << output_files.at(OutputType::static_library) << "\n";
-        create_static_library(temp_obj_dir.files(), base_target, output_files.at(OutputType::static_library));
+                 << output_files.at(OutputFileType::static_library) << "\n";
+        create_static_library(temp_obj_dir.files(), base_target, output_files.at(OutputFileType::static_library));
     }
 
-    if (contains(output_files, OutputType::compiler_log)) {
+    if (contains(output_files, OutputFileType::compiler_log)) {
         debug(1) << "compile_multitarget: compiler_log "
-                 << output_files.at(OutputType::compiler_log) << "\n";
+                 << output_files.at(OutputFileType::compiler_log) << "\n";
 
-        std::ofstream compiler_log_file(output_files.at(OutputType::compiler_log));
+        std::ofstream compiler_log_file(output_files.at(OutputFileType::compiler_log));
         compiler_log_file << "[\n";
         const auto &f = temp_compiler_log_dir.files();
         for (size_t i = 0; i < f.size(); i++) {

--- a/src/Module.h
+++ b/src/Module.h
@@ -24,7 +24,7 @@ class Buffer;
 struct Target;
 
 /** Enums specifying various kinds of outputs that can be produced from a Halide Pipeline. */
-enum class Output {
+enum class OutputFile {
     assembly,
     bitcode,
     c_header,
@@ -42,6 +42,26 @@ enum class Output {
     stmt,
     stmt_html,
 };
+
+class [[deprecated("Use OutputFile instead of Output")]] Output {
+public:
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile assembly = OutputFile::assembly;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile bitcode = OutputFile::bitcode;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile c_header = OutputFile::c_header;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile c_source = OutputFile::c_source;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile compiler_log = OutputFile::compiler_log;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile cpp_stub = OutputFile::cpp_stub;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile featurization = OutputFile::featurization;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile llvm_assembly = OutputFile::llvm_assembly;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile object = OutputFile::object;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile python_extension = OutputFile::python_extension;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile pytorch_wrapper = OutputFile::pytorch_wrapper;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile registration = OutputFile::registration;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile schedule = OutputFile::schedule;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile static_library = OutputFile::static_library;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile stmt = OutputFile::stmt;
+    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile stmt_html = OutputFile::stmt_html;
+};  // namespace Output
 
 /** Type of linkage a function in a lowered Halide module can have.
     Also controls whether auxiliary functions and metadata are generated. */
@@ -72,7 +92,7 @@ struct OutputInfo {
     //
     bool is_multi{false};
 };
-std::map<Output, const OutputInfo> get_output_info(const Target &target);
+std::map<OutputFile, const OutputInfo> get_output_info(const Target &target);
 
 /** Definition of an argument to a LoweredFunc. This is similar to
  * Argument, except it enables passing extra information useful to
@@ -163,7 +183,7 @@ public:
     // @}
 
     /** Return the function with the given name. If no such function
-    * exists in this module, assert. */
+     * exists in this module, assert. */
     Internal::LoweredFunc get_function_by_name(const std::string &name) const;
 
     /** Add a declaration to this module. */
@@ -176,7 +196,7 @@ public:
 
     /** Compile a halide Module to variety of outputs, depending on
      * the fields set in output_files. */
-    void compile(const std::map<Output, std::string> &output_files) const;
+    void compile(const std::map<OutputFile, std::string> &output_files) const;
 
     /** Compile a halide Module to in-memory object code. Currently
      * only supports LLVM based compilation, but should be extended to
@@ -214,15 +234,15 @@ void compile_standalone_runtime(const std::string &object_filename, const Target
  * for a given target. For use with Target::NoRuntime. Standalone runtimes are
  * only compatible with pipelines compiled by the same build of Halide used to
  * call this function. Return a map with just the actual outputs filled in
- * (typically, Output::object and/or Output::static_library).
+ * (typically, OutputFile::object and/or OutputFile::static_library).
  */
-std::map<Output, std::string> compile_standalone_runtime(const std::map<Output, std::string> &output_files, const Target &t);
+std::map<OutputFile, std::string> compile_standalone_runtime(const std::map<OutputFile, std::string> &output_files, const Target &t);
 
 using ModuleFactory = std::function<Module(const std::string &fn_name, const Target &target)>;
 using CompilerLoggerFactory = std::function<std::unique_ptr<Internal::CompilerLogger>(const std::string &fn_name, const Target &target)>;
 
 void compile_multitarget(const std::string &fn_name,
-                         const std::map<Output, std::string> &output_files,
+                         const std::map<OutputFile, std::string> &output_files,
                          const std::vector<Target> &targets,
                          const std::vector<std::string> &suffixes,
                          const ModuleFactory &module_factory,

--- a/src/Module.h
+++ b/src/Module.h
@@ -24,7 +24,7 @@ class Buffer;
 struct Target;
 
 /** Enums specifying various kinds of outputs that can be produced from a Halide Pipeline. */
-enum class OutputFile {
+enum class OutputType {
     assembly,
     bitcode,
     c_header,
@@ -43,24 +43,40 @@ enum class OutputFile {
     stmt_html,
 };
 
-class [[deprecated("Use OutputFile instead of Output")]] Output {
+class HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output") Output {
 public:
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile assembly = OutputFile::assembly;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile bitcode = OutputFile::bitcode;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile c_header = OutputFile::c_header;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile c_source = OutputFile::c_source;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile compiler_log = OutputFile::compiler_log;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile cpp_stub = OutputFile::cpp_stub;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile featurization = OutputFile::featurization;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile llvm_assembly = OutputFile::llvm_assembly;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile object = OutputFile::object;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile python_extension = OutputFile::python_extension;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile pytorch_wrapper = OutputFile::pytorch_wrapper;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile registration = OutputFile::registration;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile schedule = OutputFile::schedule;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile static_library = OutputFile::static_library;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile stmt = OutputFile::stmt;
-    [[deprecated("Use OutputFile instead of Output")]] static constexpr OutputFile stmt_html = OutputFile::stmt_html;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType assembly = OutputType::assembly;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType bitcode = OutputType::bitcode;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType c_header = OutputType::c_header;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType c_source = OutputType::c_source;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType compiler_log = OutputType::compiler_log;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType cpp_stub = OutputType::cpp_stub;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType featurization = OutputType::featurization;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType llvm_assembly = OutputType::llvm_assembly;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType object = OutputType::object;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType python_extension = OutputType::python_extension;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType pytorch_wrapper = OutputType::pytorch_wrapper;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType registration = OutputType::registration;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType schedule = OutputType::schedule;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType static_library = OutputType::static_library;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType stmt = OutputType::stmt;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
+    static constexpr OutputType stmt_html = OutputType::stmt_html;
 };  // namespace Output
 
 /** Type of linkage a function in a lowered Halide module can have.
@@ -92,7 +108,7 @@ struct OutputInfo {
     //
     bool is_multi{false};
 };
-std::map<OutputFile, const OutputInfo> get_output_info(const Target &target);
+std::map<OutputType, const OutputInfo> get_output_info(const Target &target);
 
 /** Definition of an argument to a LoweredFunc. This is similar to
  * Argument, except it enables passing extra information useful to
@@ -196,7 +212,7 @@ public:
 
     /** Compile a halide Module to variety of outputs, depending on
      * the fields set in output_files. */
-    void compile(const std::map<OutputFile, std::string> &output_files) const;
+    void compile(const std::map<OutputType, std::string> &output_files) const;
 
     /** Compile a halide Module to in-memory object code. Currently
      * only supports LLVM based compilation, but should be extended to
@@ -234,15 +250,15 @@ void compile_standalone_runtime(const std::string &object_filename, const Target
  * for a given target. For use with Target::NoRuntime. Standalone runtimes are
  * only compatible with pipelines compiled by the same build of Halide used to
  * call this function. Return a map with just the actual outputs filled in
- * (typically, OutputFile::object and/or OutputFile::static_library).
+ * (typically, OutputType::object and/or OutputType::static_library).
  */
-std::map<OutputFile, std::string> compile_standalone_runtime(const std::map<OutputFile, std::string> &output_files, const Target &t);
+std::map<OutputType, std::string> compile_standalone_runtime(const std::map<OutputType, std::string> &output_files, const Target &t);
 
 using ModuleFactory = std::function<Module(const std::string &fn_name, const Target &target)>;
 using CompilerLoggerFactory = std::function<std::unique_ptr<Internal::CompilerLogger>(const std::string &fn_name, const Target &target)>;
 
 void compile_multitarget(const std::string &fn_name,
-                         const std::map<OutputFile, std::string> &output_files,
+                         const std::map<OutputType, std::string> &output_files,
                          const std::vector<Target> &targets,
                          const std::vector<std::string> &suffixes,
                          const ModuleFactory &module_factory,

--- a/src/Module.h
+++ b/src/Module.h
@@ -24,7 +24,7 @@ class Buffer;
 struct Target;
 
 /** Enums specifying various kinds of outputs that can be produced from a Halide Pipeline. */
-enum class OutputType {
+enum class OutputFileType {
     assembly,
     bitcode,
     c_header,
@@ -43,40 +43,40 @@ enum class OutputType {
     stmt_html,
 };
 
-class HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output") Output {
+class HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output") Output {
 public:
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType assembly = OutputType::assembly;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType bitcode = OutputType::bitcode;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType c_header = OutputType::c_header;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType c_source = OutputType::c_source;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType compiler_log = OutputType::compiler_log;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType cpp_stub = OutputType::cpp_stub;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType featurization = OutputType::featurization;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType llvm_assembly = OutputType::llvm_assembly;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType object = OutputType::object;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType python_extension = OutputType::python_extension;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType pytorch_wrapper = OutputType::pytorch_wrapper;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType registration = OutputType::registration;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType schedule = OutputType::schedule;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType static_library = OutputType::static_library;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType stmt = OutputType::stmt;
-    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputType instead of Output")
-    static constexpr OutputType stmt_html = OutputType::stmt_html;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType assembly = OutputFileType::assembly;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType bitcode = OutputFileType::bitcode;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType c_header = OutputFileType::c_header;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType c_source = OutputFileType::c_source;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType compiler_log = OutputFileType::compiler_log;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType cpp_stub = OutputFileType::cpp_stub;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType featurization = OutputFileType::featurization;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType llvm_assembly = OutputFileType::llvm_assembly;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType object = OutputFileType::object;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType python_extension = OutputFileType::python_extension;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType pytorch_wrapper = OutputFileType::pytorch_wrapper;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType registration = OutputFileType::registration;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType schedule = OutputFileType::schedule;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType static_library = OutputFileType::static_library;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType stmt = OutputFileType::stmt;
+    HALIDE_ATTRIBUTE_DEPRECATED("Use OutputFileType instead of Output")
+    static constexpr OutputFileType stmt_html = OutputFileType::stmt_html;
 };  // namespace Output
 
 /** Type of linkage a function in a lowered Halide module can have.
@@ -108,7 +108,7 @@ struct OutputInfo {
     //
     bool is_multi{false};
 };
-std::map<OutputType, const OutputInfo> get_output_info(const Target &target);
+std::map<OutputFileType, const OutputInfo> get_output_info(const Target &target);
 
 /** Definition of an argument to a LoweredFunc. This is similar to
  * Argument, except it enables passing extra information useful to
@@ -212,7 +212,7 @@ public:
 
     /** Compile a halide Module to variety of outputs, depending on
      * the fields set in output_files. */
-    void compile(const std::map<OutputType, std::string> &output_files) const;
+    void compile(const std::map<OutputFileType, std::string> &output_files) const;
 
     /** Compile a halide Module to in-memory object code. Currently
      * only supports LLVM based compilation, but should be extended to
@@ -250,15 +250,15 @@ void compile_standalone_runtime(const std::string &object_filename, const Target
  * for a given target. For use with Target::NoRuntime. Standalone runtimes are
  * only compatible with pipelines compiled by the same build of Halide used to
  * call this function. Return a map with just the actual outputs filled in
- * (typically, OutputType::object and/or OutputType::static_library).
+ * (typically, OutputFileType::object and/or OutputFileType::static_library).
  */
-std::map<OutputType, std::string> compile_standalone_runtime(const std::map<OutputType, std::string> &output_files, const Target &t);
+std::map<OutputFileType, std::string> compile_standalone_runtime(const std::map<OutputFileType, std::string> &output_files, const Target &t);
 
 using ModuleFactory = std::function<Module(const std::string &fn_name, const Target &target)>;
 using CompilerLoggerFactory = std::function<std::unique_ptr<Internal::CompilerLogger>(const std::string &fn_name, const Target &target)>;
 
 void compile_multitarget(const std::string &fn_name,
-                         const std::map<OutputType, std::string> &output_files,
+                         const std::map<OutputFileType, std::string> &output_files,
                          const std::vector<Target> &targets,
                          const std::vector<std::string> &suffixes,
                          const ModuleFactory &module_factory,

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -34,27 +34,27 @@ std::string output_name(const string &filename, const Module &m, const string &e
     return output_name(filename, m.name(), ext);
 }
 
-std::map<OutputFile, std::string> single_output(const string &filename, const Module &m, OutputFile output_type) {
+std::map<OutputType, std::string> single_output(const string &filename, const Module &m, OutputType output_type) {
     auto ext = get_output_info(m.target());
-    std::map<OutputFile, std::string> outputs = {
+    std::map<OutputType, std::string> outputs = {
         {output_type, output_name(filename, m, ext.at(output_type).extension)}};
     return outputs;
 }
 
-std::map<OutputFile, std::string> static_library_outputs(const string &filename_prefix, const Target &target) {
+std::map<OutputType, std::string> static_library_outputs(const string &filename_prefix, const Target &target) {
     auto ext = get_output_info(target);
-    std::map<OutputFile, std::string> outputs = {
-        {OutputFile::c_header, filename_prefix + ext.at(OutputFile::c_header).extension},
-        {OutputFile::static_library, filename_prefix + ext.at(OutputFile::static_library).extension},
+    std::map<OutputType, std::string> outputs = {
+        {OutputType::c_header, filename_prefix + ext.at(OutputType::c_header).extension},
+        {OutputType::static_library, filename_prefix + ext.at(OutputType::static_library).extension},
     };
     return outputs;
 }
 
-std::map<OutputFile, std::string> object_file_outputs(const string &filename_prefix, const Target &target) {
+std::map<OutputType, std::string> object_file_outputs(const string &filename_prefix, const Target &target) {
     auto ext = get_output_info(target);
-    std::map<OutputFile, std::string> outputs = {
-        {OutputFile::c_header, filename_prefix + ext.at(OutputFile::c_header).extension},
-        {OutputFile::object, filename_prefix + ext.at(OutputFile::object).extension},
+    std::map<OutputType, std::string> outputs = {
+        {OutputType::c_header, filename_prefix + ext.at(OutputType::c_header).extension},
+        {OutputType::object, filename_prefix + ext.at(OutputType::object).extension},
     };
     return outputs;
 }
@@ -255,7 +255,7 @@ Func Pipeline::get_func(size_t index) {
     return Func(env.find(order[index])->second);
 }
 
-void Pipeline::compile_to(const std::map<OutputFile, std::string> &output_files,
+void Pipeline::compile_to(const std::map<OutputType, std::string> &output_files,
                           const vector<Argument> &args,
                           const string &fn_name,
                           const Target &target) {
@@ -267,7 +267,7 @@ void Pipeline::compile_to_bitcode(const string &filename,
                                   const string &fn_name,
                                   const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputFile::bitcode));
+    m.compile(single_output(filename, m, OutputType::bitcode));
 }
 
 void Pipeline::compile_to_llvm_assembly(const string &filename,
@@ -275,7 +275,7 @@ void Pipeline::compile_to_llvm_assembly(const string &filename,
                                         const string &fn_name,
                                         const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputFile::llvm_assembly));
+    m.compile(single_output(filename, m, OutputType::llvm_assembly));
 }
 
 void Pipeline::compile_to_object(const string &filename,
@@ -284,7 +284,7 @@ void Pipeline::compile_to_object(const string &filename,
                                  const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
     auto ext = get_output_info(target);
-    m.compile({{OutputFile::object, output_name(filename, m, ext.at(OutputFile::object).extension)}});
+    m.compile({{OutputType::object, output_name(filename, m, ext.at(OutputType::object).extension)}});
 }
 
 void Pipeline::compile_to_header(const string &filename,
@@ -292,7 +292,7 @@ void Pipeline::compile_to_header(const string &filename,
                                  const string &fn_name,
                                  const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputFile::c_header));
+    m.compile(single_output(filename, m, OutputType::c_header));
 }
 
 void Pipeline::compile_to_assembly(const string &filename,
@@ -300,7 +300,7 @@ void Pipeline::compile_to_assembly(const string &filename,
                                    const string &fn_name,
                                    const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputFile::assembly));
+    m.compile(single_output(filename, m, OutputType::assembly));
 }
 
 void Pipeline::compile_to_c(const string &filename,
@@ -308,7 +308,7 @@ void Pipeline::compile_to_c(const string &filename,
                             const string &fn_name,
                             const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputFile::c_source));
+    m.compile(single_output(filename, m, OutputType::c_source));
 }
 
 void Pipeline::print_loop_nest() {
@@ -321,7 +321,7 @@ void Pipeline::compile_to_lowered_stmt(const string &filename,
                                        StmtOutputFormat fmt,
                                        const Target &target) {
     Module m = compile_to_module(args, "", target);
-    m.compile(single_output(filename, m, fmt == HTML ? OutputFile::stmt_html : OutputFile::stmt));
+    m.compile(single_output(filename, m, fmt == HTML ? OutputType::stmt_html : OutputType::stmt));
 }
 
 void Pipeline::compile_to_static_library(const string &filename_prefix,
@@ -359,9 +359,9 @@ void Pipeline::compile_to_file(const string &filename_prefix,
                                const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
     auto ext = get_output_info(target);
-    std::map<OutputFile, std::string> outputs = {
-        {OutputFile::c_header, filename_prefix + ext.at(OutputFile::c_header).extension},
-        {OutputFile::object, filename_prefix + ext.at(OutputFile::object).extension},
+    std::map<OutputType, std::string> outputs = {
+        {OutputType::c_header, filename_prefix + ext.at(OutputType::c_header).extension},
+        {OutputType::object, filename_prefix + ext.at(OutputType::object).extension},
     };
     m.compile(outputs);
 }
@@ -634,7 +634,7 @@ void Pipeline::compile_jit(const Target &target_arg) {
         }
         string file_name = program_name + "_" + name + "_" + unique_name('g').substr(1) + ".bc";
         debug(4) << "Saving bitcode to: " << file_name << "\n";
-        module.compile({{OutputFile::bitcode, file_name}});
+        module.compile({{OutputType::bitcode, file_name}});
     }
 
     contents->jit_module = jit_module;

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -34,27 +34,27 @@ std::string output_name(const string &filename, const Module &m, const string &e
     return output_name(filename, m.name(), ext);
 }
 
-std::map<Output, std::string> single_output(const string &filename, const Module &m, Output output_type) {
+std::map<OutputFile, std::string> single_output(const string &filename, const Module &m, OutputFile output_type) {
     auto ext = get_output_info(m.target());
-    std::map<Output, std::string> outputs = {
+    std::map<OutputFile, std::string> outputs = {
         {output_type, output_name(filename, m, ext.at(output_type).extension)}};
     return outputs;
 }
 
-std::map<Output, std::string> static_library_outputs(const string &filename_prefix, const Target &target) {
+std::map<OutputFile, std::string> static_library_outputs(const string &filename_prefix, const Target &target) {
     auto ext = get_output_info(target);
-    std::map<Output, std::string> outputs = {
-        {Output::c_header, filename_prefix + ext.at(Output::c_header).extension},
-        {Output::static_library, filename_prefix + ext.at(Output::static_library).extension},
+    std::map<OutputFile, std::string> outputs = {
+        {OutputFile::c_header, filename_prefix + ext.at(OutputFile::c_header).extension},
+        {OutputFile::static_library, filename_prefix + ext.at(OutputFile::static_library).extension},
     };
     return outputs;
 }
 
-std::map<Output, std::string> object_file_outputs(const string &filename_prefix, const Target &target) {
+std::map<OutputFile, std::string> object_file_outputs(const string &filename_prefix, const Target &target) {
     auto ext = get_output_info(target);
-    std::map<Output, std::string> outputs = {
-        {Output::c_header, filename_prefix + ext.at(Output::c_header).extension},
-        {Output::object, filename_prefix + ext.at(Output::object).extension},
+    std::map<OutputFile, std::string> outputs = {
+        {OutputFile::c_header, filename_prefix + ext.at(OutputFile::c_header).extension},
+        {OutputFile::object, filename_prefix + ext.at(OutputFile::object).extension},
     };
     return outputs;
 }
@@ -255,7 +255,7 @@ Func Pipeline::get_func(size_t index) {
     return Func(env.find(order[index])->second);
 }
 
-void Pipeline::compile_to(const std::map<Output, std::string> &output_files,
+void Pipeline::compile_to(const std::map<OutputFile, std::string> &output_files,
                           const vector<Argument> &args,
                           const string &fn_name,
                           const Target &target) {
@@ -267,7 +267,7 @@ void Pipeline::compile_to_bitcode(const string &filename,
                                   const string &fn_name,
                                   const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, Output::bitcode));
+    m.compile(single_output(filename, m, OutputFile::bitcode));
 }
 
 void Pipeline::compile_to_llvm_assembly(const string &filename,
@@ -275,7 +275,7 @@ void Pipeline::compile_to_llvm_assembly(const string &filename,
                                         const string &fn_name,
                                         const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, Output::llvm_assembly));
+    m.compile(single_output(filename, m, OutputFile::llvm_assembly));
 }
 
 void Pipeline::compile_to_object(const string &filename,
@@ -284,7 +284,7 @@ void Pipeline::compile_to_object(const string &filename,
                                  const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
     auto ext = get_output_info(target);
-    m.compile({{Output::object, output_name(filename, m, ext.at(Output::object).extension)}});
+    m.compile({{OutputFile::object, output_name(filename, m, ext.at(OutputFile::object).extension)}});
 }
 
 void Pipeline::compile_to_header(const string &filename,
@@ -292,7 +292,7 @@ void Pipeline::compile_to_header(const string &filename,
                                  const string &fn_name,
                                  const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, Output::c_header));
+    m.compile(single_output(filename, m, OutputFile::c_header));
 }
 
 void Pipeline::compile_to_assembly(const string &filename,
@@ -300,7 +300,7 @@ void Pipeline::compile_to_assembly(const string &filename,
                                    const string &fn_name,
                                    const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, Output::assembly));
+    m.compile(single_output(filename, m, OutputFile::assembly));
 }
 
 void Pipeline::compile_to_c(const string &filename,
@@ -308,7 +308,7 @@ void Pipeline::compile_to_c(const string &filename,
                             const string &fn_name,
                             const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, Output::c_source));
+    m.compile(single_output(filename, m, OutputFile::c_source));
 }
 
 void Pipeline::print_loop_nest() {
@@ -321,7 +321,7 @@ void Pipeline::compile_to_lowered_stmt(const string &filename,
                                        StmtOutputFormat fmt,
                                        const Target &target) {
     Module m = compile_to_module(args, "", target);
-    m.compile(single_output(filename, m, fmt == HTML ? Output::stmt_html : Output::stmt));
+    m.compile(single_output(filename, m, fmt == HTML ? OutputFile::stmt_html : OutputFile::stmt));
 }
 
 void Pipeline::compile_to_static_library(const string &filename_prefix,
@@ -359,9 +359,9 @@ void Pipeline::compile_to_file(const string &filename_prefix,
                                const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
     auto ext = get_output_info(target);
-    std::map<Output, std::string> outputs = {
-        {Output::c_header, filename_prefix + ext.at(Output::c_header).extension},
-        {Output::object, filename_prefix + ext.at(Output::object).extension},
+    std::map<OutputFile, std::string> outputs = {
+        {OutputFile::c_header, filename_prefix + ext.at(OutputFile::c_header).extension},
+        {OutputFile::object, filename_prefix + ext.at(OutputFile::object).extension},
     };
     m.compile(outputs);
 }
@@ -634,7 +634,7 @@ void Pipeline::compile_jit(const Target &target_arg) {
         }
         string file_name = program_name + "_" + name + "_" + unique_name('g').substr(1) + ".bc";
         debug(4) << "Saving bitcode to: " << file_name << "\n";
-        module.compile({{Output::bitcode, file_name}});
+        module.compile({{OutputFile::bitcode, file_name}});
     }
 
     contents->jit_module = jit_module;

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -34,27 +34,27 @@ std::string output_name(const string &filename, const Module &m, const string &e
     return output_name(filename, m.name(), ext);
 }
 
-std::map<OutputType, std::string> single_output(const string &filename, const Module &m, OutputType output_type) {
+std::map<OutputFileType, std::string> single_output(const string &filename, const Module &m, OutputFileType output_type) {
     auto ext = get_output_info(m.target());
-    std::map<OutputType, std::string> outputs = {
+    std::map<OutputFileType, std::string> outputs = {
         {output_type, output_name(filename, m, ext.at(output_type).extension)}};
     return outputs;
 }
 
-std::map<OutputType, std::string> static_library_outputs(const string &filename_prefix, const Target &target) {
+std::map<OutputFileType, std::string> static_library_outputs(const string &filename_prefix, const Target &target) {
     auto ext = get_output_info(target);
-    std::map<OutputType, std::string> outputs = {
-        {OutputType::c_header, filename_prefix + ext.at(OutputType::c_header).extension},
-        {OutputType::static_library, filename_prefix + ext.at(OutputType::static_library).extension},
+    std::map<OutputFileType, std::string> outputs = {
+        {OutputFileType::c_header, filename_prefix + ext.at(OutputFileType::c_header).extension},
+        {OutputFileType::static_library, filename_prefix + ext.at(OutputFileType::static_library).extension},
     };
     return outputs;
 }
 
-std::map<OutputType, std::string> object_file_outputs(const string &filename_prefix, const Target &target) {
+std::map<OutputFileType, std::string> object_file_outputs(const string &filename_prefix, const Target &target) {
     auto ext = get_output_info(target);
-    std::map<OutputType, std::string> outputs = {
-        {OutputType::c_header, filename_prefix + ext.at(OutputType::c_header).extension},
-        {OutputType::object, filename_prefix + ext.at(OutputType::object).extension},
+    std::map<OutputFileType, std::string> outputs = {
+        {OutputFileType::c_header, filename_prefix + ext.at(OutputFileType::c_header).extension},
+        {OutputFileType::object, filename_prefix + ext.at(OutputFileType::object).extension},
     };
     return outputs;
 }
@@ -255,7 +255,7 @@ Func Pipeline::get_func(size_t index) {
     return Func(env.find(order[index])->second);
 }
 
-void Pipeline::compile_to(const std::map<OutputType, std::string> &output_files,
+void Pipeline::compile_to(const std::map<OutputFileType, std::string> &output_files,
                           const vector<Argument> &args,
                           const string &fn_name,
                           const Target &target) {
@@ -267,7 +267,7 @@ void Pipeline::compile_to_bitcode(const string &filename,
                                   const string &fn_name,
                                   const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputType::bitcode));
+    m.compile(single_output(filename, m, OutputFileType::bitcode));
 }
 
 void Pipeline::compile_to_llvm_assembly(const string &filename,
@@ -275,7 +275,7 @@ void Pipeline::compile_to_llvm_assembly(const string &filename,
                                         const string &fn_name,
                                         const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputType::llvm_assembly));
+    m.compile(single_output(filename, m, OutputFileType::llvm_assembly));
 }
 
 void Pipeline::compile_to_object(const string &filename,
@@ -284,7 +284,7 @@ void Pipeline::compile_to_object(const string &filename,
                                  const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
     auto ext = get_output_info(target);
-    m.compile({{OutputType::object, output_name(filename, m, ext.at(OutputType::object).extension)}});
+    m.compile({{OutputFileType::object, output_name(filename, m, ext.at(OutputFileType::object).extension)}});
 }
 
 void Pipeline::compile_to_header(const string &filename,
@@ -292,7 +292,7 @@ void Pipeline::compile_to_header(const string &filename,
                                  const string &fn_name,
                                  const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputType::c_header));
+    m.compile(single_output(filename, m, OutputFileType::c_header));
 }
 
 void Pipeline::compile_to_assembly(const string &filename,
@@ -300,7 +300,7 @@ void Pipeline::compile_to_assembly(const string &filename,
                                    const string &fn_name,
                                    const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputType::assembly));
+    m.compile(single_output(filename, m, OutputFileType::assembly));
 }
 
 void Pipeline::compile_to_c(const string &filename,
@@ -308,7 +308,7 @@ void Pipeline::compile_to_c(const string &filename,
                             const string &fn_name,
                             const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
-    m.compile(single_output(filename, m, OutputType::c_source));
+    m.compile(single_output(filename, m, OutputFileType::c_source));
 }
 
 void Pipeline::print_loop_nest() {
@@ -321,7 +321,7 @@ void Pipeline::compile_to_lowered_stmt(const string &filename,
                                        StmtOutputFormat fmt,
                                        const Target &target) {
     Module m = compile_to_module(args, "", target);
-    m.compile(single_output(filename, m, fmt == HTML ? OutputType::stmt_html : OutputType::stmt));
+    m.compile(single_output(filename, m, fmt == HTML ? OutputFileType::stmt_html : OutputFileType::stmt));
 }
 
 void Pipeline::compile_to_static_library(const string &filename_prefix,
@@ -359,9 +359,9 @@ void Pipeline::compile_to_file(const string &filename_prefix,
                                const Target &target) {
     Module m = compile_to_module(args, fn_name, target);
     auto ext = get_output_info(target);
-    std::map<OutputType, std::string> outputs = {
-        {OutputType::c_header, filename_prefix + ext.at(OutputType::c_header).extension},
-        {OutputType::object, filename_prefix + ext.at(OutputType::object).extension},
+    std::map<OutputFileType, std::string> outputs = {
+        {OutputFileType::c_header, filename_prefix + ext.at(OutputFileType::c_header).extension},
+        {OutputFileType::object, filename_prefix + ext.at(OutputFileType::object).extension},
     };
     m.compile(outputs);
 }
@@ -634,7 +634,7 @@ void Pipeline::compile_jit(const Target &target_arg) {
         }
         string file_name = program_name + "_" + name + "_" + unique_name('g').substr(1) + ".bc";
         debug(4) << "Saving bitcode to: " << file_name << "\n";
-        module.compile({{OutputType::bitcode, file_name}});
+        module.compile({{OutputFileType::bitcode, file_name}});
     }
 
     contents->jit_module = jit_module;

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -214,7 +214,7 @@ public:
      * Deduces target files based on filenames specified in
      * output_files map.
      */
-    void compile_to(const std::map<OutputType, std::string> &output_files,
+    void compile_to(const std::map<OutputFileType, std::string> &output_files,
                     const std::vector<Argument> &args,
                     const std::string &fn_name,
                     const Target &target);

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -214,7 +214,7 @@ public:
      * Deduces target files based on filenames specified in
      * output_files map.
      */
-    void compile_to(const std::map<OutputFile, std::string> &output_files,
+    void compile_to(const std::map<OutputType, std::string> &output_files,
                     const std::vector<Argument> &args,
                     const std::string &fn_name,
                     const Target &target);

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -214,7 +214,7 @@ public:
      * Deduces target files based on filenames specified in
      * output_files map.
      */
-    void compile_to(const std::map<Output, std::string> &output_files,
+    void compile_to(const std::map<OutputFile, std::string> &output_files,
                     const std::vector<Argument> &args,
                     const std::string &fn_name,
                     const Target &target);

--- a/test/correctness/compile_to.cpp
+++ b/test/correctness/compile_to.cpp
@@ -12,7 +12,7 @@ void testCompileToOutput(Func j) {
     Internal::ensure_no_file_exists(fn_object);
 
     std::vector<Argument> empty_args;
-    j.compile_to({{OutputFile::object, fn_object}}, empty_args, "");
+    j.compile_to({{OutputType::object, fn_object}}, empty_args, "");
 
     Internal::assert_file_exists(fn_object);
 }
@@ -25,7 +25,7 @@ void testCompileToOutputAndAssembly(Func j) {
     Internal::ensure_no_file_exists(fn_assembly);
 
     std::vector<Argument> empty_args;
-    j.compile_to({{OutputFile::object, fn_object}, {OutputFile::assembly, fn_assembly}}, empty_args, "");
+    j.compile_to({{OutputType::object, fn_object}, {OutputType::assembly, fn_assembly}}, empty_args, "");
 
     Internal::assert_file_exists(fn_object);
     Internal::assert_file_exists(fn_assembly);

--- a/test/correctness/compile_to.cpp
+++ b/test/correctness/compile_to.cpp
@@ -12,7 +12,7 @@ void testCompileToOutput(Func j) {
     Internal::ensure_no_file_exists(fn_object);
 
     std::vector<Argument> empty_args;
-    j.compile_to({{Output::object, fn_object}}, empty_args, "");
+    j.compile_to({{OutputFile::object, fn_object}}, empty_args, "");
 
     Internal::assert_file_exists(fn_object);
 }
@@ -25,7 +25,7 @@ void testCompileToOutputAndAssembly(Func j) {
     Internal::ensure_no_file_exists(fn_assembly);
 
     std::vector<Argument> empty_args;
-    j.compile_to({{Output::object, fn_object}, {Output::assembly, fn_assembly}}, empty_args, "");
+    j.compile_to({{OutputFile::object, fn_object}, {OutputFile::assembly, fn_assembly}}, empty_args, "");
 
     Internal::assert_file_exists(fn_object);
     Internal::assert_file_exists(fn_assembly);

--- a/test/correctness/compile_to.cpp
+++ b/test/correctness/compile_to.cpp
@@ -12,7 +12,7 @@ void testCompileToOutput(Func j) {
     Internal::ensure_no_file_exists(fn_object);
 
     std::vector<Argument> empty_args;
-    j.compile_to({{OutputType::object, fn_object}}, empty_args, "");
+    j.compile_to({{OutputFileType::object, fn_object}}, empty_args, "");
 
     Internal::assert_file_exists(fn_object);
 }
@@ -25,7 +25,7 @@ void testCompileToOutputAndAssembly(Func j) {
     Internal::ensure_no_file_exists(fn_assembly);
 
     std::vector<Argument> empty_args;
-    j.compile_to({{OutputType::object, fn_object}, {OutputType::assembly, fn_assembly}}, empty_args, "");
+    j.compile_to({{OutputFileType::object, fn_object}, {OutputFileType::assembly, fn_assembly}}, empty_args, "");
 
     Internal::assert_file_exists(fn_object);
     Internal::assert_file_exists(fn_assembly);

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -174,30 +174,30 @@ void test_compile_to_everything(Func j, bool do_object) {
     auto module_producer = [&j, &args](const std::string &name, const Target &target) -> Module {
         return j.compile_to_module(args, name, target);
     };
-    std::map<OutputFile, std::string> outputs = {
-        {OutputFile::assembly, fname + ".s"},                        // IsMulti
-        {OutputFile::bitcode, fname + ".bc"},                        // IsMulti
-        {OutputFile::c_header, fname + ".h"},                        // IsSingle
-        {OutputFile::c_source, fname + ".halide_generated.cpp"},     // IsSingle
-        {OutputFile::compiler_log, fname + ".halide_compiler_log"},  // IsSingle
+    std::map<OutputType, std::string> outputs = {
+        {OutputType::assembly, fname + ".s"},                        // IsMulti
+        {OutputType::bitcode, fname + ".bc"},                        // IsMulti
+        {OutputType::c_header, fname + ".h"},                        // IsSingle
+        {OutputType::c_source, fname + ".halide_generated.cpp"},     // IsSingle
+        {OutputType::compiler_log, fname + ".halide_compiler_log"},  // IsSingle
         // Note: compile_multitarget() doesn't produce cpp_stub output,
         // even if you pass this in.
-        // {OutputFile::cpp_stub, fname + ".stub.h"},  // IsSingle
-        {OutputFile::featurization, fname + ".featurization"},    // IsMulti
-        {OutputFile::llvm_assembly, fname + ".ll"},               // IsMulti
-        {OutputFile::object, fname + o},                          // IsMulti
-        {OutputFile::python_extension, fname + ".py.cpp"},        // IsSingle
-        {OutputFile::pytorch_wrapper, fname + ".pytorch.h"},      // IsSingle
-        {OutputFile::registration, fname + ".registration.cpp"},  // IsSingle
-        {OutputFile::schedule, fname + ".schedule.h"},            // IsSingle
-        {OutputFile::static_library, fname + a},                  // IsSingle
-        {OutputFile::stmt, fname + ".stmt"},                      // IsMulti
-        {OutputFile::stmt_html, fname + ".stmt.html"},            // IsMulti
+        // {OutputType::cpp_stub, fname + ".stub.h"},  // IsSingle
+        {OutputType::featurization, fname + ".featurization"},    // IsMulti
+        {OutputType::llvm_assembly, fname + ".ll"},               // IsMulti
+        {OutputType::object, fname + o},                          // IsMulti
+        {OutputType::python_extension, fname + ".py.cpp"},        // IsSingle
+        {OutputType::pytorch_wrapper, fname + ".pytorch.h"},      // IsSingle
+        {OutputType::registration, fname + ".registration.cpp"},  // IsSingle
+        {OutputType::schedule, fname + ".schedule.h"},            // IsSingle
+        {OutputType::static_library, fname + a},                  // IsSingle
+        {OutputType::stmt, fname + ".stmt"},                      // IsMulti
+        {OutputType::stmt_html, fname + ".stmt.html"},            // IsMulti
     };
     if (do_object) {
-        outputs.erase(OutputFile::static_library);
+        outputs.erase(OutputType::static_library);
     } else {
-        outputs.erase(OutputFile::object);
+        outputs.erase(OutputType::object);
     }
     const CompilerLoggerFactory compiler_logger_factory =
         [](const std::string &, const Target &) -> std::unique_ptr<Internal::CompilerLogger> {

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -174,30 +174,30 @@ void test_compile_to_everything(Func j, bool do_object) {
     auto module_producer = [&j, &args](const std::string &name, const Target &target) -> Module {
         return j.compile_to_module(args, name, target);
     };
-    std::map<Output, std::string> outputs = {
-        {Output::assembly, fname + ".s"},                        // IsMulti
-        {Output::bitcode, fname + ".bc"},                        // IsMulti
-        {Output::c_header, fname + ".h"},                        // IsSingle
-        {Output::c_source, fname + ".halide_generated.cpp"},     // IsSingle
-        {Output::compiler_log, fname + ".halide_compiler_log"},  // IsSingle
+    std::map<OutputFile, std::string> outputs = {
+        {OutputFile::assembly, fname + ".s"},                        // IsMulti
+        {OutputFile::bitcode, fname + ".bc"},                        // IsMulti
+        {OutputFile::c_header, fname + ".h"},                        // IsSingle
+        {OutputFile::c_source, fname + ".halide_generated.cpp"},     // IsSingle
+        {OutputFile::compiler_log, fname + ".halide_compiler_log"},  // IsSingle
         // Note: compile_multitarget() doesn't produce cpp_stub output,
         // even if you pass this in.
-        // {Output::cpp_stub, fname + ".stub.h"},  // IsSingle
-        {Output::featurization, fname + ".featurization"},    // IsMulti
-        {Output::llvm_assembly, fname + ".ll"},               // IsMulti
-        {Output::object, fname + o},                          // IsMulti
-        {Output::python_extension, fname + ".py.cpp"},        // IsSingle
-        {Output::pytorch_wrapper, fname + ".pytorch.h"},      // IsSingle
-        {Output::registration, fname + ".registration.cpp"},  // IsSingle
-        {Output::schedule, fname + ".schedule.h"},            // IsSingle
-        {Output::static_library, fname + a},                  // IsSingle
-        {Output::stmt, fname + ".stmt"},                      // IsMulti
-        {Output::stmt_html, fname + ".stmt.html"},            // IsMulti
+        // {OutputFile::cpp_stub, fname + ".stub.h"},  // IsSingle
+        {OutputFile::featurization, fname + ".featurization"},    // IsMulti
+        {OutputFile::llvm_assembly, fname + ".ll"},               // IsMulti
+        {OutputFile::object, fname + o},                          // IsMulti
+        {OutputFile::python_extension, fname + ".py.cpp"},        // IsSingle
+        {OutputFile::pytorch_wrapper, fname + ".pytorch.h"},      // IsSingle
+        {OutputFile::registration, fname + ".registration.cpp"},  // IsSingle
+        {OutputFile::schedule, fname + ".schedule.h"},            // IsSingle
+        {OutputFile::static_library, fname + a},                  // IsSingle
+        {OutputFile::stmt, fname + ".stmt"},                      // IsMulti
+        {OutputFile::stmt_html, fname + ".stmt.html"},            // IsMulti
     };
     if (do_object) {
-        outputs.erase(Output::static_library);
+        outputs.erase(OutputFile::static_library);
     } else {
-        outputs.erase(Output::object);
+        outputs.erase(OutputFile::object);
     }
     const CompilerLoggerFactory compiler_logger_factory =
         [](const std::string &, const Target &) -> std::unique_ptr<Internal::CompilerLogger> {

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -174,30 +174,30 @@ void test_compile_to_everything(Func j, bool do_object) {
     auto module_producer = [&j, &args](const std::string &name, const Target &target) -> Module {
         return j.compile_to_module(args, name, target);
     };
-    std::map<OutputType, std::string> outputs = {
-        {OutputType::assembly, fname + ".s"},                        // IsMulti
-        {OutputType::bitcode, fname + ".bc"},                        // IsMulti
-        {OutputType::c_header, fname + ".h"},                        // IsSingle
-        {OutputType::c_source, fname + ".halide_generated.cpp"},     // IsSingle
-        {OutputType::compiler_log, fname + ".halide_compiler_log"},  // IsSingle
+    std::map<OutputFileType, std::string> outputs = {
+        {OutputFileType::assembly, fname + ".s"},                        // IsMulti
+        {OutputFileType::bitcode, fname + ".bc"},                        // IsMulti
+        {OutputFileType::c_header, fname + ".h"},                        // IsSingle
+        {OutputFileType::c_source, fname + ".halide_generated.cpp"},     // IsSingle
+        {OutputFileType::compiler_log, fname + ".halide_compiler_log"},  // IsSingle
         // Note: compile_multitarget() doesn't produce cpp_stub output,
         // even if you pass this in.
-        // {OutputType::cpp_stub, fname + ".stub.h"},  // IsSingle
-        {OutputType::featurization, fname + ".featurization"},    // IsMulti
-        {OutputType::llvm_assembly, fname + ".ll"},               // IsMulti
-        {OutputType::object, fname + o},                          // IsMulti
-        {OutputType::python_extension, fname + ".py.cpp"},        // IsSingle
-        {OutputType::pytorch_wrapper, fname + ".pytorch.h"},      // IsSingle
-        {OutputType::registration, fname + ".registration.cpp"},  // IsSingle
-        {OutputType::schedule, fname + ".schedule.h"},            // IsSingle
-        {OutputType::static_library, fname + a},                  // IsSingle
-        {OutputType::stmt, fname + ".stmt"},                      // IsMulti
-        {OutputType::stmt_html, fname + ".stmt.html"},            // IsMulti
+        // {OutputFileType::cpp_stub, fname + ".stub.h"},  // IsSingle
+        {OutputFileType::featurization, fname + ".featurization"},    // IsMulti
+        {OutputFileType::llvm_assembly, fname + ".ll"},               // IsMulti
+        {OutputFileType::object, fname + o},                          // IsMulti
+        {OutputFileType::python_extension, fname + ".py.cpp"},        // IsSingle
+        {OutputFileType::pytorch_wrapper, fname + ".pytorch.h"},      // IsSingle
+        {OutputFileType::registration, fname + ".registration.cpp"},  // IsSingle
+        {OutputFileType::schedule, fname + ".schedule.h"},            // IsSingle
+        {OutputFileType::static_library, fname + a},                  // IsSingle
+        {OutputFileType::stmt, fname + ".stmt"},                      // IsMulti
+        {OutputFileType::stmt_html, fname + ".stmt.html"},            // IsMulti
     };
     if (do_object) {
-        outputs.erase(OutputType::static_library);
+        outputs.erase(OutputFileType::static_library);
     } else {
-        outputs.erase(OutputType::object);
+        outputs.erase(OutputFileType::object);
     }
     const CompilerLoggerFactory compiler_logger_factory =
         [](const std::string &, const Target &) -> std::unique_ptr<Internal::CompilerLogger> {

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -261,10 +261,10 @@ private:
         std::string file_name = output_directory + fn_name;
 
         auto ext = Internal::get_output_info(target);
-        std::map<Output, std::string> outputs = {
-            {Output::c_header, file_name + ext.at(Output::c_header).extension},
-            {Output::object, file_name + ext.at(Output::object).extension},
-            {Output::assembly, file_name + ".s"},
+        std::map<OutputFile, std::string> outputs = {
+            {OutputFile::c_header, file_name + ext.at(OutputFile::c_header).extension},
+            {OutputFile::object, file_name + ext.at(OutputFile::object).extension},
+            {OutputFile::assembly, file_name + ".s"},
         };
         error.compile_to(outputs, arg_types, fn_name, target);
 
@@ -275,7 +275,9 @@ private:
 
         string suffix = suffix_map[name];
         std::ostringstream msg;
-        msg << op << " did not generate for target=" << target.to_string() << " suffix=" << suffix << " vector_width=" << vector_width << ". Instead we got:\n";
+        msg << op << " did not generate for target=" << target.to_string()
+            << " suffix=" << suffix
+            << " vector_width=" << vector_width << ". Instead we got:\n";
 
         string line;
         while (getline(asm_file, line)) {

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -261,10 +261,10 @@ private:
         std::string file_name = output_directory + fn_name;
 
         auto ext = Internal::get_output_info(target);
-        std::map<OutputType, std::string> outputs = {
-            {OutputType::c_header, file_name + ext.at(OutputType::c_header).extension},
-            {OutputType::object, file_name + ext.at(OutputType::object).extension},
-            {OutputType::assembly, file_name + ".s"},
+        std::map<OutputFileType, std::string> outputs = {
+            {OutputFileType::c_header, file_name + ext.at(OutputFileType::c_header).extension},
+            {OutputFileType::object, file_name + ext.at(OutputFileType::object).extension},
+            {OutputFileType::assembly, file_name + ".s"},
         };
         error.compile_to(outputs, arg_types, fn_name, target);
 

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -261,10 +261,10 @@ private:
         std::string file_name = output_directory + fn_name;
 
         auto ext = Internal::get_output_info(target);
-        std::map<OutputFile, std::string> outputs = {
-            {OutputFile::c_header, file_name + ext.at(OutputFile::c_header).extension},
-            {OutputFile::object, file_name + ext.at(OutputFile::object).extension},
-            {OutputFile::assembly, file_name + ".s"},
+        std::map<OutputType, std::string> outputs = {
+            {OutputType::c_header, file_name + ext.at(OutputType::c_header).extension},
+            {OutputType::object, file_name + ext.at(OutputType::object).extension},
+            {OutputType::assembly, file_name + ".s"},
         };
         error.compile_to(outputs, arg_types, fn_name, target);
 

--- a/test/correctness/python_extension_gen.cpp
+++ b/test/correctness/python_extension_gen.cpp
@@ -42,8 +42,8 @@ int main(int argc, char **argv) {
     std::string function_name = "org::halide::halide_python::f";
 
     f.compile_to(
-        {{OutputType::c_source, c_filename},
-         {OutputType::python_extension, pyext_filename}},
+        {{OutputFileType::c_source, c_filename},
+         {OutputFileType::python_extension, pyext_filename}},
         params,
         function_name,
         target);

--- a/test/correctness/python_extension_gen.cpp
+++ b/test/correctness/python_extension_gen.cpp
@@ -42,8 +42,8 @@ int main(int argc, char **argv) {
     std::string function_name = "org::halide::halide_python::f";
 
     f.compile_to(
-        {{OutputFile::c_source, c_filename},
-         {OutputFile::python_extension, pyext_filename}},
+        {{OutputType::c_source, c_filename},
+         {OutputType::python_extension, pyext_filename}},
         params,
         function_name,
         target);

--- a/test/correctness/python_extension_gen.cpp
+++ b/test/correctness/python_extension_gen.cpp
@@ -42,8 +42,8 @@ int main(int argc, char **argv) {
     std::string function_name = "org::halide::halide_python::f";
 
     f.compile_to(
-        {{Output::c_source, c_filename},
-         {Output::python_extension, pyext_filename}},
+        {{OutputFile::c_source, c_filename},
+         {OutputFile::python_extension, pyext_filename}},
         params,
         function_name,
         target);

--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
         Internal::ensure_no_file_exists(pytorch_out);
 
         std::vector<Argument> args{alpha, beta};
-        buf.compile_to({{Output::pytorch_wrapper, pytorch_out}}, args, "test1", t);
+        buf.compile_to({{OutputFile::pytorch_wrapper, pytorch_out}}, args, "test1", t);
 
         Internal::assert_file_exists(pytorch_out);
         std::string actual = read_entire_file(pytorch_out);
@@ -160,7 +160,7 @@ inline int test1_th_(float _alpha, int32_t _beta, at::Tensor &_buf) {
         Internal::ensure_no_file_exists(pytorch_out);
 
         std::vector<Argument> args{alpha, beta};
-        buf.compile_to({{Output::pytorch_wrapper, pytorch_out}}, args, "test2", t);
+        buf.compile_to({{OutputFile::pytorch_wrapper, pytorch_out}}, args, "test2", t);
 
         Internal::assert_file_exists(pytorch_out);
         std::string actual = read_entire_file(pytorch_out);

--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
         Internal::ensure_no_file_exists(pytorch_out);
 
         std::vector<Argument> args{alpha, beta};
-        buf.compile_to({{OutputType::pytorch_wrapper, pytorch_out}}, args, "test1", t);
+        buf.compile_to({{OutputFileType::pytorch_wrapper, pytorch_out}}, args, "test1", t);
 
         Internal::assert_file_exists(pytorch_out);
         std::string actual = read_entire_file(pytorch_out);
@@ -160,7 +160,7 @@ inline int test1_th_(float _alpha, int32_t _beta, at::Tensor &_buf) {
         Internal::ensure_no_file_exists(pytorch_out);
 
         std::vector<Argument> args{alpha, beta};
-        buf.compile_to({{OutputType::pytorch_wrapper, pytorch_out}}, args, "test2", t);
+        buf.compile_to({{OutputFileType::pytorch_wrapper, pytorch_out}}, args, "test2", t);
 
         Internal::assert_file_exists(pytorch_out);
         std::string actual = read_entire_file(pytorch_out);

--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
         Internal::ensure_no_file_exists(pytorch_out);
 
         std::vector<Argument> args{alpha, beta};
-        buf.compile_to({{OutputFile::pytorch_wrapper, pytorch_out}}, args, "test1", t);
+        buf.compile_to({{OutputType::pytorch_wrapper, pytorch_out}}, args, "test1", t);
 
         Internal::assert_file_exists(pytorch_out);
         std::string actual = read_entire_file(pytorch_out);
@@ -160,7 +160,7 @@ inline int test1_th_(float _alpha, int32_t _beta, at::Tensor &_buf) {
         Internal::ensure_no_file_exists(pytorch_out);
 
         std::vector<Argument> args{alpha, beta};
-        buf.compile_to({{OutputFile::pytorch_wrapper, pytorch_out}}, args, "test2", t);
+        buf.compile_to({{OutputType::pytorch_wrapper, pytorch_out}}, args, "test2", t);
 
         Internal::assert_file_exists(pytorch_out);
         std::string actual = read_entire_file(pytorch_out);

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -101,10 +101,10 @@ public:
         std::string file_name = output_directory + fn_name;
 
         auto ext = Internal::get_output_info(target);
-        std::map<Output, std::string> outputs = {
-            {Output::c_header, file_name + ext.at(Output::c_header).extension},
-            {Output::object, file_name + ext.at(Output::object).extension},
-            {Output::assembly, file_name + ".s"},
+        std::map<OutputFile, std::string> outputs = {
+            {OutputFile::c_header, file_name + ext.at(OutputFile::c_header).extension},
+            {OutputFile::object, file_name + ext.at(OutputFile::object).extension},
+            {OutputFile::assembly, file_name + ".s"},
         };
         error.compile_to(outputs, arg_types, fn_name, target);
 

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -101,10 +101,10 @@ public:
         std::string file_name = output_directory + fn_name;
 
         auto ext = Internal::get_output_info(target);
-        std::map<OutputFile, std::string> outputs = {
-            {OutputFile::c_header, file_name + ext.at(OutputFile::c_header).extension},
-            {OutputFile::object, file_name + ext.at(OutputFile::object).extension},
-            {OutputFile::assembly, file_name + ".s"},
+        std::map<OutputType, std::string> outputs = {
+            {OutputType::c_header, file_name + ext.at(OutputType::c_header).extension},
+            {OutputType::object, file_name + ext.at(OutputType::object).extension},
+            {OutputType::assembly, file_name + ".s"},
         };
         error.compile_to(outputs, arg_types, fn_name, target);
 

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -101,10 +101,10 @@ public:
         std::string file_name = output_directory + fn_name;
 
         auto ext = Internal::get_output_info(target);
-        std::map<OutputType, std::string> outputs = {
-            {OutputType::c_header, file_name + ext.at(OutputType::c_header).extension},
-            {OutputType::object, file_name + ext.at(OutputType::object).extension},
-            {OutputType::assembly, file_name + ".s"},
+        std::map<OutputFileType, std::string> outputs = {
+            {OutputFileType::c_header, file_name + ext.at(OutputFileType::c_header).extension},
+            {OutputFileType::object, file_name + ext.at(OutputFileType::object).extension},
+            {OutputFileType::assembly, file_name + ".s"},
         };
         error.compile_to(outputs, arg_types, fn_name, target);
 


### PR DESCRIPTION
It would be nice in future if we could promote Generator::Input and
Generator::Output to the Halide namespace. For that to happen, we need
to rename the enum Output first. This PR adds a new name for it, and
deprecates the old name. 

Not married to the name OutputFile. Other suggestions welcome.