### PR TITLE
Expand optional static-typing for Buffer to include dimensionality

### DIFF
--- a/apps/fft/fft_aot_test.cpp
+++ b/apps/fft/fft_aot_test.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
         auto in = real_buffer();
         for (int j = 0; j < kSize; j++) {
             for (int i = 0; i < kSize; i++) {
-                in(i, j) = signal_1d[i] + signal_1d[j];
+                in(i, j, 0) = signal_1d[i] + signal_1d[j];
             }
         }
 
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
 
         for (size_t j = 0; j < kSize; j++) {
             for (size_t i = 0; i < kSize; i++) {
-                float sample = out(i, j);
+                float sample = out(i, j, 0);
                 float expected = cos(2 * kPi * (i / 16.0f + .125f));
                 if (fabs(sample - expected) > .001) {
                     std::cerr << "fft_inverse_c2r mismatch at (" << i << ", " << j << ") " << sample << " vs. " << expected << "\n";

--- a/apps/fft/fft_aot_test.cpp
+++ b/apps/fft/fft_aot_test.cpp
@@ -19,6 +19,9 @@ const int32_t kSize = 16;
 
 using Halide::Runtime::Buffer;
 
+// Note that real_buffer() is 3D (with the 3rd dimension having extent 0)
+// because the fft is written generically to require 3D inputs, even when they are real.
+// Hence, the resulting buffer must be accessed with buf(i, j, 0).
 Buffer<float, 3> real_buffer(int32_t y_size = kSize) {
     return Buffer<float, 3>::make_interleaved(kSize, y_size, 1);
 }

--- a/apps/hannk/util/buffer_util.h
+++ b/apps/hannk/util/buffer_util.h
@@ -14,7 +14,7 @@ namespace hannk {
 // Using a Buffer with space for max_rank dimensions is a meaningful
 // win for some corner cases (when adding dimensions to > 4).
 template<typename T>
-using HalideBuffer = Halide::Runtime::Buffer<T, max_rank>;
+using HalideBuffer = Halide::Runtime::Buffer<T, Halide::Runtime::Buffer<>::DynamicDims, max_rank>;
 
 // dynamic_type_dispatch is a utility for functors that want to be able
 // to dynamically dispatch a halide_type_t to type-specialized code.

--- a/apps/hannk/util/buffer_util.h
+++ b/apps/hannk/util/buffer_util.h
@@ -14,7 +14,7 @@ namespace hannk {
 // Using a Buffer with space for max_rank dimensions is a meaningful
 // win for some corner cases (when adding dimensions to > 4).
 template<typename T>
-using HalideBuffer = Halide::Runtime::Buffer<T, Halide::Runtime::Buffer<>::DynamicDims, max_rank>;
+using HalideBuffer = Halide::Runtime::Buffer<T, Halide::Runtime::BufferDimsUnconstrained, max_rank>;
 
 // dynamic_type_dispatch is a utility for functors that want to be able
 // to dynamically dispatch a halide_type_t to type-specialized code.

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -393,7 +393,7 @@ void define_buffer(py::module &m) {
                 py::arg("dirty") = true)
 
             .def("copy", &Buffer<>::copy)
-            .def("copy_from", &Buffer<>::copy_from<void>)
+            .def("copy_from", &Buffer<>::copy_from<void, Buffer<>::DynamicDims>)
 
             .def("add_dimension", (void (Buffer<>::*)()) & Buffer<>::add_dimension)
 

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -393,7 +393,7 @@ void define_buffer(py::module &m) {
                 py::arg("dirty") = true)
 
             .def("copy", &Buffer<>::copy)
-            .def("copy_from", &Buffer<>::copy_from<void, Buffer<>::DynamicDims>)
+            .def("copy_from", &Buffer<>::copy_from<void, Buffer<>::BufferDimsUnconstrained>)
 
             .def("add_dimension", (void (Buffer<>::*)()) & Buffer<>::add_dimension)
 

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -12,7 +12,7 @@
 
 namespace Halide {
 
-template<typename T>
+template<typename T, int Dims>
 class Buffer;
 
 struct ArgumentEstimates {
@@ -78,8 +78,8 @@ struct Argument {
     // Not explicit, so that you can put Buffer in an argument list,
     // to indicate that it shouldn't be baked into the object file,
     // but instead received as an argument at runtime
-    template<typename T>
-    Argument(Buffer<T> im)
+    template<typename T, int Dims>
+    Argument(Buffer<T, Dims> im)
         : name(im.name()),
           kind(InputBuffer),
           dimensions(im.dimensions()),

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -8,7 +8,7 @@
 
 namespace Halide {
 
-template<typename T = void, int Dims = -1>
+template<typename T = void, int Dims = Halide::Runtime::BufferDimsUnconstrained>
 class Buffer;
 
 struct JITUserContext;
@@ -114,7 +114,7 @@ std::string buffer_type_name() {
  * template parameter is T = void.
  *
  * A Buffer<T, D1> can refer to a Buffer<T, D2> if D1 == D2,
- * or if D1 is -1 (meaning "dimensionality is checked at runtime, not compiletime").
+ * or if D1 is BufferDimsUnconstrained (meaning "dimensionality is checked at runtime, not compiletime").
  */
 template<typename T, int Dims>
 class Buffer {
@@ -134,7 +134,7 @@ class Buffer {
                               std::is_void<T>::value ||
                               std::is_void<T2>::value,
                           "type mismatch constructing Buffer");
-            static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2,
+            static_assert(Dims == BufferDimsUnconstrained || D2 == BufferDimsUnconstrained || Dims == D2,
                           "Can't convert from a Buffer with static dimensionality to a Buffer with different static dimensionality");
         } else {
             // Don't delegate to
@@ -153,8 +153,8 @@ class Buffer {
     }
 
 public:
-    static constexpr int DynamicDims = -1;
-    static_assert(Dims == DynamicDims || Dims >= 0);
+    static constexpr int BufferDimsUnconstrained = Halide::Runtime::BufferDimsUnconstrained;
+    static_assert(Dims == BufferDimsUnconstrained || Dims >= 0);
 
     typedef T ElemType;
 

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -8,7 +8,7 @@
 
 namespace Halide {
 
-template<typename T = void>
+template<typename T = void, int Dims = -1>
 class Buffer;
 
 struct JITUserContext;
@@ -108,20 +108,23 @@ std::string buffer_type_name() {
 /** A Halide::Buffer is a named shared reference to a
  * Halide::Runtime::Buffer.
  *
- * A Buffer<T1> can refer to a Buffer<T2> if T1 is const whenever T2
- * is const, and either T1 = T2 or T1 is void. A Buffer<void> can
+ * A Buffer<T1, D> can refer to a Buffer<T2, D> if T1 is const whenever T2
+ * is const, and either T1 = T2 or T1 is void. A Buffer<void, D> can
  * refer to any Buffer of any non-const type, and the default
  * template parameter is T = void.
+ *
+ * A Buffer<T, D1> can refer to a Buffer<T, D2> if D1 == D2,
+ * or if D1 is -1 (meaning "dimensionality is checked at runtime, not compiletime").
  */
-template<typename T>
+template<typename T, int Dims>
 class Buffer {
     Internal::IntrusivePtr<Internal::BufferContents> contents;
 
-    template<typename T2>
+    template<typename T2, int D2>
     friend class Buffer;
 
-    template<typename T2>
-    static void assert_can_convert_from(const Buffer<T2> &other) {
+    template<typename T2, int D2>
+    static void assert_can_convert_from(const Buffer<T2, D2> &other) {
         if (!other.defined()) {
             // Avoid UB of deferencing offset of a null contents ptr
             static_assert((!std::is_const<T2>::value || std::is_const<T>::value),
@@ -131,6 +134,8 @@ class Buffer {
                               std::is_void<T>::value ||
                               std::is_void<T2>::value,
                           "type mismatch constructing Buffer");
+            static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2,
+                          "Can't convert from a Buffer with static dimensionality to a Buffer with different static dimensionality");
         } else {
             // Don't delegate to
             // Runtime::Buffer<T>::assert_can_convert_from. It might
@@ -139,7 +144,8 @@ class Buffer {
             // debugging symbols are found, it throws an exception
             // when exceptions are enabled, and we can print the
             // actual types in question.
-            user_assert(Runtime::Buffer<T>::can_convert_from(*(other.get())))
+            using BufType = Runtime::Buffer<T, Dims>;  // alias because commas in user_assert() macro confuses compiler
+            user_assert(BufType::can_convert_from(*(other.get())))
                 << "Type mismatch constructing Buffer. Can't construct Buffer<"
                 << Internal::buffer_type_name<T>() << "> from Buffer<"
                 << type_to_c_type(other.type(), false) << ">\n";
@@ -147,6 +153,9 @@ class Buffer {
     }
 
 public:
+    static constexpr int DynamicDims = -1;
+    static_assert(Dims == DynamicDims || Dims >= 0);
+
     typedef T ElemType;
 
     // This class isn't final (and is subclassed from the Python binding
@@ -166,22 +175,22 @@ public:
     Buffer &operator=(Buffer &&) noexcept = default;
 
     /** Make a Buffer from a Buffer of a different type */
-    template<typename T2>
-    Buffer(const Buffer<T2> &other)
+    template<typename T2, int D2>
+    Buffer(const Buffer<T2, D2> &other)
         : contents(other.contents) {
         assert_can_convert_from(other);
     }
 
     /** Move construct from a Buffer of a different type */
-    template<typename T2>
-    Buffer(Buffer<T2> &&other) noexcept {
+    template<typename T2, int D2>
+    Buffer(Buffer<T2, D2> &&other) noexcept {
         assert_can_convert_from(other);
         contents = std::move(other.contents);
     }
 
     /** Construct a Buffer that captures and owns an rvalue Runtime::Buffer */
-    template<int D>
-    Buffer(Runtime::Buffer<T, D> &&buf, const std::string &name = "")
+    template<int D2>
+    Buffer(Runtime::Buffer<T, D2> &&buf, const std::string &name = "")
         : contents(new Internal::BufferContents) {
         contents->buf = std::move(buf);
         if (name.empty()) {
@@ -200,50 +209,50 @@ public:
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(Type t,
                     int first, Args... rest)
-        : Buffer(Runtime::Buffer<T>(t, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(t, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
     explicit Buffer(const halide_buffer_t &buf,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(buf), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(buf), name) {
     }
 
     template<typename... Args,
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(int first, Args... rest)
-        : Buffer(Runtime::Buffer<T>(Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
     explicit Buffer(Type t,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, sizes), name) {
     }
 
     explicit Buffer(Type t,
                     const std::vector<int> &sizes,
                     const std::vector<int> &storage_order,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, sizes, storage_order), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, sizes, storage_order), name) {
     }
 
     explicit Buffer(const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(sizes), name) {
     }
 
     explicit Buffer(const std::vector<int> &sizes,
                     const std::vector<int> &storage_order,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(sizes, storage_order), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(sizes, storage_order), name) {
     }
 
     template<typename Array, size_t N>
     explicit Buffer(Array (&vals)[N],
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(vals), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(vals), name) {
     }
 
     template<typename... Args,
@@ -251,7 +260,7 @@ public:
     explicit Buffer(Type t,
                     Internal::add_const_if_T_is_const<T, void> *data,
                     int first, Args &&...rest)
-        : Buffer(Runtime::Buffer<T>(t, data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
@@ -261,28 +270,28 @@ public:
                     Internal::add_const_if_T_is_const<T, void> *data,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, data, sizes, name)) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, sizes, name)) {
     }
 
     template<typename... Args,
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(T *data,
                     int first, Args &&...rest)
-        : Buffer(Runtime::Buffer<T>(data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
     explicit Buffer(T *data,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(data, sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(data, sizes), name) {
     }
 
     explicit Buffer(Type t,
                     Internal::add_const_if_T_is_const<T, void> *data,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, data, sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, sizes), name) {
     }
 
     explicit Buffer(Type t,
@@ -290,66 +299,60 @@ public:
                     int d,
                     const halide_dimension_t *shape,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, data, d, shape), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, d, shape), name) {
     }
 
     explicit Buffer(T *data,
                     int d,
                     const halide_dimension_t *shape,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(data, d, shape), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(data, d, shape), name) {
     }
 
-    static Buffer<T> make_scalar(const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_scalar(), name);
+    static Buffer<T, Dims> make_scalar(const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_scalar(), name);
     }
 
     static Buffer<> make_scalar(Type t, const std::string &name = "") {
         return Buffer<>(Runtime::Buffer<>::make_scalar(t), name);
     }
 
-    static Buffer<T> make_scalar(T *data, const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_scalar(data), name);
+    static Buffer<T, Dims> make_scalar(T *data, const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_scalar(data), name);
     }
 
-    static Buffer<T> make_interleaved(int width, int height, int channels, const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_interleaved(width, height, channels),
-                         name);
+    static Buffer<T, Dims> make_interleaved(int width, int height, int channels, const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_interleaved(width, height, channels), name);
     }
 
     static Buffer<> make_interleaved(Type t, int width, int height, int channels, const std::string &name = "") {
-        return Buffer<>(Runtime::Buffer<>::make_interleaved(t, width, height, channels),
-                        name);
+        return Buffer<>(Runtime::Buffer<>::make_interleaved(t, width, height, channels), name);
     }
 
-    static Buffer<T> make_interleaved(T *data, int width, int height, int channels, const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_interleaved(data, width, height, channels),
-                         name);
+    static Buffer<T, Dims> make_interleaved(T *data, int width, int height, int channels, const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_interleaved(data, width, height, channels), name);
     }
 
     static Buffer<Internal::add_const_if_T_is_const<T, void>>
     make_interleaved(Type t, T *data, int width, int height, int channels, const std::string &name = "") {
         using T2 = Internal::add_const_if_T_is_const<T, void>;
-        return Buffer<T2>(Runtime::Buffer<T2>::make_interleaved(t, data, width, height, channels),
-                          name);
+        return Buffer<T2, Dims>(Runtime::Buffer<T2, Dims>::make_interleaved(t, data, width, height, channels), name);
     }
 
-    template<typename T2>
-    static Buffer<T> make_with_shape_of(Buffer<T2> src,
-                                        void *(*allocate_fn)(size_t) = nullptr,
-                                        void (*deallocate_fn)(void *) = nullptr,
-                                        const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_with_shape_of(*src.get(), allocate_fn, deallocate_fn),
-                         name);
+    template<typename T2, int D2>
+    static Buffer<T, Dims> make_with_shape_of(Buffer<T2, D2> src,
+                                              void *(*allocate_fn)(size_t) = nullptr,
+                                              void (*deallocate_fn)(void *) = nullptr,
+                                              const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_with_shape_of(*src.get(), allocate_fn, deallocate_fn), name);
     }
 
-    template<typename T2>
-    static Buffer<T> make_with_shape_of(const Runtime::Buffer<T2> &src,
-                                        void *(*allocate_fn)(size_t) = nullptr,
-                                        void (*deallocate_fn)(void *) = nullptr,
-                                        const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_with_shape_of(src, allocate_fn, deallocate_fn),
-                         name);
+    template<typename T2, int D2>
+    static Buffer<T, Dims> make_with_shape_of(const Runtime::Buffer<T2, D2> &src,
+                                              void *(*allocate_fn)(size_t) = nullptr,
+                                              void (*deallocate_fn)(void *) = nullptr,
+                                              const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_with_shape_of(src, allocate_fn, deallocate_fn), name);
     }
     // @}
 
@@ -365,8 +368,8 @@ public:
     // @}
 
     /** Check if two Buffer objects point to the same underlying Buffer */
-    template<typename T2>
-    bool same_as(const Buffer<T2> &other) const {
+    template<typename T2, int D2>
+    bool same_as(const Buffer<T2, D2> &other) const {
         return (const void *)(contents.get()) == (const void *)(other.contents.get());
     }
 
@@ -379,28 +382,28 @@ public:
 
     /** Get a pointer to the underlying Runtime::Buffer */
     // @{
-    Runtime::Buffer<T> *get() {
+    Runtime::Buffer<T, Dims> *get() {
         // It's already type-checked, so no need to use as<T>.
-        return (Runtime::Buffer<T> *)(&contents->buf);
+        return (Runtime::Buffer<T, Dims> *)(&contents->buf);
     }
-    const Runtime::Buffer<T> *get() const {
-        return (const Runtime::Buffer<T> *)(&contents->buf);
+    const Runtime::Buffer<T, Dims> *get() const {
+        return (const Runtime::Buffer<T, Dims> *)(&contents->buf);
     }
     // @}
 
     // We forward numerous methods from the underlying Buffer
-#define HALIDE_BUFFER_FORWARD_CONST(method)                                                                                     \
-    template<typename... Args>                                                                                                  \
-    auto method(Args &&...args) const->decltype(std::declval<const Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
-        user_assert(defined()) << "Undefined buffer calling const method " #method "\n";                                        \
-        return get()->method(std::forward<Args>(args)...);                                                                      \
+#define HALIDE_BUFFER_FORWARD_CONST(method)                                                                                           \
+    template<typename... Args>                                                                                                        \
+    auto method(Args &&...args) const->decltype(std::declval<const Runtime::Buffer<T, Dims>>().method(std::forward<Args>(args)...)) { \
+        user_assert(defined()) << "Undefined buffer calling const method " #method "\n";                                              \
+        return get()->method(std::forward<Args>(args)...);                                                                            \
     }
 
-#define HALIDE_BUFFER_FORWARD(method)                                                                               \
-    template<typename... Args>                                                                                      \
-    auto method(Args &&...args)->decltype(std::declval<Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
-        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                                  \
-        return get()->method(std::forward<Args>(args)...);                                                          \
+#define HALIDE_BUFFER_FORWARD(method)                                                                                     \
+    template<typename... Args>                                                                                            \
+    auto method(Args &&...args)->decltype(std::declval<Runtime::Buffer<T, Dims>>().method(std::forward<Args>(args)...)) { \
+        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                                        \
+        return get()->method(std::forward<Args>(args)...);                                                                \
     }
 
 // This is a weird-looking but effective workaround for a deficiency in "perfect forwarding":
@@ -413,10 +416,10 @@ public:
 // and forward it as is, we can just use ... to allow an arbitrary number of commas,
 // then use __VA_ARGS__ to forward the mess as-is, and while it looks horrible, it
 // works.
-#define HALIDE_BUFFER_FORWARD_INITIALIZER_LIST(method, ...)                                            \
-    inline auto method(const __VA_ARGS__ &a)->decltype(std::declval<Runtime::Buffer<T>>().method(a)) { \
-        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                     \
-        return get()->method(a);                                                                       \
+#define HALIDE_BUFFER_FORWARD_INITIALIZER_LIST(method, ...)                                                  \
+    inline auto method(const __VA_ARGS__ &a)->decltype(std::declval<Runtime::Buffer<T, Dims>>().method(a)) { \
+        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                           \
+        return get()->method(a);                                                                             \
     }
 
     /** Does the same thing as the equivalent Halide::Runtime::Buffer method */
@@ -475,44 +478,50 @@ public:
 #undef HALIDE_BUFFER_FORWARD_CONST
 
     template<typename Fn, typename... Args>
-    Buffer<T> &for_each_value(Fn &&f, Args... other_buffers) {
+    Buffer<T, Dims> &for_each_value(Fn &&f, Args... other_buffers) {
         get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...);
         return *this;
     }
 
     template<typename Fn, typename... Args>
-    const Buffer<T> &for_each_value(Fn &&f, Args... other_buffers) const {
+    const Buffer<T, Dims> &for_each_value(Fn &&f, Args... other_buffers) const {
         get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...);
         return *this;
     }
 
     template<typename Fn>
-    Buffer<T> &for_each_element(Fn &&f) {
+    Buffer<T, Dims> &for_each_element(Fn &&f) {
         get()->for_each_element(std::forward<Fn>(f));
         return *this;
     }
 
     template<typename Fn>
-    const Buffer<T> &for_each_element(Fn &&f) const {
+    const Buffer<T, Dims> &for_each_element(Fn &&f) const {
         get()->for_each_element(std::forward<Fn>(f));
         return *this;
     }
 
     template<typename FnOrValue>
-    Buffer<T> &fill(FnOrValue &&f) {
+    Buffer<T, Dims> &fill(FnOrValue &&f) {
         get()->fill(std::forward<FnOrValue>(f));
         return *this;
     }
 
-    static constexpr bool has_static_halide_type = Runtime::Buffer<T>::has_static_halide_type;
+    static constexpr bool has_static_halide_type = Runtime::Buffer<T, Dims>::has_static_halide_type;
 
     static halide_type_t static_halide_type() {
-        return Runtime::Buffer<T>::static_halide_type();
+        return Runtime::Buffer<T, Dims>::static_halide_type();
     }
 
-    template<typename T2>
-    static bool can_convert_from(const Buffer<T2> &other) {
-        return Halide::Runtime::Buffer<T>::can_convert_from(*other.get());
+    static constexpr bool has_static_dimensions = Runtime::Buffer<T, Dims>::has_static_dimensions;
+
+    static int static_dimensions() {
+        return Runtime::Buffer<T, Dims>::static_dimensions();
+    }
+
+    template<typename T2, int D2>
+    static bool can_convert_from(const Buffer<T2, D2> &other) {
+        return Halide::Runtime::Buffer<T, Dims>::can_convert_from(*other.get());
     }
 
     // Note that since Runtime::Buffer stores halide_type_t rather than Halide::Type,
@@ -524,42 +533,42 @@ public:
     }
 
     template<typename T2>
-    Buffer<T2> as() const {
-        return Buffer<T2>(*this);
+    Buffer<T2, Dims> as() const {
+        return Buffer<T2, Dims>(*this);
     }
 
-    Buffer<T> copy() const {
-        return Buffer<T>(std::move(contents->buf.as<T>().copy()));
+    Buffer<T, Dims> copy() const {
+        return Buffer<T, Dims>(std::move(contents->buf.as<T>().copy()));
     }
 
-    template<typename T2>
-    void copy_from(const Buffer<T2> &other) {
+    template<typename T2, int D2>
+    void copy_from(const Buffer<T2, D2> &other) {
         contents->buf.copy_from(*other.get());
     }
 
     template<typename... Args>
-    auto operator()(int first, Args &&...args) -> decltype(std::declval<Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
+    auto operator()(int first, Args &&...args) -> decltype(std::declval<Runtime::Buffer<T, Dims>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    auto operator()(int first, Args &&...args) const -> decltype(std::declval<const Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
+    auto operator()(int first, Args &&...args) const -> decltype(std::declval<const Runtime::Buffer<T, Dims>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 
-    auto operator()(const int *pos) -> decltype(std::declval<Runtime::Buffer<T>>()(pos)) {
+    auto operator()(const int *pos) -> decltype(std::declval<Runtime::Buffer<T, Dims>>()(pos)) {
         return (*get())(pos);
     }
 
-    auto operator()(const int *pos) const -> decltype(std::declval<const Runtime::Buffer<T>>()(pos)) {
+    auto operator()(const int *pos) const -> decltype(std::declval<const Runtime::Buffer<T, Dims>>()(pos)) {
         return (*get())(pos);
     }
 
-    auto operator()() -> decltype(std::declval<Runtime::Buffer<T>>()()) {
+    auto operator()() -> decltype(std::declval<Runtime::Buffer<T, Dims>>()()) {
         return (*get())();
     }
 
-    auto operator()() const -> decltype(std::declval<const Runtime::Buffer<T>>()()) {
+    auto operator()() const -> decltype(std::declval<const Runtime::Buffer<T, Dims>>()()) {
         return (*get())();
     }
     // @}

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -532,13 +532,13 @@ public:
         return contents->buf.type();
     }
 
-    template<typename T2>
+    template<typename T2, int D2 = Dims>
     Buffer<T2, Dims> as() const {
-        return Buffer<T2, Dims>(*this);
+        return Buffer<T2, D2>(*this);
     }
 
     Buffer<T, Dims> copy() const {
-        return Buffer<T, Dims>(std::move(contents->buf.as<T>().copy()));
+        return Buffer<T, Dims>(std::move(contents->buf.as<T, Dims>().copy()));
     }
 
     template<typename T2, int D2>

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -8,14 +8,12 @@
 #include <map>
 #include <string>
 
+#include "Buffer.h"
 #include "IR.h"
 #include "IRVisitor.h"
 #include "Scope.h"
 
 namespace Halide {
-
-template<typename T>
-class Buffer;
 
 namespace Internal {
 
@@ -66,7 +64,7 @@ public:
 
 protected:
     void found_buffer_ref(const std::string &name, Type type,
-                          bool read, bool written, const Halide::Buffer<void> &image);
+                          bool read, bool written, const Halide::Buffer<> &image);
 
 public:
     Closure() = default;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2259,7 +2259,7 @@ void generator_test() {
             Input<Func> input_func_typed{"input_func_typed", Int(16), 1};
             Input<Func> input_func_untyped{"input_func_untyped", 1};
             Input<Func[]> input_func_array{"input_func_array", 1};
-            Input<Buffer<uint8_t>> input_buffer_typed{"input_buffer_typed", 3};
+            Input<Buffer<uint8_t, 3>> input_buffer_typed{"input_buffer_typed"};
             Input<Buffer<>> input_buffer_untyped{"input_buffer_untyped"};
             Output<Func> output{"output", Float(32), 1};
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1678,10 +1678,15 @@ public:
                 TBase::has_static_dimensions ? TBase::static_dimensions() : -1) {
     }
 
-    GeneratorInput_Buffer(const std::string &name, const Type &t, int d = -1)
+    GeneratorInput_Buffer(const std::string &name, const Type &t, int d)
         : Super(name, IOKind::Buffer, {t}, d) {
         static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Input<Buffer<T>> if T is void or omitted.");
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Input<Buffer<T, D>> if D is -1 or omitted.");
+    }
+
+    GeneratorInput_Buffer(const std::string &name, const Type &t)
+        : Super(name, IOKind::Buffer, {t}, -1) {
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Input<Buffer<T>> if T is void or omitted.");
     }
 
     GeneratorInput_Buffer(const std::string &name, int d)

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2477,58 +2477,58 @@ private:
 protected:
     using TBase = typename Super::TBase;
 
-    static std::vector<Type> my_types(const std::vector<Type> &t) {
-        if (TBase::has_static_halide_type) {
-            user_assert(t.empty()) << "Cannot pass a Type argument for an Output<Buffer> with a non-void static type\n";
-            return std::vector<Type>{TBase::static_halide_type()};
-        }
-        return t;
-    }
-
     explicit GeneratorOutput_Buffer(const std::string &name)
-        : Super(name, IOKind::Buffer, my_types({}), -1) {
+        : Super(name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                TBase::has_static_dimensions ? TBase::static_dimensions() : -1) {
     }
 
     GeneratorOutput_Buffer(const std::string &name, const std::vector<Type> &t, int d)
-        : Super(name, IOKind::Buffer, my_types(t), d) {
+        : Super(name, IOKind::Buffer, t, d) {
         internal_assert(!t.empty());
         internal_assert(d != -1);
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }
 
     GeneratorOutput_Buffer(const std::string &name, const std::vector<Type> &t)
-        : Super(name, IOKind::Buffer, my_types(t), -1) {
+        : Super(name, IOKind::Buffer, t, -1) {
         internal_assert(!t.empty());
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
     }
 
     GeneratorOutput_Buffer(const std::string &name, int d)
-        : Super(name, IOKind::Buffer, my_types({}), d) {
+        : Super(name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                d) {
         internal_assert(d != -1);
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name)
-        : Super(array_size, name, IOKind::Buffer, my_types({}), -1) {
+        : Super(array_size, name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                TBase::has_static_dimensions ? TBase::static_dimensions() : -1) {
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name, const std::vector<Type> &t, int d)
-        : Super(array_size, name, IOKind::Buffer, my_types(t), d) {
+        : Super(array_size, name, IOKind::Buffer, t, d) {
         internal_assert(!t.empty());
         internal_assert(d != -1);
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name, const std::vector<Type> &t)
-        : Super(array_size, name, IOKind::Buffer, my_types(t), -1) {
+        : Super(array_size, name, IOKind::Buffer, t, -1) {
         internal_assert(!t.empty());
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name, int d)
-        : Super(array_size, name, IOKind::Buffer, my_types({}), d) {
+        : Super(array_size, name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                d) {
         internal_assert(d != -1);
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }

--- a/src/Module.h
+++ b/src/Module.h
@@ -19,7 +19,7 @@
 
 namespace Halide {
 
-template<typename T>
+template<typename T, int Dims>
 class Buffer;
 struct Target;
 

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -6,6 +6,7 @@
  */
 #include <string>
 
+#include "Buffer.h"
 #include "IntrusivePtr.h"
 #include "Type.h"
 #include "Util.h"                   // for HALIDE_NO_USER_CODE_INLINE
@@ -14,8 +15,6 @@
 namespace Halide {
 
 struct ArgumentEstimates;
-template<typename T>
-class Buffer;
 struct Expr;
 struct Type;
 enum class MemoryType;

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -17,7 +17,7 @@
 
 namespace Halide {
 
-template<typename T>
+template<typename T, int Dims>
 class Buffer;
 class OutputImageParam;
 
@@ -227,11 +227,11 @@ public:
      * a given Buffer or ImageParam. Has the same dimensionality as
      * the argument. */
     // @{
-    RDom(const Buffer<void> &);
+    RDom(const Buffer<void, -1> &);
     RDom(const OutputImageParam &);
-    template<typename T>
-    HALIDE_NO_USER_CODE_INLINE RDom(const Buffer<T> &im)
-        : RDom(Buffer<void>(im)) {
+    template<typename T, int Dims>
+    HALIDE_NO_USER_CODE_INLINE RDom(const Buffer<T, Dims> &im)
+        : RDom(Buffer<void, -1>(im)) {
     }
     // @}
 

--- a/src/Realization.h
+++ b/src/Realization.h
@@ -31,18 +31,19 @@ public:
     Buffer<void> &operator[](size_t x);
 
     /** Single-element realizations are implicitly castable to Buffers. */
-    template<typename T>
-    operator Buffer<T>() const {
-        return images[0];
+    template<typename T, int Dims>
+    operator Buffer<T, Dims>() const {
+        return images[0].as<T, Dims>();
     }
 
     /** Construct a Realization that acts as a reference to some
      * existing Buffers. The element type of the Buffers may not be
      * const. */
     template<typename T,
+             int Dims,
              typename... Args,
              typename = typename std::enable_if<Internal::all_are_convertible<Buffer<void>, Args...>::value>::type>
-    Realization(Buffer<T> &a, Args &&...args) {
+    Realization(Buffer<T, Dims> &a, Args &&...args) {
         images = std::vector<Buffer<void>>({a, args...});
     }
 

--- a/src/Realization.h
+++ b/src/Realization.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "Buffer.h"
 #include "Util.h"  // for all_are_convertible
 
 /** \file
@@ -12,9 +13,6 @@
  */
 
 namespace Halide {
-
-template<typename T>
-class Buffer;
 
 /** A Realization is a vector of references to existing Buffer objects.
  *  A pipeline with multiple outputs realize to a Realization.  */

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -556,10 +556,13 @@ public:
     }
 
     /** Get the dimensionality of the buffer. */
-    // TODO: make constexpr, optimize for const case
     int dimensions() const {
-        assert(Dims == BufferDimsUnconstrained || Dims == buf.dimensions);
-        return buf.dimensions;
+        if constexpr (has_static_dimensions) {
+            return Dims;
+        } else {
+            assert(Dims == BufferDimsUnconstrained || Dims == buf.dimensions);
+            return buf.dimensions;
+        }
     }
 
     /** Get the type of the elements. */
@@ -932,7 +935,6 @@ public:
      * take ownership of the data, and does not set the host_dirty flag. */
     template<typename Array, size_t N>
     explicit Buffer(Array (&vals)[N]) {
-        // TODO: this could probably be made constexpr
         const int buf_dimensions = dimensionality_of_array(vals);
         buf.type = scalar_type_of_array(vals);
         buf.host = (uint8_t *)vals;

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -39,7 +39,7 @@ namespace Halide {
 namespace Runtime {
 
 // Forward-declare our Buffer class
-template<typename T, int D>
+template<typename T, int Dims, int InClassDimStorage>
 class Buffer;
 
 // A helper to check if a parameter pack is entirely implicitly
@@ -116,24 +116,29 @@ struct DeviceRefCount {
  * The template parameter T is the element type. For buffers where the
  * element type is unknown, or may vary, use void or const void.
  *
- * D is the maximum number of dimensions that can be represented using
- * space inside the class itself. Set it to the maximum dimensionality
+ * The template parameter Dims is the number of dimensions. For buffers where
+ * the dimensionality type is unknown at, or may vary, use -1 (or Buffer::DynamicDims).
+ *
+ * InClassDimStorage is the maximum number of dimensions that can be represented
+ * using space inside the class itself. Set it to the maximum dimensionality
  * you expect this buffer to be. If the actual dimensionality exceeds
- * this, heap storage is allocated to track the shape of the buffer. D
- * defaults to 4, which should cover nearly all usage.
+ * this, heap storage is allocated to track the shape of the buffer.
+ * InClassDimStorage defaults to 4, which should cover nearly all usage.
  *
  * The class optionally allocates and owns memory for the image using
  * a shared pointer allocated with the provided allocator. If they are
  * null, malloc and free are used.  Any device-side allocation is
  * considered as owned if and only if the host-side allocation is
  * owned. */
-template<typename T = void, int D = 4>
+template<typename T = void,
+         int Dims = -1,
+         int InClassDimStorage = (Dims == -1 ? 4 : std::max(Dims, 1))>
 class Buffer {
     /** The underlying halide_buffer_t */
     halide_buffer_t buf = {};
 
     /** Some in-class storage for shape of the dimensions. */
-    halide_dimension_t shape[D];
+    halide_dimension_t shape[InClassDimStorage];
 
     /** The allocation owned by this Buffer. NULL if the Buffer does not
      * own the memory. */
@@ -171,7 +176,7 @@ public:
 
     /** Get the Halide type of T. Callers should not use the result if
      * has_static_halide_type is false. */
-    static halide_type_t static_halide_type() {
+    static constexpr halide_type_t static_halide_type() {
         return halide_type_of<typename std::remove_cv<not_void_T>::type>();
     }
 
@@ -179,6 +184,18 @@ public:
     bool owns_host_memory() const {
         return alloc != nullptr;
     }
+
+    static constexpr int DynamicDims = -1;
+
+    static constexpr bool has_static_dimensions = (Dims != DynamicDims);
+
+    /** Callers should not use the result if
+     * has_static_dimensions is false. */
+    static constexpr int static_dimensions() {
+        return Dims;
+    }
+
+    static_assert(!has_static_dimensions || static_dimensions() >= 0);
 
 private:
     /** Increment the reference count of any owned allocation */
@@ -202,15 +219,15 @@ private:
     // Note that this is called "cropped" but can also encompass a slice/embed
     // operation as well.
     struct DevRefCountCropped : DeviceRefCount {
-        Buffer<T, D> cropped_from;
-        DevRefCountCropped(const Buffer<T, D> &cropped_from)
+        Buffer<T, Dims, InClassDimStorage> cropped_from;
+        DevRefCountCropped(const Buffer<T, Dims, InClassDimStorage> &cropped_from)
             : cropped_from(cropped_from) {
             ownership = BufferDeviceOwnership::Cropped;
         }
     };
 
     /** Setup the device ref count for a buffer to indicate it is a crop (or slice, embed, etc) of cropped_from */
-    void crop_from(const Buffer<T, D> &cropped_from) {
+    void crop_from(const Buffer<T, Dims, InClassDimStorage> &cropped_from) {
         assert(dev_ref_count == nullptr);
         dev_ref_count = new DevRefCountCropped(cropped_from);
     }
@@ -274,11 +291,27 @@ private:
         }
     }
 
+    template<int DimsSpecified>
+    void make_static_shape_storage() {
+        static_assert(Dims == DynamicDims || Dims == DimsSpecified,
+                      "Number of arguments to Buffer() does not match static dimensionality");
+        buf.dimensions = DimsSpecified;
+        if constexpr (Dims == DynamicDims) {
+            buf.dim = (DimsSpecified <= InClassDimStorage) ? shape : new halide_dimension_t[DimsSpecified];
+        } else {
+            static_assert(InClassDimStorage >= Dims);
+            buf.dim = shape;
+        }
+    }
+
     void make_shape_storage(const int dimensions) {
+        if (Dims != DynamicDims && Dims != dimensions) {
+            assert(false && "Number of arguments to Buffer() does not match static dimensionality");
+        }
         // This should usually be inlined, so if dimensions is statically known,
         // we can skip the call to new
         buf.dimensions = dimensions;
-        buf.dim = (dimensions <= D) ? shape : new halide_dimension_t[dimensions];
+        buf.dim = (dimensions <= InClassDimStorage) ? shape : new halide_dimension_t[dimensions];
     }
 
     void copy_shape_from(const halide_buffer_t &other) {
@@ -287,8 +320,8 @@ private:
         std::copy(other.dim, other.dim + other.dimensions, buf.dim);
     }
 
-    template<typename T2, int D2>
-    void move_shape_from(Buffer<T2, D2> &&other) {
+    template<typename T2, int D2, int S2>
+    void move_shape_from(Buffer<T2, D2, S2> &&other) {
         if (other.shape == other.buf.dim) {
             copy_shape_from(other.buf);
         } else {
@@ -389,10 +422,10 @@ private:
         }
     }
 
-    void complete_device_crop(Buffer<T, D> &result_host_cropped) const {
+    void complete_device_crop(Buffer<T, Dims, InClassDimStorage> &result_host_cropped) const {
         assert(buf.device_interface != nullptr);
         if (buf.device_interface->device_crop(nullptr, &this->buf, &result_host_cropped.buf) == 0) {
-            const Buffer<T, D> *cropped_from = this;
+            const Buffer<T, Dims, InClassDimStorage> *cropped_from = this;
             // TODO: Figure out what to do if dev_ref_count is nullptr. Should incref logic run here?
             // is it possible to get to this point without incref having run at least once since
             // the device field was set? (I.e. in the internal logic of crop. incref might have been
@@ -406,6 +439,8 @@ private:
 
     /** slice a single dimension without handling device allocation. */
     void slice_host(int d, int pos) {
+        static_assert(Dims == DynamicDims);
+        assert(dimensions() > 0);
         assert(d >= 0 && d < dimensions());
         assert(pos >= dim(d).min() && pos <= dim(d).max());
         buf.dimensions--;
@@ -419,10 +454,10 @@ private:
         buf.dim[buf.dimensions] = {0, 0, 0};
     }
 
-    void complete_device_slice(Buffer<T, D> &result_host_sliced, int d, int pos) const {
+    void complete_device_slice(Buffer<T, DynamicDims, InClassDimStorage> &result_host_sliced, int d, int pos) const {
         assert(buf.device_interface != nullptr);
         if (buf.device_interface->device_slice(nullptr, &this->buf, d, pos, &result_host_sliced.buf) == 0) {
-            const Buffer<T, D> *sliced_from = this;
+            const Buffer<T, Dims, InClassDimStorage> *sliced_from = this;
             // TODO: Figure out what to do if dev_ref_count is nullptr. Should incref logic run here?
             // is it possible to get to this point without incref having run at least once since
             // the device field was set? (I.e. in the internal logic of slice. incref might have been
@@ -521,7 +556,9 @@ public:
     }
 
     /** Get the dimensionality of the buffer. */
+    // TODO: make constexpr, optimize for const case
     int dimensions() const {
+        assert(Dims == DynamicDims || Dims == buf.dimensions);
         return buf.dimensions;
     }
 
@@ -558,7 +595,7 @@ public:
     Buffer()
         : shape() {
         buf.type = static_halide_type();
-        make_shape_storage(0);
+        make_static_shape_storage<0>();
     }
 
     /** Make a Buffer from a halide_buffer_t */
@@ -569,46 +606,55 @@ public:
     }
 
     /** Give Buffers access to the members of Buffers of different dimensionalities and types. */
-    template<typename T2, int D2>
+    template<typename T2, int D2, int S2>
     friend class Buffer;
 
 private:
-    template<typename T2, int D2>
+    template<typename T2, int D2, int S2>
     static void static_assert_can_convert_from() {
         static_assert((!std::is_const<T2>::value || std::is_const<T>::value),
                       "Can't convert from a Buffer<const T> to a Buffer<T>");
         static_assert(std::is_same<typename std::remove_const<T>::type,
                                    typename std::remove_const<T2>::type>::value ||
-                          T_is_void || Buffer<T2, D2>::T_is_void,
+                          T_is_void || Buffer<T2, D2, S2>::T_is_void,
                       "type mismatch constructing Buffer");
+        static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2,
+                      "Can't convert from a Buffer with static dimensionality to a Buffer with different static dimensionality");
     }
 
 public:
-    /** Determine if a Buffer<T, D> can be constructed from some other Buffer type.
+    /** Determine if a Buffer<T, Dims, InClassDimStorage> can be constructed from some other Buffer type.
      * If this can be determined at compile time, fail with a static assert; otherwise
      * return a boolean based on runtime typing. */
-    template<typename T2, int D2>
-    static bool can_convert_from(const Buffer<T2, D2> &other) {
-        static_assert_can_convert_from<T2, D2>();
-        if (Buffer<T2, D2>::T_is_void && !T_is_void) {
-            return other.type() == static_halide_type();
+    template<typename T2, int D2, int S2>
+    static bool can_convert_from(const Buffer<T2, D2, S2> &other) {
+        static_assert_can_convert_from<T2, D2, S2>();
+        if (Buffer<T2, D2, S2>::T_is_void && !T_is_void) {
+            if (other.type() != static_halide_type()) {
+                return false;
+            }
+        }
+        if (Dims != DynamicDims) {
+            if (other.dimensions() != Dims) {
+                return false;
+            }
         }
         return true;
     }
 
-    /** Fail an assertion at runtime or compile-time if an Buffer<T, D>
+    /** Fail an assertion at runtime or compile-time if an Buffer<T, Dims, InClassDimStorage>
      * cannot be constructed from some other Buffer type. */
-    template<typename T2, int D2>
-    static void assert_can_convert_from(const Buffer<T2, D2> &other) {
+    template<typename T2, int D2, int S2>
+    static void assert_can_convert_from(const Buffer<T2, D2, S2> &other) {
         // Explicitly call static_assert_can_convert_from() here so
         // that we always get compile-time checking, even if compiling with
         // assertions disabled.
-        static_assert_can_convert_from<T2, D2>();
+        static_assert_can_convert_from<T2, D2, S2>();
         assert(can_convert_from(other));
     }
 
     /** Copy constructor. Does not copy underlying data. */
-    Buffer(const Buffer<T, D> &other)
+    Buffer(const Buffer<T, Dims, InClassDimStorage> &other)
         : buf(other.buf),
           alloc(other.alloc) {
         other.incref();
@@ -617,13 +663,13 @@ public:
     }
 
     /** Construct a Buffer from a Buffer of different dimensionality
-     * and type. Asserts that the type matches (at runtime, if one of
-     * the types is void). Note that this constructor is
+     * and type. Asserts that the type and dimensionality matches (at runtime,
+     * if one of the types is void). Note that this constructor is
      * implicit. This, for example, lets you pass things like
      * Buffer<T> or Buffer<const void> to functions expected
      * Buffer<const T>. */
-    template<typename T2, int D2>
-    Buffer(const Buffer<T2, D2> &other)
+    template<typename T2, int D2, int S2>
+    Buffer(const Buffer<T2, D2, S2> &other)
         : buf(other.buf),
           alloc(other.alloc) {
         assert_can_convert_from(other);
@@ -633,36 +679,36 @@ public:
     }
 
     /** Move constructor */
-    Buffer(Buffer<T, D> &&other) noexcept
+    Buffer(Buffer<T, Dims, InClassDimStorage> &&other) noexcept
         : buf(other.buf),
           alloc(other.alloc),
           dev_ref_count(other.dev_ref_count) {
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
-        move_shape_from(std::forward<Buffer<T, D>>(other));
+        move_shape_from(std::forward<Buffer<T, Dims, InClassDimStorage>>(other));
         other.buf = halide_buffer_t();
     }
 
     /** Move-construct a Buffer from a Buffer of different
      * dimensionality and type. Asserts that the types match (at
      * runtime if one of the types is void). */
-    template<typename T2, int D2>
-    Buffer(Buffer<T2, D2> &&other)
+    template<typename T2, int D2, int S2>
+    Buffer(Buffer<T2, D2, S2> &&other)
         : buf(other.buf),
           alloc(other.alloc),
           dev_ref_count(other.dev_ref_count) {
         assert_can_convert_from(other);
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
-        move_shape_from(std::forward<Buffer<T2, D2>>(other));
+        move_shape_from(std::forward<Buffer<T2, D2, S2>>(other));
         other.buf = halide_buffer_t();
     }
 
     /** Assign from another Buffer of possibly-different
      * dimensionality and type. Asserts that the types match (at
      * runtime if one of the types is void). */
-    template<typename T2, int D2>
-    Buffer<T, D> &operator=(const Buffer<T2, D2> &other) {
+    template<typename T2, int D2, int S2>
+    Buffer<T, Dims, InClassDimStorage> &operator=(const Buffer<T2, D2, S2> &other) {
         if ((const void *)this == (const void *)&other) {
             return *this;
         }
@@ -678,7 +724,7 @@ public:
     }
 
     /** Standard assignment operator */
-    Buffer<T, D> &operator=(const Buffer<T, D> &other) {
+    Buffer<T, Dims, InClassDimStorage> &operator=(const Buffer<T, Dims, InClassDimStorage> &other) {
         // The cast to void* here is just to satisfy clang-tidy
         if ((const void *)this == (const void *)&other) {
             return *this;
@@ -696,8 +742,8 @@ public:
     /** Move from another Buffer of possibly-different
      * dimensionality and type. Asserts that the types match (at
      * runtime if one of the types is void). */
-    template<typename T2, int D2>
-    Buffer<T, D> &operator=(Buffer<T2, D2> &&other) {
+    template<typename T2, int D2, int S2>
+    Buffer<T, Dims, InClassDimStorage> &operator=(Buffer<T2, D2, S2> &&other) {
         assert_can_convert_from(other);
         decref();
         alloc = other.alloc;
@@ -706,13 +752,13 @@ public:
         other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
-        move_shape_from(std::forward<Buffer<T2, D2>>(other));
+        move_shape_from(std::forward<Buffer<T2, D2, S2>>(other));
         other.buf = halide_buffer_t();
         return *this;
     }
 
     /** Standard move-assignment operator */
-    Buffer<T, D> &operator=(Buffer<T, D> &&other) noexcept {
+    Buffer<T, Dims, InClassDimStorage> &operator=(Buffer<T, Dims, InClassDimStorage> &&other) noexcept {
         decref();
         alloc = other.alloc;
         other.alloc = nullptr;
@@ -720,7 +766,7 @@ public:
         other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
-        move_shape_from(std::forward<Buffer<T, D>>(other));
+        move_shape_from(std::forward<Buffer<T, Dims, InClassDimStorage>>(other));
         other.buf = halide_buffer_t();
         return *this;
     }
@@ -792,7 +838,7 @@ public:
         int extents[] = {first, (int)rest...};
         buf.type = t;
         constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
-        make_shape_storage(buf_dimensions);
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
         if (!Internal::any_zero(extents)) {
             check_overflow();
@@ -812,7 +858,7 @@ public:
         int extents[] = {first};
         buf.type = static_halide_type();
         constexpr int buf_dimensions = 1;
-        make_shape_storage(buf_dimensions);
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
         if (first != 0) {
             check_overflow();
@@ -828,7 +874,7 @@ public:
         int extents[] = {first, second, (int)rest...};
         buf.type = static_halide_type();
         constexpr int buf_dimensions = 2 + (int)(sizeof...(rest));
-        make_shape_storage(buf_dimensions);
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
         if (!Internal::any_zero(extents)) {
             check_overflow();
@@ -843,6 +889,7 @@ public:
             assert(static_halide_type() == t);
         }
         buf.type = t;
+        // make_shape_storage() will do a runtime check that dimensionality matches.
         make_shape_storage((int)sizes.size());
         initialize_shape(sizes);
         if (!Internal::any_zero(sizes)) {
@@ -885,6 +932,7 @@ public:
      * take ownership of the data, and does not set the host_dirty flag. */
     template<typename Array, size_t N>
     explicit Buffer(Array (&vals)[N]) {
+        // TODO: this could probably be made constexpr
         const int buf_dimensions = dimensionality_of_array(vals);
         buf.type = scalar_type_of_array(vals);
         buf.host = (uint8_t *)vals;
@@ -904,9 +952,9 @@ public:
         }
         int extents[] = {first, (int)rest...};
         buf.type = t;
-        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
         buf.host = (uint8_t *)const_cast<void *>(data);
-        make_shape_storage(buf_dimensions);
+        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
     }
 
@@ -918,9 +966,9 @@ public:
     explicit Buffer(T *data, int first, Args &&...rest) {
         int extents[] = {first, (int)rest...};
         buf.type = static_halide_type();
-        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
         buf.host = (uint8_t *)const_cast<typename std::remove_const<T>::type *>(data);
-        make_shape_storage(buf_dimensions);
+        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
     }
 
@@ -1021,9 +1069,9 @@ public:
      * Buffer<const uint8_t>, or converting a Buffer<T>& to Buffer<const T>&.
      * Does a runtime assert if the source buffer type is void. */
     template<typename T2>
-    HALIDE_ALWAYS_INLINE Buffer<T2, D> &as() & {
-        Buffer<T2, D>::assert_can_convert_from(*this);
-        return *((Buffer<T2, D> *)this);
+    HALIDE_ALWAYS_INLINE Buffer<T2, Dims, InClassDimStorage> &as() & {
+        Buffer<T2, Dims, InClassDimStorage>::assert_can_convert_from(*this);
+        return *((Buffer<T2, Dims, InClassDimStorage> *)this);
     }
 
     /** Return a const typed reference to this Buffer. Useful for
@@ -1031,37 +1079,37 @@ public:
      * reference to another Buffer type. Does a runtime assert if the
      * source buffer type is void. */
     template<typename T2>
-    HALIDE_ALWAYS_INLINE const Buffer<T2, D> &as() const & {
-        Buffer<T2, D>::assert_can_convert_from(*this);
-        return *((const Buffer<T2, D> *)this);
+    HALIDE_ALWAYS_INLINE const Buffer<T2, Dims, InClassDimStorage> &as() const & {
+        Buffer<T2, Dims, InClassDimStorage>::assert_can_convert_from(*this);
+        return *((const Buffer<T2, Dims, InClassDimStorage> *)this);
     }
 
     /** Returns this rval Buffer with a different type attached. Does
      * a dynamic type check if the source type is void. */
     template<typename T2>
-    HALIDE_ALWAYS_INLINE Buffer<T2, D> as() && {
-        Buffer<T2, D>::assert_can_convert_from(*this);
-        return *((Buffer<T2, D> *)this);
+    HALIDE_ALWAYS_INLINE Buffer<T2, Dims, InClassDimStorage> as() && {
+        Buffer<T2, Dims, InClassDimStorage>::assert_can_convert_from(*this);
+        return *((Buffer<T2, Dims, InClassDimStorage> *)this);
     }
 
     /** as_const() is syntactic sugar for .as<const T>(), to avoid the need
      * to recapitulate the type argument. */
     // @{
     HALIDE_ALWAYS_INLINE
-    Buffer<typename std::add_const<T>::type, D> &as_const() & {
+    Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> &as_const() & {
         // Note that we can skip the assert_can_convert_from(), since T -> const T
         // conversion is always legal.
-        return *((Buffer<typename std::add_const<T>::type, D> *)this);
+        return *((Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
     }
 
     HALIDE_ALWAYS_INLINE
-    const Buffer<typename std::add_const<T>::type, D> &as_const() const & {
-        return *((const Buffer<typename std::add_const<T>::type, D> *)this);
+    const Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> &as_const() const & {
+        return *((const Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
     }
 
     HALIDE_ALWAYS_INLINE
-    Buffer<typename std::add_const<T>::type, D> as_const() && {
-        return *((Buffer<typename std::add_const<T>::type, D> *)this);
+    Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> as_const() && {
+        return *((Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
     }
     // @}
 
@@ -1109,9 +1157,9 @@ public:
      * can easily cast it back to Buffer<const T> if desired, which is
      * always safe and free.)
      */
-    Buffer<not_const_T, D> copy(void *(*allocate_fn)(size_t) = nullptr,
-                                void (*deallocate_fn)(void *) = nullptr) const {
-        Buffer<not_const_T, D> dst = Buffer<not_const_T, D>::make_with_shape_of(*this, allocate_fn, deallocate_fn);
+    Buffer<not_const_T, Dims, InClassDimStorage> copy(void *(*allocate_fn)(size_t) = nullptr,
+                                                      void (*deallocate_fn)(void *) = nullptr) const {
+        Buffer<not_const_T, Dims, InClassDimStorage> dst = Buffer<not_const_T, Dims, InClassDimStorage>::make_with_shape_of(*this, allocate_fn, deallocate_fn);
         dst.copy_from(*this);
         return dst;
     }
@@ -1120,10 +1168,11 @@ public:
      * (vs. keeping the same memory layout as the original). Requires that 'this'
      * has exactly 3 dimensions.
      */
-    Buffer<not_const_T, D> copy_to_interleaved(void *(*allocate_fn)(size_t) = nullptr,
-                                               void (*deallocate_fn)(void *) = nullptr) const {
+    Buffer<not_const_T, Dims, InClassDimStorage> copy_to_interleaved(void *(*allocate_fn)(size_t) = nullptr,
+                                                                     void (*deallocate_fn)(void *) = nullptr) const {
+        static_assert(Dims == DynamicDims || Dims == 3);
         assert(dimensions() == 3);
-        Buffer<not_const_T, D> dst = Buffer<not_const_T, D>::make_interleaved(nullptr, width(), height(), channels());
+        Buffer<not_const_T, Dims, InClassDimStorage> dst = Buffer<not_const_T, Dims, InClassDimStorage>::make_interleaved(nullptr, width(), height(), channels());
         dst.set_min(min(0), min(1), min(2));
         dst.allocate(allocate_fn, deallocate_fn);
         dst.copy_from(*this);
@@ -1133,8 +1182,8 @@ public:
     /** Like copy(), but the copy is created in planar memory layout
      * (vs. keeping the same memory layout as the original).
      */
-    Buffer<not_const_T, D> copy_to_planar(void *(*allocate_fn)(size_t) = nullptr,
-                                          void (*deallocate_fn)(void *) = nullptr) const {
+    Buffer<not_const_T, Dims, InClassDimStorage> copy_to_planar(void *(*allocate_fn)(size_t) = nullptr,
+                                                                void (*deallocate_fn)(void *) = nullptr) const {
         std::vector<int> mins, extents;
         const int dims = dimensions();
         mins.reserve(dims);
@@ -1143,7 +1192,7 @@ public:
             mins.push_back(dim(d).min());
             extents.push_back(dim(d).extent());
         }
-        Buffer<not_const_T, D> dst = Buffer<not_const_T, D>(nullptr, extents);
+        Buffer<not_const_T, Dims, InClassDimStorage> dst = Buffer<not_const_T, Dims, InClassDimStorage>(nullptr, extents);
         dst.set_min(mins);
         dst.allocate(allocate_fn, deallocate_fn);
         dst.copy_from(*this);
@@ -1159,7 +1208,7 @@ public:
      *     my_func(input.alias(), output);
      * }\endcode
      */
-    inline Buffer<T, D> alias() const {
+    inline Buffer<T, Dims, InClassDimStorage> alias() const {
         return *this;
     }
 
@@ -1172,18 +1221,20 @@ public:
      * to the correct location first like so: \code
      * framebuffer.copy_from(sprite.translated({x, y})); \endcode
      */
-    template<typename T2, int D2>
-    void copy_from(Buffer<T2, D2> src) {
+    template<typename T2, int D2, int S2>
+    void copy_from(Buffer<T2, D2, S2> src) {
         static_assert(!std::is_const<T>::value, "Cannot call copy_from() on a Buffer<const T>");
         assert(!device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty destination.");
         assert(!src.device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty source.");
 
-        Buffer<T, D> dst(*this);
+        Buffer<T, Dims, InClassDimStorage> dst(*this);
 
+        static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2);
         assert(src.dimensions() == dst.dimensions());
 
         // Trim the copy to the region in common
-        for (int i = 0; i < dimensions(); i++) {
+        const int d = dimensions();
+        for (int i = 0; i < d; i++) {
             int min_coord = std::max(dst.dim(i).min(), src.dim(i).min());
             int max_coord = std::min(dst.dim(i).max(), src.dim(i).max());
             if (max_coord < min_coord) {
@@ -1200,23 +1251,23 @@ public:
         // into a static dispatch to the right-sized copy.)
         if (T_is_void ? (type().bytes() == 1) : (sizeof(not_void_T) == 1)) {
             using MemType = uint8_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 2) : (sizeof(not_void_T) == 2)) {
             using MemType = uint16_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 4) : (sizeof(not_void_T) == 4)) {
             using MemType = uint32_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 8) : (sizeof(not_void_T) == 8)) {
             using MemType = uint64_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else {
             assert(false && "type().bytes() must be 1, 2, 4, or 8");
@@ -1228,10 +1279,10 @@ public:
      * the given dimension. Asserts that the crop region is within
      * the existing bounds: you cannot "crop outwards", even if you know there
      * is valid Buffer storage (e.g. because you already cropped inwards). */
-    Buffer<T, D> cropped(int d, int min, int extent) const {
+    Buffer<T, Dims, InClassDimStorage> cropped(int d, int min, int extent) const {
         // Make a fresh copy of the underlying buffer (but not a fresh
         // copy of the allocation, if there is one).
-        Buffer<T, D> im = *this;
+        Buffer<T, Dims, InClassDimStorage> im = *this;
 
         // This guarantees the prexisting device ref is dropped if the
         // device_crop call fails and maintains the buffer in a consistent
@@ -1264,10 +1315,10 @@ public:
      * the first N dimensions. Asserts that the crop region is within
      * the existing bounds. The cropped image may drop any device handle
      * if the device_interface cannot accomplish the crop in-place. */
-    Buffer<T, D> cropped(const std::vector<std::pair<int, int>> &rect) const {
+    Buffer<T, Dims, InClassDimStorage> cropped(const std::vector<std::pair<int, int>> &rect) const {
         // Make a fresh copy of the underlying buffer (but not a fresh
         // copy of the allocation, if there is one).
-        Buffer<T, D> im = *this;
+        Buffer<T, Dims, InClassDimStorage> im = *this;
 
         // This guarantees the prexisting device ref is dropped if the
         // device_crop call fails and maintains the buffer in a consistent
@@ -1301,8 +1352,8 @@ public:
      * translated coordinates in the given dimension. Positive values
      * move the image data to the right or down relative to the
      * coordinate system. Drops any device handle. */
-    Buffer<T, D> translated(int d, int dx) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> translated(int d, int dx) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.translate(d, dx);
         return im;
     }
@@ -1317,8 +1368,8 @@ public:
 
     /** Make an image which refers to the same data translated along
      * the first N dimensions. */
-    Buffer<T, D> translated(const std::vector<int> &delta) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> translated(const std::vector<int> &delta) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.translate(delta);
         return im;
     }
@@ -1373,8 +1424,8 @@ public:
      * using a swapped indexing order for the dimensions given. So
      * A = B.transposed(0, 1) means that A(i, j) == B(j, i), and more
      * strongly that A.address_of(i, j) == B.address_of(j, i). */
-    Buffer<T, D> transposed(int d1, int d2) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> transposed(int d1, int d2) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.transpose(d1, d2);
         return im;
     }
@@ -1414,16 +1465,19 @@ public:
 
     /** Make a buffer which refers to the same data in the same
      * layout using a different ordering of the dimensions. */
-    Buffer<T, D> transposed(const std::vector<int> &order) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> transposed(const std::vector<int> &order) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.transpose(order);
         return im;
     }
 
     /** Make a lower-dimensional buffer that refers to one slice of
      * this buffer. */
-    Buffer<T, D> sliced(int d, int pos) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims - 1), InClassDimStorage> sliced(int d, int pos) const {
+        static_assert(Dims == DynamicDims || Dims > 0, "Cannot slice a 0-dimensional buffer");
+        assert(dimensions() > 0);
+
+        Buffer<T, DynamicDims, InClassDimStorage> im = *this;
 
         // This guarantees the prexisting device ref is dropped if the
         // device_slice call fails and maintains the buffer in a consistent
@@ -1439,15 +1493,22 @@ public:
 
     /** Make a lower-dimensional buffer that refers to one slice of this
      * buffer at the dimension's minimum. */
-    inline Buffer<T, D> sliced(int d) const {
+    inline Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims - 1), InClassDimStorage> sliced(int d) const {
+        static_assert(Dims == DynamicDims || Dims > 0, "Cannot slice a 0-dimensional buffer");
+        assert(dimensions() > 0);
+
         return sliced(d, dim(d).min());
     }
 
     /** Rewrite the buffer to refer to a single lower-dimensional
      * slice of itself along the given dimension at the given
      * coordinate. Does not move any data around or free the original
-     * memory, so other views of the same data are unaffected. */
+     * memory, so other views of the same data are unaffected. Can
+     * only be called on a Buffer with dynamic dimensionality. */
     void slice(int d, int pos) {
+        static_assert(Dims == DynamicDims, "Cannot call slice() on a Buffer with static dimensionality.");
+        assert(dimensions() > 0);
+
         // An optimization for non-device buffers. For the device case,
         // a temp buffer is required, so reuse the not-in-place version.
         // TODO(zalman|abadams): Are nop slices common enough to special
@@ -1474,8 +1535,8 @@ public:
      &im(x, y, c) == &im2(x, 17, y, c);
      \endcode
      */
-    Buffer<T, D> embedded(int d, int pos = 0) const {
-        Buffer<T, D> im(*this);
+    Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims + 1), InClassDimStorage> embedded(int d, int pos = 0) const {
+        Buffer<T, DynamicDims, InClassDimStorage> im(*this);
         im.embed(d, pos);
         return im;
     }
@@ -1483,6 +1544,7 @@ public:
     /** Embed a buffer in-place, increasing the
      * dimensionality. */
     void embed(int d, int pos = 0) {
+        static_assert(Dims == DynamicDims, "Cannot call embed() on a Buffer with static dimensionality.");
         assert(d >= 0 && d <= dimensions());
         add_dimension();
         translate(dimensions() - 1, pos);
@@ -1496,6 +1558,7 @@ public:
      * its stride. The new dimension is the last dimension. This is a
      * special case of embed. */
     void add_dimension() {
+        static_assert(Dims == DynamicDims, "Cannot call add_dimension() on a Buffer with static dimensionality.");
         const int dims = buf.dimensions;
         buf.dimensions++;
         if (buf.dim != shape) {
@@ -1506,7 +1569,7 @@ public:
             }
             delete[] buf.dim;
             buf.dim = new_shape;
-        } else if (dims == D) {
+        } else if (dims == InClassDimStorage) {
             // Transition from the in-class storage to the heap
             make_shape_storage(buf.dimensions);
             for (int i = 0; i < dims; i++) {
@@ -1679,8 +1742,9 @@ public:
      * using (x, y, c). Passing it to a generator requires that the
      * generator has been compiled with support for interleaved (also
      * known as packed or chunky) memory layouts. */
-    static Buffer<void, D> make_interleaved(halide_type_t t, int width, int height, int channels) {
-        Buffer<void, D> im(t, channels, width, height);
+    static Buffer<void, Dims, InClassDimStorage> make_interleaved(halide_type_t t, int width, int height, int channels) {
+        static_assert(Dims == DynamicDims || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
+        Buffer<void, Dims, InClassDimStorage> im(t, channels, width, height);
         // Note that this is equivalent to calling transpose({2, 0, 1}),
         // but slightly more efficient.
         im.transpose(0, 1);
@@ -1694,52 +1758,56 @@ public:
      * using (x, y, c). Passing it to a generator requires that the
      * generator has been compiled with support for interleaved (also
      * known as packed or chunky) memory layouts. */
-    static Buffer<T, D> make_interleaved(int width, int height, int channels) {
+    static Buffer<T, Dims, InClassDimStorage> make_interleaved(int width, int height, int channels) {
         return make_interleaved(static_halide_type(), width, height, channels);
     }
 
     /** Wrap an existing interleaved image. */
-    static Buffer<add_const_if_T_is_const<void>, D>
+    static Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage>
     make_interleaved(halide_type_t t, T *data, int width, int height, int channels) {
-        Buffer<add_const_if_T_is_const<void>, D> im(t, data, channels, width, height);
+        static_assert(Dims == DynamicDims || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
+        Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage> im(t, data, channels, width, height);
         im.transpose(0, 1);
         im.transpose(1, 2);
         return im;
     }
 
     /** Wrap an existing interleaved image. */
-    static Buffer<T, D> make_interleaved(T *data, int width, int height, int channels) {
+    static Buffer<T, Dims, InClassDimStorage> make_interleaved(T *data, int width, int height, int channels) {
         return make_interleaved(static_halide_type(), data, width, height, channels);
     }
 
     /** Make a zero-dimensional Buffer */
-    static Buffer<add_const_if_T_is_const<void>, D> make_scalar(halide_type_t t) {
-        Buffer<add_const_if_T_is_const<void>, 1> buf(t, 1);
+    static Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage> make_scalar(halide_type_t t) {
+        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<add_const_if_T_is_const<void>, DynamicDims, InClassDimStorage> buf(t, 1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a zero-dimensional Buffer */
-    static Buffer<T, D> make_scalar() {
-        Buffer<T, 1> buf(1);
+    static Buffer<T, Dims, InClassDimStorage> make_scalar() {
+        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<T, DynamicDims, InClassDimStorage> buf(1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a zero-dimensional Buffer that points to non-owned, existing data */
-    static Buffer<T, D> make_scalar(T *data) {
-        Buffer<T, 1> buf(data, 1);
+    static Buffer<T, Dims, InClassDimStorage> make_scalar(T *data) {
+        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<T, DynamicDims, InClassDimStorage> buf(data, 1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a buffer with the same shape and memory nesting order as
      * another buffer. It may have a different type. */
-    template<typename T2, int D2>
-    static Buffer<T, D> make_with_shape_of(Buffer<T2, D2> src,
-                                           void *(*allocate_fn)(size_t) = nullptr,
-                                           void (*deallocate_fn)(void *) = nullptr) {
-
+    template<typename T2, int D2, int S2>
+    static Buffer<T, Dims, InClassDimStorage> make_with_shape_of(Buffer<T2, D2, S2> src,
+                                                                 void *(*allocate_fn)(size_t) = nullptr,
+                                                                 void (*deallocate_fn)(void *) = nullptr) {
+        static_assert(Dims == D2 || Dims == DynamicDims);
         const halide_type_t dst_type = T_is_void ? src.type() : halide_type_of<typename std::remove_cv<not_void_T>::type>();
         return Buffer<>::make_with_shape_of_helper(dst_type, src.dimensions(), src.buf.dim,
                                                    allocate_fn, deallocate_fn);
@@ -1846,6 +1914,8 @@ public:
     HALIDE_ALWAYS_INLINE const not_void_T &operator()(int first, Args... rest) const {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 1 + (int)(sizeof...(rest));
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         assert(!device_dirty());
         return *((const not_void_T *)(address_of(first, rest...)));
     }
@@ -1855,6 +1925,8 @@ public:
     operator()() const {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 0;
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         assert(!device_dirty());
         return *((const not_void_T *)(data()));
     }
@@ -1875,6 +1947,8 @@ public:
         operator()(int first, Args... rest) {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 1 + (int)(sizeof...(rest));
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         set_host_dirty();
         return *((not_void_T *)(address_of(first, rest...)));
     }
@@ -1884,6 +1958,8 @@ public:
     operator()() {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 0;
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         set_host_dirty();
         return *((not_void_T *)(data()));
     }
@@ -1905,7 +1981,7 @@ public:
         return all_equal;
     }
 
-    Buffer<T, D> &fill(not_void_T val) {
+    Buffer<T, Dims, InClassDimStorage> &fill(not_void_T val) {
         set_host_dirty();
         for_each_value([=](T &v) { v = val; });
         return *this;
@@ -2059,14 +2135,14 @@ public:
      * will result in a compilation error. */
     // @{
     template<typename Fn, typename... Args, int N = sizeof...(Args) + 1>
-    HALIDE_ALWAYS_INLINE const Buffer<T, D> &for_each_value(Fn &&f, Args &&...other_buffers) const {
+    HALIDE_ALWAYS_INLINE const Buffer<T, Dims, InClassDimStorage> &for_each_value(Fn &&f, Args &&...other_buffers) const {
         for_each_value_impl(f, std::forward<Args>(other_buffers)...);
         return *this;
     }
 
     template<typename Fn, typename... Args, int N = sizeof...(Args) + 1>
     HALIDE_ALWAYS_INLINE
-        Buffer<T, D> &
+        Buffer<T, Dims, InClassDimStorage> &
         for_each_value(Fn &&f, Args &&...other_buffers) {
         for_each_value_impl(f, std::forward<Args>(other_buffers)...);
         return *this;
@@ -2258,14 +2334,14 @@ public:
     */
     // @{
     template<typename Fn>
-    HALIDE_ALWAYS_INLINE const Buffer<T, D> &for_each_element(Fn &&f) const {
+    HALIDE_ALWAYS_INLINE const Buffer<T, Dims, InClassDimStorage> &for_each_element(Fn &&f) const {
         for_each_element_impl(f);
         return *this;
     }
 
     template<typename Fn>
     HALIDE_ALWAYS_INLINE
-        Buffer<T, D> &
+        Buffer<T, Dims, InClassDimStorage> &
         for_each_element(Fn &&f) {
         for_each_element_impl(f);
         return *this;
@@ -2276,7 +2352,7 @@ private:
     template<typename Fn>
     struct FillHelper {
         Fn f;
-        Buffer<T, D> *buf;
+        Buffer<T, Dims, InClassDimStorage> *buf;
 
         template<typename... Args,
                  typename = decltype(std::declval<Fn>()(std::declval<Args>()...))>
@@ -2284,7 +2360,7 @@ private:
             (*buf)(args...) = f(args...);
         }
 
-        FillHelper(Fn &&f, Buffer<T, D> *buf)
+        FillHelper(Fn &&f, Buffer<T, Dims, InClassDimStorage> *buf)
             : f(std::forward<Fn>(f)), buf(buf) {
         }
     };
@@ -2296,7 +2372,7 @@ public:
      * stored to the coordinate corresponding to the arguments. */
     template<typename Fn,
              typename = typename std::enable_if<!std::is_arithmetic<typename std::decay<Fn>::type>::value>::type>
-    Buffer<T, D> &fill(Fn &&f) {
+    Buffer<T, Dims, InClassDimStorage> &fill(Fn &&f) {
         // We'll go via for_each_element. We need a variadic wrapper lambda.
         FillHelper<Fn> wrapper(std::forward<Fn>(f), this);
         return for_each_element(wrapper);

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -106,6 +106,8 @@ struct DeviceRefCount {
     BufferDeviceOwnership ownership{BufferDeviceOwnership::Allocated};
 };
 
+constexpr int BufferDimsUnconstrained = -1;
+
 /** A templated Buffer class that wraps halide_buffer_t and adds
  * functionality. When using Halide from C++, this is the preferred
  * way to create input and output buffers. The overhead of using this
@@ -117,7 +119,7 @@ struct DeviceRefCount {
  * element type is unknown, or may vary, use void or const void.
  *
  * The template parameter Dims is the number of dimensions. For buffers where
- * the dimensionality type is unknown at, or may vary, use -1 (or Buffer::DynamicDims).
+ * the dimensionality type is unknown at, or may vary, use BufferDimsUnconstrained.
  *
  * InClassDimStorage is the maximum number of dimensions that can be represented
  * using space inside the class itself. Set it to the maximum dimensionality
@@ -131,8 +133,8 @@ struct DeviceRefCount {
  * considered as owned if and only if the host-side allocation is
  * owned. */
 template<typename T = void,
-         int Dims = -1,
-         int InClassDimStorage = (Dims == -1 ? 4 : std::max(Dims, 1))>
+         int Dims = BufferDimsUnconstrained,
+         int InClassDimStorage = (Dims == BufferDimsUnconstrained ? 4 : std::max(Dims, 1))>
 class Buffer {
     /** The underlying halide_buffer_t */
     halide_buffer_t buf = {};
@@ -185,9 +187,7 @@ public:
         return alloc != nullptr;
     }
 
-    static constexpr int DynamicDims = -1;
-
-    static constexpr bool has_static_dimensions = (Dims != DynamicDims);
+    static constexpr bool has_static_dimensions = (Dims != BufferDimsUnconstrained);
 
     /** Callers should not use the result if
      * has_static_dimensions is false. */
@@ -293,10 +293,10 @@ private:
 
     template<int DimsSpecified>
     void make_static_shape_storage() {
-        static_assert(Dims == DynamicDims || Dims == DimsSpecified,
+        static_assert(Dims == BufferDimsUnconstrained || Dims == DimsSpecified,
                       "Number of arguments to Buffer() does not match static dimensionality");
         buf.dimensions = DimsSpecified;
-        if constexpr (Dims == DynamicDims) {
+        if constexpr (Dims == BufferDimsUnconstrained) {
             buf.dim = (DimsSpecified <= InClassDimStorage) ? shape : new halide_dimension_t[DimsSpecified];
         } else {
             static_assert(InClassDimStorage >= Dims);
@@ -305,7 +305,7 @@ private:
     }
 
     void make_shape_storage(const int dimensions) {
-        if (Dims != DynamicDims && Dims != dimensions) {
+        if (Dims != BufferDimsUnconstrained && Dims != dimensions) {
             assert(false && "Number of arguments to Buffer() does not match static dimensionality");
         }
         // This should usually be inlined, so if dimensions is statically known,
@@ -439,7 +439,7 @@ private:
 
     /** slice a single dimension without handling device allocation. */
     void slice_host(int d, int pos) {
-        static_assert(Dims == DynamicDims);
+        static_assert(Dims == BufferDimsUnconstrained);
         assert(dimensions() > 0);
         assert(d >= 0 && d < dimensions());
         assert(pos >= dim(d).min() && pos <= dim(d).max());
@@ -454,7 +454,7 @@ private:
         buf.dim[buf.dimensions] = {0, 0, 0};
     }
 
-    void complete_device_slice(Buffer<T, DynamicDims, InClassDimStorage> &result_host_sliced, int d, int pos) const {
+    void complete_device_slice(Buffer<T, BufferDimsUnconstrained, InClassDimStorage> &result_host_sliced, int d, int pos) const {
         assert(buf.device_interface != nullptr);
         if (buf.device_interface->device_slice(nullptr, &this->buf, d, pos, &result_host_sliced.buf) == 0) {
             const Buffer<T, Dims, InClassDimStorage> *sliced_from = this;
@@ -558,7 +558,7 @@ public:
     /** Get the dimensionality of the buffer. */
     // TODO: make constexpr, optimize for const case
     int dimensions() const {
-        assert(Dims == DynamicDims || Dims == buf.dimensions);
+        assert(Dims == BufferDimsUnconstrained || Dims == buf.dimensions);
         return buf.dimensions;
     }
 
@@ -618,7 +618,7 @@ private:
                                    typename std::remove_const<T2>::type>::value ||
                           T_is_void || Buffer<T2, D2, S2>::T_is_void,
                       "type mismatch constructing Buffer");
-        static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2,
+        static_assert(Dims == BufferDimsUnconstrained || D2 == BufferDimsUnconstrained || Dims == D2,
                       "Can't convert from a Buffer with static dimensionality to a Buffer with different static dimensionality");
     }
 
@@ -634,7 +634,7 @@ public:
                 return false;
             }
         }
-        if (Dims != DynamicDims) {
+        if (Dims != BufferDimsUnconstrained) {
             if (other.dimensions() != Dims) {
                 return false;
             }
@@ -1170,7 +1170,7 @@ public:
      */
     Buffer<not_const_T, Dims, InClassDimStorage> copy_to_interleaved(void *(*allocate_fn)(size_t) = nullptr,
                                                                      void (*deallocate_fn)(void *) = nullptr) const {
-        static_assert(Dims == DynamicDims || Dims == 3);
+        static_assert(Dims == BufferDimsUnconstrained || Dims == 3);
         assert(dimensions() == 3);
         Buffer<not_const_T, Dims, InClassDimStorage> dst = Buffer<not_const_T, Dims, InClassDimStorage>::make_interleaved(nullptr, width(), height(), channels());
         dst.set_min(min(0), min(1), min(2));
@@ -1229,7 +1229,7 @@ public:
 
         Buffer<T, Dims, InClassDimStorage> dst(*this);
 
-        static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2);
+        static_assert(Dims == BufferDimsUnconstrained || D2 == BufferDimsUnconstrained || Dims == D2);
         assert(src.dimensions() == dst.dimensions());
 
         // Trim the copy to the region in common
@@ -1473,11 +1473,12 @@ public:
 
     /** Make a lower-dimensional buffer that refers to one slice of
      * this buffer. */
-    Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims - 1), InClassDimStorage> sliced(int d, int pos) const {
-        static_assert(Dims == DynamicDims || Dims > 0, "Cannot slice a 0-dimensional buffer");
+    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims - 1), InClassDimStorage>
+    sliced(int d, int pos) const {
+        static_assert(Dims == BufferDimsUnconstrained || Dims > 0, "Cannot slice a 0-dimensional buffer");
         assert(dimensions() > 0);
 
-        Buffer<T, DynamicDims, InClassDimStorage> im = *this;
+        Buffer<T, BufferDimsUnconstrained, InClassDimStorage> im = *this;
 
         // This guarantees the prexisting device ref is dropped if the
         // device_slice call fails and maintains the buffer in a consistent
@@ -1493,8 +1494,9 @@ public:
 
     /** Make a lower-dimensional buffer that refers to one slice of this
      * buffer at the dimension's minimum. */
-    inline Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims - 1), InClassDimStorage> sliced(int d) const {
-        static_assert(Dims == DynamicDims || Dims > 0, "Cannot slice a 0-dimensional buffer");
+    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims - 1), InClassDimStorage>
+    sliced(int d) const {
+        static_assert(Dims == BufferDimsUnconstrained || Dims > 0, "Cannot slice a 0-dimensional buffer");
         assert(dimensions() > 0);
 
         return sliced(d, dim(d).min());
@@ -1506,7 +1508,7 @@ public:
      * memory, so other views of the same data are unaffected. Can
      * only be called on a Buffer with dynamic dimensionality. */
     void slice(int d, int pos) {
-        static_assert(Dims == DynamicDims, "Cannot call slice() on a Buffer with static dimensionality.");
+        static_assert(Dims == BufferDimsUnconstrained, "Cannot call slice() on a Buffer with static dimensionality.");
         assert(dimensions() > 0);
 
         // An optimization for non-device buffers. For the device case,
@@ -1535,8 +1537,9 @@ public:
      &im(x, y, c) == &im2(x, 17, y, c);
      \endcode
      */
-    Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims + 1), InClassDimStorage> embedded(int d, int pos = 0) const {
-        Buffer<T, DynamicDims, InClassDimStorage> im(*this);
+    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims + 1), InClassDimStorage>
+    embedded(int d, int pos = 0) const {
+        Buffer<T, BufferDimsUnconstrained, InClassDimStorage> im(*this);
         im.embed(d, pos);
         return im;
     }
@@ -1544,7 +1547,7 @@ public:
     /** Embed a buffer in-place, increasing the
      * dimensionality. */
     void embed(int d, int pos = 0) {
-        static_assert(Dims == DynamicDims, "Cannot call embed() on a Buffer with static dimensionality.");
+        static_assert(Dims == BufferDimsUnconstrained, "Cannot call embed() on a Buffer with static dimensionality.");
         assert(d >= 0 && d <= dimensions());
         add_dimension();
         translate(dimensions() - 1, pos);
@@ -1558,7 +1561,7 @@ public:
      * its stride. The new dimension is the last dimension. This is a
      * special case of embed. */
     void add_dimension() {
-        static_assert(Dims == DynamicDims, "Cannot call add_dimension() on a Buffer with static dimensionality.");
+        static_assert(Dims == BufferDimsUnconstrained, "Cannot call add_dimension() on a Buffer with static dimensionality.");
         const int dims = buf.dimensions;
         buf.dimensions++;
         if (buf.dim != shape) {
@@ -1743,7 +1746,7 @@ public:
      * generator has been compiled with support for interleaved (also
      * known as packed or chunky) memory layouts. */
     static Buffer<void, Dims, InClassDimStorage> make_interleaved(halide_type_t t, int width, int height, int channels) {
-        static_assert(Dims == DynamicDims || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
+        static_assert(Dims == BufferDimsUnconstrained || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
         Buffer<void, Dims, InClassDimStorage> im(t, channels, width, height);
         // Note that this is equivalent to calling transpose({2, 0, 1}),
         // but slightly more efficient.
@@ -1765,7 +1768,7 @@ public:
     /** Wrap an existing interleaved image. */
     static Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage>
     make_interleaved(halide_type_t t, T *data, int width, int height, int channels) {
-        static_assert(Dims == DynamicDims || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
+        static_assert(Dims == BufferDimsUnconstrained || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
         Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage> im(t, data, channels, width, height);
         im.transpose(0, 1);
         im.transpose(1, 2);
@@ -1779,24 +1782,24 @@ public:
 
     /** Make a zero-dimensional Buffer */
     static Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage> make_scalar(halide_type_t t) {
-        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
-        Buffer<add_const_if_T_is_const<void>, DynamicDims, InClassDimStorage> buf(t, 1);
+        static_assert(Dims == BufferDimsUnconstrained || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<add_const_if_T_is_const<void>, BufferDimsUnconstrained, InClassDimStorage> buf(t, 1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a zero-dimensional Buffer */
     static Buffer<T, Dims, InClassDimStorage> make_scalar() {
-        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
-        Buffer<T, DynamicDims, InClassDimStorage> buf(1);
+        static_assert(Dims == BufferDimsUnconstrained || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<T, BufferDimsUnconstrained, InClassDimStorage> buf(1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a zero-dimensional Buffer that points to non-owned, existing data */
     static Buffer<T, Dims, InClassDimStorage> make_scalar(T *data) {
-        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
-        Buffer<T, DynamicDims, InClassDimStorage> buf(data, 1);
+        static_assert(Dims == BufferDimsUnconstrained || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<T, BufferDimsUnconstrained, InClassDimStorage> buf(data, 1);
         buf.slice(0, 0);
         return buf;
     }
@@ -1807,7 +1810,7 @@ public:
     static Buffer<T, Dims, InClassDimStorage> make_with_shape_of(Buffer<T2, D2, S2> src,
                                                                  void *(*allocate_fn)(size_t) = nullptr,
                                                                  void (*deallocate_fn)(void *) = nullptr) {
-        static_assert(Dims == D2 || Dims == DynamicDims);
+        static_assert(Dims == D2 || Dims == BufferDimsUnconstrained);
         const halide_type_t dst_type = T_is_void ? src.type() : halide_type_of<typename std::remove_cv<not_void_T>::type>();
         return Buffer<>::make_with_shape_of_helper(dst_type, src.dimensions(), src.buf.dim,
                                                    allocate_fn, deallocate_fn);
@@ -1915,7 +1918,7 @@ public:
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
         constexpr int expected_dims = 1 + (int)(sizeof...(rest));
-        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
+        static_assert(Dims == BufferDimsUnconstrained || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         assert(!device_dirty());
         return *((const not_void_T *)(address_of(first, rest...)));
     }
@@ -1926,7 +1929,7 @@ public:
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
         constexpr int expected_dims = 0;
-        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
+        static_assert(Dims == BufferDimsUnconstrained || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         assert(!device_dirty());
         return *((const not_void_T *)(data()));
     }
@@ -1948,7 +1951,7 @@ public:
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
         constexpr int expected_dims = 1 + (int)(sizeof...(rest));
-        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
+        static_assert(Dims == BufferDimsUnconstrained || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         set_host_dirty();
         return *((not_void_T *)(address_of(first, rest...)));
     }
@@ -1959,7 +1962,7 @@ public:
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
         constexpr int expected_dims = 0;
-        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
+        static_assert(Dims == BufferDimsUnconstrained || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         set_host_dirty();
         return *((not_void_T *)(data()));
     }

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -560,7 +560,6 @@ public:
         if constexpr (has_static_dimensions) {
             return Dims;
         } else {
-            assert(Dims == BufferDimsUnconstrained || Dims == buf.dimensions);
             return buf.dimensions;
         }
     }

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -128,12 +128,84 @@ int main(int argc, char **argv) {
 
     {
         // Check make a Buffer from a Buffer of a different type
+        Buffer<float> a(100, 80);
+        Buffer<const float> b(a);  // statically safe
+        Buffer<const void> c(b);   // statically safe
+        Buffer<const float> d(c);  // does runtime check of actual type.
+        Buffer<void> e(a);         // statically safe
+        Buffer<float> f(e);        // runtime checks
+
+        static_assert(a.has_static_halide_type);
+        static_assert(b.has_static_halide_type);
+        static_assert(!c.has_static_halide_type);
+        static_assert(d.has_static_halide_type);
+        static_assert(!e.has_static_halide_type);
+        static_assert(f.has_static_halide_type);
+
+        static_assert(a.static_halide_type() == halide_type_of<float>());
+        static_assert(b.static_halide_type() == halide_type_of<float>());
+        static_assert(d.static_halide_type() == halide_type_of<float>());
+        static_assert(f.static_halide_type() == halide_type_of<float>());
+    }
+
+    {
+        // Check Buffers with static dimensionality
         Buffer<float, 2> a(100, 80);
-        Buffer<const float, 3> b(a);  // statically safe
-        Buffer<const void, 4> c(b);   // statically safe
-        Buffer<const float, 3> d(c);  // does runtime check of actual type.
-        Buffer<void, 3> e(a);         // statically safe
-        Buffer<float, 2> f(e);        // runtime checks
+        Buffer<float, 2> b(a);                      // statically safe
+        Buffer<float> c(a);                         // checks at runtime (and succeeds)
+        Buffer<float, Buffer<>::DynamicDims> d(a);  // same as previous, just explicit syntax
+        Buffer<float, 2> e(d);                      // checks at runtime (and succeeds because d.dims = 2)
+        // Buffer<float, 3> f(a);                   // won't compile: static_assert failure
+        // Buffer<float, 3> g(c);                   // fails at runtime: c.dims = 2
+
+        static_assert(a.has_static_dimensions);
+        static_assert(b.has_static_dimensions);
+        static_assert(!c.has_static_dimensions);
+        static_assert(!d.has_static_dimensions);
+        static_assert(e.has_static_dimensions);
+
+        static_assert(a.static_dimensions() == 2);
+        static_assert(b.static_dimensions() == 2);
+        static_assert(e.static_dimensions() == 2);
+
+        Buffer<float> s1 = a.sliced(0);
+        assert(s1.dimensions() == 1);
+        assert(s1.dim(0).extent() == 80);
+
+        Buffer<float, 1> s2 = a.sliced(1);
+        assert(s2.dimensions() == 1);
+        assert(s2.dim(0).extent() == 100);
+
+        Buffer<float, 0> s3 = s2.sliced(0);
+        static_assert(a.has_static_dimensions && s3.static_dimensions() == 0);
+        assert(s3.dimensions() == 0);
+
+        // auto s3a = s3.sliced(0);              // won't compile: can't call sliced() on a zero-dim buffer
+        // Buffer<float, 2> s3b = a.sliced(0);   // won't compile: return type has incompatible dimensionality
+        // a.slice(0);                          // won't compile: can't call slice() on static-dimensioned buffer
+
+        Buffer<float> s4 = a.sliced(0);  // assign to dynamic-dimensioned result
+        static_assert(!s4.has_static_dimensions);
+        assert(s4.dimensions() == 1);
+
+        s4.slice(0);  // ok to call on dynamic-dimensioned
+        assert(s4.dimensions() == 0);
+
+        Buffer<float, 0> e0 = Buffer<float, 0>::make_scalar();
+
+        auto e1 = e0.embedded(0);
+        static_assert(e1.has_static_dimensions && e1.static_dimensions() == 1);
+        assert(e1.dimensions() == 1);
+
+        // Buffer<float, 0> e2 = a.embedded(0);  // won't compile: return type has incompatible dimensionality
+        // e1.embed(0);                          // won't compile: can't call embed() on static-dimensioned buffer
+
+        Buffer<float> e3 = e0.embedded(0);  // assign to dynamic-dimensioned result
+        static_assert(!e3.has_static_dimensions);
+        assert(e3.dimensions() == 1);
+
+        e3.embed(0);  // ok to call on dynamic-dimensioned
+        assert(e3.dimensions() == 2);
     }
 
     {

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -151,12 +151,12 @@ int main(int argc, char **argv) {
     {
         // Check Buffers with static dimensionality
         Buffer<float, 2> a(100, 80);
-        Buffer<float, 2> b(a);                      // statically safe
-        Buffer<float> c(a);                         // checks at runtime (and succeeds)
-        Buffer<float, Buffer<>::DynamicDims> d(a);  // same as previous, just explicit syntax
-        Buffer<float, 2> e(d);                      // checks at runtime (and succeeds because d.dims = 2)
-        // Buffer<float, 3> f(a);                   // won't compile: static_assert failure
-        // Buffer<float, 3> g(c);                   // fails at runtime: c.dims = 2
+        Buffer<float, 2> b(a);                        // statically safe
+        Buffer<float> c(a);                           // checks at runtime (and succeeds)
+        Buffer<float, BufferDimsUnconstrained> d(a);  // same as previous, just explicit syntax
+        Buffer<float, 2> e(d);                        // checks at runtime (and succeeds because d.dims = 2)
+        // Buffer<float, 3> f(a);                     // won't compile: static_assert failure
+        // Buffer<float, 3> g(c);                     // fails at runtime: c.dims = 2
 
         static_assert(a.has_static_dimensions);
         static_assert(b.has_static_dimensions);

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -10,9 +10,9 @@ enum class SomeEnum { Foo,
 class MetadataTester : public Halide::Generator<MetadataTester> {
 public:
     Input<Func> input{"input"};  // must be overridden to {UInt(8), 3}
-    Input<Buffer<uint8_t>> typed_input_buffer{"typed_input_buffer", 3};
-    Input<Buffer<>> dim_only_input_buffer{"dim_only_input_buffer", 3};  // must be overridden to type=UInt(8)
-    Input<Buffer<>> untyped_input_buffer{"untyped_input_buffer"};       // must be overridden to {UInt(8), 3}
+    Input<Buffer<uint8_t, 3>> typed_input_buffer{"typed_input_buffer"};
+    Input<Buffer<void, 3>> dim_only_input_buffer{"dim_only_input_buffer"};  // must be overridden to type=UInt(8)
+    Input<Buffer<>> untyped_input_buffer{"untyped_input_buffer"};           // must be overridden to {UInt(8), 3}
     Input<int32_t> no_default_value{"no_default_value"};
     Input<bool> b{"b", true};
     Input<int8_t> i8{"i8", 8, -8, 127};
@@ -26,11 +26,9 @@ public:
     Input<float> f32{"f32", 32.1234f, -3200.1234f, 3200.1234f};
     Input<double> f64{"f64", 64.25f, -6400.25f, 6400.25f};
     Input<void *> h{"h", nullptr};
-
     Input<Func> input_not_nod{"input_not_nod"};   // must be overridden to type=uint8 dim=3
     Input<Func> input_nod{"input_nod", UInt(8)};  // must be overridden to type=uint8 dim=3
     Input<Func> input_not{"input_not", 3};        // must be overridden to type=uint8
-
     Input<Func[]> array_input{"array_input", UInt(8), 3};  // must be overridden to size=2
     Input<Func[2]> array2_input{"array2_input", UInt(8), 3};
     Input<int8_t[]> array_i8{"array_i8"};  // must be overridden to size=2
@@ -41,38 +39,38 @@ public:
     Input<int32_t[2]> array2_i32{"array2_i32", 32, -32, 127};
     Input<void *[]> array_h { "array_h", nullptr };  // must be overridden to size=2
 
-    Input<Buffer<float>[2]> buffer_array_input1 { "buffer_array_input1", 3 };
-    Input<Buffer<float>[2]> buffer_array_input2 { "buffer_array_input2" };  // buffer_array_input2.dim must be set
-    Input<Buffer<>[2]> buffer_array_input3 { "buffer_array_input3", 3 };    // buffer_array_input2.type must be set
-    Input<Buffer<>[2]> buffer_array_input4 { "buffer_array_input4" };       // dim and type must be set
+    Input<Buffer<float, 3>[2]> buffer_array_input1 { "buffer_array_input1" };
+    Input<Buffer<float>[2]> buffer_array_input2 { "buffer_array_input2" };    // buffer_array_input2.dim must be set
+    Input<Buffer<void, 3>[2]> buffer_array_input3 { "buffer_array_input3" };  // buffer_array_input2.type must be set
+    Input<Buffer<>[2]> buffer_array_input4 { "buffer_array_input4" };         // dim and type must be set
     // .size must be specified for all of these
-    Input<Buffer<float>[]> buffer_array_input5 { "buffer_array_input5", 3 };
-    Input<Buffer<float>[]> buffer_array_input6 { "buffer_array_input6" };  // buffer_array_input2.dim must be set
-    Input<Buffer<>[]> buffer_array_input7 { "buffer_array_input7", 3 };    // buffer_array_input2.type must be set
-    Input<Buffer<>[]> buffer_array_input8 { "buffer_array_input8" };       // dim and type must be set
+    Input<Buffer<float, 3>[]> buffer_array_input5 { "buffer_array_input5" };
+    Input<Buffer<float>[]> buffer_array_input6 { "buffer_array_input6" };    // buffer_array_input2.dim must be set
+    Input<Buffer<void, 3>[]> buffer_array_input7 { "buffer_array_input7" };  // buffer_array_input2.type must be set
+    Input<Buffer<>[]> buffer_array_input8 { "buffer_array_input8" };         // dim and type must be set
 
-    Input<Buffer<float16_t>> buffer_f16_typed{"buffer_f16_typed", 1};
-    Input<Buffer<>> buffer_f16_untyped{"buffer_f16_untyped", 1};
+    Input<Buffer<float16_t, 1>> buffer_f16_typed{"buffer_f16_typed"};
+    Input<Buffer<void, 1>> buffer_f16_untyped{"buffer_f16_untyped"};
 
     Input<Expr> untyped_scalar_input{"untyped_scalar_input"};  // untyped_scalar_input.type must be set to uint8
 
     Output<Func> output{"output"};  // must be overridden to {{Float(32), Float(32)}, 3}
-    Output<Buffer<float>> typed_output_buffer{"typed_output_buffer", 3};
+    Output<Buffer<float, 3>> typed_output_buffer{"typed_output_buffer"};
     Output<Buffer<float>> type_only_output_buffer{"type_only_output_buffer"};  // untyped outputs can have type and/or dimensions inferred
-    Output<Buffer<>> dim_only_output_buffer{"dim_only_output_buffer", 3};      // untyped outputs can have type and/or dimensions inferred
+    Output<Buffer<void, 3>> dim_only_output_buffer{"dim_only_output_buffer"};  // untyped outputs can have type and/or dimensions inferred
     Output<Buffer<>> untyped_output_buffer{"untyped_output_buffer"};           // untyped outputs can have type and/or dimensions inferred
-    Output<Buffer<>> tupled_output_buffer{"tupled_output_buffer", {Float(32), Int(32)}, 3};
+    Output<Buffer<void, 3>> tupled_output_buffer{"tupled_output_buffer", {Float(32), Int(32)}};
     Output<float> output_scalar{"output_scalar"};
     Output<Func[]> array_outputs{"array_outputs", Float(32), 3};  // must be overridden to size=2
     Output<Func[2]> array_outputs2{"array_outputs2", {Float(32), Float(32)}, 3};
     Output<float[2]> array_outputs3{"array_outputs3"};
 
-    Output<Buffer<float>[2]> array_outputs4 { "array_outputs4", 3 };
+    Output<Buffer<float, 3>[2]> array_outputs4 { "array_outputs4" };
     Output<Buffer<float>[2]> array_outputs5 { "array_outputs5" };  // dimensions will be inferred by usage
     Output<Buffer<>[2]> array_outputs6 { "array_outputs6" };       // dimensions and type will be inferred by usage
 
     // .size must be specified for all of these
-    Output<Buffer<float>[]> array_outputs7 { "array_outputs7", 3 };
+    Output<Buffer<float, 3>[]> array_outputs7 { "array_outputs7" };
     Output<Buffer<float>[]> array_outputs8 { "array_outputs8" };
     Output<Buffer<>[]> array_outputs9 { "array_outputs9" };
 

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -26,9 +26,9 @@ public:
     Input<float> f32{"f32", 32.1234f, -3200.1234f, 3200.1234f};
     Input<double> f64{"f64", 64.25f, -6400.25f, 6400.25f};
     Input<void *> h{"h", nullptr};
-    Input<Func> input_not_nod{"input_not_nod"};   // must be overridden to type=uint8 dim=3
-    Input<Func> input_nod{"input_nod", UInt(8)};  // must be overridden to type=uint8 dim=3
-    Input<Func> input_not{"input_not", 3};        // must be overridden to type=uint8
+    Input<Func> input_not_nod{"input_not_nod"};            // must be overridden to type=uint8 dim=3
+    Input<Func> input_nod{"input_nod", UInt(8)};           // must be overridden to type=uint8 dim=3
+    Input<Func> input_not{"input_not", 3};                 // must be overridden to type=uint8
     Input<Func[]> array_input{"array_input", UInt(8), 3};  // must be overridden to size=2
     Input<Func[2]> array2_input{"array2_input", UInt(8), 3};
     Input<int8_t[]> array_i8{"array_i8"};  // must be overridden to size=2


### PR DESCRIPTION
Currently, `Halide::Runtime::Buffer<>`* allows you to provide a static ElementType, which allows you to enforce compile-time type checking to ensure incompatible Buffers aren't intermixed. You can also defeat this by using an ElementType of `void`, which defers all type checking to runtime.

Unfortunately, there isn't a way to do the same for the *dimensionality* of a Buffer; all checking for matching dimensionality is done at runtime. This PR proposes to extend `Halide::Runtime::Buffer<>`* to allow for optional specification of dimensionality as well, with only a slight incompatibility with existing code.

Currently, `H::R::B<>` is a template with two arguments:
- `H::R::B<typename T = void, int D = 4>`
    - `T`, which is the element type; if omitted, defaults to `void`.
    - `D`, which specifies the amount of storage to reserve for dimensionality (but *not* the actual dimensionality); if omitted, defaults to `4`. Note that I've often seen this argument specified on the (mistaken) assumption that it is the dimensionality! In practice, almost no code ever needs to specify this (with apps/hannk being the only notable counterexample that comes to mind).

This PR proposes to change H::R::B<> to a template with three arguments:
- `H::R::B<typename T = void, int Dims = -1, int InClassDimStorage = ...>`
    - `T`, which is the element type; if omitted, defaults to `void`. **This is unchanged from previous behavior.**
    - `Dims`, which specifies the dimensionality of the Buffer:
        - If `Dims` >= 0, the Buffer must always have `dimensions() == Dims`; attempts to (e.g.) construct or access such a buffer with the 'wrong' number of arguments will fail at compile time, assignment between Buffers with different dimensionality will fail at compile time, `slice()` and `embed()` will return properly-typed results, etc.
        - If `Dims` == -1, the Buffer can have any dimensionality, with compatibility being checked at runtime. (Basically, the same behavior as before.)
    - `InClassDimStorage`, which is the same as the old `D` argument. Its default value is determined like so:
       - If `Dims` is >= 1, its default value is `Dims`, since we shouldn't ever see any more or less.
       - If `Dims` is 0, we use a default value of 1 (just to be defensive against rogue code that assumes a valid pointer for dims in all cases)
       - Otherwise, it defaults to 4 (i.e., the same value as before)

TL;DR:
- Code that uses `Buffer<>`, `Buffer<void>`, or `Buffer<SomeType>` should work as-is, unchanged, with this change.
- Code that uses `Buffer<void, SomeInt>` or `Buffer<void, SomeInt>` will need attention to work after this change, but most uses I've seen fail at compile time and are easy to spot.

Note that the Generator infrastructure was expanded to add appropriate overloads for `Input<>` and `Output<>` to infer dimensionality from the Buffer specification (and metadata_tester_generator.cpp was modified to use this approach, for testing purposes); if this PR is approved, it is my intent to follow up with a PR that deprecates the ability to specify dimensionality in the old way.


*all this also applies to Halide::Buffer<> as well, just omitting it above for simplicitly

