### PR TITLE
Deprecate GeneratorInput/Output ctors that are obsolete after #6574

### DIFF
--- a/apps/HelloAndroid/jni/hello_generator.cpp
+++ b/apps/HelloAndroid/jni/hello_generator.cpp
@@ -6,8 +6,8 @@ namespace {
 
 class Hello : public Generator<Hello> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 2};
-    Output<Buffer<uint8_t>> result{"result", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
+    Output<Buffer<uint8_t, 2>> result{"result"};
 
     void generate() {
         tone_curve(x) = cast<int16_t>(pow(cast<float>(x) / 256.0f, 1.8f) * 256.0f);

--- a/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
+++ b/apps/HelloAndroidCamera2/jni/deinterleave_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class Deinterleave : public Halide::Generator<Deinterleave> {
 public:
-    Input<Buffer<uint8_t>> uvInterleaved{"uvInterleaved", 2};
+    Input<Buffer<uint8_t, 2>> uvInterleaved{"uvInterleaved"};
     // There is no way to declare a Buffer<Tuple>, so we must use Output<Func> instead
     Output<Func> result{"result", {UInt(8), UInt(8)}, 2};
 

--- a/apps/HelloAndroidCamera2/jni/edge_detect_generator.cpp
+++ b/apps/HelloAndroidCamera2/jni/edge_detect_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class EdgeDetect : public Halide::Generator<EdgeDetect> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 2};
-    Output<Buffer<uint8_t>> result{"result", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
+    Output<Buffer<uint8_t, 2>> result{"result"};
 
     void generate() {
         Var x, y;

--- a/apps/HelloMatlab/iir_blur.cpp
+++ b/apps/HelloMatlab/iir_blur.cpp
@@ -59,12 +59,12 @@ class IirBlur : public Generator<IirBlur> {
 public:
     // This is the input image: a 3D (color) image with 32 bit float
     // pixels.
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     // The filter coefficient, alpha is the weight of the input to the
     // filter.
     Input<float> alpha{"alpha"};
 
-    Output<Buffer<float>> output{"output", 3};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Expr width = input.width();

--- a/apps/HelloWasm/reaction_diffusion_generator.cpp
+++ b/apps/HelloWasm/reaction_diffusion_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class ReactionDiffusionInit : public Halide::Generator<ReactionDiffusionInit> {
 public:
-    Output<Buffer<float>> output{"output", 3};
+    Output<Buffer<float, 3>> output{"output"};
     GeneratorParam<bool> threads{"threads", true};
 
     void generate() {
@@ -24,11 +24,11 @@ private:
 
 class ReactionDiffusionUpdate : public Halide::Generator<ReactionDiffusionUpdate> {
 public:
-    Input<Buffer<float>> state{"state", 3};
+    Input<Buffer<float, 3>> state{"state"};
     Input<int> mouse_x{"mouse_x"};
     Input<int> mouse_y{"mouse_y"};
     Input<int> frame{"frame"};
-    Output<Buffer<float>> new_state{"new_state", 3};
+    Output<Buffer<float, 3>> new_state{"new_state"};
     GeneratorParam<bool> threads{"threads", false};
 
     void generate() {
@@ -139,8 +139,8 @@ private:
 
 class ReactionDiffusionRender : public Halide::Generator<ReactionDiffusionRender> {
 public:
-    Input<Buffer<float>> state{"state", 3};
-    Output<Buffer<uint32_t>> render{"render", 2};
+    Input<Buffer<float, 3>> state{"state"};
+    Output<Buffer<uint32_t, 2>> render{"render"};
     GeneratorParam<bool> threads{"threads", false};
 
     void generate() {

--- a/apps/HelloiOS/HelloiOS/reaction_diffusion_2_generator.cpp
+++ b/apps/HelloiOS/HelloiOS/reaction_diffusion_2_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class ReactionDiffusion2Init : public Halide::Generator<ReactionDiffusion2Init> {
 public:
-    Output<Buffer<float>> output{"output", 3};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         output(x, y, c) = Halide::random_float();
@@ -28,11 +28,11 @@ private:
 
 class ReactionDiffusion2Update : public Halide::Generator<ReactionDiffusion2Update> {
 public:
-    Input<Buffer<float>> state{"state", 3};
+    Input<Buffer<float, 3>> state{"state"};
     Input<int> mouse_x{"mouse_x"};
     Input<int> mouse_y{"mouse_y"};
     Input<int> frame{"frame"};
-    Output<Buffer<float>> new_state{"new_state", 3};
+    Output<Buffer<float, 3>> new_state{"new_state"};
 
     void generate() {
         clamped = Halide::BoundaryConditions::repeat_edge(state);
@@ -163,10 +163,10 @@ private:
 
 class ReactionDiffusion2Render : public Halide::Generator<ReactionDiffusion2Render> {
 public:
-    Input<Buffer<float>> state{"state", 3};
+    Input<Buffer<float, 3>> state{"state"};
     // TODO(srj): should be Input<bool>; using Input<int> to work around Issue #1760
     Input<int> output_bgra{"output_bgra", 0, 0, 1};
-    Output<Buffer<uint8_t>> render{"render", 3};
+    Output<Buffer<uint8_t, 3>> render{"render"};
 
     void generate() {
         Func contour;

--- a/apps/auto_viz/auto_viz_demo_generator.cpp
+++ b/apps/auto_viz/auto_viz_demo_generator.cpp
@@ -24,9 +24,9 @@ public:
     // resample in x and in y).
     GeneratorParam<bool> upsample{"upsample", false};
 
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     Input<float> scale_factor{"scale_factor"};
-    Output<Buffer<float>> output{"output", 3};
+    Output<Buffer<float, 3>> output{"output"};
 
     // Common Vars
     Var x, y, c, k;

--- a/apps/bgu/bgu_generator.cpp
+++ b/apps/bgu/bgu_generator.cpp
@@ -265,11 +265,11 @@ public:
     // Size of each spatial bin in the grid. Typically 16.
     Input<int> s_sigma{"s_sigma"};
 
-    Input<Buffer<float>> splat_loc{"splat_loc", 3};
-    Input<Buffer<float>> values{"values", 3};
-    Input<Buffer<float>> slice_loc{"slice_loc", 3};
+    Input<Buffer<float, 3>> splat_loc{"splat_loc"};
+    Input<Buffer<float, 3>> values{"values"};
+    Input<Buffer<float, 3>> slice_loc{"slice_loc"};
 
-    Output<Buffer<float>> output{"output", 3};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         // Algorithm

--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -7,10 +7,9 @@ class BilateralGrid : public Halide::Generator<BilateralGrid> {
 public:
     GeneratorParam<int> s_sigma{"s_sigma", 8};
 
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float, 2>> input{"input"};
     Input<float> r_sigma{"r_sigma"};
-
-    Output<Buffer<float>> bilateral_grid{"bilateral_grid", 2};
+    Output<Buffer<float, 2>> bilateral_grid{"bilateral_grid"};
 
     void generate() {
         Var x("x"), y("y"), z("z"), c("c");

--- a/apps/blur/halide_blur_generator.cpp
+++ b/apps/blur/halide_blur_generator.cpp
@@ -28,8 +28,8 @@ public:
     GeneratorParam<int> tile_x{"tile_x", 32};  // X tile.
     GeneratorParam<int> tile_y{"tile_y", 8};   // Y tile.
 
-    Input<Buffer<uint16_t>> input{"input", 2};
-    Output<Buffer<uint16_t>> blur_y{"blur_y", 2};
+    Input<Buffer<uint16_t, 2>> input{"input"};
+    Output<Buffer<uint16_t, 2>> blur_y{"blur_y"};
 
     void generate() {
         Func blur_x("blur_x");

--- a/apps/c_backend/pipeline_cpp_generator.cpp
+++ b/apps/c_backend/pipeline_cpp_generator.cpp
@@ -50,8 +50,8 @@ HalideExtern_2(int, an_extern_c_func, int, float);
 
 class PipelineCpp : public Halide::Generator<PipelineCpp> {
 public:
-    Input<Buffer<uint16_t>> input{"input", 2};
-    Output<Buffer<uint16_t>> output{"output", 2};
+    Input<Buffer<uint16_t, 2>> input{"input"};
+    Output<Buffer<uint16_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/apps/c_backend/pipeline_generator.cpp
+++ b/apps/c_backend/pipeline_generator.cpp
@@ -7,8 +7,8 @@ HalideExtern_2(int, an_extern_func, int, int);
 
 class Pipeline : public Halide::Generator<Pipeline> {
 public:
-    Input<Buffer<uint16_t>> input{"input", 2};
-    Output<Buffer<uint16_t>> output{"output", 2};
+    Input<Buffer<uint16_t, 2>> input{"input"};
+    Output<Buffer<uint16_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -216,17 +216,16 @@ public:
     // currently allow 8-bit computations
     GeneratorParam<Type> result_type{"result_type", UInt(8)};
 
-    Input<Buffer<uint16_t>> input{"input", 2};
-    Input<Buffer<float>> matrix_3200{"matrix_3200", 2};
-    Input<Buffer<float>> matrix_7000{"matrix_7000", 2};
+    Input<Buffer<uint16_t, 2>> input{"input"};
+    Input<Buffer<float, 2>> matrix_3200{"matrix_3200"};
+    Input<Buffer<float, 2>> matrix_7000{"matrix_7000"};
     Input<float> color_temp{"color_temp"};
     Input<float> gamma{"gamma"};
     Input<float> contrast{"contrast"};
     Input<float> sharpen_strength{"sharpen_strength"};
     Input<int> blackLevel{"blackLevel"};
     Input<int> whiteLevel{"whiteLevel"};
-
-    Output<Buffer<uint8_t>> processed{"processed", 3};
+    Output<Buffer<uint8_t, 3>> processed{"processed"};
 
     void generate();
 

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -6,11 +6,10 @@ using namespace Halide;
 
 class ConvolutionLayer : public Halide::Generator<ConvolutionLayer> {
 public:
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 128, CO = 128, W = 100, H = 80;

--- a/apps/cuda_mat_mul/mat_mul_generator.cpp
+++ b/apps/cuda_mat_mul/mat_mul_generator.cpp
@@ -15,10 +15,10 @@ void set_alignment_and_bounds(OutputImageParam p, int size) {
 class MatMul : public Halide::Generator<MatMul> {
 public:
     GeneratorParam<int> size{"size", 1024};
-    Input<Buffer<float>> A{"A", 2};
-    Input<Buffer<float>> B{"B", 2};
+    Input<Buffer<float, 2>> A{"A"};
+    Input<Buffer<float, 2>> B{"B"};
 
-    Output<Buffer<float>> out{"out", 2};
+    Output<Buffer<float, 2>> out{"out"};
 
     void generate() {
         // 688 us on an RTX 2060

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -8,19 +8,19 @@ using namespace Halide::BoundaryConditions;
 class DepthwiseSeparableConvolution : public Generator<DepthwiseSeparableConvolution> {
 public:
     // [in_channels, width, height, batch_size]
-    Input<Buffer<float>> input{"input", 4};
+    Input<Buffer<float, 4>> input{"input"};
 
     // [channel_multiplier, in_channels, filter_width, filter_height]
-    Input<Buffer<float>> depthwise_filter{"depthwise_filter", 4};
+    Input<Buffer<float, 4>> depthwise_filter{"depthwise_filter"};
 
     // [out_channels, channel_multiplier * in_channels]
-    Input<Buffer<float>> pointwise_filter{"pointwise_filter", 2};
+    Input<Buffer<float, 2>> pointwise_filter{"pointwise_filter"};
 
     // [out_channels]
-    Input<Buffer<float>> bias{"bias", 1};
+    Input<Buffer<float, 1>> bias{"bias"};
 
     // [out_channels, width, height, batch_size]
-    Output<Buffer<float>> output{"output", 4};
+    Output<Buffer<float, 4>> output{"output"};
 
     void generate() {
         // The algorithm. It will be a generic depthwise convolution,

--- a/apps/fft/fft_aot_test.cpp
+++ b/apps/fft/fft_aot_test.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
         auto in = real_buffer();
         for (int j = 0; j < kSize; j++) {
             for (int i = 0; i < kSize; i++) {
-                in(i, j) = signal_1d[i] + signal_1d[j];
+                in(i, j, 0) = signal_1d[i] + signal_1d[j];
             }
         }
 
@@ -155,7 +155,7 @@ int main(int argc, char **argv) {
 
         for (size_t j = 0; j < kSize; j++) {
             for (size_t i = 0; i < kSize; i++) {
-                float sample = out(i, j);
+                float sample = out(i, j, 0);
                 float expected = cos(2 * kPi * (i / 16.0f + .125f));
                 if (fabs(sample - expected) > .001) {
                     std::cerr << "fft_inverse_c2r mismatch at (" << i << ", " << j << ") " << sample << " vs. " << expected << "\n";

--- a/apps/fft/fft_aot_test.cpp
+++ b/apps/fft/fft_aot_test.cpp
@@ -19,27 +19,27 @@ const int32_t kSize = 16;
 
 using Halide::Runtime::Buffer;
 
-Buffer<float, 3> real_buffer(int32_t y_size = kSize) {
-    return Buffer<float, 3>::make_interleaved(kSize, y_size, 1);
+Buffer<float> real_buffer(int32_t y_size = kSize) {
+    return Buffer<float>::make_interleaved(kSize, y_size, 1);
 }
 
-Buffer<float, 3> complex_buffer(int32_t y_size = kSize) {
-    return Buffer<float, 3>::make_interleaved(kSize, y_size, 2);
+Buffer<float> complex_buffer(int32_t y_size = kSize) {
+    return Buffer<float>::make_interleaved(kSize, y_size, 2);
 }
 
-float &re(Buffer<float, 3> &b, int x, int y) {
+float &re(Buffer<float> &b, int x, int y) {
     return b(x, y, 0);
 }
 
-float &im(Buffer<float, 3> &b, int x, int y) {
+float &im(Buffer<float> &b, int x, int y) {
     return b(x, y, 1);
 }
 
-float re(const Buffer<float, 3> &b, int x, int y) {
+float re(const Buffer<float> &b, int x, int y) {
     return b(x, y, 0);
 }
 
-float im(const Buffer<float, 3> &b, int x, int y) {
+float im(const Buffer<float> &b, int x, int y) {
     return b(x, y, 1);
 }
 

--- a/apps/fft/fft_generator.cpp
+++ b/apps/fft/fft_generator.cpp
@@ -81,8 +81,8 @@ public:
     // Dim0: extent = size0, stride = 2
     // Dim1: extent = size1, stride = size0 * 2
     // Dim2: extent = 2, stride = 1 (real followed by imaginary components)
-    Input<Buffer<float>> input{"input", 3};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         _halide_user_assert(size0 > 0) << "FFT must be at least 1D\n";

--- a/apps/hannk/halide/conv_generator.cpp
+++ b/apps/hannk/halide/conv_generator.cpp
@@ -43,17 +43,17 @@ public:
     GeneratorParam<int> unroll_reduction_{"unroll_reduction", 4};
 
     // Unsigned 8-bit input tensor, indexed by c, x, y, b.
-    Input<Buffer<uint8_t>> input_{"input", 4};
+    Input<Buffer<uint8_t, 4>> input_{"input"};
     Input<uint8_t> input_zero_{"input_zero"};
 
     // A 6D array of filter coefficients indexed by ci % n, co % k, ci / n, co / k, x, y,
     // where n = vector_reduction and k = accum_vector_size (below).
-    Input<Buffer<>> filter_{"filter", 6};
+    Input<Buffer<void, 6>> filter_{"filter"};
     Input<uint8_t> filter_zero_{"filter_zero"};
 
     // A 1D array of 32-bit biases. The bias should be added to the c
     // dimension of the output.
-    Input<Buffer<int32_t>> bias_{"bias", 1};
+    Input<Buffer<int32_t, 1>> bias_{"bias"};
 
     // The stride specifies how the input [x, y] is sub-subsampled. For every
     // spatial location [x, y] in the output buffer, the input buffer is sampled
@@ -70,7 +70,7 @@ public:
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
-    Output<Buffer<>> output_{"output", 4};
+    Output<Buffer<void, 4>> output_{"output"};
 
     void configure() {
         if (use_8bit_multiply(target)) {
@@ -321,13 +321,13 @@ public:
 // The above generator expects the filter to already be tiled into
 class TileConvFilter : public Generator<TileConvFilter> {
 public:
-    Input<Buffer<uint8_t>> input_{"input", 4};
+    Input<Buffer<uint8_t, 4>> input_{"input"};
     Input<uint8_t> input_zero_{"input_zero"};
     Input<uint8_t> output_zero_{"output_zero"};
 
     // 6D array of filter coefficients indexed by ci % n, co % k, ci / n, co / k, x, y,
     // where n = vector_reduction and k = accum_vector_size (below).
-    Output<Buffer<>> output_{"output", 6};
+    Output<Buffer<void, 6>> output_{"output"};
 
     void configure() {
         if (use_8bit_multiply(target)) {

--- a/apps/hannk/halide/copy_generator.cpp
+++ b/apps/hannk/halide/copy_generator.cpp
@@ -9,11 +9,9 @@ namespace hannk {
 // TODO: It might be better to implement this in C++ and not Halide. It's a trivial pipeline.
 class Copy : public Generator<Copy> {
 public:
-    Input<Buffer<>> input_{"input", 4};
-
+    Input<Buffer<void, 4>> input_{"input"};
     Input<int> pad_value_{"pad_value"};
-
-    Output<Buffer<>> output_{"output", 4};
+    Output<Buffer<void, 4>> output_{"output"};
 
     void generate() {
         Var c("c"), x("x"), y("y"), b("b");

--- a/apps/hannk/halide/depthwise_conv_generator.cpp
+++ b/apps/hannk/halide/depthwise_conv_generator.cpp
@@ -20,15 +20,15 @@ public:
     GeneratorParam<bool> shallow_{"shallow", false};
 
     // Unsigned 8-bit input tensor, indexed by ci, x, y, b.
-    Input<Buffer<uint8_t>> input_{"input", 4};
+    Input<Buffer<uint8_t, 4>> input_{"input"};
     Input<uint8_t> input_zero_{"input_zero"};
 
     // A 3D array of 8-bit filter coefficients indexed by co, x, y.
-    Input<Buffer<uint8_t>> filter_{"filter", 3};
+    Input<Buffer<uint8_t, 3>> filter_{"filter"};
     Input<uint8_t> filter_zero_{"filter_zero"};
 
     // A 1D array of 32-bit biases indexed by co.
-    Input<Buffer<int32_t>> bias_{"bias", 1};
+    Input<Buffer<int32_t, 1>> bias_{"bias"};
 
     // The stride specifies how the input [x, y] are sub-subsampled. For every
     // spatial location [x, y] in the output buffer, the input buffer is sampled
@@ -51,7 +51,7 @@ public:
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
-    Output<Buffer<uint8_t>> output_{"output", 4};
+    Output<Buffer<uint8_t, 4>> output_{"output"};
 
     void generate() {
         // The algorithm.
@@ -244,13 +244,13 @@ public:
 class UpsampleChannels : public Generator<UpsampleChannels> {
 public:
     // Unsigned 8-bit input tensor, indexed by ci, x, y, b.
-    Input<Buffer<uint8_t>> input_{"input", 4};
+    Input<Buffer<uint8_t, 4>> input_{"input"};
 
     // The depth multiplier specifies the ratio between co and ci.
     Input<int> factor_{"factor"};
 
     // Unsigned 8-bit output tensor, indexed by co, x, y, b.
-    Output<Buffer<uint8_t>> output_{"output", 4};
+    Output<Buffer<uint8_t, 4>> output_{"output"};
 
     void generate() {
         Var x("x"), y("y"), c("c"), b("b");

--- a/apps/hannk/halide/elementwise_generator.cpp
+++ b/apps/hannk/halide/elementwise_generator.cpp
@@ -11,11 +11,11 @@ namespace hannk {
 class Add : public Generator<Add> {
 public:
     // Input buffers and quantization parameters.
-    Input<Buffer<uint8_t>> input1_{"input1", 2};
+    Input<Buffer<uint8_t, 2>> input1_{"input1"};
     Input<uint8_t> input1_zero_{"input1_zero"};
     Input<int16_t> input1_multiplier_{"input1_multiplier"};
 
-    Input<Buffer<uint8_t>> input2_{"input2", 2};
+    Input<Buffer<uint8_t, 2>> input2_{"input2"};
     Input<uint8_t> input2_zero_{"input2_zero"};
     Input<int16_t> input2_multiplier_{"input2_multiplier"};
 
@@ -23,7 +23,7 @@ public:
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
-    Output<Buffer<uint8_t>> output_{"output", 2};
+    Output<Buffer<uint8_t, 2>> output_{"output"};
 
     void generate() {
         Var x("x"), y("y");
@@ -61,10 +61,10 @@ public:
 
 class Mul : public Generator<Mul> {
 public:
-    Input<Buffer<uint8_t>> input1_{"input1", 2};
+    Input<Buffer<uint8_t, 2>> input1_{"input1"};
     Input<uint8_t> input1_zero_{"input1_zero"};
 
-    Input<Buffer<uint8_t>> input2_{"input2", 2};
+    Input<Buffer<uint8_t, 2>> input2_{"input2"};
     Input<uint8_t> input2_zero_{"input2_zero"};
 
     Input<uint8_t> output_zero_{"output_zero"};
@@ -73,7 +73,7 @@ public:
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
-    Output<Buffer<uint8_t>> output_{"output", 2};
+    Output<Buffer<uint8_t, 2>> output_{"output"};
 
     void generate() {
         Var x("x"), y("y");
@@ -122,13 +122,13 @@ public:
     GeneratorParam<Type> output3_type_{"output3_type", Int(0)};
 
     // An array of inputs.
-    Input<Buffer<>[]> inputs_ { "inputs", 2 };
+    Input<Buffer<void, 2>[]> inputs_ { "inputs" };
     // The program to run. See elementwise_program.h for a description of
     // this buffer.
-    Input<Buffer<int16_t>> program_{"program", 2};
+    Input<Buffer<int16_t, 2>> program_{"program"};
 
     // Type is determined by the GeneratorParams specified.
-    Output<Buffer<>> output_{"output", 2};
+    Output<Buffer<void, 2>> output_{"output"};
 
     void generate() {
         Var x("x"), y("y"), u("u");

--- a/apps/hannk/halide/fill_generator.cpp
+++ b/apps/hannk/halide/fill_generator.cpp
@@ -10,8 +10,7 @@ class Fill : public Generator<Fill> {
 public:
     // Value to fill the output with.
     Input<uint8_t> value_{"value"};
-
-    Output<Buffer<uint8_t>> output_{"output", 4};
+    Output<Buffer<uint8_t, 4>> output_{"output"};
 
     void generate() {
         Var c("c"), x("x"), y("y"), b("b");

--- a/apps/hannk/halide/normalizations_generator.cpp
+++ b/apps/hannk/halide/normalizations_generator.cpp
@@ -9,10 +9,10 @@ namespace hannk {
 
 class L2Normalization : public Generator<L2Normalization> {
 public:
-    Input<Buffer<uint8_t>> input_{"input", 2};
+    Input<Buffer<uint8_t, 2>> input_{"input"};
     Input<uint8_t> input_zero_{"input_zero"};
 
-    Output<Buffer<uint8_t>> output_{"output", 2};
+    Output<Buffer<uint8_t, 2>> output_{"output"};
 
     void generate() {
         Var x("x"), y("y");
@@ -61,7 +61,7 @@ public:
 
 class Softmax : public Generator<Softmax> {
 public:
-    Input<Buffer<uint8_t>> input_{"input", 2};
+    Input<Buffer<uint8_t, 2>> input_{"input"};
     // The beta multiplier and shift should have an extra factor of log2(e).
     Input<int16_t> beta_multiplier_{"beta_multiplier"};
     Input<uint16_t> beta_shift_{"beta_shift"};
@@ -69,7 +69,7 @@ public:
     Input<uint8_t> output_zero_{"output_zero"};
     Input<int16_t> output_multiplier_{"output_multiplier"};
     Input<uint16_t> output_shift_{"output_shift"};
-    Output<Buffer<uint8_t>> output_{"output", 2};
+    Output<Buffer<uint8_t, 2>> output_{"output"};
 
     void generate() {
         // The algorithm.

--- a/apps/hannk/halide/pool_generator.cpp
+++ b/apps/hannk/halide/pool_generator.cpp
@@ -10,7 +10,7 @@ namespace hannk {
 class AveragePool : public Generator<AveragePool> {
 public:
     // Unsigned 8-bit input tensor, indexed by c, x, y, b.
-    Input<Buffer<uint8_t>> input_{"input", 4};
+    Input<Buffer<uint8_t, 4>> input_{"input"};
 
     // The stride specifies how the input [x, y] are sub-subsampled. For every
     // spatial location [x, y] in the output buffer, the input buffer is sampled
@@ -23,7 +23,7 @@ public:
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
-    Output<Buffer<uint8_t>> output_{"output", 4};
+    Output<Buffer<uint8_t, 4>> output_{"output"};
 
     void generate() {
         // The algorithm.
@@ -96,7 +96,7 @@ public:
 class MaxPool : public Generator<MaxPool> {
 public:
     // Unsigned 8-bit input tensor, indexed by c, x, y, b.
-    Input<Buffer<uint8_t>> input_{"input", 4};
+    Input<Buffer<uint8_t, 4>> input_{"input"};
 
     // The stride specifies how the input [x, y] are sub-subsampled. For every
     // spatial location [x, y] in the output buffer, the input buffer is sampled
@@ -109,7 +109,7 @@ public:
     Input<uint8_t> output_min_{"output_min"};
     Input<uint8_t> output_max_{"output_max"};
 
-    Output<Buffer<uint8_t>> output_{"output", 4};
+    Output<Buffer<uint8_t, 4>> output_{"output"};
 
     void generate() {
         // The algorithm.

--- a/apps/hannk/halide/reductions_generator.cpp
+++ b/apps/hannk/halide/reductions_generator.cpp
@@ -8,7 +8,7 @@ namespace hannk {
 
 class Mean : public Generator<Mean> {
 public:
-    Input<Buffer<uint8_t>> input_{"input", 4};
+    Input<Buffer<uint8_t, 4>> input_{"input"};
 
     // The bounds of the region to reduce. This pipeline is
     // implemented as a stencil over this reach at each output.
@@ -23,7 +23,7 @@ public:
     Input<int> b_min_{"b_min"};
     Input<int> b_extent_{"b_extent"};
 
-    Output<Buffer<uint8_t>> output_{"output", 4};
+    Output<Buffer<uint8_t, 4>> output_{"output"};
 
     void generate() {
         // The algorithm.

--- a/apps/hannk/util/buffer_util.h
+++ b/apps/hannk/util/buffer_util.h
@@ -14,7 +14,7 @@ namespace hannk {
 // Using a Buffer with space for max_rank dimensions is a meaningful
 // win for some corner cases (when adding dimensions to > 4).
 template<typename T>
-using HalideBuffer = Halide::Runtime::Buffer<T, max_rank>;
+using HalideBuffer = Halide::Runtime::Buffer<T, Halide::Runtime::Buffer<>::DynamicDims, max_rank>;
 
 // dynamic_type_dispatch is a utility for functors that want to be able
 // to dynamically dispatch a halide_type_t to type-specialized code.

--- a/apps/harris/harris_generator.cpp
+++ b/apps/harris/harris_generator.cpp
@@ -12,8 +12,8 @@ Expr sum3x3(Func f, Var x, Var y) {
 
 class Harris : public Halide::Generator<Harris> {
 public:
-    Input<Buffer<float>> input{"input", 3};
-    Output<Buffer<float>> output{"output", 2};
+    Input<Buffer<float, 3>> input{"input"};
+    Output<Buffer<float, 2>> output{"output"};
 
     void generate() {
         Var x("x"), y("y"), c("c");

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -6,10 +6,10 @@ class Conv3x3 : public Generator<Conv3x3> {
 public:
     GeneratorParam<Type> accumulator_type{"accumulator_type", Int(16)};
     // Takes an 8 bit image; one channel.
-    Input<Buffer<uint8_t>> input{"input", 2};
-    Input<Buffer<int8_t>> mask{"mask", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
+    Input<Buffer<int8_t, 2>> mask{"mask"};
     // Outputs an 8 bit image; one channel.
-    Output<Buffer<uint8_t>> output{"output", 2};
+    Output<Buffer<uint8_t, 2>> output{"output"};
 
     GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
     GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};

--- a/apps/hexagon_benchmarks/conv3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/conv3x3_generator.cpp
@@ -52,7 +52,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -5,9 +5,9 @@ using namespace Halide;
 class Dilate3x3 : public Generator<Dilate3x3> {
 public:
     // Takes an 8 bit image; one channel.
-    Input<Buffer<uint8_t>> input{"input", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
     // Outputs an 8 bit image; one channel.
-    Output<Buffer<uint8_t>> output{"output", 2};
+    Output<Buffer<uint8_t, 2>> output{"output"};
 
     GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
     GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};

--- a/apps/hexagon_benchmarks/dilate3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/dilate3x3_generator.cpp
@@ -45,7 +45,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -4,8 +4,8 @@ using namespace Halide;
 
 class Gaussian5x5 : public Generator<Gaussian5x5> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 2};
-    Output<Buffer<uint8_t>> output{"output", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
+    Output<Buffer<uint8_t, 2>> output{"output"};
 
     GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
     GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};

--- a/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
+++ b/apps/hexagon_benchmarks/gaussian5x5_generator.cpp
@@ -52,7 +52,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -10,9 +10,9 @@ private:
 
 public:
     // Takes an 8 bit image; one channel.
-    Input<Buffer<uint8_t>> input{"input", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
     // Outputs an 8 bit image; one channel.
-    Output<Buffer<uint8_t>> output{"output", 2};
+    Output<Buffer<uint8_t, 2>> output{"output"};
 
     GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
     GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};

--- a/apps/hexagon_benchmarks/median3x3_generator.cpp
+++ b/apps/hexagon_benchmarks/median3x3_generator.cpp
@@ -56,7 +56,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -50,7 +50,7 @@ public:
                 .vectorize(xi)
                 .unroll(yi);
             if (use_prefetch_sched) {
-                output.prefetch(input, y, 2);
+                output.prefetch(input, y, y, 2);
             }
             if (use_parallel_sched) {
                 Var yo;

--- a/apps/hexagon_benchmarks/sobel_generator.cpp
+++ b/apps/hexagon_benchmarks/sobel_generator.cpp
@@ -4,8 +4,8 @@ using namespace Halide;
 
 class Sobel : public Generator<Sobel> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 2};
-    Output<Buffer<uint8_t>> output{"output", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
+    Output<Buffer<uint8_t, 2>> output{"output"};
 
     GeneratorParam<bool> use_parallel_sched{"use_parallel_sched", true};
     GeneratorParam<bool> use_prefetch_sched{"use_prefetch_sched", true};

--- a/apps/hexagon_dma/pipeline_raw_linear_interleaved_basic.cpp
+++ b/apps/hexagon_dma/pipeline_raw_linear_interleaved_basic.cpp
@@ -6,8 +6,8 @@ using namespace Halide;
 // 2, and (optionally) writes it back via DMA.
 class DmaPipeline : public Generator<DmaPipeline> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 3};
-    Output<Buffer<uint8_t>> output{"output", 3};
+    Input<Buffer<uint8_t, 3>> input{"input"};
+    Output<Buffer<uint8_t, 3>> output{"output"};
 
     enum class Schedule { Basic,
                           Fold,

--- a/apps/hist/hist_generator.cpp
+++ b/apps/hist/hist_generator.cpp
@@ -6,8 +6,8 @@ using namespace Halide::ConciseCasts;
 
 class Hist : public Halide::Generator<Hist> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 3};
-    Output<Buffer<uint8_t>> output{"output", 3};
+    Input<Buffer<uint8_t, 3>> input{"input"};
+    Output<Buffer<uint8_t, 3>> output{"output"};
 
     void generate() {
         Var x("x"), y("y"), c("c");

--- a/apps/iir_blur/iir_blur_generator.cpp
+++ b/apps/iir_blur/iir_blur_generator.cpp
@@ -133,12 +133,12 @@ class IirBlur : public Generator<IirBlur> {
 public:
     // This is the input image: a 3D (color) image with 32 bit float
     // pixels.
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     // The filter coefficient, alpha is the weight of the input to the
     // filter.
     Input<float> alpha{"alpha"};
 
-    Output<Buffer<float>> output{"output", 3};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Expr width = input.width();

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -14,8 +14,8 @@ class Interpolate : public Halide::Generator<Interpolate> {
 public:
     GeneratorParam<int> levels{"levels", 10};
 
-    Input<Buffer<float>> input{"input", 3};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Var x("x"), y("y"), c("c");

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -8,8 +8,8 @@ using namespace Halide;
 
 class LensBlur : public Halide::Generator<LensBlur> {
 public:
-    Input<Buffer<uint8_t>> left_im{"left_im", 3};
-    Input<Buffer<uint8_t>> right_im{"right_im", 3};
+    Input<Buffer<uint8_t, 3>> left_im{"left_im"};
+    Input<Buffer<uint8_t, 3>> right_im{"right_im"};
     // The number of displacements to consider
     Input<int> slices{"slices", 32, 1, 64};
     // The depth to focus on
@@ -19,7 +19,7 @@ public:
     // The number of samples of the aperture to use
     Input<int> aperture_samples{"aperture_samples", 32, 1, 64};
 
-    Output<Buffer<float>> final{"final", 3};
+    Output<Buffer<float, 3>> final{"final"};
 
     void generate() {
         /* THE ALGORITHM */

--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -18,17 +18,17 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1024};
-    GeneratorParam<bool> scale_x_ = {"scale_x", true};
-    GeneratorParam<bool> add_to_y_ = {"add_to_y", true};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<int> block_size_{"block_size", 1024};
+    GeneratorParam<bool> scale_x_{"scale_x", true};
+    GeneratorParam<bool> add_to_y_{"add_to_y", true};
 
     // Standard ordering of parameters in AXPY functions.
-    Input<T> a_ = {"a", 1};
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<T> a_{"a", 1};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> result_ = {"result", 1};
+    Output<Buffer<T>> result_{"result", 1};
 
     template<class Arg>
     Expr calc(Arg i) {
@@ -82,14 +82,14 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1024};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1024};
 
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> result_ = {"result", 0};
+    Output<Buffer<T>> result_{"result", 0};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));
@@ -136,13 +136,13 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1024};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1024};
 
-    Input<Buffer<T>> x_ = {"x", 1};
+    Input<Buffer<T>> x_{"x", 1};
 
-    Output<Buffer<T>> result_ = {"result", 0};
+    Output<Buffer<T>> result_{"result", 0};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));

--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -25,10 +25,10 @@ public:
 
     // Standard ordering of parameters in AXPY functions.
     Input<T> a_{"a", 1};
-    Input<Buffer<T>> x_{"x", 1};
-    Input<Buffer<T>> y_{"y", 1};
+    Input<Buffer<T, 1>> x_{"x"};
+    Input<Buffer<T, 1>> y_{"y"};
 
-    Output<Buffer<T>> result_{"result", 1};
+    Output<Buffer<T, 1>> result_{"result"};
 
     template<class Arg>
     Expr calc(Arg i) {
@@ -86,10 +86,10 @@ public:
     GeneratorParam<bool> parallel_{"parallel", true};
     GeneratorParam<int> block_size_{"block_size", 1024};
 
-    Input<Buffer<T>> x_{"x", 1};
-    Input<Buffer<T>> y_{"y", 1};
+    Input<Buffer<T, 1>> x_{"x"};
+    Input<Buffer<T, 1>> y_{"y"};
 
-    Output<Buffer<T>> result_{"result", 0};
+    Output<Buffer<T, 0>> result_{"result"};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));
@@ -140,9 +140,9 @@ public:
     GeneratorParam<bool> parallel_{"parallel", true};
     GeneratorParam<int> block_size_{"block_size", 1024};
 
-    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T, 1>> x_{"x"};
 
-    Output<Buffer<T>> result_{"result", 0};
+    Output<Buffer<T, 0>> result_{"result"};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -18,19 +18,19 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1 << 8};
-    GeneratorParam<bool> transpose_ = {"transpose", false};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1 << 8};
+    GeneratorParam<bool> transpose_{"transpose", false};
 
     // Standard ordering of parameters in GEMV functions.
-    Input<T> a_ = {"a", 1};
-    Input<Buffer<T>> A_ = {"A", 2};
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<T> b_ = {"b", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<T> a_{"a", 1};
+    Input<Buffer<T>> A_{"A", 2};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<T> b_{"b", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> output_ = {"output", 1};
+    Output<Buffer<T>> output_{"output", 1};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));
@@ -209,16 +209,16 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> vectorize_ = {"vectorize", true};
-    GeneratorParam<bool> parallel_ = {"parallel", true};
-    GeneratorParam<int> block_size_ = {"block_size", 1 << 5};
+    GeneratorParam<bool> vectorize_{"vectorize", true};
+    GeneratorParam<bool> parallel_{"parallel", true};
+    GeneratorParam<int> block_size_{"block_size", 1 << 5};
 
     // Standard ordering of parameters in GEMV functions.
-    Input<T> a_ = {"a", 1};
-    Input<Buffer<T>> x_ = {"x", 1};
-    Input<Buffer<T>> y_ = {"y", 1};
+    Input<T> a_{"a", 1};
+    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T>> y_{"y", 1};
 
-    Output<Buffer<T>> result_ = {"result", 2};
+    Output<Buffer<T>> result_{"result", 2};
 
     void generate() {
         const int vec_size = vectorize_ ? natural_vector_size(type_of<T>()) : 1;

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -25,12 +25,12 @@ public:
 
     // Standard ordering of parameters in GEMV functions.
     Input<T> a_{"a", 1};
-    Input<Buffer<T>> A_{"A", 2};
-    Input<Buffer<T>> x_{"x", 1};
+    Input<Buffer<T, 2>> A_{"A"};
+    Input<Buffer<T, 1>> x_{"x"};
     Input<T> b_{"b", 1};
-    Input<Buffer<T>> y_{"y", 1};
+    Input<Buffer<T, 1>> y_{"y"};
 
-    Output<Buffer<T>> output_{"output", 1};
+    Output<Buffer<T, 1>> output_{"output"};
 
     void generate() {
         assert(get_target().has_feature(Target::NoBoundsQuery));
@@ -215,10 +215,10 @@ public:
 
     // Standard ordering of parameters in GEMV functions.
     Input<T> a_{"a", 1};
-    Input<Buffer<T>> x_{"x", 1};
-    Input<Buffer<T>> y_{"y", 1};
+    Input<Buffer<T, 1>> x_{"x"};
+    Input<Buffer<T, 1>> y_{"y"};
 
-    Output<Buffer<T>> result_{"result", 2};
+    Output<Buffer<T, 2>> result_{"result"};
 
     void generate() {
         const int vec_size = vectorize_ ? natural_vector_size(type_of<T>()) : 1;

--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -18,17 +18,17 @@ public:
     template<typename T2>
     using Output = typename Base::template Output<T2>;
 
-    GeneratorParam<bool> transpose_A_ = {"transpose_A", false};
-    GeneratorParam<bool> transpose_B_ = {"transpose_B", false};
+    GeneratorParam<bool> transpose_A_{"transpose_A", false};
+    GeneratorParam<bool> transpose_B_{"transpose_B", false};
 
     // Standard ordering of parameters in GEMM functions.
-    Input<T> a_ = {"a_", 1};
-    Input<Buffer<T>> A_ = {"A_", 2};
-    Input<Buffer<T>> B_ = {"B_", 2};
-    Input<T> b_ = {"b_", 1};
-    Input<Buffer<T>> C_ = {"C_", 2};
+    Input<T> a_{"a_", 1};
+    Input<Buffer<T>> A_{"A_", 2};
+    Input<Buffer<T>> B_{"B_", 2};
+    Input<T> b_{"b_", 1};
+    Input<Buffer<T>> C_{"C_", 2};
 
-    Output<Buffer<T>> result_ = {"result", 2};
+    Output<Buffer<T>> result_{"result", 2};
 
     void generate() {
         // Matrices are interpreted as column-major by default. The

--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -23,12 +23,12 @@ public:
 
     // Standard ordering of parameters in GEMM functions.
     Input<T> a_{"a_", 1};
-    Input<Buffer<T>> A_{"A_", 2};
-    Input<Buffer<T>> B_{"B_", 2};
+    Input<Buffer<T, 2>> A_{"A_"};
+    Input<Buffer<T, 2>> B_{"B_"};
     Input<T> b_{"b_", 1};
-    Input<Buffer<T>> C_{"C_", 2};
+    Input<Buffer<T, 2>> C_{"C_"};
 
-    Output<Buffer<T>> result_{"result", 2};
+    Output<Buffer<T, 2>> result_{"result"};
 
     void generate() {
         // Matrices are interpreted as column-major by default. The
@@ -41,8 +41,8 @@ public:
         const int vec = std::max(4, natural_vector_size(a_.type()));
         const int s = vec * 2;
 
-        Input<Buffer<T>> *A_in = &A_;
-        Input<Buffer<T>> *B_in = &B_;
+        Input<Buffer<T, 2>> *A_in = &A_;
+        Input<Buffer<T, 2>> *B_in = &B_;
 
         // If they're both transposed, then reverse the order and transpose the result instead.
         const bool transpose_AB = (bool)transpose_A_ && (bool)transpose_B_;

--- a/apps/linear_algebra/src/halide_blas.cpp
+++ b/apps/linear_algebra/src/halide_blas.cpp
@@ -5,10 +5,12 @@
 
 using Halide::Runtime::Buffer;
 
-#define assert_no_error(func)                                           \
-    if (func != 0) {                                                    \
-        std::cerr << "ERROR! Halide kernel returned non-zero value.\n"; \
-    }
+#define assert_no_error(func)                                               \
+    do {                                                                    \
+        if (func != 0) {                                                    \
+            std::cerr << "ERROR! Halide kernel returned non-zero value.\n"; \
+        }                                                                   \
+    } while (0)
 
 namespace {
 

--- a/apps/linear_blur/linear_blur_generator.cpp
+++ b/apps/linear_blur/linear_blur_generator.cpp
@@ -6,8 +6,8 @@
 namespace {
 
 struct LinearBlur : public Halide::Generator<LinearBlur> {
-    Input<Buffer<float>> input{"input", 3};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Var x("x"), y("y"), c("c");

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -9,12 +9,11 @@ class LocalLaplacian : public Halide::Generator<LocalLaplacian> {
 public:
     GeneratorParam<int> pyramid_levels{"pyramid_levels", 8, 1, maxJ};
 
-    Input<Buffer<uint16_t>> input{"input", 3};
+    Input<Buffer<uint16_t, 3>> input{"input"};
     Input<int> levels{"levels"};
     Input<float> alpha{"alpha"};
     Input<float> beta{"beta"};
-
-    Output<Buffer<uint16_t>> output{"output", 3};
+    Output<Buffer<uint16_t, 3>> output{"output"};
 
     void generate() {
         /* THE ALGORITHM */

--- a/apps/max_filter/max_filter_generator.cpp
+++ b/apps/max_filter/max_filter_generator.cpp
@@ -8,8 +8,8 @@ using namespace Halide::BoundaryConditions;
 class Max : public Halide::Generator<Max> {
 public:
     GeneratorParam<int> radius_{"radius", 26};
-    Input<Buffer<float>> input_{"input", 3};
-    Output<Buffer<float>> output_{"output", 3};
+    Input<Buffer<float, 3>> input_{"input"};
+    Output<Buffer<float, 3>> output_{"output"};
 
     void generate() {
         Var x("x"), y("y"), c("c"), t("t");

--- a/apps/nl_means/nl_means_generator.cpp
+++ b/apps/nl_means/nl_means_generator.cpp
@@ -6,12 +6,12 @@ using namespace Halide;
 
 class NonLocalMeans : public Halide::Generator<NonLocalMeans> {
 public:
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     Input<int> patch_size{"patch_size"};
     Input<int> search_area{"search_area"};
     Input<float> sigma{"sigma"};
 
-    Output<Buffer<float>> non_local_means{"non_local_means", 3};
+    Output<Buffer<float, 3>> non_local_means{"non_local_means"};
 
     void generate() {
         /* THE ALGORITHM */

--- a/apps/resize/resize_generator.cpp
+++ b/apps/resize/resize_generator.cpp
@@ -63,9 +63,9 @@ public:
     // resample in x and in y).
     GeneratorParam<bool> upsample{"upsample", false};
 
-    Input<Buffer<>> input{"input", 3};
+    Input<Buffer<void, 3>> input{"input"};
     Input<float> scale_factor{"scale_factor"};
-    Output<Buffer<>> output{"output", 3};
+    Output<Buffer<void, 3>> output{"output"};
 
     // Common Vars
     Var x, y, c, k;

--- a/apps/resnet_50/Resnet50Generator.cpp
+++ b/apps/resnet_50/Resnet50Generator.cpp
@@ -28,42 +28,42 @@ int find_index(int value, std::vector<int> vec) {
 
 class Resnet50Generator : public Halide::Generator<Resnet50Generator> {
 public:
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     /** parameter values for scaling layers **/
-    Input<Buffer<float>> conv1_gamma{"conv1_gamma", 1};
-    Input<Buffer<float>[4]> br1_gamma { "br1_gamma", 1 };
-    Input<Buffer<float>[16]> br2a_gamma { "br2a_gamma", 1 };
-    Input<Buffer<float>[16]> br2b_gamma { "br2b_gamma", 1 };
-    Input<Buffer<float>[16]> br2c_gamma { "br2c_gamma", 1 };
+    Input<Buffer<float, 1>> conv1_gamma{"conv1_gamma"};
+    Input<Buffer<float, 1>[4]> br1_gamma { "br1_gamma" };
+    Input<Buffer<float, 1>[16]> br2a_gamma { "br2a_gamma" };
+    Input<Buffer<float, 1>[16]> br2b_gamma { "br2b_gamma" };
+    Input<Buffer<float, 1>[16]> br2c_gamma { "br2c_gamma" };
 
-    Input<Buffer<float>> conv1_beta{"conv1_beta", 1};
-    Input<Buffer<float>[4]> br1_beta { "br1_beta", 1 };
-    Input<Buffer<float>[16]> br2a_beta { "br2a_beta", 1 };
-    Input<Buffer<float>[16]> br2b_beta { "br2b_beta", 1 };
-    Input<Buffer<float>[16]> br2c_beta { "br2c_beta", 1 };
+    Input<Buffer<float, 1>> conv1_beta{"conv1_beta"};
+    Input<Buffer<float, 1>[4]> br1_beta { "br1_beta" };
+    Input<Buffer<float, 1>[16]> br2a_beta { "br2a_beta" };
+    Input<Buffer<float, 1>[16]> br2b_beta { "br2b_beta" };
+    Input<Buffer<float, 1>[16]> br2c_beta { "br2c_beta" };
 
-    Input<Buffer<float>> conv1_mu{"conv1_mu", 1};
-    Input<Buffer<float>[4]> br1_mu { "br1_mu", 1 };
-    Input<Buffer<float>[16]> br2a_mu { "br2a_mu", 1 };
-    Input<Buffer<float>[16]> br2b_mu { "br2b_mu", 1 };
-    Input<Buffer<float>[16]> br2c_mu { "br2c_mu", 1 };
+    Input<Buffer<float, 1>> conv1_mu{"conv1_mu"};
+    Input<Buffer<float, 1>[4]> br1_mu { "br1_mu" };
+    Input<Buffer<float, 1>[16]> br2a_mu { "br2a_mu" };
+    Input<Buffer<float, 1>[16]> br2b_mu { "br2b_mu" };
+    Input<Buffer<float, 1>[16]> br2c_mu { "br2c_mu" };
 
-    Input<Buffer<float>> conv1_sig{"conv1_sig", 1};
-    Input<Buffer<float>[4]> br1_sig { "br1_sig", 1 };
-    Input<Buffer<float>[16]> br2a_sig { "br2a_sig", 1 };
-    Input<Buffer<float>[16]> br2b_sig { "br2b_sig", 1 };
-    Input<Buffer<float>[16]> br2c_sig { "br2c_sig", 1 };
+    Input<Buffer<float, 1>> conv1_sig{"conv1_sig"};
+    Input<Buffer<float, 1>[4]> br1_sig { "br1_sig" };
+    Input<Buffer<float, 1>[16]> br2a_sig { "br2a_sig" };
+    Input<Buffer<float, 1>[16]> br2b_sig { "br2b_sig" };
+    Input<Buffer<float, 1>[16]> br2c_sig { "br2c_sig" };
 
     /** weights and biases for convolutions **/
-    Input<Buffer<float>> conv1_weights{"conv1_weights", 4};
-    Input<Buffer<float>[4]> br1_conv_weights { "br1_conv_weights", 4 };
-    Input<Buffer<float>[16]> br2a_conv_weights { "br2a_conv_weights", 4 };
-    Input<Buffer<float>[16]> br2b_conv_weights { "br2b_conv_weights", 4 };
-    Input<Buffer<float>[16]> br2c_conv_weights { "br2c_conv_weights", 4 };
+    Input<Buffer<float, 4>> conv1_weights{"conv1_weights"};
+    Input<Buffer<float, 4>[4]> br1_conv_weights { "br1_conv_weights" };
+    Input<Buffer<float, 4>[16]> br2a_conv_weights { "br2a_conv_weights" };
+    Input<Buffer<float, 4>[16]> br2b_conv_weights { "br2b_conv_weights" };
+    Input<Buffer<float, 4>[16]> br2c_conv_weights { "br2c_conv_weights" };
 
-    Input<Buffer<float>> fc1000_weights{"fc1000_weights", 2};
-    Input<Buffer<float>> fc1000_bias{"fc1000_bias", 1};
-    Output<Buffer<float>> final_output{"final_output", 1};
+    Input<Buffer<float, 2>> fc1000_weights{"fc1000_weights"};
+    Input<Buffer<float, 1>> fc1000_bias{"fc1000_bias"};
+    Output<Buffer<float, 1>> final_output{"final_output"};
 
     /** list out shapes of each layers weights **/
     // weight shapes: out channels, kernel_w, kernel_h, pad, stride. In channels infered by input tensor shape
@@ -378,6 +378,6 @@ private:
         return output;
     }
 };
-}  //namespace
+}  // namespace
 
 HALIDE_REGISTER_GENERATOR(Resnet50Generator, resnet50)

--- a/apps/stencil_chain/stencil_chain_generator.cpp
+++ b/apps/stencil_chain/stencil_chain_generator.cpp
@@ -6,8 +6,8 @@ class StencilChain : public Halide::Generator<StencilChain> {
 public:
     GeneratorParam<int> stencils{"stencils", 32, 1, 100};
 
-    Input<Buffer<uint16_t>> input{"input", 2};
-    Output<Buffer<uint16_t>> output{"output", 2};
+    Input<Buffer<uint16_t, 2>> input{"input"};
+    Output<Buffer<uint16_t, 2>> output{"output"};
 
     void generate() {
 

--- a/apps/unsharp/unsharp_generator.cpp
+++ b/apps/unsharp/unsharp_generator.cpp
@@ -6,8 +6,8 @@ class Unsharp : public Halide::Generator<Unsharp> {
 public:
     GeneratorParam<float> sigma{"sigma", 1.5f};
 
-    Input<Buffer<float>> input{"input", 3};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Var x("x"), y("y"), c("c");

--- a/apps/wavelet/daubechies_x_generator.cpp
+++ b/apps/wavelet/daubechies_x_generator.cpp
@@ -8,8 +8,8 @@ Halide::Var x("x"), y("y"), c("c");
 
 class daubechies_x : public Halide::Generator<daubechies_x> {
 public:
-    Input<Buffer<float>> in_{"in", 2};
-    Output<Buffer<float>> out_{"out", 3};
+    Input<Buffer<float, 2>> in_{"in"};
+    Output<Buffer<float, 3>> out_{"out"};
 
     void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/apps/wavelet/haar_x_generator.cpp
+++ b/apps/wavelet/haar_x_generator.cpp
@@ -8,8 +8,8 @@ Halide::Var x("x"), y("y"), c("c");
 
 class haar_x : public Halide::Generator<haar_x> {
 public:
-    Input<Buffer<float>> in_{"in", 2};
-    Output<Buffer<float>> out_{"out", 3};
+    Input<Buffer<float, 2>> in_{"in"};
+    Output<Buffer<float, 3>> out_{"out"};
 
     void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/apps/wavelet/inverse_daubechies_x_generator.cpp
+++ b/apps/wavelet/inverse_daubechies_x_generator.cpp
@@ -8,8 +8,8 @@ Halide::Var x("x"), y("y"), c("c");
 
 class inverse_daubechies_x : public Halide::Generator<inverse_daubechies_x> {
 public:
-    Input<Buffer<float>> in_{"in", 3};
-    Output<Buffer<float>> out_{"out", 2};
+    Input<Buffer<float, 3>> in_{"in"};
+    Output<Buffer<float, 2>> out_{"out"};
 
     void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/apps/wavelet/inverse_haar_x_generator.cpp
+++ b/apps/wavelet/inverse_haar_x_generator.cpp
@@ -8,8 +8,8 @@ Halide::Var x("x"), y("y"), c("c");
 
 class inverse_haar_x : public Halide::Generator<inverse_haar_x> {
 public:
-    Input<Buffer<float>> in_{"in", 3};
-    Output<Buffer<float>> out_{"out", 2};
+    Input<Buffer<float, 3>> in_{"in"};
+    Output<Buffer<float, 2>> out_{"out"};
 
     void generate() {
         Func in = Halide::BoundaryConditions::repeat_edge(in_);

--- a/python_bindings/correctness/addconstant_generator.cpp
+++ b/python_bindings/correctness/addconstant_generator.cpp
@@ -16,31 +16,31 @@ public:
     Input<float> constant_float{"constant_float"};
     Input<double> constant_double{"constant_double"};
 
-    Input<Buffer<uint8_t>> input_uint8{"input_uint8", 1};
-    Input<Buffer<uint16_t>> input_uint16{"input_uint16", 1};
-    Input<Buffer<uint32_t>> input_uint32{"input_uint32", 1};
-    Input<Buffer<uint64_t>> input_uint64{"input_uint64", 1};
-    Input<Buffer<int8_t>> input_int8{"input_int8", 1};
-    Input<Buffer<int16_t>> input_int16{"input_int16", 1};
-    Input<Buffer<int32_t>> input_int32{"input_int32", 1};
-    Input<Buffer<int64_t>> input_int64{"input_int64", 1};
-    Input<Buffer<float>> input_float{"input_float", 1};
-    Input<Buffer<double>> input_double{"input_double", 1};
-    Input<Buffer<int8_t>> input_2d{"input_2d", 2};
-    Input<Buffer<int8_t>> input_3d{"input_3d", 3};
+    Input<Buffer<uint8_t, 1>> input_uint8{"input_uint8"};
+    Input<Buffer<uint16_t, 1>> input_uint16{"input_uint16"};
+    Input<Buffer<uint32_t, 1>> input_uint32{"input_uint32"};
+    Input<Buffer<uint64_t, 1>> input_uint64{"input_uint64"};
+    Input<Buffer<int8_t, 1>> input_int8{"input_int8"};
+    Input<Buffer<int16_t, 1>> input_int16{"input_int16"};
+    Input<Buffer<int32_t, 1>> input_int32{"input_int32"};
+    Input<Buffer<int64_t, 1>> input_int64{"input_int64"};
+    Input<Buffer<float, 1>> input_float{"input_float"};
+    Input<Buffer<double, 1>> input_double{"input_double"};
+    Input<Buffer<int8_t, 2>> input_2d{"input_2d"};
+    Input<Buffer<int8_t, 3>> input_3d{"input_3d"};
 
-    Output<Buffer<uint8_t>> output_uint8{"output_uint8", 1};
-    Output<Buffer<uint16_t>> output_uint16{"output_uint16", 1};
-    Output<Buffer<uint32_t>> output_uint32{"output_uint32", 1};
-    Output<Buffer<uint64_t>> output_uint64{"output_uint64", 1};
-    Output<Buffer<int8_t>> output_int8{"output_int8", 1};
-    Output<Buffer<int16_t>> output_int16{"output_int16", 1};
-    Output<Buffer<int32_t>> output_int32{"output_int32", 1};
-    Output<Buffer<int64_t>> output_int64{"output_int64", 1};
-    Output<Buffer<float>> output_float{"output_float", 1};
-    Output<Buffer<double>> output_double{"output_double", 1};
-    Output<Buffer<int8_t>> output_2d{"buffer_2d", 2};
-    Output<Buffer<int8_t>> output_3d{"buffer_3d", 3};
+    Output<Buffer<uint8_t, 1>> output_uint8{"output_uint8"};
+    Output<Buffer<uint16_t, 1>> output_uint16{"output_uint16"};
+    Output<Buffer<uint32_t, 1>> output_uint32{"output_uint32"};
+    Output<Buffer<uint64_t, 1>> output_uint64{"output_uint64"};
+    Output<Buffer<int8_t, 1>> output_int8{"output_int8"};
+    Output<Buffer<int16_t, 1>> output_int16{"output_int16"};
+    Output<Buffer<int32_t, 1>> output_int32{"output_int32"};
+    Output<Buffer<int64_t, 1>> output_int64{"output_int64"};
+    Output<Buffer<float, 1>> output_float{"output_float"};
+    Output<Buffer<double, 1>> output_double{"output_double"};
+    Output<Buffer<int8_t, 2>> output_2d{"buffer_2d"};
+    Output<Buffer<int8_t, 3>> output_3d{"buffer_3d"};
 
     Var x, y, z;
 

--- a/python_bindings/correctness/bit_generator.cpp
+++ b/python_bindings/correctness/bit_generator.cpp
@@ -4,10 +4,9 @@ using namespace Halide;
 
 class BitGenerator : public Halide::Generator<BitGenerator> {
 public:
-    Input<Buffer<bool>> bit_input{"input_uint1", 1};
+    Input<Buffer<bool, 1>> bit_input{"input_uint1"};
     Input<bool> bit_constant{"constant_uint1"};
-
-    Output<Buffer<bool>> bit_output{"output_uint1", 1};
+    Output<Buffer<bool, 1>> bit_output{"output_uint1"};
 
     Var x, y, z;
 

--- a/python_bindings/correctness/complexstub_generator.cpp
+++ b/python_bindings/correctness/complexstub_generator.cpp
@@ -21,7 +21,7 @@ public:
     GeneratorParam<bool> vectorize{"vectorize", true};
     GeneratorParam<LoopLevel> intermediate_level{"intermediate_level", LoopLevel::root()};
 
-    Input<Buffer<uint8_t>> typed_buffer_input{"typed_buffer_input", 3};
+    Input<Buffer<uint8_t, 3>> typed_buffer_input{"typed_buffer_input"};
     Input<Buffer<>> untyped_buffer_input{"untyped_buffer_input"};
     Input<Func> simple_input{"simple_input", 3};  // require a 3-dimensional Func but leave Type unspecified
     Input<Func[]> array_input{"array_input", 3};  // require a 3-dimensional Func but leave Type and ArraySize unspecified
@@ -34,7 +34,7 @@ public:
     Output<Func[]> array_output{"array_output", Int(16), 2};  // leave ArraySize unspecified
     Output<Buffer<float>> typed_buffer_output{"typed_buffer_output"};
     Output<Buffer<>> untyped_buffer_output{"untyped_buffer_output"};
-    Output<Buffer<uint8_t>> static_compiled_buffer_output{"static_compiled_buffer_output", 3};
+    Output<Buffer<uint8_t, 3>> static_compiled_buffer_output{"static_compiled_buffer_output"};
 
     void configure() {
         // Pointers returned by add_input() are managed by the Generator;

--- a/python_bindings/correctness/nobuildmethod_generator.cpp
+++ b/python_bindings/correctness/nobuildmethod_generator.cpp
@@ -7,10 +7,9 @@ class NoBuildMethod : public Halide::Generator<NoBuildMethod> {
 public:
     GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
 
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float, 2>> input{"input"};
     Input<float> runtime_factor{"runtime_factor", 1.0};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/python_bindings/correctness/partialbuildmethod_generator.cpp
+++ b/python_bindings/correctness/partialbuildmethod_generator.cpp
@@ -12,7 +12,7 @@ class PartialBuildMethod : public Halide::Generator<PartialBuildMethod> {
 public:
     GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
 
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float, 2>> input{"input"};
     Input<float> runtime_factor{"runtime_factor", 1.0};
 
     Func build() {

--- a/python_bindings/correctness/simplestub_generator.cpp
+++ b/python_bindings/correctness/simplestub_generator.cpp
@@ -7,7 +7,7 @@ public:
     GeneratorParam<int> offset{"offset", 0};
     GeneratorParam<LoopLevel> compute_level{"compute_level", LoopLevel::root()};
 
-    Input<Buffer<uint8_t>> buffer_input{"buffer_input", 2};
+    Input<Buffer<uint8_t, 2>> buffer_input{"buffer_input"};
     Input<Func> func_input{"func_input", 2};  // require a 2-dimensional Func but leave Type unspecified
     Input<float> float_arg{"float_arg", 1.0f, 0.0f, 100.0f};
 

--- a/python_bindings/correctness/user_context_generator.cpp
+++ b/python_bindings/correctness/user_context_generator.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 class UserContextGenerator : public Halide::Generator<UserContextGenerator> {
 public:
     Input<uint8_t> constant{"constant"};
-    Output<Buffer<uint8_t>> output{"output", 1};
+    Output<Buffer<uint8_t, 1>> output{"output"};
 
     Var x;
 

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -393,7 +393,7 @@ void define_buffer(py::module &m) {
                 py::arg("dirty") = true)
 
             .def("copy", &Buffer<>::copy)
-            .def("copy_from", &Buffer<>::copy_from<void>)
+            .def("copy_from", &Buffer<>::copy_from<void, Buffer<>::DynamicDims>)
 
             .def("add_dimension", (void (Buffer<>::*)()) & Buffer<>::add_dimension)
 

--- a/src/Argument.h
+++ b/src/Argument.h
@@ -12,7 +12,7 @@
 
 namespace Halide {
 
-template<typename T>
+template<typename T, int Dims>
 class Buffer;
 
 struct ArgumentEstimates {
@@ -78,8 +78,8 @@ struct Argument {
     // Not explicit, so that you can put Buffer in an argument list,
     // to indicate that it shouldn't be baked into the object file,
     // but instead received as an argument at runtime
-    template<typename T>
-    Argument(Buffer<T> im)
+    template<typename T, int Dims>
+    Argument(Buffer<T, Dims> im)
         : name(im.name()),
           kind(InputBuffer),
           dimensions(im.dimensions()),

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -8,7 +8,7 @@
 
 namespace Halide {
 
-template<typename T = void>
+template<typename T = void, int Dims = -1>
 class Buffer;
 
 struct JITUserContext;
@@ -108,20 +108,23 @@ std::string buffer_type_name() {
 /** A Halide::Buffer is a named shared reference to a
  * Halide::Runtime::Buffer.
  *
- * A Buffer<T1> can refer to a Buffer<T2> if T1 is const whenever T2
- * is const, and either T1 = T2 or T1 is void. A Buffer<void> can
+ * A Buffer<T1, D> can refer to a Buffer<T2, D> if T1 is const whenever T2
+ * is const, and either T1 = T2 or T1 is void. A Buffer<void, D> can
  * refer to any Buffer of any non-const type, and the default
  * template parameter is T = void.
+ *
+ * A Buffer<T, D1> can refer to a Buffer<T, D2> if D1 == D2,
+ * or if D1 is -1 (meaning "dimensionality is checked at runtime, not compiletime").
  */
-template<typename T>
+template<typename T, int Dims>
 class Buffer {
     Internal::IntrusivePtr<Internal::BufferContents> contents;
 
-    template<typename T2>
+    template<typename T2, int D2>
     friend class Buffer;
 
-    template<typename T2>
-    static void assert_can_convert_from(const Buffer<T2> &other) {
+    template<typename T2, int D2>
+    static void assert_can_convert_from(const Buffer<T2, D2> &other) {
         if (!other.defined()) {
             // Avoid UB of deferencing offset of a null contents ptr
             static_assert((!std::is_const<T2>::value || std::is_const<T>::value),
@@ -131,6 +134,8 @@ class Buffer {
                               std::is_void<T>::value ||
                               std::is_void<T2>::value,
                           "type mismatch constructing Buffer");
+            static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2,
+                          "Can't convert from a Buffer with static dimensionality to a Buffer with different static dimensionality");
         } else {
             // Don't delegate to
             // Runtime::Buffer<T>::assert_can_convert_from. It might
@@ -139,7 +144,8 @@ class Buffer {
             // debugging symbols are found, it throws an exception
             // when exceptions are enabled, and we can print the
             // actual types in question.
-            user_assert(Runtime::Buffer<T>::can_convert_from(*(other.get())))
+            using BufType = Runtime::Buffer<T, Dims>;  // alias because commas in user_assert() macro confuses compiler
+            user_assert(BufType::can_convert_from(*(other.get())))
                 << "Type mismatch constructing Buffer. Can't construct Buffer<"
                 << Internal::buffer_type_name<T>() << "> from Buffer<"
                 << type_to_c_type(other.type(), false) << ">\n";
@@ -147,6 +153,9 @@ class Buffer {
     }
 
 public:
+    static constexpr int DynamicDims = -1;
+    static_assert(Dims == DynamicDims || Dims >= 0);
+
     typedef T ElemType;
 
     // This class isn't final (and is subclassed from the Python binding
@@ -166,22 +175,22 @@ public:
     Buffer &operator=(Buffer &&) noexcept = default;
 
     /** Make a Buffer from a Buffer of a different type */
-    template<typename T2>
-    Buffer(const Buffer<T2> &other)
+    template<typename T2, int D2>
+    Buffer(const Buffer<T2, D2> &other)
         : contents(other.contents) {
         assert_can_convert_from(other);
     }
 
     /** Move construct from a Buffer of a different type */
-    template<typename T2>
-    Buffer(Buffer<T2> &&other) noexcept {
+    template<typename T2, int D2>
+    Buffer(Buffer<T2, D2> &&other) noexcept {
         assert_can_convert_from(other);
         contents = std::move(other.contents);
     }
 
     /** Construct a Buffer that captures and owns an rvalue Runtime::Buffer */
-    template<int D>
-    Buffer(Runtime::Buffer<T, D> &&buf, const std::string &name = "")
+    template<int D2>
+    Buffer(Runtime::Buffer<T, D2> &&buf, const std::string &name = "")
         : contents(new Internal::BufferContents) {
         contents->buf = std::move(buf);
         if (name.empty()) {
@@ -200,50 +209,50 @@ public:
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(Type t,
                     int first, Args... rest)
-        : Buffer(Runtime::Buffer<T>(t, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(t, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
     explicit Buffer(const halide_buffer_t &buf,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(buf), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(buf), name) {
     }
 
     template<typename... Args,
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(int first, Args... rest)
-        : Buffer(Runtime::Buffer<T>(Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
     explicit Buffer(Type t,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, sizes), name) {
     }
 
     explicit Buffer(Type t,
                     const std::vector<int> &sizes,
                     const std::vector<int> &storage_order,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, sizes, storage_order), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, sizes, storage_order), name) {
     }
 
     explicit Buffer(const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(sizes), name) {
     }
 
     explicit Buffer(const std::vector<int> &sizes,
                     const std::vector<int> &storage_order,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(sizes, storage_order), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(sizes, storage_order), name) {
     }
 
     template<typename Array, size_t N>
     explicit Buffer(Array (&vals)[N],
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(vals), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(vals), name) {
     }
 
     template<typename... Args,
@@ -251,7 +260,7 @@ public:
     explicit Buffer(Type t,
                     Internal::add_const_if_T_is_const<T, void> *data,
                     int first, Args &&...rest)
-        : Buffer(Runtime::Buffer<T>(t, data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
@@ -261,28 +270,28 @@ public:
                     Internal::add_const_if_T_is_const<T, void> *data,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, data, sizes, name)) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, sizes, name)) {
     }
 
     template<typename... Args,
              typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
     explicit Buffer(T *data,
                     int first, Args &&...rest)
-        : Buffer(Runtime::Buffer<T>(data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
+        : Buffer(Runtime::Buffer<T, Dims>(data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
     }
 
     explicit Buffer(T *data,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(data, sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(data, sizes), name) {
     }
 
     explicit Buffer(Type t,
                     Internal::add_const_if_T_is_const<T, void> *data,
                     const std::vector<int> &sizes,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, data, sizes), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, sizes), name) {
     }
 
     explicit Buffer(Type t,
@@ -290,66 +299,60 @@ public:
                     int d,
                     const halide_dimension_t *shape,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(t, data, d, shape), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(t, data, d, shape), name) {
     }
 
     explicit Buffer(T *data,
                     int d,
                     const halide_dimension_t *shape,
                     const std::string &name = "")
-        : Buffer(Runtime::Buffer<T>(data, d, shape), name) {
+        : Buffer(Runtime::Buffer<T, Dims>(data, d, shape), name) {
     }
 
-    static Buffer<T> make_scalar(const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_scalar(), name);
+    static Buffer<T, Dims> make_scalar(const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_scalar(), name);
     }
 
     static Buffer<> make_scalar(Type t, const std::string &name = "") {
         return Buffer<>(Runtime::Buffer<>::make_scalar(t), name);
     }
 
-    static Buffer<T> make_scalar(T *data, const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_scalar(data), name);
+    static Buffer<T, Dims> make_scalar(T *data, const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_scalar(data), name);
     }
 
-    static Buffer<T> make_interleaved(int width, int height, int channels, const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_interleaved(width, height, channels),
-                         name);
+    static Buffer<T, Dims> make_interleaved(int width, int height, int channels, const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_interleaved(width, height, channels), name);
     }
 
     static Buffer<> make_interleaved(Type t, int width, int height, int channels, const std::string &name = "") {
-        return Buffer<>(Runtime::Buffer<>::make_interleaved(t, width, height, channels),
-                        name);
+        return Buffer<>(Runtime::Buffer<>::make_interleaved(t, width, height, channels), name);
     }
 
-    static Buffer<T> make_interleaved(T *data, int width, int height, int channels, const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_interleaved(data, width, height, channels),
-                         name);
+    static Buffer<T, Dims> make_interleaved(T *data, int width, int height, int channels, const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_interleaved(data, width, height, channels), name);
     }
 
     static Buffer<Internal::add_const_if_T_is_const<T, void>>
     make_interleaved(Type t, T *data, int width, int height, int channels, const std::string &name = "") {
         using T2 = Internal::add_const_if_T_is_const<T, void>;
-        return Buffer<T2>(Runtime::Buffer<T2>::make_interleaved(t, data, width, height, channels),
-                          name);
+        return Buffer<T2, Dims>(Runtime::Buffer<T2, Dims>::make_interleaved(t, data, width, height, channels), name);
     }
 
-    template<typename T2>
-    static Buffer<T> make_with_shape_of(Buffer<T2> src,
-                                        void *(*allocate_fn)(size_t) = nullptr,
-                                        void (*deallocate_fn)(void *) = nullptr,
-                                        const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_with_shape_of(*src.get(), allocate_fn, deallocate_fn),
-                         name);
+    template<typename T2, int D2>
+    static Buffer<T, Dims> make_with_shape_of(Buffer<T2, D2> src,
+                                              void *(*allocate_fn)(size_t) = nullptr,
+                                              void (*deallocate_fn)(void *) = nullptr,
+                                              const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_with_shape_of(*src.get(), allocate_fn, deallocate_fn), name);
     }
 
-    template<typename T2>
-    static Buffer<T> make_with_shape_of(const Runtime::Buffer<T2> &src,
-                                        void *(*allocate_fn)(size_t) = nullptr,
-                                        void (*deallocate_fn)(void *) = nullptr,
-                                        const std::string &name = "") {
-        return Buffer<T>(Runtime::Buffer<T>::make_with_shape_of(src, allocate_fn, deallocate_fn),
-                         name);
+    template<typename T2, int D2>
+    static Buffer<T, Dims> make_with_shape_of(const Runtime::Buffer<T2, D2> &src,
+                                              void *(*allocate_fn)(size_t) = nullptr,
+                                              void (*deallocate_fn)(void *) = nullptr,
+                                              const std::string &name = "") {
+        return Buffer<T, Dims>(Runtime::Buffer<T, Dims>::make_with_shape_of(src, allocate_fn, deallocate_fn), name);
     }
     // @}
 
@@ -365,8 +368,8 @@ public:
     // @}
 
     /** Check if two Buffer objects point to the same underlying Buffer */
-    template<typename T2>
-    bool same_as(const Buffer<T2> &other) const {
+    template<typename T2, int D2>
+    bool same_as(const Buffer<T2, D2> &other) const {
         return (const void *)(contents.get()) == (const void *)(other.contents.get());
     }
 
@@ -379,28 +382,28 @@ public:
 
     /** Get a pointer to the underlying Runtime::Buffer */
     // @{
-    Runtime::Buffer<T> *get() {
+    Runtime::Buffer<T, Dims> *get() {
         // It's already type-checked, so no need to use as<T>.
-        return (Runtime::Buffer<T> *)(&contents->buf);
+        return (Runtime::Buffer<T, Dims> *)(&contents->buf);
     }
-    const Runtime::Buffer<T> *get() const {
-        return (const Runtime::Buffer<T> *)(&contents->buf);
+    const Runtime::Buffer<T, Dims> *get() const {
+        return (const Runtime::Buffer<T, Dims> *)(&contents->buf);
     }
     // @}
 
     // We forward numerous methods from the underlying Buffer
-#define HALIDE_BUFFER_FORWARD_CONST(method)                                                                                     \
-    template<typename... Args>                                                                                                  \
-    auto method(Args &&...args) const->decltype(std::declval<const Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
-        user_assert(defined()) << "Undefined buffer calling const method " #method "\n";                                        \
-        return get()->method(std::forward<Args>(args)...);                                                                      \
+#define HALIDE_BUFFER_FORWARD_CONST(method)                                                                                           \
+    template<typename... Args>                                                                                                        \
+    auto method(Args &&...args) const->decltype(std::declval<const Runtime::Buffer<T, Dims>>().method(std::forward<Args>(args)...)) { \
+        user_assert(defined()) << "Undefined buffer calling const method " #method "\n";                                              \
+        return get()->method(std::forward<Args>(args)...);                                                                            \
     }
 
-#define HALIDE_BUFFER_FORWARD(method)                                                                               \
-    template<typename... Args>                                                                                      \
-    auto method(Args &&...args)->decltype(std::declval<Runtime::Buffer<T>>().method(std::forward<Args>(args)...)) { \
-        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                                  \
-        return get()->method(std::forward<Args>(args)...);                                                          \
+#define HALIDE_BUFFER_FORWARD(method)                                                                                     \
+    template<typename... Args>                                                                                            \
+    auto method(Args &&...args)->decltype(std::declval<Runtime::Buffer<T, Dims>>().method(std::forward<Args>(args)...)) { \
+        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                                        \
+        return get()->method(std::forward<Args>(args)...);                                                                \
     }
 
 // This is a weird-looking but effective workaround for a deficiency in "perfect forwarding":
@@ -413,10 +416,10 @@ public:
 // and forward it as is, we can just use ... to allow an arbitrary number of commas,
 // then use __VA_ARGS__ to forward the mess as-is, and while it looks horrible, it
 // works.
-#define HALIDE_BUFFER_FORWARD_INITIALIZER_LIST(method, ...)                                            \
-    inline auto method(const __VA_ARGS__ &a)->decltype(std::declval<Runtime::Buffer<T>>().method(a)) { \
-        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                     \
-        return get()->method(a);                                                                       \
+#define HALIDE_BUFFER_FORWARD_INITIALIZER_LIST(method, ...)                                                  \
+    inline auto method(const __VA_ARGS__ &a)->decltype(std::declval<Runtime::Buffer<T, Dims>>().method(a)) { \
+        user_assert(defined()) << "Undefined buffer calling method " #method "\n";                           \
+        return get()->method(a);                                                                             \
     }
 
     /** Does the same thing as the equivalent Halide::Runtime::Buffer method */
@@ -475,44 +478,50 @@ public:
 #undef HALIDE_BUFFER_FORWARD_CONST
 
     template<typename Fn, typename... Args>
-    Buffer<T> &for_each_value(Fn &&f, Args... other_buffers) {
+    Buffer<T, Dims> &for_each_value(Fn &&f, Args... other_buffers) {
         get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...);
         return *this;
     }
 
     template<typename Fn, typename... Args>
-    const Buffer<T> &for_each_value(Fn &&f, Args... other_buffers) const {
+    const Buffer<T, Dims> &for_each_value(Fn &&f, Args... other_buffers) const {
         get()->for_each_value(std::forward<Fn>(f), (*std::forward<Args>(other_buffers).get())...);
         return *this;
     }
 
     template<typename Fn>
-    Buffer<T> &for_each_element(Fn &&f) {
+    Buffer<T, Dims> &for_each_element(Fn &&f) {
         get()->for_each_element(std::forward<Fn>(f));
         return *this;
     }
 
     template<typename Fn>
-    const Buffer<T> &for_each_element(Fn &&f) const {
+    const Buffer<T, Dims> &for_each_element(Fn &&f) const {
         get()->for_each_element(std::forward<Fn>(f));
         return *this;
     }
 
     template<typename FnOrValue>
-    Buffer<T> &fill(FnOrValue &&f) {
+    Buffer<T, Dims> &fill(FnOrValue &&f) {
         get()->fill(std::forward<FnOrValue>(f));
         return *this;
     }
 
-    static constexpr bool has_static_halide_type = Runtime::Buffer<T>::has_static_halide_type;
+    static constexpr bool has_static_halide_type = Runtime::Buffer<T, Dims>::has_static_halide_type;
 
     static halide_type_t static_halide_type() {
-        return Runtime::Buffer<T>::static_halide_type();
+        return Runtime::Buffer<T, Dims>::static_halide_type();
     }
 
-    template<typename T2>
-    static bool can_convert_from(const Buffer<T2> &other) {
-        return Halide::Runtime::Buffer<T>::can_convert_from(*other.get());
+    static constexpr bool has_static_dimensions = Runtime::Buffer<T, Dims>::has_static_dimensions;
+
+    static int static_dimensions() {
+        return Runtime::Buffer<T, Dims>::static_dimensions();
+    }
+
+    template<typename T2, int D2>
+    static bool can_convert_from(const Buffer<T2, D2> &other) {
+        return Halide::Runtime::Buffer<T, Dims>::can_convert_from(*other.get());
     }
 
     // Note that since Runtime::Buffer stores halide_type_t rather than Halide::Type,
@@ -524,42 +533,42 @@ public:
     }
 
     template<typename T2>
-    Buffer<T2> as() const {
-        return Buffer<T2>(*this);
+    Buffer<T2, Dims> as() const {
+        return Buffer<T2, Dims>(*this);
     }
 
-    Buffer<T> copy() const {
-        return Buffer<T>(std::move(contents->buf.as<T>().copy()));
+    Buffer<T, Dims> copy() const {
+        return Buffer<T, Dims>(std::move(contents->buf.as<T>().copy()));
     }
 
-    template<typename T2>
-    void copy_from(const Buffer<T2> &other) {
+    template<typename T2, int D2>
+    void copy_from(const Buffer<T2, D2> &other) {
         contents->buf.copy_from(*other.get());
     }
 
     template<typename... Args>
-    auto operator()(int first, Args &&...args) -> decltype(std::declval<Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
+    auto operator()(int first, Args &&...args) -> decltype(std::declval<Runtime::Buffer<T, Dims>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 
     template<typename... Args>
-    auto operator()(int first, Args &&...args) const -> decltype(std::declval<const Runtime::Buffer<T>>()(first, std::forward<Args>(args)...)) {
+    auto operator()(int first, Args &&...args) const -> decltype(std::declval<const Runtime::Buffer<T, Dims>>()(first, std::forward<Args>(args)...)) {
         return (*get())(first, std::forward<Args>(args)...);
     }
 
-    auto operator()(const int *pos) -> decltype(std::declval<Runtime::Buffer<T>>()(pos)) {
+    auto operator()(const int *pos) -> decltype(std::declval<Runtime::Buffer<T, Dims>>()(pos)) {
         return (*get())(pos);
     }
 
-    auto operator()(const int *pos) const -> decltype(std::declval<const Runtime::Buffer<T>>()(pos)) {
+    auto operator()(const int *pos) const -> decltype(std::declval<const Runtime::Buffer<T, Dims>>()(pos)) {
         return (*get())(pos);
     }
 
-    auto operator()() -> decltype(std::declval<Runtime::Buffer<T>>()()) {
+    auto operator()() -> decltype(std::declval<Runtime::Buffer<T, Dims>>()()) {
         return (*get())();
     }
 
-    auto operator()() const -> decltype(std::declval<const Runtime::Buffer<T>>()()) {
+    auto operator()() const -> decltype(std::declval<const Runtime::Buffer<T, Dims>>()()) {
         return (*get())();
     }
     // @}

--- a/src/Closure.h
+++ b/src/Closure.h
@@ -8,14 +8,12 @@
 #include <map>
 #include <string>
 
+#include "Buffer.h"
 #include "IR.h"
 #include "IRVisitor.h"
 #include "Scope.h"
 
 namespace Halide {
-
-template<typename T>
-class Buffer;
 
 namespace Internal {
 
@@ -66,7 +64,7 @@ public:
 
 protected:
     void found_buffer_ref(const std::string &name, Type type,
-                          bool read, bool written, const Halide::Buffer<void> &image);
+                          bool read, bool written, const Halide::Buffer<> &image);
 
 public:
     Closure() = default;

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -76,6 +76,10 @@ const WasmIntrinsic intrinsic_defs[] = {
     {"llvm.wasm.avgr.unsigned.v16i8", UInt(8, 16), "rounding_halving_add", {UInt(8, 16), UInt(8, 16)}, Target::WasmSimd128},
     {"llvm.wasm.avgr.unsigned.v8i16", UInt(16, 8), "rounding_halving_add", {UInt(16, 8), UInt(16, 8)}, Target::WasmSimd128},
 
+#if LLVM_VERSION == 130
+    {"float_to_double", Float(64, 4), "float_to_double", {Float(32, 4)}, Target::WasmSimd128},
+#endif
+
 #if LLVM_VERSION >= 130
     // With some work, some of these could possibly be adapted to work under earlier versions of LLVM.
     {"widening_mul_i8x16", Int(16, 16), "widening_mul", {Int(8, 16), Int(8, 16)}, Target::WasmSimd128},
@@ -93,14 +97,6 @@ const WasmIntrinsic intrinsic_defs[] = {
     // since the result will be the same for our purposes here
     {"llvm.wasm.extadd.pairwise.unsigned.v8i16", Int(16, 8), "pairwise_widening_add", {UInt(8, 16)}, Target::WasmSimd128},
     {"llvm.wasm.extadd.pairwise.unsigned.v4i32", Int(32, 4), "pairwise_widening_add", {UInt(16, 8)}, Target::WasmSimd128},
-
-    // TODO: these instructions are no longer available at LLVM top of tree,
-    // but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions;
-    // investigation needed.
-    // {"i32_to_double_s", Float(64, 4), "int_to_double", {Int(32, 4)}, Target::WasmSimd128},
-    // {"i32_to_double_u", Float(64, 4), "int_to_double", {UInt(32, 4)}, Target::WasmSimd128},
-
-    {"float_to_double", Float(64, 4), "float_to_double", {Float(32, 4)}, Target::WasmSimd128},
 
     // Basically like ARM's SQRDMULH
     {"llvm.wasm.q15mulr.sat.signed", Int(16, 8), "q15mulr_sat_s", {Int(16, 8), Int(16, 8)}, Target::WasmSimd128},
@@ -157,7 +153,9 @@ void CodeGen_WebAssembly::visit(const Cast *op) {
         {"saturating_narrow", u16_sat(wild_i32x_), Target::WasmSimd128},
         {"int_to_double", f64(wild_i32x_), Target::WasmSimd128},
         {"int_to_double", f64(wild_u32x_), Target::WasmSimd128},
+#if LLVM_VERSION == 130
         {"float_to_double", f64(wild_f32x_), Target::WasmSimd128},
+#endif
     };
     // clang-format on
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2259,7 +2259,7 @@ void generator_test() {
             Input<Func> input_func_typed{"input_func_typed", Int(16), 1};
             Input<Func> input_func_untyped{"input_func_untyped", 1};
             Input<Func[]> input_func_array{"input_func_array", 1};
-            Input<Buffer<uint8_t>> input_buffer_typed{"input_buffer_typed", 3};
+            Input<Buffer<uint8_t, 3>> input_buffer_typed{"input_buffer_typed"};
             Input<Buffer<>> input_buffer_untyped{"input_buffer_untyped"};
             Output<Func> output{"output", Float(32), 1};
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1678,10 +1678,15 @@ public:
                 TBase::has_static_dimensions ? TBase::static_dimensions() : -1) {
     }
 
-    GeneratorInput_Buffer(const std::string &name, const Type &t, int d = -1)
+    GeneratorInput_Buffer(const std::string &name, const Type &t, int d)
         : Super(name, IOKind::Buffer, {t}, d) {
         static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Input<Buffer<T>> if T is void or omitted.");
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Input<Buffer<T, D>> if D is -1 or omitted.");
+    }
+
+    GeneratorInput_Buffer(const std::string &name, const Type &t)
+        : Super(name, IOKind::Buffer, {t}, -1) {
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Input<Buffer<T>> if T is void or omitted.");
     }
 
     GeneratorInput_Buffer(const std::string &name, int d)

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2477,58 +2477,58 @@ private:
 protected:
     using TBase = typename Super::TBase;
 
-    static std::vector<Type> my_types(const std::vector<Type> &t) {
-        if (TBase::has_static_halide_type) {
-            user_assert(t.empty()) << "Cannot pass a Type argument for an Output<Buffer> with a non-void static type\n";
-            return std::vector<Type>{TBase::static_halide_type()};
-        }
-        return t;
-    }
-
     explicit GeneratorOutput_Buffer(const std::string &name)
-        : Super(name, IOKind::Buffer, my_types({}), -1) {
+        : Super(name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                TBase::has_static_dimensions ? TBase::static_dimensions() : -1) {
     }
 
     GeneratorOutput_Buffer(const std::string &name, const std::vector<Type> &t, int d)
-        : Super(name, IOKind::Buffer, my_types(t), d) {
+        : Super(name, IOKind::Buffer, t, d) {
         internal_assert(!t.empty());
         internal_assert(d != -1);
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }
 
     GeneratorOutput_Buffer(const std::string &name, const std::vector<Type> &t)
-        : Super(name, IOKind::Buffer, my_types(t), -1) {
+        : Super(name, IOKind::Buffer, t, -1) {
         internal_assert(!t.empty());
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
     }
 
     GeneratorOutput_Buffer(const std::string &name, int d)
-        : Super(name, IOKind::Buffer, my_types({}), d) {
+        : Super(name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                d) {
         internal_assert(d != -1);
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name)
-        : Super(array_size, name, IOKind::Buffer, my_types({}), -1) {
+        : Super(array_size, name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                TBase::has_static_dimensions ? TBase::static_dimensions() : -1) {
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name, const std::vector<Type> &t, int d)
-        : Super(array_size, name, IOKind::Buffer, my_types(t), d) {
+        : Super(array_size, name, IOKind::Buffer, t, d) {
         internal_assert(!t.empty());
         internal_assert(d != -1);
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name, const std::vector<Type> &t)
-        : Super(array_size, name, IOKind::Buffer, my_types(t), -1) {
+        : Super(array_size, name, IOKind::Buffer, t, -1) {
         internal_assert(!t.empty());
-        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T>> if T is void or omitted.");
+        static_assert(!TBase::has_static_halide_type, "You can only specify a Type argument for Output<Buffer<T, D>> if T is void or omitted.");
     }
 
     GeneratorOutput_Buffer(size_t array_size, const std::string &name, int d)
-        : Super(array_size, name, IOKind::Buffer, my_types({}), d) {
+        : Super(array_size, name, IOKind::Buffer,
+                TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
+                d) {
         internal_assert(d != -1);
         static_assert(!TBase::has_static_dimensions, "You can only specify a dimension argument for Output<Buffer<T, D>> if D is -1 or omitted.");
     }

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1676,7 +1676,7 @@ protected:
     }
 
 public:
-    GeneratorInput_Buffer(const std::string &name)
+    explicit GeneratorInput_Buffer(const std::string &name)
         : Super(name, IOKind::Buffer,
                 TBase::has_static_halide_type ? std::vector<Type>{TBase::static_halide_type()} : std::vector<Type>{},
                 -1) {
@@ -1834,7 +1834,7 @@ public:
     }
 
     // unspecified type & dimension
-    GeneratorInput_Func(const std::string &name)
+    explicit GeneratorInput_Func(const std::string &name)
         : Super(name, IOKind::Function, {}, -1) {
     }
 
@@ -2166,56 +2166,59 @@ protected:
             Internal::cond<true, Unused>>::type;
 
 public:
+    // Mark all of these explicit (not just single-arg versions) so that
+    // we disallow copy-list-initialization form (i.e., Input foo{"foo"} is ok,
+    // but Input foo = {"foo"} is not).
     explicit GeneratorInput(const std::string &name)
         : Super(name) {
     }
 
-    GeneratorInput(const std::string &name, const TBase &def)
+    explicit GeneratorInput(const std::string &name, const TBase &def)
         : Super(name, def) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name, const TBase &def)
+    explicit GeneratorInput(size_t array_size, const std::string &name, const TBase &def)
         : Super(array_size, name, def) {
     }
 
-    GeneratorInput(const std::string &name,
-                   const TBase &def, const TBase &min, const TBase &max)
+    explicit GeneratorInput(const std::string &name,
+                            const TBase &def, const TBase &min, const TBase &max)
         : Super(name, def, min, max) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name,
-                   const TBase &def, const TBase &min, const TBase &max)
+    explicit GeneratorInput(size_t array_size, const std::string &name,
+                            const TBase &def, const TBase &min, const TBase &max)
         : Super(array_size, name, def, min, max) {
     }
 
-    GeneratorInput(const std::string &name, const Type &t, int d)
+    explicit GeneratorInput(const std::string &name, const Type &t, int d)
         : Super(name, t, d) {
     }
 
-    GeneratorInput(const std::string &name, const Type &t)
+    explicit GeneratorInput(const std::string &name, const Type &t)
         : Super(name, t) {
     }
 
     // Avoid ambiguity between Func-with-dim and int-with-default
-    GeneratorInput(const std::string &name, IntIfNonScalar d)
+    explicit GeneratorInput(const std::string &name, IntIfNonScalar d)
         : Super(name, d) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name, const Type &t, int d)
+    explicit GeneratorInput(size_t array_size, const std::string &name, const Type &t, int d)
         : Super(array_size, name, t, d) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name, const Type &t)
+    explicit GeneratorInput(size_t array_size, const std::string &name, const Type &t)
         : Super(array_size, name, t) {
     }
 
     // Avoid ambiguity between Func-with-dim and int-with-default
     // template <typename T2 = T, typename std::enable_if<std::is_same<TBase, Func>::value>::type * = nullptr>
-    GeneratorInput(size_t array_size, const std::string &name, IntIfNonScalar d)
+    explicit GeneratorInput(size_t array_size, const std::string &name, IntIfNonScalar d)
         : Super(array_size, name, d) {
     }
 
-    GeneratorInput(size_t array_size, const std::string &name)
+    explicit GeneratorInput(size_t array_size, const std::string &name)
         : Super(array_size, name) {
     }
 };
@@ -2598,7 +2601,7 @@ private:
 protected:
     using TBase = typename Super::TBase;
 
-    GeneratorOutput_Func(const std::string &name)
+    explicit GeneratorOutput_Func(const std::string &name)
         : Super(name, IOKind::Function, std::vector<Type>{}, -1) {
     }
 
@@ -2692,6 +2695,9 @@ protected:
     using TBase = typename Super::TBase;
 
 public:
+    // Mark all of these explicit (not just single-arg versions) so that
+    // we disallow copy-list-initialization form (i.e., Output foo{"foo"} is ok,
+    // but Output foo = {"foo"} is not).
     explicit GeneratorOutput(const std::string &name)
         : Super(name) {
     }
@@ -2700,31 +2706,47 @@ public:
         : GeneratorOutput(std::string(name)) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name)
+    explicit GeneratorOutput(size_t array_size, const std::string &name)
         : Super(array_size, name) {
     }
 
-    GeneratorOutput(const std::string &name, int d)
+    explicit GeneratorOutput(const std::string &name, int d)
         : Super(name, {}, d) {
     }
 
-    GeneratorOutput(const std::string &name, const Type &t, int d)
+    explicit GeneratorOutput(const std::string &name, const Type &t)
+        : Super(name, {t}) {
+    }
+
+    explicit GeneratorOutput(const std::string &name, const std::vector<Type> &t)
+        : Super(name, t) {
+    }
+
+    explicit GeneratorOutput(const std::string &name, const Type &t, int d)
         : Super(name, {t}, d) {
     }
 
-    GeneratorOutput(const std::string &name, const std::vector<Type> &t, int d)
+    explicit GeneratorOutput(const std::string &name, const std::vector<Type> &t, int d)
         : Super(name, t, d) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name, int d)
+    explicit GeneratorOutput(size_t array_size, const std::string &name, int d)
         : Super(array_size, name, {}, d) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name, const Type &t, int d)
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const Type &t)
+        : Super(array_size, name, {t}) {
+    }
+
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const std::vector<Type> &t)
+        : Super(array_size, name, t) {
+    }
+
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const Type &t, int d)
         : Super(array_size, name, {t}, d) {
     }
 
-    GeneratorOutput(size_t array_size, const std::string &name, const std::vector<Type> &t, int d)
+    explicit GeneratorOutput(size_t array_size, const std::string &name, const std::vector<Type> &t, int d)
         : Super(array_size, name, t, d) {
     }
 

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -293,17 +293,9 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
             } else if (target.os == Target::IOS) {
                 return llvm::DataLayout("e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:128-n8:16:32-S128");
             } else if (target.os == Target::Windows && !target.has_feature(Target::JIT)) {
-#if LLVM_VERSION >= 140
-                return llvm::DataLayout("e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32-a:0:32-S32");
-#else
                 return llvm::DataLayout("e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:32-n8:16:32-a:0:32-S32");
-#endif
             } else if (target.os == Target::Windows) {
-#if LLVM_VERSION >= 140
-                return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32-a:0:32-S32");
-#else
                 return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:32-n8:16:32-a:0:32-S32");
-#endif
             } else {
                 // Linux/Android
                 return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128");

--- a/src/Module.h
+++ b/src/Module.h
@@ -19,7 +19,7 @@
 
 namespace Halide {
 
-template<typename T>
+template<typename T, int Dims>
 class Buffer;
 struct Target;
 

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -6,6 +6,7 @@
  */
 #include <string>
 
+#include "Buffer.h"
 #include "IntrusivePtr.h"
 #include "Type.h"
 #include "Util.h"                   // for HALIDE_NO_USER_CODE_INLINE
@@ -14,8 +15,6 @@
 namespace Halide {
 
 struct ArgumentEstimates;
-template<typename T>
-class Buffer;
 struct Expr;
 struct Type;
 enum class MemoryType;

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -17,7 +17,7 @@
 
 namespace Halide {
 
-template<typename T>
+template<typename T, int Dims>
 class Buffer;
 class OutputImageParam;
 
@@ -227,11 +227,11 @@ public:
      * a given Buffer or ImageParam. Has the same dimensionality as
      * the argument. */
     // @{
-    RDom(const Buffer<void> &);
+    RDom(const Buffer<void, -1> &);
     RDom(const OutputImageParam &);
-    template<typename T>
-    HALIDE_NO_USER_CODE_INLINE RDom(const Buffer<T> &im)
-        : RDom(Buffer<void>(im)) {
+    template<typename T, int Dims>
+    HALIDE_NO_USER_CODE_INLINE RDom(const Buffer<T, Dims> &im)
+        : RDom(Buffer<void, -1>(im)) {
     }
     // @}
 

--- a/src/Realization.h
+++ b/src/Realization.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "Buffer.h"
 #include "Util.h"  // for all_are_convertible
 
 /** \file
@@ -12,9 +13,6 @@
  */
 
 namespace Halide {
-
-template<typename T>
-class Buffer;
 
 /** A Realization is a vector of references to existing Buffer objects.
  *  A pipeline with multiple outputs realize to a Realization.  */

--- a/src/autoschedulers/adams2019/demo_generator.cpp
+++ b/src/autoschedulers/adams2019/demo_generator.cpp
@@ -6,10 +6,10 @@ using namespace Halide;
 
 class ConvRelu : public Halide::Generator<ConvRelu> {
 public:
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 120, CO = 24, W = 100, H = 80;

--- a/src/autoschedulers/adams2019/included_schedule_file_generator.cpp
+++ b/src/autoschedulers/adams2019/included_schedule_file_generator.cpp
@@ -13,10 +13,10 @@ namespace {
 // demo_generator.cpp, but packaged separately to avoid confusion for
 // newcomers.
 struct IncludedScheduleFile : public Halide::Generator<IncludedScheduleFile> {
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 120, CO = 24, W = 100, H = 80;

--- a/src/autoschedulers/li2018/demo_generator.cpp
+++ b/src/autoschedulers/li2018/demo_generator.cpp
@@ -6,10 +6,10 @@ using namespace Halide;
 
 class ConvRelu : public Halide::Generator<ConvRelu> {
 public:
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 120, CO = 24, W = 100, H = 80;

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -584,7 +584,7 @@ private:
     }
 
 public:
-    /** Determine if if an Buffer<T, D> can be constructed from some other Buffer type.
+    /** Determine if a Buffer<T, D> can be constructed from some other Buffer type.
      * If this can be determined at compile time, fail with a static assert; otherwise
      * return a boolean based on runtime typing. */
     template<typename T2, int D2>

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -39,7 +39,7 @@ namespace Halide {
 namespace Runtime {
 
 // Forward-declare our Buffer class
-template<typename T, int D>
+template<typename T, int Dims, int InClassDimStorage>
 class Buffer;
 
 // A helper to check if a parameter pack is entirely implicitly
@@ -116,24 +116,29 @@ struct DeviceRefCount {
  * The template parameter T is the element type. For buffers where the
  * element type is unknown, or may vary, use void or const void.
  *
- * D is the maximum number of dimensions that can be represented using
- * space inside the class itself. Set it to the maximum dimensionality
+ * The template parameter Dims is the number of dimensions. For buffers where
+ * the dimensionality type is unknown at, or may vary, use -1 (or Buffer::DynamicDims).
+ *
+ * InClassDimStorage is the maximum number of dimensions that can be represented
+ * using space inside the class itself. Set it to the maximum dimensionality
  * you expect this buffer to be. If the actual dimensionality exceeds
- * this, heap storage is allocated to track the shape of the buffer. D
- * defaults to 4, which should cover nearly all usage.
+ * this, heap storage is allocated to track the shape of the buffer.
+ * InClassDimStorage defaults to 4, which should cover nearly all usage.
  *
  * The class optionally allocates and owns memory for the image using
  * a shared pointer allocated with the provided allocator. If they are
  * null, malloc and free are used.  Any device-side allocation is
  * considered as owned if and only if the host-side allocation is
  * owned. */
-template<typename T = void, int D = 4>
+template<typename T = void,
+         int Dims = -1,
+         int InClassDimStorage = (Dims == -1 ? 4 : std::max(Dims, 1))>
 class Buffer {
     /** The underlying halide_buffer_t */
     halide_buffer_t buf = {};
 
     /** Some in-class storage for shape of the dimensions. */
-    halide_dimension_t shape[D];
+    halide_dimension_t shape[InClassDimStorage];
 
     /** The allocation owned by this Buffer. NULL if the Buffer does not
      * own the memory. */
@@ -171,7 +176,7 @@ public:
 
     /** Get the Halide type of T. Callers should not use the result if
      * has_static_halide_type is false. */
-    static halide_type_t static_halide_type() {
+    static constexpr halide_type_t static_halide_type() {
         return halide_type_of<typename std::remove_cv<not_void_T>::type>();
     }
 
@@ -179,6 +184,18 @@ public:
     bool owns_host_memory() const {
         return alloc != nullptr;
     }
+
+    static constexpr int DynamicDims = -1;
+
+    static constexpr bool has_static_dimensions = (Dims != DynamicDims);
+
+    /** Callers should not use the result if
+     * has_static_dimensions is false. */
+    static constexpr int static_dimensions() {
+        return Dims;
+    }
+
+    static_assert(!has_static_dimensions || static_dimensions() >= 0);
 
 private:
     /** Increment the reference count of any owned allocation */
@@ -202,15 +219,15 @@ private:
     // Note that this is called "cropped" but can also encompass a slice/embed
     // operation as well.
     struct DevRefCountCropped : DeviceRefCount {
-        Buffer<T, D> cropped_from;
-        DevRefCountCropped(const Buffer<T, D> &cropped_from)
+        Buffer<T, Dims, InClassDimStorage> cropped_from;
+        DevRefCountCropped(const Buffer<T, Dims, InClassDimStorage> &cropped_from)
             : cropped_from(cropped_from) {
             ownership = BufferDeviceOwnership::Cropped;
         }
     };
 
     /** Setup the device ref count for a buffer to indicate it is a crop (or slice, embed, etc) of cropped_from */
-    void crop_from(const Buffer<T, D> &cropped_from) {
+    void crop_from(const Buffer<T, Dims, InClassDimStorage> &cropped_from) {
         assert(dev_ref_count == nullptr);
         dev_ref_count = new DevRefCountCropped(cropped_from);
     }
@@ -274,11 +291,27 @@ private:
         }
     }
 
+    template<int DimsSpecified>
+    void make_static_shape_storage() {
+        static_assert(Dims == DynamicDims || Dims == DimsSpecified,
+                      "Number of arguments to Buffer() does not match static dimensionality");
+        buf.dimensions = DimsSpecified;
+        if constexpr (Dims == DynamicDims) {
+            buf.dim = (DimsSpecified <= InClassDimStorage) ? shape : new halide_dimension_t[DimsSpecified];
+        } else {
+            static_assert(InClassDimStorage >= Dims);
+            buf.dim = shape;
+        }
+    }
+
     void make_shape_storage(const int dimensions) {
+        if (Dims != DynamicDims && Dims != dimensions) {
+            assert(false && "Number of arguments to Buffer() does not match static dimensionality");
+        }
         // This should usually be inlined, so if dimensions is statically known,
         // we can skip the call to new
         buf.dimensions = dimensions;
-        buf.dim = (dimensions <= D) ? shape : new halide_dimension_t[dimensions];
+        buf.dim = (dimensions <= InClassDimStorage) ? shape : new halide_dimension_t[dimensions];
     }
 
     void copy_shape_from(const halide_buffer_t &other) {
@@ -287,8 +320,8 @@ private:
         std::copy(other.dim, other.dim + other.dimensions, buf.dim);
     }
 
-    template<typename T2, int D2>
-    void move_shape_from(Buffer<T2, D2> &&other) {
+    template<typename T2, int D2, int S2>
+    void move_shape_from(Buffer<T2, D2, S2> &&other) {
         if (other.shape == other.buf.dim) {
             copy_shape_from(other.buf);
         } else {
@@ -389,10 +422,10 @@ private:
         }
     }
 
-    void complete_device_crop(Buffer<T, D> &result_host_cropped) const {
+    void complete_device_crop(Buffer<T, Dims, InClassDimStorage> &result_host_cropped) const {
         assert(buf.device_interface != nullptr);
         if (buf.device_interface->device_crop(nullptr, &this->buf, &result_host_cropped.buf) == 0) {
-            const Buffer<T, D> *cropped_from = this;
+            const Buffer<T, Dims, InClassDimStorage> *cropped_from = this;
             // TODO: Figure out what to do if dev_ref_count is nullptr. Should incref logic run here?
             // is it possible to get to this point without incref having run at least once since
             // the device field was set? (I.e. in the internal logic of crop. incref might have been
@@ -406,6 +439,8 @@ private:
 
     /** slice a single dimension without handling device allocation. */
     void slice_host(int d, int pos) {
+        static_assert(Dims == DynamicDims);
+        assert(dimensions() > 0);
         assert(d >= 0 && d < dimensions());
         assert(pos >= dim(d).min() && pos <= dim(d).max());
         buf.dimensions--;
@@ -419,10 +454,10 @@ private:
         buf.dim[buf.dimensions] = {0, 0, 0};
     }
 
-    void complete_device_slice(Buffer<T, D> &result_host_sliced, int d, int pos) const {
+    void complete_device_slice(Buffer<T, DynamicDims, InClassDimStorage> &result_host_sliced, int d, int pos) const {
         assert(buf.device_interface != nullptr);
         if (buf.device_interface->device_slice(nullptr, &this->buf, d, pos, &result_host_sliced.buf) == 0) {
-            const Buffer<T, D> *sliced_from = this;
+            const Buffer<T, Dims, InClassDimStorage> *sliced_from = this;
             // TODO: Figure out what to do if dev_ref_count is nullptr. Should incref logic run here?
             // is it possible to get to this point without incref having run at least once since
             // the device field was set? (I.e. in the internal logic of slice. incref might have been
@@ -521,7 +556,9 @@ public:
     }
 
     /** Get the dimensionality of the buffer. */
+    // TODO: make constexpr, optimize for const case
     int dimensions() const {
+        assert(Dims == DynamicDims || Dims == buf.dimensions);
         return buf.dimensions;
     }
 
@@ -558,7 +595,7 @@ public:
     Buffer()
         : shape() {
         buf.type = static_halide_type();
-        make_shape_storage(0);
+        make_static_shape_storage<0>();
     }
 
     /** Make a Buffer from a halide_buffer_t */
@@ -569,46 +606,55 @@ public:
     }
 
     /** Give Buffers access to the members of Buffers of different dimensionalities and types. */
-    template<typename T2, int D2>
+    template<typename T2, int D2, int S2>
     friend class Buffer;
 
 private:
-    template<typename T2, int D2>
+    template<typename T2, int D2, int S2>
     static void static_assert_can_convert_from() {
         static_assert((!std::is_const<T2>::value || std::is_const<T>::value),
                       "Can't convert from a Buffer<const T> to a Buffer<T>");
         static_assert(std::is_same<typename std::remove_const<T>::type,
                                    typename std::remove_const<T2>::type>::value ||
-                          T_is_void || Buffer<T2, D2>::T_is_void,
+                          T_is_void || Buffer<T2, D2, S2>::T_is_void,
                       "type mismatch constructing Buffer");
+        static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2,
+                      "Can't convert from a Buffer with static dimensionality to a Buffer with different static dimensionality");
     }
 
 public:
-    /** Determine if a Buffer<T, D> can be constructed from some other Buffer type.
+    /** Determine if a Buffer<T, Dims, InClassDimStorage> can be constructed from some other Buffer type.
      * If this can be determined at compile time, fail with a static assert; otherwise
      * return a boolean based on runtime typing. */
-    template<typename T2, int D2>
-    static bool can_convert_from(const Buffer<T2, D2> &other) {
-        static_assert_can_convert_from<T2, D2>();
-        if (Buffer<T2, D2>::T_is_void && !T_is_void) {
-            return other.type() == static_halide_type();
+    template<typename T2, int D2, int S2>
+    static bool can_convert_from(const Buffer<T2, D2, S2> &other) {
+        static_assert_can_convert_from<T2, D2, S2>();
+        if (Buffer<T2, D2, S2>::T_is_void && !T_is_void) {
+            if (other.type() != static_halide_type()) {
+                return false;
+            }
+        }
+        if (Dims != DynamicDims) {
+            if (other.dimensions() != Dims) {
+                return false;
+            }
         }
         return true;
     }
 
-    /** Fail an assertion at runtime or compile-time if an Buffer<T, D>
+    /** Fail an assertion at runtime or compile-time if an Buffer<T, Dims, InClassDimStorage>
      * cannot be constructed from some other Buffer type. */
-    template<typename T2, int D2>
-    static void assert_can_convert_from(const Buffer<T2, D2> &other) {
+    template<typename T2, int D2, int S2>
+    static void assert_can_convert_from(const Buffer<T2, D2, S2> &other) {
         // Explicitly call static_assert_can_convert_from() here so
         // that we always get compile-time checking, even if compiling with
         // assertions disabled.
-        static_assert_can_convert_from<T2, D2>();
+        static_assert_can_convert_from<T2, D2, S2>();
         assert(can_convert_from(other));
     }
 
     /** Copy constructor. Does not copy underlying data. */
-    Buffer(const Buffer<T, D> &other)
+    Buffer(const Buffer<T, Dims, InClassDimStorage> &other)
         : buf(other.buf),
           alloc(other.alloc) {
         other.incref();
@@ -617,13 +663,13 @@ public:
     }
 
     /** Construct a Buffer from a Buffer of different dimensionality
-     * and type. Asserts that the type matches (at runtime, if one of
-     * the types is void). Note that this constructor is
+     * and type. Asserts that the type and dimensionality matches (at runtime,
+     * if one of the types is void). Note that this constructor is
      * implicit. This, for example, lets you pass things like
      * Buffer<T> or Buffer<const void> to functions expected
      * Buffer<const T>. */
-    template<typename T2, int D2>
-    Buffer(const Buffer<T2, D2> &other)
+    template<typename T2, int D2, int S2>
+    Buffer(const Buffer<T2, D2, S2> &other)
         : buf(other.buf),
           alloc(other.alloc) {
         assert_can_convert_from(other);
@@ -633,36 +679,36 @@ public:
     }
 
     /** Move constructor */
-    Buffer(Buffer<T, D> &&other) noexcept
+    Buffer(Buffer<T, Dims, InClassDimStorage> &&other) noexcept
         : buf(other.buf),
           alloc(other.alloc),
           dev_ref_count(other.dev_ref_count) {
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
-        move_shape_from(std::forward<Buffer<T, D>>(other));
+        move_shape_from(std::forward<Buffer<T, Dims, InClassDimStorage>>(other));
         other.buf = halide_buffer_t();
     }
 
     /** Move-construct a Buffer from a Buffer of different
      * dimensionality and type. Asserts that the types match (at
      * runtime if one of the types is void). */
-    template<typename T2, int D2>
-    Buffer(Buffer<T2, D2> &&other)
+    template<typename T2, int D2, int S2>
+    Buffer(Buffer<T2, D2, S2> &&other)
         : buf(other.buf),
           alloc(other.alloc),
           dev_ref_count(other.dev_ref_count) {
         assert_can_convert_from(other);
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
-        move_shape_from(std::forward<Buffer<T2, D2>>(other));
+        move_shape_from(std::forward<Buffer<T2, D2, S2>>(other));
         other.buf = halide_buffer_t();
     }
 
     /** Assign from another Buffer of possibly-different
      * dimensionality and type. Asserts that the types match (at
      * runtime if one of the types is void). */
-    template<typename T2, int D2>
-    Buffer<T, D> &operator=(const Buffer<T2, D2> &other) {
+    template<typename T2, int D2, int S2>
+    Buffer<T, Dims, InClassDimStorage> &operator=(const Buffer<T2, D2, S2> &other) {
         if ((const void *)this == (const void *)&other) {
             return *this;
         }
@@ -678,7 +724,7 @@ public:
     }
 
     /** Standard assignment operator */
-    Buffer<T, D> &operator=(const Buffer<T, D> &other) {
+    Buffer<T, Dims, InClassDimStorage> &operator=(const Buffer<T, Dims, InClassDimStorage> &other) {
         // The cast to void* here is just to satisfy clang-tidy
         if ((const void *)this == (const void *)&other) {
             return *this;
@@ -696,8 +742,8 @@ public:
     /** Move from another Buffer of possibly-different
      * dimensionality and type. Asserts that the types match (at
      * runtime if one of the types is void). */
-    template<typename T2, int D2>
-    Buffer<T, D> &operator=(Buffer<T2, D2> &&other) {
+    template<typename T2, int D2, int S2>
+    Buffer<T, Dims, InClassDimStorage> &operator=(Buffer<T2, D2, S2> &&other) {
         assert_can_convert_from(other);
         decref();
         alloc = other.alloc;
@@ -706,13 +752,13 @@ public:
         other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
-        move_shape_from(std::forward<Buffer<T2, D2>>(other));
+        move_shape_from(std::forward<Buffer<T2, D2, S2>>(other));
         other.buf = halide_buffer_t();
         return *this;
     }
 
     /** Standard move-assignment operator */
-    Buffer<T, D> &operator=(Buffer<T, D> &&other) noexcept {
+    Buffer<T, Dims, InClassDimStorage> &operator=(Buffer<T, Dims, InClassDimStorage> &&other) noexcept {
         decref();
         alloc = other.alloc;
         other.alloc = nullptr;
@@ -720,7 +766,7 @@ public:
         other.dev_ref_count = nullptr;
         free_shape_storage();
         buf = other.buf;
-        move_shape_from(std::forward<Buffer<T, D>>(other));
+        move_shape_from(std::forward<Buffer<T, Dims, InClassDimStorage>>(other));
         other.buf = halide_buffer_t();
         return *this;
     }
@@ -792,7 +838,7 @@ public:
         int extents[] = {first, (int)rest...};
         buf.type = t;
         constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
-        make_shape_storage(buf_dimensions);
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
         if (!Internal::any_zero(extents)) {
             check_overflow();
@@ -812,7 +858,7 @@ public:
         int extents[] = {first};
         buf.type = static_halide_type();
         constexpr int buf_dimensions = 1;
-        make_shape_storage(buf_dimensions);
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
         if (first != 0) {
             check_overflow();
@@ -828,7 +874,7 @@ public:
         int extents[] = {first, second, (int)rest...};
         buf.type = static_halide_type();
         constexpr int buf_dimensions = 2 + (int)(sizeof...(rest));
-        make_shape_storage(buf_dimensions);
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
         if (!Internal::any_zero(extents)) {
             check_overflow();
@@ -843,6 +889,7 @@ public:
             assert(static_halide_type() == t);
         }
         buf.type = t;
+        // make_shape_storage() will do a runtime check that dimensionality matches.
         make_shape_storage((int)sizes.size());
         initialize_shape(sizes);
         if (!Internal::any_zero(sizes)) {
@@ -885,6 +932,7 @@ public:
      * take ownership of the data, and does not set the host_dirty flag. */
     template<typename Array, size_t N>
     explicit Buffer(Array (&vals)[N]) {
+        // TODO: this could probably be made constexpr
         const int buf_dimensions = dimensionality_of_array(vals);
         buf.type = scalar_type_of_array(vals);
         buf.host = (uint8_t *)vals;
@@ -904,9 +952,9 @@ public:
         }
         int extents[] = {first, (int)rest...};
         buf.type = t;
-        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
         buf.host = (uint8_t *)const_cast<void *>(data);
-        make_shape_storage(buf_dimensions);
+        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
     }
 
@@ -918,9 +966,9 @@ public:
     explicit Buffer(T *data, int first, Args &&...rest) {
         int extents[] = {first, (int)rest...};
         buf.type = static_halide_type();
-        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
         buf.host = (uint8_t *)const_cast<typename std::remove_const<T>::type *>(data);
-        make_shape_storage(buf_dimensions);
+        constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
+        make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
     }
 
@@ -1021,9 +1069,9 @@ public:
      * Buffer<const uint8_t>, or converting a Buffer<T>& to Buffer<const T>&.
      * Does a runtime assert if the source buffer type is void. */
     template<typename T2>
-    HALIDE_ALWAYS_INLINE Buffer<T2, D> &as() & {
-        Buffer<T2, D>::assert_can_convert_from(*this);
-        return *((Buffer<T2, D> *)this);
+    HALIDE_ALWAYS_INLINE Buffer<T2, Dims, InClassDimStorage> &as() & {
+        Buffer<T2, Dims, InClassDimStorage>::assert_can_convert_from(*this);
+        return *((Buffer<T2, Dims, InClassDimStorage> *)this);
     }
 
     /** Return a const typed reference to this Buffer. Useful for
@@ -1031,37 +1079,37 @@ public:
      * reference to another Buffer type. Does a runtime assert if the
      * source buffer type is void. */
     template<typename T2>
-    HALIDE_ALWAYS_INLINE const Buffer<T2, D> &as() const & {
-        Buffer<T2, D>::assert_can_convert_from(*this);
-        return *((const Buffer<T2, D> *)this);
+    HALIDE_ALWAYS_INLINE const Buffer<T2, Dims, InClassDimStorage> &as() const & {
+        Buffer<T2, Dims, InClassDimStorage>::assert_can_convert_from(*this);
+        return *((const Buffer<T2, Dims, InClassDimStorage> *)this);
     }
 
     /** Returns this rval Buffer with a different type attached. Does
      * a dynamic type check if the source type is void. */
     template<typename T2>
-    HALIDE_ALWAYS_INLINE Buffer<T2, D> as() && {
-        Buffer<T2, D>::assert_can_convert_from(*this);
-        return *((Buffer<T2, D> *)this);
+    HALIDE_ALWAYS_INLINE Buffer<T2, Dims, InClassDimStorage> as() && {
+        Buffer<T2, Dims, InClassDimStorage>::assert_can_convert_from(*this);
+        return *((Buffer<T2, Dims, InClassDimStorage> *)this);
     }
 
     /** as_const() is syntactic sugar for .as<const T>(), to avoid the need
      * to recapitulate the type argument. */
     // @{
     HALIDE_ALWAYS_INLINE
-    Buffer<typename std::add_const<T>::type, D> &as_const() & {
+    Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> &as_const() & {
         // Note that we can skip the assert_can_convert_from(), since T -> const T
         // conversion is always legal.
-        return *((Buffer<typename std::add_const<T>::type, D> *)this);
+        return *((Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
     }
 
     HALIDE_ALWAYS_INLINE
-    const Buffer<typename std::add_const<T>::type, D> &as_const() const & {
-        return *((const Buffer<typename std::add_const<T>::type, D> *)this);
+    const Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> &as_const() const & {
+        return *((const Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
     }
 
     HALIDE_ALWAYS_INLINE
-    Buffer<typename std::add_const<T>::type, D> as_const() && {
-        return *((Buffer<typename std::add_const<T>::type, D> *)this);
+    Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> as_const() && {
+        return *((Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
     }
     // @}
 
@@ -1109,9 +1157,9 @@ public:
      * can easily cast it back to Buffer<const T> if desired, which is
      * always safe and free.)
      */
-    Buffer<not_const_T, D> copy(void *(*allocate_fn)(size_t) = nullptr,
-                                void (*deallocate_fn)(void *) = nullptr) const {
-        Buffer<not_const_T, D> dst = Buffer<not_const_T, D>::make_with_shape_of(*this, allocate_fn, deallocate_fn);
+    Buffer<not_const_T, Dims, InClassDimStorage> copy(void *(*allocate_fn)(size_t) = nullptr,
+                                                      void (*deallocate_fn)(void *) = nullptr) const {
+        Buffer<not_const_T, Dims, InClassDimStorage> dst = Buffer<not_const_T, Dims, InClassDimStorage>::make_with_shape_of(*this, allocate_fn, deallocate_fn);
         dst.copy_from(*this);
         return dst;
     }
@@ -1120,10 +1168,11 @@ public:
      * (vs. keeping the same memory layout as the original). Requires that 'this'
      * has exactly 3 dimensions.
      */
-    Buffer<not_const_T, D> copy_to_interleaved(void *(*allocate_fn)(size_t) = nullptr,
-                                               void (*deallocate_fn)(void *) = nullptr) const {
+    Buffer<not_const_T, Dims, InClassDimStorage> copy_to_interleaved(void *(*allocate_fn)(size_t) = nullptr,
+                                                                     void (*deallocate_fn)(void *) = nullptr) const {
+        static_assert(Dims == DynamicDims || Dims == 3);
         assert(dimensions() == 3);
-        Buffer<not_const_T, D> dst = Buffer<not_const_T, D>::make_interleaved(nullptr, width(), height(), channels());
+        Buffer<not_const_T, Dims, InClassDimStorage> dst = Buffer<not_const_T, Dims, InClassDimStorage>::make_interleaved(nullptr, width(), height(), channels());
         dst.set_min(min(0), min(1), min(2));
         dst.allocate(allocate_fn, deallocate_fn);
         dst.copy_from(*this);
@@ -1133,8 +1182,8 @@ public:
     /** Like copy(), but the copy is created in planar memory layout
      * (vs. keeping the same memory layout as the original).
      */
-    Buffer<not_const_T, D> copy_to_planar(void *(*allocate_fn)(size_t) = nullptr,
-                                          void (*deallocate_fn)(void *) = nullptr) const {
+    Buffer<not_const_T, Dims, InClassDimStorage> copy_to_planar(void *(*allocate_fn)(size_t) = nullptr,
+                                                                void (*deallocate_fn)(void *) = nullptr) const {
         std::vector<int> mins, extents;
         const int dims = dimensions();
         mins.reserve(dims);
@@ -1143,7 +1192,7 @@ public:
             mins.push_back(dim(d).min());
             extents.push_back(dim(d).extent());
         }
-        Buffer<not_const_T, D> dst = Buffer<not_const_T, D>(nullptr, extents);
+        Buffer<not_const_T, Dims, InClassDimStorage> dst = Buffer<not_const_T, Dims, InClassDimStorage>(nullptr, extents);
         dst.set_min(mins);
         dst.allocate(allocate_fn, deallocate_fn);
         dst.copy_from(*this);
@@ -1159,7 +1208,7 @@ public:
      *     my_func(input.alias(), output);
      * }\endcode
      */
-    inline Buffer<T, D> alias() const {
+    inline Buffer<T, Dims, InClassDimStorage> alias() const {
         return *this;
     }
 
@@ -1172,18 +1221,20 @@ public:
      * to the correct location first like so: \code
      * framebuffer.copy_from(sprite.translated({x, y})); \endcode
      */
-    template<typename T2, int D2>
-    void copy_from(Buffer<T2, D2> src) {
+    template<typename T2, int D2, int S2>
+    void copy_from(Buffer<T2, D2, S2> src) {
         static_assert(!std::is_const<T>::value, "Cannot call copy_from() on a Buffer<const T>");
         assert(!device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty destination.");
         assert(!src.device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty source.");
 
-        Buffer<T, D> dst(*this);
+        Buffer<T, Dims, InClassDimStorage> dst(*this);
 
+        static_assert(Dims == DynamicDims || D2 == DynamicDims || Dims == D2);
         assert(src.dimensions() == dst.dimensions());
 
         // Trim the copy to the region in common
-        for (int i = 0; i < dimensions(); i++) {
+        const int d = dimensions();
+        for (int i = 0; i < d; i++) {
             int min_coord = std::max(dst.dim(i).min(), src.dim(i).min());
             int max_coord = std::min(dst.dim(i).max(), src.dim(i).max());
             if (max_coord < min_coord) {
@@ -1200,23 +1251,23 @@ public:
         // into a static dispatch to the right-sized copy.)
         if (T_is_void ? (type().bytes() == 1) : (sizeof(not_void_T) == 1)) {
             using MemType = uint8_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 2) : (sizeof(not_void_T) == 2)) {
             using MemType = uint16_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 4) : (sizeof(not_void_T) == 4)) {
             using MemType = uint32_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 8) : (sizeof(not_void_T) == 8)) {
             using MemType = uint64_t;
-            auto &typed_dst = (Buffer<MemType, D> &)dst;
-            auto &typed_src = (Buffer<const MemType, D> &)src;
+            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
+            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else {
             assert(false && "type().bytes() must be 1, 2, 4, or 8");
@@ -1228,10 +1279,10 @@ public:
      * the given dimension. Asserts that the crop region is within
      * the existing bounds: you cannot "crop outwards", even if you know there
      * is valid Buffer storage (e.g. because you already cropped inwards). */
-    Buffer<T, D> cropped(int d, int min, int extent) const {
+    Buffer<T, Dims, InClassDimStorage> cropped(int d, int min, int extent) const {
         // Make a fresh copy of the underlying buffer (but not a fresh
         // copy of the allocation, if there is one).
-        Buffer<T, D> im = *this;
+        Buffer<T, Dims, InClassDimStorage> im = *this;
 
         // This guarantees the prexisting device ref is dropped if the
         // device_crop call fails and maintains the buffer in a consistent
@@ -1264,10 +1315,10 @@ public:
      * the first N dimensions. Asserts that the crop region is within
      * the existing bounds. The cropped image may drop any device handle
      * if the device_interface cannot accomplish the crop in-place. */
-    Buffer<T, D> cropped(const std::vector<std::pair<int, int>> &rect) const {
+    Buffer<T, Dims, InClassDimStorage> cropped(const std::vector<std::pair<int, int>> &rect) const {
         // Make a fresh copy of the underlying buffer (but not a fresh
         // copy of the allocation, if there is one).
-        Buffer<T, D> im = *this;
+        Buffer<T, Dims, InClassDimStorage> im = *this;
 
         // This guarantees the prexisting device ref is dropped if the
         // device_crop call fails and maintains the buffer in a consistent
@@ -1301,8 +1352,8 @@ public:
      * translated coordinates in the given dimension. Positive values
      * move the image data to the right or down relative to the
      * coordinate system. Drops any device handle. */
-    Buffer<T, D> translated(int d, int dx) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> translated(int d, int dx) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.translate(d, dx);
         return im;
     }
@@ -1317,8 +1368,8 @@ public:
 
     /** Make an image which refers to the same data translated along
      * the first N dimensions. */
-    Buffer<T, D> translated(const std::vector<int> &delta) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> translated(const std::vector<int> &delta) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.translate(delta);
         return im;
     }
@@ -1373,8 +1424,8 @@ public:
      * using a swapped indexing order for the dimensions given. So
      * A = B.transposed(0, 1) means that A(i, j) == B(j, i), and more
      * strongly that A.address_of(i, j) == B.address_of(j, i). */
-    Buffer<T, D> transposed(int d1, int d2) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> transposed(int d1, int d2) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.transpose(d1, d2);
         return im;
     }
@@ -1414,16 +1465,19 @@ public:
 
     /** Make a buffer which refers to the same data in the same
      * layout using a different ordering of the dimensions. */
-    Buffer<T, D> transposed(const std::vector<int> &order) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, Dims, InClassDimStorage> transposed(const std::vector<int> &order) const {
+        Buffer<T, Dims, InClassDimStorage> im = *this;
         im.transpose(order);
         return im;
     }
 
     /** Make a lower-dimensional buffer that refers to one slice of
      * this buffer. */
-    Buffer<T, D> sliced(int d, int pos) const {
-        Buffer<T, D> im = *this;
+    Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims - 1), InClassDimStorage> sliced(int d, int pos) const {
+        static_assert(Dims == DynamicDims || Dims > 0, "Cannot slice a 0-dimensional buffer");
+        assert(dimensions() > 0);
+
+        Buffer<T, DynamicDims, InClassDimStorage> im = *this;
 
         // This guarantees the prexisting device ref is dropped if the
         // device_slice call fails and maintains the buffer in a consistent
@@ -1439,15 +1493,22 @@ public:
 
     /** Make a lower-dimensional buffer that refers to one slice of this
      * buffer at the dimension's minimum. */
-    inline Buffer<T, D> sliced(int d) const {
+    inline Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims - 1), InClassDimStorage> sliced(int d) const {
+        static_assert(Dims == DynamicDims || Dims > 0, "Cannot slice a 0-dimensional buffer");
+        assert(dimensions() > 0);
+
         return sliced(d, dim(d).min());
     }
 
     /** Rewrite the buffer to refer to a single lower-dimensional
      * slice of itself along the given dimension at the given
      * coordinate. Does not move any data around or free the original
-     * memory, so other views of the same data are unaffected. */
+     * memory, so other views of the same data are unaffected. Can
+     * only be called on a Buffer with dynamic dimensionality. */
     void slice(int d, int pos) {
+        static_assert(Dims == DynamicDims, "Cannot call slice() on a Buffer with static dimensionality.");
+        assert(dimensions() > 0);
+
         // An optimization for non-device buffers. For the device case,
         // a temp buffer is required, so reuse the not-in-place version.
         // TODO(zalman|abadams): Are nop slices common enough to special
@@ -1474,8 +1535,8 @@ public:
      &im(x, y, c) == &im2(x, 17, y, c);
      \endcode
      */
-    Buffer<T, D> embedded(int d, int pos = 0) const {
-        Buffer<T, D> im(*this);
+    Buffer<T, (Dims == DynamicDims ? DynamicDims : Dims + 1), InClassDimStorage> embedded(int d, int pos = 0) const {
+        Buffer<T, DynamicDims, InClassDimStorage> im(*this);
         im.embed(d, pos);
         return im;
     }
@@ -1483,6 +1544,7 @@ public:
     /** Embed a buffer in-place, increasing the
      * dimensionality. */
     void embed(int d, int pos = 0) {
+        static_assert(Dims == DynamicDims, "Cannot call embed() on a Buffer with static dimensionality.");
         assert(d >= 0 && d <= dimensions());
         add_dimension();
         translate(dimensions() - 1, pos);
@@ -1496,6 +1558,7 @@ public:
      * its stride. The new dimension is the last dimension. This is a
      * special case of embed. */
     void add_dimension() {
+        static_assert(Dims == DynamicDims, "Cannot call add_dimension() on a Buffer with static dimensionality.");
         const int dims = buf.dimensions;
         buf.dimensions++;
         if (buf.dim != shape) {
@@ -1506,7 +1569,7 @@ public:
             }
             delete[] buf.dim;
             buf.dim = new_shape;
-        } else if (dims == D) {
+        } else if (dims == InClassDimStorage) {
             // Transition from the in-class storage to the heap
             make_shape_storage(buf.dimensions);
             for (int i = 0; i < dims; i++) {
@@ -1679,8 +1742,9 @@ public:
      * using (x, y, c). Passing it to a generator requires that the
      * generator has been compiled with support for interleaved (also
      * known as packed or chunky) memory layouts. */
-    static Buffer<void, D> make_interleaved(halide_type_t t, int width, int height, int channels) {
-        Buffer<void, D> im(t, channels, width, height);
+    static Buffer<void, Dims, InClassDimStorage> make_interleaved(halide_type_t t, int width, int height, int channels) {
+        static_assert(Dims == DynamicDims || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
+        Buffer<void, Dims, InClassDimStorage> im(t, channels, width, height);
         // Note that this is equivalent to calling transpose({2, 0, 1}),
         // but slightly more efficient.
         im.transpose(0, 1);
@@ -1694,52 +1758,56 @@ public:
      * using (x, y, c). Passing it to a generator requires that the
      * generator has been compiled with support for interleaved (also
      * known as packed or chunky) memory layouts. */
-    static Buffer<T, D> make_interleaved(int width, int height, int channels) {
+    static Buffer<T, Dims, InClassDimStorage> make_interleaved(int width, int height, int channels) {
         return make_interleaved(static_halide_type(), width, height, channels);
     }
 
     /** Wrap an existing interleaved image. */
-    static Buffer<add_const_if_T_is_const<void>, D>
+    static Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage>
     make_interleaved(halide_type_t t, T *data, int width, int height, int channels) {
-        Buffer<add_const_if_T_is_const<void>, D> im(t, data, channels, width, height);
+        static_assert(Dims == DynamicDims || Dims == 3, "make_interleaved() must be called on a Buffer that can represent 3 dimensions.");
+        Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage> im(t, data, channels, width, height);
         im.transpose(0, 1);
         im.transpose(1, 2);
         return im;
     }
 
     /** Wrap an existing interleaved image. */
-    static Buffer<T, D> make_interleaved(T *data, int width, int height, int channels) {
+    static Buffer<T, Dims, InClassDimStorage> make_interleaved(T *data, int width, int height, int channels) {
         return make_interleaved(static_halide_type(), data, width, height, channels);
     }
 
     /** Make a zero-dimensional Buffer */
-    static Buffer<add_const_if_T_is_const<void>, D> make_scalar(halide_type_t t) {
-        Buffer<add_const_if_T_is_const<void>, 1> buf(t, 1);
+    static Buffer<add_const_if_T_is_const<void>, Dims, InClassDimStorage> make_scalar(halide_type_t t) {
+        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<add_const_if_T_is_const<void>, DynamicDims, InClassDimStorage> buf(t, 1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a zero-dimensional Buffer */
-    static Buffer<T, D> make_scalar() {
-        Buffer<T, 1> buf(1);
+    static Buffer<T, Dims, InClassDimStorage> make_scalar() {
+        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<T, DynamicDims, InClassDimStorage> buf(1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a zero-dimensional Buffer that points to non-owned, existing data */
-    static Buffer<T, D> make_scalar(T *data) {
-        Buffer<T, 1> buf(data, 1);
+    static Buffer<T, Dims, InClassDimStorage> make_scalar(T *data) {
+        static_assert(Dims == DynamicDims || Dims == 0, "make_scalar() must be called on a Buffer that can represent 0 dimensions.");
+        Buffer<T, DynamicDims, InClassDimStorage> buf(data, 1);
         buf.slice(0, 0);
         return buf;
     }
 
     /** Make a buffer with the same shape and memory nesting order as
      * another buffer. It may have a different type. */
-    template<typename T2, int D2>
-    static Buffer<T, D> make_with_shape_of(Buffer<T2, D2> src,
-                                           void *(*allocate_fn)(size_t) = nullptr,
-                                           void (*deallocate_fn)(void *) = nullptr) {
-
+    template<typename T2, int D2, int S2>
+    static Buffer<T, Dims, InClassDimStorage> make_with_shape_of(Buffer<T2, D2, S2> src,
+                                                                 void *(*allocate_fn)(size_t) = nullptr,
+                                                                 void (*deallocate_fn)(void *) = nullptr) {
+        static_assert(Dims == D2 || Dims == DynamicDims);
         const halide_type_t dst_type = T_is_void ? src.type() : halide_type_of<typename std::remove_cv<not_void_T>::type>();
         return Buffer<>::make_with_shape_of_helper(dst_type, src.dimensions(), src.buf.dim,
                                                    allocate_fn, deallocate_fn);
@@ -1846,6 +1914,8 @@ public:
     HALIDE_ALWAYS_INLINE const not_void_T &operator()(int first, Args... rest) const {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 1 + (int)(sizeof...(rest));
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         assert(!device_dirty());
         return *((const not_void_T *)(address_of(first, rest...)));
     }
@@ -1855,6 +1925,8 @@ public:
     operator()() const {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 0;
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         assert(!device_dirty());
         return *((const not_void_T *)(data()));
     }
@@ -1875,6 +1947,8 @@ public:
         operator()(int first, Args... rest) {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 1 + (int)(sizeof...(rest));
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         set_host_dirty();
         return *((not_void_T *)(address_of(first, rest...)));
     }
@@ -1884,6 +1958,8 @@ public:
     operator()() {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
+        constexpr int expected_dims = 0;
+        static_assert(Dims == DynamicDims || Dims == expected_dims, "Buffer with static dimensions was accessed with the wrong number of coordinates in operator()");
         set_host_dirty();
         return *((not_void_T *)(data()));
     }
@@ -1905,7 +1981,7 @@ public:
         return all_equal;
     }
 
-    Buffer<T, D> &fill(not_void_T val) {
+    Buffer<T, Dims, InClassDimStorage> &fill(not_void_T val) {
         set_host_dirty();
         for_each_value([=](T &v) { v = val; });
         return *this;
@@ -2059,14 +2135,14 @@ public:
      * will result in a compilation error. */
     // @{
     template<typename Fn, typename... Args, int N = sizeof...(Args) + 1>
-    HALIDE_ALWAYS_INLINE const Buffer<T, D> &for_each_value(Fn &&f, Args &&...other_buffers) const {
+    HALIDE_ALWAYS_INLINE const Buffer<T, Dims, InClassDimStorage> &for_each_value(Fn &&f, Args &&...other_buffers) const {
         for_each_value_impl(f, std::forward<Args>(other_buffers)...);
         return *this;
     }
 
     template<typename Fn, typename... Args, int N = sizeof...(Args) + 1>
     HALIDE_ALWAYS_INLINE
-        Buffer<T, D> &
+        Buffer<T, Dims, InClassDimStorage> &
         for_each_value(Fn &&f, Args &&...other_buffers) {
         for_each_value_impl(f, std::forward<Args>(other_buffers)...);
         return *this;
@@ -2258,14 +2334,14 @@ public:
     */
     // @{
     template<typename Fn>
-    HALIDE_ALWAYS_INLINE const Buffer<T, D> &for_each_element(Fn &&f) const {
+    HALIDE_ALWAYS_INLINE const Buffer<T, Dims, InClassDimStorage> &for_each_element(Fn &&f) const {
         for_each_element_impl(f);
         return *this;
     }
 
     template<typename Fn>
     HALIDE_ALWAYS_INLINE
-        Buffer<T, D> &
+        Buffer<T, Dims, InClassDimStorage> &
         for_each_element(Fn &&f) {
         for_each_element_impl(f);
         return *this;
@@ -2276,7 +2352,7 @@ private:
     template<typename Fn>
     struct FillHelper {
         Fn f;
-        Buffer<T, D> *buf;
+        Buffer<T, Dims, InClassDimStorage> *buf;
 
         template<typename... Args,
                  typename = decltype(std::declval<Fn>()(std::declval<Args>()...))>
@@ -2284,7 +2360,7 @@ private:
             (*buf)(args...) = f(args...);
         }
 
-        FillHelper(Fn &&f, Buffer<T, D> *buf)
+        FillHelper(Fn &&f, Buffer<T, Dims, InClassDimStorage> *buf)
             : f(std::forward<Fn>(f)), buf(buf) {
         }
     };
@@ -2296,7 +2372,7 @@ public:
      * stored to the coordinate corresponding to the arguments. */
     template<typename Fn,
              typename = typename std::enable_if<!std::is_arithmetic<typename std::decay<Fn>::type>::value>::type>
-    Buffer<T, D> &fill(Fn &&f) {
+    Buffer<T, Dims, InClassDimStorage> &fill(Fn &&f) {
         // We'll go via for_each_element. We need a variadic wrapper lambda.
         FillHelper<Fn> wrapper(std::forward<Fn>(f), this);
         return for_each_element(wrapper);

--- a/src/runtime/wasm_math.ll
+++ b/src/runtime/wasm_math.ll
@@ -234,31 +234,7 @@ define weak_odr <8 x i16> @saturating_narrow_i32x8_to_u16x8(<8 x i32> %x) nounwi
   ret <8 x i16> %3
 }
 
-; Integer to double-precision floating point
-
-; COMMENTED OUT AT TOP OF TREE; llvm.wasm.convert.low.[un]signed is no longer
-; available, but LLVM isn't generating the f64x2.convert_low_i32x4_s/u instructions
-; that we'd expect, so investigation needs to be done.
-;   declare <2 x double> @llvm.wasm.convert.low.signed(<4 x i32>)
-;   declare <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32>)
-;
-;   define weak_odr <4 x double> @i32_to_double_s(<4 x i32> %x) nounwind alwaysinline {
-;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-;     %2 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %x)
-;     %3 = tail call <2 x double> @llvm.wasm.convert.low.signed(<4 x i32> %1)
-;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-;     ret <4 x double> %4
-;   }
-;
-;   define weak_odr <4 x double> @i32_to_double_u(<4 x i32> %x) nounwind alwaysinline {
-;     %1 = shufflevector <4 x i32> %x, <4 x i32> undef, <4 x i32> <i32 2, i32 3, i32 undef, i32 undef>
-;     %2 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %x)
-;     %3 = tail call <2 x double> @llvm.wasm.convert.low.unsigned(<4 x i32> %1)
-;     %4 = shufflevector <2 x double> %2, <2 x double> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-;     ret <4 x double> %4
-;   }
-
-; single to double-precision floating point
+; single to double-precision floating point (only needed for LLVM_VERSION == 13)
 define weak_odr <4 x double> @float_to_double(<4 x float> %x) nounwind alwaysinline {
   %1 = fpext <4 x float> %x to <4 x double>
   ret <4 x double> %1

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -128,12 +128,84 @@ int main(int argc, char **argv) {
 
     {
         // Check make a Buffer from a Buffer of a different type
+        Buffer<float> a(100, 80);
+        Buffer<const float> b(a);  // statically safe
+        Buffer<const void> c(b);   // statically safe
+        Buffer<const float> d(c);  // does runtime check of actual type.
+        Buffer<void> e(a);         // statically safe
+        Buffer<float> f(e);        // runtime checks
+
+        static_assert(a.has_static_halide_type);
+        static_assert(b.has_static_halide_type);
+        static_assert(!c.has_static_halide_type);
+        static_assert(d.has_static_halide_type);
+        static_assert(!e.has_static_halide_type);
+        static_assert(f.has_static_halide_type);
+
+        static_assert(a.static_halide_type() == halide_type_of<float>());
+        static_assert(b.static_halide_type() == halide_type_of<float>());
+        static_assert(d.static_halide_type() == halide_type_of<float>());
+        static_assert(f.static_halide_type() == halide_type_of<float>());
+    }
+
+    {
+        // Check Buffers with static dimensionality
         Buffer<float, 2> a(100, 80);
-        Buffer<const float, 3> b(a);  // statically safe
-        Buffer<const void, 4> c(b);   // statically safe
-        Buffer<const float, 3> d(c);  // does runtime check of actual type.
-        Buffer<void, 3> e(a);         // statically safe
-        Buffer<float, 2> f(e);        // runtime checks
+        Buffer<float, 2> b(a);                      // statically safe
+        Buffer<float> c(a);                         // checks at runtime (and succeeds)
+        Buffer<float, Buffer<>::DynamicDims> d(a);  // same as previous, just explicit syntax
+        Buffer<float, 2> e(d);                      // checks at runtime (and succeeds because d.dims = 2)
+        // Buffer<float, 3> f(a);                   // won't compile: static_assert failure
+        // Buffer<float, 3> g(c);                   // fails at runtime: c.dims = 2
+
+        static_assert(a.has_static_dimensions);
+        static_assert(b.has_static_dimensions);
+        static_assert(!c.has_static_dimensions);
+        static_assert(!d.has_static_dimensions);
+        static_assert(e.has_static_dimensions);
+
+        static_assert(a.static_dimensions() == 2);
+        static_assert(b.static_dimensions() == 2);
+        static_assert(e.static_dimensions() == 2);
+
+        Buffer<float> s1 = a.sliced(0);
+        assert(s1.dimensions() == 1);
+        assert(s1.dim(0).extent() == 80);
+
+        Buffer<float, 1> s2 = a.sliced(1);
+        assert(s2.dimensions() == 1);
+        assert(s2.dim(0).extent() == 100);
+
+        Buffer<float, 0> s3 = s2.sliced(0);
+        static_assert(a.has_static_dimensions && s3.static_dimensions() == 0);
+        assert(s3.dimensions() == 0);
+
+        // auto s3a = s3.sliced(0);              // won't compile: can't call sliced() on a zero-dim buffer
+        // Buffer<float, 2> s3b = a.sliced(0);   // won't compile: return type has incompatible dimensionality
+        // a.slice(0);                          // won't compile: can't call slice() on static-dimensioned buffer
+
+        Buffer<float> s4 = a.sliced(0);  // assign to dynamic-dimensioned result
+        static_assert(!s4.has_static_dimensions);
+        assert(s4.dimensions() == 1);
+
+        s4.slice(0);  // ok to call on dynamic-dimensioned
+        assert(s4.dimensions() == 0);
+
+        Buffer<float, 0> e0 = Buffer<float, 0>::make_scalar();
+
+        auto e1 = e0.embedded(0);
+        static_assert(e1.has_static_dimensions && e1.static_dimensions() == 1);
+        assert(e1.dimensions() == 1);
+
+        // Buffer<float, 0> e2 = a.embedded(0);  // won't compile: return type has incompatible dimensionality
+        // e1.embed(0);                          // won't compile: can't call embed() on static-dimensioned buffer
+
+        Buffer<float> e3 = e0.embedded(0);  // assign to dynamic-dimensioned result
+        static_assert(!e3.has_static_dimensions);
+        assert(e3.dimensions() == 1);
+
+        e3.embed(0);  // ok to call on dynamic-dimensioned
+        assert(e3.dimensions() == 2);
     }
 
     {

--- a/test/generator/acquire_release_generator.cpp
+++ b/test/generator/acquire_release_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class AcquireRelease : public Halide::Generator<AcquireRelease> {
 public:
-    Input<Buffer<float>> input{"input", 2};
-    Output<Buffer<float>> output{"output", 2};
+    Input<Buffer<float, 2>> input{"input"};
+    Output<Buffer<float, 2>> output{"output"};
 
     void generate() {
         Var x("x"), y("y");

--- a/test/generator/alias_generator.cpp
+++ b/test/generator/alias_generator.cpp
@@ -5,8 +5,8 @@ namespace {
 class Alias : public Halide::Generator<Alias> {
 public:
     GeneratorParam<int32_t> offset{"offset", 0};
-    Input<Buffer<int32_t>> input{"input", 1};
-    Output<Buffer<int32_t>> output{"output", 1};
+    Input<Buffer<int32_t, 1>> input{"input"};
+    Output<Buffer<int32_t, 1>> output{"output"};
 
     void generate() {
         Var x;

--- a/test/generator/argvcall_generator.cpp
+++ b/test/generator/argvcall_generator.cpp
@@ -6,8 +6,7 @@ class ArgvCall : public Halide::Generator<ArgvCall> {
 public:
     Input<float> f1{"f1", 1.0};
     Input<float> f2{"f2", 1.0};
-
-    Output<Buffer<int32_t>> output{"output", 3};
+    Output<Buffer<int32_t, 3>> output{"output"};
 
     void generate() {
         Var x, y, c;

--- a/test/generator/autograd_generator.cpp
+++ b/test/generator/autograd_generator.cpp
@@ -6,16 +6,16 @@ constexpr int kSize = 64;
 
 class Autograd : public Halide::Generator<Autograd> {
 public:
-    Input<Buffer<float>> input_a{"input_a", 1};
-    Input<Buffer<float>> input_b{"input_b", 1};
-    Input<Buffer<float>> input_c{"input_c", 1};
+    Input<Buffer<float, 1>> input_a{"input_a"};
+    Input<Buffer<float, 1>> input_b{"input_b"};
+    Input<Buffer<float, 1>> input_c{"input_c"};
 
     // Test a case for which won't be able to find a derivative
-    Input<Buffer<uint8_t>> lut{"lut", 1};
-    Input<Buffer<uint8_t>> lut_indices{"lut_indices", 1};
+    Input<Buffer<uint8_t, 1>> lut{"lut"};
+    Input<Buffer<uint8_t, 1>> lut_indices{"lut_indices"};
 
-    Output<Buffer<float>> output{"output", 1};
-    Output<Buffer<uint8_t>> output_lut{"output_lut", 1};
+    Output<Buffer<float, 1>> output{"output"};
+    Output<Buffer<uint8_t, 1>> output_lut{"output_lut"};
 
     void generate() {
         lut.dim(0).set_bounds(0, 256);

--- a/test/generator/bit_operations_generator.cpp
+++ b/test/generator/bit_operations_generator.cpp
@@ -4,15 +4,15 @@ namespace {
 
 class BitOperations : public Halide::Generator<BitOperations> {
 public:
-    Input<Buffer<uint8_t>> input8{"input8", 1};
-    Input<Buffer<uint16_t>> input16{"input16", 1};
-    Input<Buffer<uint32_t>> input32{"input32", 1};
-    Input<Buffer<uint64_t>> input64{"input64", 1};
+    Input<Buffer<uint8_t, 1>> input8{"input8"};
+    Input<Buffer<uint16_t, 1>> input16{"input16"};
+    Input<Buffer<uint32_t, 1>> input32{"input32"};
+    Input<Buffer<uint64_t, 1>> input64{"input64"};
 
-    Output<Buffer<uint8_t>> output8{"output8", 1};
-    Output<Buffer<uint8_t>> output16{"output16", 1};
-    Output<Buffer<uint8_t>> output32{"output32", 1};
-    Output<Buffer<uint8_t>> output64{"output64", 1};
+    Output<Buffer<uint8_t, 1>> output8{"output8"};
+    Output<Buffer<uint8_t, 1>> output16{"output16"};
+    Output<Buffer<uint8_t, 1>> output32{"output32"};
+    Output<Buffer<uint8_t, 1>> output64{"output64"};
 
     void generate() {
         Var x;

--- a/test/generator/blur2x2_generator.cpp
+++ b/test/generator/blur2x2_generator.cpp
@@ -15,11 +15,10 @@ Halide::Expr is_planar(const T &p, int channels = 3) {
 // A trivial 2x2 blur.
 class Blur2x2 : public Halide::Generator<Blur2x2> {
 public:
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     Input<int32_t> width{"width"};
     Input<int32_t> height{"height"};
-
-    Output<Buffer<float>> blur{"blur", 3};
+    Output<Buffer<float, 3>> blur{"blur"};
 
     void generate() {
         // We pass in parameters to tell us where the boundary

--- a/test/generator/buildmethod_generator.cpp
+++ b/test/generator/buildmethod_generator.cpp
@@ -10,7 +10,7 @@ class BuildMethod : public Halide::Generator<BuildMethod> {
 public:
     GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
 
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     Input<float> runtime_factor{"runtime_factor", 1.0};
 
     Func build() {

--- a/test/generator/can_use_target_generator.cpp
+++ b/test/generator/can_use_target_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class CanUseTarget : public Halide::Generator<CanUseTarget> {
 public:
-    Output<Buffer<uint32_t>> output{"output", 2};
+    Output<Buffer<uint32_t, 2>> output{"output"};
 
     // Current really just a placeholder: can_use_target_aottest.cpp just
     // needs to test the runtime itself, not the generator function.

--- a/test/generator/cleanup_on_error_generator.cpp
+++ b/test/generator/cleanup_on_error_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class CleanupOnError : public Halide::Generator<CleanupOnError> {
 public:
-    Output<Buffer<int32_t>> output{"output", 1};
+    Output<Buffer<int32_t, 1>> output{"output"};
 
     void generate() {
         Var x;

--- a/test/generator/configure_generator.cpp
+++ b/test/generator/configure_generator.cpp
@@ -25,7 +25,7 @@ public:
             extra_buffer_inputs.push_back(extra);
         }
 
-        typed_extra_buffer_input = add_input<Buffer<int16_t>>("typed_extra_buffer_input", 2);
+        typed_extra_buffer_input = add_input<Buffer<int16_t, 2>>("typed_extra_buffer_input");
 
         extra_func_input = add_input<Func>("extra_func_input", UInt(16), 3);
 
@@ -95,7 +95,7 @@ private:
     int configure_calls = 0;
 
     std::vector<Input<Buffer<>> *> extra_buffer_inputs;
-    Input<Buffer<int16_t>> *typed_extra_buffer_input;
+    Input<Buffer<int16_t, 2>> *typed_extra_buffer_input;
     Input<Func> *extra_func_input;
     Input<int> *extra_scalar_input;
     Input<Expr> *extra_dynamic_scalar_input;

--- a/test/generator/cxx_mangling_generator.cpp
+++ b/test/generator/cxx_mangling_generator.cpp
@@ -37,35 +37,35 @@ class CPlusPlusNameManglingGenerator : public Halide::Generator<CPlusPlusNameMan
 public:
     // Use all the parameter types to make sure mangling works for each of them.
     // TODO: verify this provides full coverage.
-    Input<Buffer<uint8_t>> input{"input", 1};
-    Input<int8_t> offset_i8{"offset_i8", 0};
-    Input<uint8_t> offset_u8{"offset_u8", 0};
-    Input<int16_t> offset_i16{"offset_i16", 0};
-    Input<uint16_t> offset_u16{"offset_u16", 0};
-    Input<int32_t> offset_i32{"offset_i32", 0};
-    Input<uint32_t> offset_u32{"offset_u32", 0};
-    Input<int64_t> offset_i64{"offset_i64", 0};
-    Input<uint64_t> offset_u64{"offset_u64", 0};
+    Input<Buffer<uint8_t, 1>> input{"input"};
+    Input<int8_t> offset_i8{"offset_i8"};
+    Input<uint8_t> offset_u8{"offset_u8"};
+    Input<int16_t> offset_i16{"offset_i16"};
+    Input<uint16_t> offset_u16{"offset_u16"};
+    Input<int32_t> offset_i32{"offset_i32"};
+    Input<uint32_t> offset_u32{"offset_u32"};
+    Input<int64_t> offset_i64{"offset_i64"};
+    Input<uint64_t> offset_u64{"offset_u64"};
 
-    Input<bool> scale_direction{"scale_direction", 1};
-    Input<float> scale_f{"scale_f", 0};
-    Input<double> scale_d{"scale_d", 0};
-    Input<int32_t *> ptr{"ptr", 0};
-    Input<int32_t const *> const_ptr{"const_ptr", 0};
-    Input<void *> void_ptr{"void_ptr", 0};
-    Input<void const *> const_void_ptr{"const_void_ptr", 0};
+    Input<bool> scale_direction{"scale_direction"};
+    Input<float> scale_f{"scale_f"};
+    Input<double> scale_d{"scale_d"};
+    Input<int32_t *> ptr{"ptr"};
+    Input<int32_t const *> const_ptr{"const_ptr"};
+    Input<void *> void_ptr{"void_ptr"};
+    Input<void const *> const_void_ptr{"const_void_ptr"};
     // 'string' is just a convenient struct-like thing that isn't special
     // cased by Halide; it will be generated as a void* (but const-ness
     // should be preserved).
-    Input<std::string *> string_ptr{"string_ptr", 0};
-    Input<std::string const *> const_string_ptr{"const_string_ptr", 0};
+    Input<std::string *> string_ptr{"string_ptr"};
+    Input<std::string const *> const_string_ptr{"const_string_ptr"};
 
     // Test some manually-registered types. These won't be void *.
-    Input<const my_namespace::my_class *> const_my_class_ptr{"const_my_class_ptr", 0};
-    Input<const my_namespace::my_subnamespace::my_struct *> const_my_struct_ptr{"const_my_struct_ptr", 0};
-    Input<const my_union *> const_my_union_ptr{"const_my_union_ptr", 0};
+    Input<const my_namespace::my_class *> const_my_class_ptr{"const_my_class_ptr"};
+    Input<const my_namespace::my_subnamespace::my_struct *> const_my_struct_ptr{"const_my_struct_ptr"};
+    Input<const my_union *> const_my_union_ptr{"const_my_union_ptr"};
 
-    Output<Buffer<double>> output{"output", 1};
+    Output<Buffer<double, 1>> output{"output"};
 
     void generate() {
         assert(get_target().has_feature(Target::CPlusPlusMangling));

--- a/test/generator/define_extern_opencl_generator.cpp
+++ b/test/generator/define_extern_opencl_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class DefineExternOpenCLOutput : public Halide::Generator<DefineExternOpenCLOutput> {
 public:
-    Input<Buffer<int32_t>> input{"input", 1};
+    Input<Buffer<int32_t, 1>> input{"input"};
     Output<Func> output{"output", Int(32), 1};
 
     Var x{"x"};

--- a/test/generator/embed_image_generator.cpp
+++ b/test/generator/embed_image_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class EmbedImage : public Halide::Generator<EmbedImage> {
 public:
-    Input<Buffer<float>> input{"input", 3};
-    Output<Buffer<float>> output{"output", 3};
+    Input<Buffer<float, 3>> input{"input"};
+    Output<Buffer<float, 3>> output{"output"};
 
     void generate() {
         Buffer<float> matrix(3, 3);

--- a/test/generator/error_codes_generator.cpp
+++ b/test/generator/error_codes_generator.cpp
@@ -4,10 +4,9 @@ namespace {
 
 class ErrorCodes : public Halide::Generator<ErrorCodes> {
 public:
-    Input<Buffer<int32_t>> input{"input", 2};
+    Input<Buffer<int32_t, 2>> input{"input"};
     Input<int> f_explicit_bound{"f_explicit_bound", 1, 0, 64};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         assert(!get_target().has_feature(Target::LargeBuffers));

--- a/test/generator/extern_output_generator.cpp
+++ b/test/generator/extern_output_generator.cpp
@@ -5,9 +5,9 @@ using namespace Halide;
 namespace {
 
 class ExternOutput : public Generator<ExternOutput> {
-    Input<Buffer<int>> input{"input", 2};
+    Input<Buffer<int, 2>> input{"input"};
     Input<int> addend{"addend"};
-    Output<Buffer<int>> output{"output", 2};
+    Output<Buffer<int, 2>> output{"output"};
 
     Func work;
     Var x, y;

--- a/test/generator/external_code_generator.cpp
+++ b/test/generator/external_code_generator.cpp
@@ -12,8 +12,8 @@ namespace {
 class ExternalCode : public Halide::Generator<ExternalCode> {
 public:
     GeneratorParam<bool> external_code_is_bitcode{"external_code_is_bitcode", true};
-    Input<Buffer<int32_t>> input{"input", 2};
-    Output<Buffer<float>> output{"output", 2};
+    Input<Buffer<int32_t, 2>> input{"input"};
+    Output<Buffer<float, 2>> output{"output"};
     HalidePureExtern_1(float, gen_extern_tester, float);
 
     void generate() {

--- a/test/generator/float16_t_generator.cpp
+++ b/test/generator/float16_t_generator.cpp
@@ -2,7 +2,7 @@
 
 class Float16T : public Halide::Generator<Float16T> {
 public:
-    Output<Buffer<int32_t>> output{"output", 1};
+    Output<Buffer<int32_t, 1>> output{"output"};
 
     void generate() {
         // Currently the float16 aot test just exercises the

--- a/test/generator/gpu_multi_context_threaded_generator.cpp
+++ b/test/generator/gpu_multi_context_threaded_generator.cpp
@@ -4,9 +4,8 @@ namespace {
 
 class GpuAdd : public Halide::Generator<GpuAdd> {
 public:
-    Input<Buffer<int32_t>> input{"input", 2};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Input<Buffer<int32_t, 2>> input{"input"};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x("x"), y("y");
@@ -24,9 +23,8 @@ public:
 
 class GpuMul : public Halide::Generator<GpuMul> {
 public:
-    Input<Buffer<int32_t>> input{"input", 2};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Input<Buffer<int32_t, 2>> input{"input"};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x("x"), y("y");

--- a/test/generator/gpu_object_lifetime_generator.cpp
+++ b/test/generator/gpu_object_lifetime_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class GpuObjectLifetime : public Halide::Generator<GpuObjectLifetime> {
 public:
-    Output<Buffer<int32_t>> output{"output", 1};
+    Output<Buffer<int32_t, 1>> output{"output"};
 
     void generate() {
         Var x;

--- a/test/generator/gpu_only_generator.cpp
+++ b/test/generator/gpu_only_generator.cpp
@@ -4,9 +4,8 @@ namespace {
 
 class GpuOnly : public Halide::Generator<GpuOnly> {
 public:
-    Input<Buffer<int32_t>> input{"input", 2};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Input<Buffer<int32_t, 2>> input{"input"};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x("x"), y("y");

--- a/test/generator/gpu_texture_generator.cpp
+++ b/test/generator/gpu_texture_generator.cpp
@@ -4,9 +4,8 @@ namespace {
 
 class GpuTexture : public Halide::Generator<GpuTexture> {
 public:
-    Input<Buffer<int32_t>> input{"input", 2};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Input<Buffer<int32_t, 2>> input{"input"};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x("x"), y("y");

--- a/test/generator/image_from_array_generator.cpp
+++ b/test/generator/image_from_array_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class ImageFromArray : public Halide::Generator<ImageFromArray> {
 public:
-    Output<Buffer<int32_t>> output{"output", 1};
+    Output<Buffer<int32_t, 1>> output{"output"};
 
     void generate() {
         // Currently the test just exercises halide_image.h.

--- a/test/generator/mandelbrot_generator.cpp
+++ b/test/generator/mandelbrot_generator.cpp
@@ -58,8 +58,7 @@ public:
     Input<int> iters{"iters"};
     Input<int> w{"w"};
     Input<int> h{"h"};
-
-    Output<Buffer<int32_t>> count{"count", 2};
+    Output<Buffer<int32_t, 2>> count{"count"};
 
     void generate() {
         Var x, y, z;

--- a/test/generator/matlab_generator.cpp
+++ b/test/generator/matlab_generator.cpp
@@ -6,11 +6,10 @@ namespace {
 
 class Matlab : public Halide::Generator<Matlab> {
 public:
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float, 2>> input{"input"};
     Input<float> scale{"scale"};
     Input<bool> negate{"negate"};
-
-    Output<Buffer<float>> output{"output", 2};
+    Output<Buffer<float, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/test/generator/memory_profiler_mandelbrot_generator.cpp
+++ b/test/generator/memory_profiler_mandelbrot_generator.cpp
@@ -58,8 +58,7 @@ public:
     Input<int> iters{"iters"};
     Input<int> w{"w"};
     Input<int> h{"h"};
-
-    Output<Buffer<int32_t>> count{"count", 2};
+    Output<Buffer<int32_t, 2>> count{"count"};
 
     void generate() {
         assert(get_target().has_feature(Target::Profile));

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -10,9 +10,9 @@ enum class SomeEnum { Foo,
 class MetadataTester : public Halide::Generator<MetadataTester> {
 public:
     Input<Func> input{"input"};  // must be overridden to {UInt(8), 3}
-    Input<Buffer<uint8_t>> typed_input_buffer{"typed_input_buffer", 3};
-    Input<Buffer<>> dim_only_input_buffer{"dim_only_input_buffer", 3};  // must be overridden to type=UInt(8)
-    Input<Buffer<>> untyped_input_buffer{"untyped_input_buffer"};       // must be overridden to {UInt(8), 3}
+    Input<Buffer<uint8_t, 3>> typed_input_buffer{"typed_input_buffer"};
+    Input<Buffer<void, 3>> dim_only_input_buffer{"dim_only_input_buffer"};  // must be overridden to type=UInt(8)
+    Input<Buffer<>> untyped_input_buffer{"untyped_input_buffer"};           // must be overridden to {UInt(8), 3}
     Input<int32_t> no_default_value{"no_default_value"};
     Input<bool> b{"b", true};
     Input<int8_t> i8{"i8", 8, -8, 127};
@@ -26,11 +26,9 @@ public:
     Input<float> f32{"f32", 32.1234f, -3200.1234f, 3200.1234f};
     Input<double> f64{"f64", 64.25f, -6400.25f, 6400.25f};
     Input<void *> h{"h", nullptr};
-
     Input<Func> input_not_nod{"input_not_nod"};   // must be overridden to type=uint8 dim=3
     Input<Func> input_nod{"input_nod", UInt(8)};  // must be overridden to type=uint8 dim=3
     Input<Func> input_not{"input_not", 3};        // must be overridden to type=uint8
-
     Input<Func[]> array_input{"array_input", UInt(8), 3};  // must be overridden to size=2
     Input<Func[2]> array2_input{"array2_input", UInt(8), 3};
     Input<int8_t[]> array_i8{"array_i8"};  // must be overridden to size=2
@@ -41,38 +39,38 @@ public:
     Input<int32_t[2]> array2_i32{"array2_i32", 32, -32, 127};
     Input<void *[]> array_h { "array_h", nullptr };  // must be overridden to size=2
 
-    Input<Buffer<float>[2]> buffer_array_input1 { "buffer_array_input1", 3 };
-    Input<Buffer<float>[2]> buffer_array_input2 { "buffer_array_input2" };  // buffer_array_input2.dim must be set
-    Input<Buffer<>[2]> buffer_array_input3 { "buffer_array_input3", 3 };    // buffer_array_input2.type must be set
-    Input<Buffer<>[2]> buffer_array_input4 { "buffer_array_input4" };       // dim and type must be set
+    Input<Buffer<float, 3>[2]> buffer_array_input1 { "buffer_array_input1" };
+    Input<Buffer<float>[2]> buffer_array_input2 { "buffer_array_input2" };    // buffer_array_input2.dim must be set
+    Input<Buffer<void, 3>[2]> buffer_array_input3 { "buffer_array_input3" };  // buffer_array_input2.type must be set
+    Input<Buffer<>[2]> buffer_array_input4 { "buffer_array_input4" };         // dim and type must be set
     // .size must be specified for all of these
-    Input<Buffer<float>[]> buffer_array_input5 { "buffer_array_input5", 3 };
-    Input<Buffer<float>[]> buffer_array_input6 { "buffer_array_input6" };  // buffer_array_input2.dim must be set
-    Input<Buffer<>[]> buffer_array_input7 { "buffer_array_input7", 3 };    // buffer_array_input2.type must be set
-    Input<Buffer<>[]> buffer_array_input8 { "buffer_array_input8" };       // dim and type must be set
+    Input<Buffer<float, 3>[]> buffer_array_input5 { "buffer_array_input5" };
+    Input<Buffer<float>[]> buffer_array_input6 { "buffer_array_input6" };    // buffer_array_input2.dim must be set
+    Input<Buffer<void, 3>[]> buffer_array_input7 { "buffer_array_input7" };  // buffer_array_input2.type must be set
+    Input<Buffer<>[]> buffer_array_input8 { "buffer_array_input8" };         // dim and type must be set
 
-    Input<Buffer<float16_t>> buffer_f16_typed{"buffer_f16_typed", 1};
-    Input<Buffer<>> buffer_f16_untyped{"buffer_f16_untyped", 1};
+    Input<Buffer<float16_t, 1>> buffer_f16_typed{"buffer_f16_typed"};
+    Input<Buffer<void, 1>> buffer_f16_untyped{"buffer_f16_untyped"};
 
     Input<Expr> untyped_scalar_input{"untyped_scalar_input"};  // untyped_scalar_input.type must be set to uint8
 
     Output<Func> output{"output"};  // must be overridden to {{Float(32), Float(32)}, 3}
-    Output<Buffer<float>> typed_output_buffer{"typed_output_buffer", 3};
+    Output<Buffer<float, 3>> typed_output_buffer{"typed_output_buffer"};
     Output<Buffer<float>> type_only_output_buffer{"type_only_output_buffer"};  // untyped outputs can have type and/or dimensions inferred
-    Output<Buffer<>> dim_only_output_buffer{"dim_only_output_buffer", 3};      // untyped outputs can have type and/or dimensions inferred
+    Output<Buffer<void, 3>> dim_only_output_buffer{"dim_only_output_buffer"};  // untyped outputs can have type and/or dimensions inferred
     Output<Buffer<>> untyped_output_buffer{"untyped_output_buffer"};           // untyped outputs can have type and/or dimensions inferred
-    Output<Buffer<>> tupled_output_buffer{"tupled_output_buffer", {Float(32), Int(32)}, 3};
+    Output<Buffer<void, 3>> tupled_output_buffer{"tupled_output_buffer", {Float(32), Int(32)}};
     Output<float> output_scalar{"output_scalar"};
     Output<Func[]> array_outputs{"array_outputs", Float(32), 3};  // must be overridden to size=2
     Output<Func[2]> array_outputs2{"array_outputs2", {Float(32), Float(32)}, 3};
     Output<float[2]> array_outputs3{"array_outputs3"};
 
-    Output<Buffer<float>[2]> array_outputs4 { "array_outputs4", 3 };
+    Output<Buffer<float, 3>[2]> array_outputs4 { "array_outputs4" };
     Output<Buffer<float>[2]> array_outputs5 { "array_outputs5" };  // dimensions will be inferred by usage
     Output<Buffer<>[2]> array_outputs6 { "array_outputs6" };       // dimensions and type will be inferred by usage
 
     // .size must be specified for all of these
-    Output<Buffer<float>[]> array_outputs7 { "array_outputs7", 3 };
+    Output<Buffer<float, 3>[]> array_outputs7 { "array_outputs7" };
     Output<Buffer<float>[]> array_outputs8 { "array_outputs8" };
     Output<Buffer<>[]> array_outputs9 { "array_outputs9" };
 

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -26,9 +26,9 @@ public:
     Input<float> f32{"f32", 32.1234f, -3200.1234f, 3200.1234f};
     Input<double> f64{"f64", 64.25f, -6400.25f, 6400.25f};
     Input<void *> h{"h", nullptr};
-    Input<Func> input_not_nod{"input_not_nod"};   // must be overridden to type=uint8 dim=3
-    Input<Func> input_nod{"input_nod", UInt(8)};  // must be overridden to type=uint8 dim=3
-    Input<Func> input_not{"input_not", 3};        // must be overridden to type=uint8
+    Input<Func> input_not_nod{"input_not_nod"};            // must be overridden to type=uint8 dim=3
+    Input<Func> input_nod{"input_nod", UInt(8)};           // must be overridden to type=uint8 dim=3
+    Input<Func> input_not{"input_not", 3};                 // must be overridden to type=uint8
     Input<Func[]> array_input{"array_input", UInt(8), 3};  // must be overridden to size=2
     Input<Func[2]> array2_input{"array2_input", UInt(8), 3};
     Input<int8_t[]> array_i8{"array_i8"};  // must be overridden to size=2

--- a/test/generator/msan_generator.cpp
+++ b/test/generator/msan_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class MSAN : public Halide::Generator<MSAN> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 3};
-    Output<Buffer<uint8_t>> output{"output", 3};
+    Input<Buffer<uint8_t, 3>> input{"input"};
+    Output<Buffer<uint8_t, 3>> output{"output"};
 
     void generate() {
         // Currently the test just exercises Target::MSAN

--- a/test/generator/multitarget_generator.cpp
+++ b/test/generator/multitarget_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class Multitarget : public Halide::Generator<Multitarget> {
 public:
-    Output<Buffer<uint32_t>> output{"output", 2};
+    Output<Buffer<uint32_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/test/generator/nested_externs_generator.cpp
+++ b/test/generator/nested_externs_generator.cpp
@@ -12,8 +12,8 @@ void set_interleaved(T &t) {
 // Add two inputs
 class NestedExternsCombine : public Generator<NestedExternsCombine> {
 public:
-    Input<Buffer<float>> input_a{"input_a", 3};
-    Input<Buffer<float>> input_b{"input_b", 3};
+    Input<Buffer<float, 3>> input_a{"input_a"};
+    Input<Buffer<float, 3>> input_b{"input_b"};
     Output<Buffer<>> combine{"combine"};  // unspecified type-and-dim will be inferred
 
     void generate() {
@@ -32,7 +32,7 @@ public:
 class NestedExternsInner : public Generator<NestedExternsInner> {
 public:
     Input<float> value{"value", 1.0f};
-    Output<Buffer<float>> inner{"inner", 3};
+    Output<Buffer<float, 3>> inner{"inner"};
 
     void generate() {
         extern_stage_1.define_extern("nested_externs_leaf", {value}, Float(32), 3);
@@ -59,7 +59,7 @@ private:
 class NestedExternsLeaf : public Generator<NestedExternsLeaf> {
 public:
     Input<float> value{"value", 1.0f};
-    Output<Buffer<float>> leaf{"leaf", 3};
+    Output<Buffer<float, 3>> leaf{"leaf"};
 
     void generate() {
         Var x, y, c;
@@ -75,7 +75,7 @@ public:
 class NestedExternsRoot : public Generator<NestedExternsRoot> {
 public:
     Input<float> value{"value", 1.0f};
-    Output<Buffer<float>> root{"root", 3};
+    Output<Buffer<float, 3>> root{"root"};
 
     void generate() {
         extern_stage_1.define_extern("nested_externs_inner", {value}, Float(32), 3);

--- a/test/generator/opencl_runtime_generator.cpp
+++ b/test/generator/opencl_runtime_generator.cpp
@@ -4,9 +4,8 @@ namespace {
 
 class OpenCL_Runtime : public Halide::Generator<OpenCL_Runtime> {
 public:
-    Input<Buffer<int32_t>> input{"input", 2};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Input<Buffer<int32_t, 2>> input{"input"};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x("x"), y("y");

--- a/test/generator/rdom_input_generator.cpp
+++ b/test/generator/rdom_input_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class RDomInput : public Halide::Generator<RDomInput> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 2};
-    Output<Buffer<uint8_t>> output{"output", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
+    Output<Buffer<uint8_t, 2>> output{"output"};
 
     void generate() {
         RDom r(input);

--- a/test/generator/sanitizercoverage_generator.cpp
+++ b/test/generator/sanitizercoverage_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class SanitizerCoverage : public Halide::Generator<SanitizerCoverage> {
 public:
-    Output<Buffer<int8_t>> output{"output", 3};
+    Output<Buffer<int8_t, 3>> output{"output"};
 
     void generate() {
         // Currently the test just exercises Target::SanitizerCoverage

--- a/test/generator/shuffler_generator.cpp
+++ b/test/generator/shuffler_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class Shuffler : public Halide::Generator<Shuffler> {
 public:
-    Input<Buffer<int32_t>> input{"input", 1};
-    Output<Buffer<int32_t>> output{"output", 1};
+    Input<Buffer<int32_t, 1>> input{"input"};
+    Output<Buffer<int32_t, 1>> output{"output"};
 
     void generate() {
         // The +1 is just to get a Broadcast node

--- a/test/generator/string_param_generator.cpp
+++ b/test/generator/string_param_generator.cpp
@@ -7,7 +7,7 @@ class StringParam : public Halide::Generator<StringParam> {
 public:
     GeneratorParam<std::string> rpn{"rpn_expr", ""};
 
-    Output<Buffer<int>> output{"output", 2};
+    Output<Buffer<int, 2>> output{"output"};
 
     void generate() {
         // Remove cmake extra skip characters if any exist.

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -30,9 +30,9 @@ public:
     GeneratorParam<bool> vectorize{"vectorize", true};
     GeneratorParam<LoopLevel> intermediate_level{"intermediate_level", LoopLevel::root()};
 
-    Input<Buffer<uint8_t>> typed_buffer_input{"typed_buffer_input", 3};
+    Input<Buffer<uint8_t, 3>> typed_buffer_input{"typed_buffer_input"};
     Input<Buffer<>> untyped_buffer_input{"untyped_buffer_input"};
-    Input<Buffer<uint8_t>[2]> array_buffer_input { "array_buffer_input", 3 };
+    Input<Buffer<uint8_t, 3>[2]> array_buffer_input { "array_buffer_input" };
     Input<Func> simple_input{"simple_input", 3};  // require a 3-dimensional Func but leave Type unspecified
     Input<Func[]> array_input{"array_input", 3};  // require a 3-dimensional Func but leave Type and ArraySize unspecified
     // Note that Input<Func> does not (yet) support Tuples
@@ -44,11 +44,11 @@ public:
     Output<Func[]> array_output{"array_output", Int(16), 2};  // leave ArraySize unspecified
     Output<Buffer<float>> typed_buffer_output{"typed_buffer_output"};
     Output<Buffer<>> untyped_buffer_output{"untyped_buffer_output"};
-    Output<Buffer<>> tupled_output{"tupled_output", {Float(32), Int(32)}, 3};
-    Output<Buffer<uint8_t>> static_compiled_buffer_output{"static_compiled_buffer_output", 3};
-    Output<Buffer<uint8_t>[2]> array_buffer_output { "array_buffer_output", 3 };
-    Output<Buffer<Halide::float16_t>> float16_output{"float16_output", 3};
-    Output<Buffer<Halide::bfloat16_t>> bfloat16_output{"bfloat16_output", 3};
+    Output<Buffer<void, 3>> tupled_output{"tupled_output", {Float(32), Int(32)}};
+    Output<Buffer<uint8_t, 3>> static_compiled_buffer_output{"static_compiled_buffer_output"};
+    Output<Buffer<uint8_t, 3>[2]> array_buffer_output { "array_buffer_output" };
+    Output<Buffer<Halide::float16_t, 3>> float16_output{"float16_output"};
+    Output<Buffer<Halide::bfloat16_t, 3>> bfloat16_output{"bfloat16_output"};
 
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -24,16 +24,16 @@ class StubUser : public Halide::Generator<StubUser> {
 public:
     GeneratorParam<int32_t> int_arg{"int_arg", 33};
 
-    Input<Buffer<uint8_t>> input{"input", 3};
+    Input<Buffer<uint8_t, 3>> input{"input"};
     Output<Buffer<uint8_t>> calculated_output{"calculated_output"};
     Output<Buffer<float>> float32_buffer_output{"float32_buffer_output"};
     Output<Buffer<int32_t>> int32_buffer_output{"int32_buffer_output"};
     Output<Buffer<uint8_t>> array_test_output{"array_test_output"};
     // We can infer the tupled-output-type from the Stub
-    Output<Buffer<>> tupled_output{"tupled_output", 3};
-    Output<Buffer<int>> int_output{"int_output", 3};
-    Output<Buffer<Halide::float16_t>> float16_output{"float16_output", 3};
-    Output<Buffer<Halide::bfloat16_t>> bfloat16_output{"bfloat16_output", 3};
+    Output<Buffer<void, 3>> tupled_output{"tupled_output"};
+    Output<Buffer<int, 3>> int_output{"int_output"};
+    Output<Buffer<Halide::float16_t, 3>> float16_output{"float16_output"};
+    Output<Buffer<Halide::bfloat16_t, 3>> bfloat16_output{"bfloat16_output"};
 
     void generate() {
         Var x{"x"}, y{"y"}, c{"c"};

--- a/test/generator/templated_generator.cpp
+++ b/test/generator/templated_generator.cpp
@@ -16,8 +16,8 @@ public:
     // A major downside of templated generators is that because we use CRTP, you
     // must manually import names of types from the base class. For Input and
     // Output you can also just use these equivalent globally-scoped names:
-    GeneratorInput<Buffer<T1>> input{"input", 2};
-    GeneratorOutput<Buffer<T2>> output{"output", 2};
+    GeneratorInput<Buffer<T1, 2>> input{"input"};
+    GeneratorOutput<Buffer<T2, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/test/generator/tiled_blur_generator.cpp
+++ b/test/generator/tiled_blur_generator.cpp
@@ -16,8 +16,8 @@ Halide::Expr is_planar(const T &p, int channels = 3) {
 
 class TiledBlur : public Halide::Generator<TiledBlur> {
 public:
-    Input<Buffer<uint8_t>> input{"input", 3};
-    Output<Buffer<uint8_t>> output{"output", 3};
+    Input<Buffer<uint8_t, 3>> input{"input"};
+    Output<Buffer<uint8_t, 3>> output{"output"};
 
     void generate() {
         Expr input_float = cast<float>(input(x, y, c)) / 255.f;

--- a/test/generator/user_context_generator.cpp
+++ b/test/generator/user_context_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class UserContext : public Halide::Generator<UserContext> {
 public:
-    Input<Buffer<float>> input{"input", 2};
-    Output<Buffer<float>> output{"output", 2};
+    Input<Buffer<float, 2>> input{"input"};
+    Output<Buffer<float, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/test/generator/user_context_insanity_generator.cpp
+++ b/test/generator/user_context_insanity_generator.cpp
@@ -4,8 +4,8 @@ namespace {
 
 class UserContextInsanity : public Halide::Generator<UserContextInsanity> {
 public:
-    Input<Buffer<float>> input{"input", 2};
-    Output<Buffer<float>> output{"output", 2};
+    Input<Buffer<float, 2>> input{"input"};
+    Output<Buffer<float, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/test/generator/variable_num_threads_generator.cpp
+++ b/test/generator/variable_num_threads_generator.cpp
@@ -4,7 +4,7 @@ namespace {
 
 class VariableNumThreads : public Halide::Generator<VariableNumThreads> {
 public:
-    Output<Buffer<float>> output{"output", 2};
+    Output<Buffer<float, 2>> output{"output"};
 
     void generate() {
         // A job with lots of nested parallelism

--- a/test/integration/aot/add.cpp
+++ b/test/integration/aot/add.cpp
@@ -2,7 +2,7 @@
 using namespace Halide;
 
 struct Add : Generator<Add> {
-    Output<Buffer<int32_t>> output{"output", 2};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/test/integration/xc/add.cpp
+++ b/test/integration/xc/add.cpp
@@ -2,7 +2,7 @@
 using namespace Halide;
 
 struct Add : Generator<Add> {
-    Output<Buffer<int32_t>> output{"output", 2};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/tutorial/lesson_15_generators.cpp
+++ b/tutorial/lesson_15_generators.cpp
@@ -32,10 +32,10 @@ public:
     // member variables. They'll appear in the signature of our generated
     // function in the same order as we declare them.
     Input<uint8_t> offset{"offset"};
-    Input<Buffer<uint8_t>> input{"input", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
 
     // We also declare the Outputs as public member variables.
-    Output<Buffer<uint8_t>> brighter{"brighter", 2};
+    Output<Buffer<uint8_t, 2>> brighter{"brighter"};
 
     // Typically you declare your Vars at this scope as well, so that
     // they can be used in any helper methods you add later.
@@ -97,12 +97,12 @@ public:
 
     // We'll use the same Inputs as before:
     Input<uint8_t> offset{"offset"};
-    Input<Buffer<uint8_t>> input{"input", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
 
     // And a similar Output. Note that we don't specify a type for the Buffer:
     // at compile-time, we must specify an explicit type via the "output.type"
     // GeneratorParam (which is implicitly defined for this Output).
-    Output<Buffer<>> output{"output", 2};
+    Output<Buffer<void, 2>> output{"output"};
 
     // And we'll declare our Vars here as before.
     Var x, y;

--- a/tutorial/lesson_16_rgb_generate.cpp
+++ b/tutorial/lesson_16_rgb_generate.cpp
@@ -33,7 +33,7 @@ public:
     // We declare a three-dimensional input image. The first two
     // dimensions will be x, and y, and the third dimension will be
     // the color channel.
-    Input<Buffer<uint8_t>> input{"input", 3};
+    Input<Buffer<uint8_t, 3>> input{"input"};
 
     // We will compile this generator in several ways to accept
     // several different memory layouts for the input and output. This
@@ -56,7 +56,7 @@ public:
     Input<uint8_t> offset{"offset"};
 
     // Declare our outputs
-    Output<Buffer<uint8_t>> brighter{"brighter", 3};
+    Output<Buffer<uint8_t, 3>> brighter{"brighter"};
 
     // Declare our Vars
     Var x, y, c;

--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -29,11 +29,10 @@ using namespace Halide;
 // We will define a generator to auto-schedule.
 class AutoScheduled : public Halide::Generator<AutoScheduled> {
 public:
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     Input<float> factor{"factor"};
-
-    Output<Buffer<float>> output1{"output1", 2};
-    Output<Buffer<float>> output2{"output2", 2};
+    Output<Buffer<float, 2>> output1{"output1"};
+    Output<Buffer<float, 2>> output2{"output2"};
 
     Expr sum3x3(Func f, Var x, Var y) {
         return f(x - 1, y - 1) + f(x - 1, y) + f(x - 1, y + 1) +


### PR DESCRIPTION
This deprecates the ctors to Generator Input/Output that are "redundant" after #6574 lands (i.e.: type and dimensions should be specified in the Buffer<T, D> declaration instead of as arguments). Also updates all our existing Generators to conform. Additive to #6574.
