### PR TITLE
Add `explicit` to a handful of Generator-related ctors.

### DIFF
--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -18,17 +18,17 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1024};
-    GeneratorParam<bool> scale_x_ = {"scale_x", true};
-    GeneratorParam<bool> add_to_y_ = {"add_to_y", true};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<int> block_size_{"block_size", 1024};
+    GeneratorParam<bool> scale_x_{"scale_x", true};
+    GeneratorParam<bool> add_to_y_{"add_to_y", true};
 
     // Standard ordering of parameters in AXPY functions.
-    Input<T> a_ = {"a", 1};
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<T> a_{"a", 1};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> result_ = {"result", 1};
+    Output<Buffer<T>> result_{"result", 1};
 
     template<class Arg>
     Expr calc(Arg i) {
@@ -82,14 +82,14 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1024};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1024};
 
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> result_ = {"result", 0};
+    Output<Buffer<T>> result_{"result", 0};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));
@@ -136,13 +136,13 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1024};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1024};
 
-    Input<Buffer<T>> x_ = {"x", 1};
+    Input<Buffer<T>> x_{"x", 1};
 
-    Output<Buffer<T>> result_ = {"result", 0};
+    Output<Buffer<T>> result_{"result", 0};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -18,19 +18,19 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1 << 8};
-    GeneratorParam<bool> transpose_ = {"transpose", false};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1 << 8};
+    GeneratorParam<bool> transpose_{"transpose", false};
 
     // Standard ordering of parameters in GEMV functions.
-    Input<T> a_ = {"a", 1};
-    Input<Buffer<T>> A_ = {"A", 2};
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<T> b_ = {"b", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<T> a_{"a", 1};
+    Input<Buffer<T>> A_{"A", 2};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<T> b_{"b", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> output_ = {"output", 1};
+    Output<Buffer<T>> output_{"output", 1};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));
@@ -209,16 +209,16 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1 << 5};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1 << 5};
 
     // Standard ordering of parameters in GEMV functions.
-    Input<T> a_ = {"a", 1};
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<T> a_{"a", 1};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> result_ = {"result", 2};
+    Output<Buffer<T>> result_{"result", 2};
 
     void generate() {
         const int vec_size = vectorize_ ? natural_vector_size(type_of<T>()) : 1;

--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -18,17 +18,17 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> transpose_A_ = {"transpose_A", false};
-    GeneratorParam<bool> transpose_B_ = {"transpose_B", false};
+    GeneratorParam<bool> transpose_A_{"transpose_A", false};
+    GeneratorParam<bool> transpose_B_{"transpose_B", false};
 
     // Standard ordering of parameters in GEMM functions.
-    Input<T> a_ = {"a_", 1};
-    Input<Buffer<T>> A_ = {"A_", 2};
-    Input<Buffer<T>> B_ = {"B_", 2};
-    Input<T> b_ = {"b_", 1};
-    Input<Buffer<T>> C_ = {"C_", 2};
+    Input<T> a_{"a_", 1};
+    Input<Buffer<T>> A_{"A_", 2};
+    Input<Buffer<T>> B_{"B_", 2};
+    Input<T> b_{"b_", 1};
+    Input<Buffer<T>> C_{"C_", 2};
 
-    Output<Buffer<T>> result_ = {"result", 2};
+    Output<Buffer<T>> result_{"result", 2};
 
     void generate() {
         // Matrices are interpreted as column-major by default. The

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1676,7 +1676,7 @@ protected:
     }
 
 public:
-    GeneratorInput_Buffer(const std::string &name)
+    explicit GeneratorInput_Buffer(const std::string &name)
         : Super(name, IOKind::Buffer,
                 TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
                 -1) {
@@ -1834,7 +1834,7 @@ public:
     }
 
     // unspecified type & dimension
-    GeneratorInput_Func(const std::string &name)
+    explicit GeneratorInput_Func(const std::string &name)
         : Super(name, IOKind::Function, {}, -1) {
     }
 
@@ -2166,56 +2166,59 @@ protected:
             Internal::cond<true, Unused>>::type;
 
 public:
+    // Mark all of these explicit (not just single-arg versions) so that
+    // we disallow copy-list-initialization form (i.e., Input foo{"foo"} is ok,
+    // but Input foo = {"foo"} is not).
     explicit GeneratorInput(const std::string &name)
         : Super(name) {
     }
 
-    GeneratorInput(const std::string &name, const TBase &def)
+    explicit GeneratorInput(const std::string &name, const TBase &def)
         : Super(name, def) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name, const TBase &def)
