### PR TITLE
Allow calling scheduling methods on Output<Buffer[]>

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2338,7 +2338,7 @@ void generator_test() {
         static_assert(std::is_same<decltype(tester_instance.func_array_output[0]), Func &>::value, "type mismatch");
 
         static_assert(std::is_same<decltype(tester_instance.buffer_array_input[0]), ImageParam>::value, "type mismatch");
-        static_assert(std::is_same<decltype(tester_instance.buffer_array_output[0]), const Func &>::value, "type mismatch");
+        static_assert(std::is_same<decltype(tester_instance.buffer_array_output[0]), Func>::value, "type mismatch");
     }
 
     class GPTester : public Generator<GPTester> {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2570,6 +2570,19 @@ public:
         return *this;
     }
 
+    template<typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
+    const Func &operator[](size_t i) const {
+        this->check_gio_access();
+        return this->template get_values<Func>()[i];
+    }
+
+    // Allow Output<Buffer[]>.compute_root() (or other scheduling directive that requires nonconst)
+    template<typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
+    Func operator[](size_t i) {
+        this->check_gio_access();
+        return this->template get_values<Func>()[i];
+    }
+
     /** Forward methods to the OutputImageParam. */
     // @{
     HALIDE_FORWARD_METHOD(OutputImageParam, dim)

--- a/test/generator/metadata_tester_generator.cpp
+++ b/test/generator/metadata_tester_generator.cpp
@@ -169,6 +169,11 @@ public:
         // Note that calling set_bounds()/bound() implicitly calls set_estimate()/estimate() as well.
         type_only_output_buffer.dim(1).set_bounds(0, 32);
         type_only_output_buffer.bound(c, 0, 3);
+
+        // Verify that we can call schedule methods on arrays-of-Buffer
+        for (int i = 0; i < 2; i++) {
+            array_outputs4[i].compute_root();
+        }
     }
 
     void schedule() {


### PR DESCRIPTION
The constness of the inherited operator[] meant you couldn't call scheduling methods on array-of-output-buffer in a Generator. Fixed and added a test case.