+    explicit GeneratorInput(size_t array_size, const std::string &name, const TBase &def)
         : Super(array_size, name, def) {
     }
 
-    GeneratorInput(const std::string &name,
-                   const TBase &def, const TBase &min, const TBase &max)
+    explicit GeneratorInput(const std::string &name,
+                            const TBase &def, const TBase &min, const TBase &max)
         : Super(name, def, min, max) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name,
-                   const TBase &def, const TBase &min, const TBase &max)
+    explicit GeneratorInput(size_t array_size, const std::string &name,
+                            const TBase &def, const TBase &min, const TBase &max)
         : Super(array_size, name, def, min, max) {
     }
 
-    GeneratorInput(const std::string &name, const Type &t, int d)
+    explicit GeneratorInput(const std::string &name, const Type &t, int d)
         : Super(name, t, d) {
     }
 
-    GeneratorInput(const std::string &name, const Type &t)
+    explicit GeneratorInput(const std::string &name, const Type &t)
         : Super(name, t) {
     }
 
     // Avoid ambiguity between Func-with-dim and int-with-default
-    GeneratorInput(const std::string &name, IntIfNonScalar d)
+    explicit GeneratorInput(const std::string &name, IntIfNonScalar d)
         : Super(name, d) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name, const Type &t, int d)
+    explicit GeneratorInput(size_t array_size, const std::string &name, const Type &t, int d)
         : Super(array_size, name, t, d) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name, const Type &t)
+    explicit GeneratorInput(size_t array_size, const std::string &name, const Type &t)
         : Super(array_size, name, t) {
     }
 
     // Avoid ambiguity between Func-with-dim and int-with-default
     // template <typename T2 = T, typename std::enable_if<std::is_same<TBase, Func>::value>::type * = nullptr>
-    GeneratorInput(size_t array_size, const std::string &name, IntIfNonScalar d)
+    explicit GeneratorInput(size_t array_size, const std::string &name, IntIfNonScalar d)
         : Super(array_size, name, d) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name)
+    explicit GeneratorInput(size_t array_size, const std::string &name)
         : Super(array_size, name) {
     }
 };
@@ -2598,7 +2601,7 @@ private:
 protected:
     using TBase = typename Super::TBase;
 
-    GeneratorOutput_Func(const std::string &name)
+    explicit GeneratorOutput_Func(const std::string &name)
         : Super(name, IOKind::Function, std::vector<Type>{}, -1) {
     }
 
@@ -2692,6 +2695,9 @@ protected:
     using TBase = typename Super::TBase;
 
 public:
+    // Mark all of these explicit (not just single-arg versions) so that
+    // we disallow copy-list-initialization form (i.e., Output foo{"foo"} is ok,
+    // but Output foo = {"foo"} is not).
     explicit GeneratorOutput(const std::string &name)
         : Super(name) {
     }
@@ -2700,31 +2706,47 @@ public:
         : GeneratorOutput(std::string(name)) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name)
+    explicit GeneratorOutput(size_t array_size, const std::string &name)
         : Super(array_size, name) {
     }
 
-    GeneratorOutput(const std::string &name, int d)
+    explicit GeneratorOutput(const std::string &name, int d)
         : Super(name, {}, d) {
     }
 
-    GeneratorOutput(const std::string &name, const Type &t, int d)
+    explicit GeneratorOutput(const std::string &name, const Type &t)
+        : Super(name, {t}) {
+    }
+
+    explicit GeneratorOutput(const std::string &name, const std::vector<Type> &t)
+        : Super(name, t) {
+    }
+
+    explicit GeneratorOutput(const std::string &name, const Type &t, int d)
         : Super(name, {t}, d) {
     }
 
-    GeneratorOutput(const std::string &name, const std::vector<Type> &t, int d)
+    explicit GeneratorOutput(const std::string &name, const std::vector<Type> &t, int d)
         : Super(name, t, d) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name, int d)
+    explicit GeneratorOutput(size_t array_size, const std::string &name, int d)
         : Super(array_size, name, {}, d) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name, const Type &t, int d)
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const Type &t)
+        : Super(array_size, name, {t}) {
+    }
+
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const std::vector<Type> &t)
+        : Super(array_size, name, t) {
+    }
+
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const Type &t, int d)
         : Super(array_size, name, {t}, d) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name, const std::vector<Type> &t, int d)
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const std::vector<Type> &t, int d)
         : Super(array_size, name, t, d) {
     }
 


### PR DESCRIPTION
Some are just to pacify tooling that wants single-arg ctors to be `explicit` as a matter of policy; others are to disallow variant forms of Generator input/output initialization in the name of uniformity.