### PR TITLE
Deprecate the Generator::build() method

### DIFF
--- a/python_bindings/correctness/partialbuildmethod_generator.cpp
+++ b/python_bindings/correctness/partialbuildmethod_generator.cpp
@@ -2,6 +2,7 @@
 
 namespace {
 
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
 // This Generator exists solely to test converted old-style
 // generators -- which use Input<> rather than Param/ImageParam, but *don't* use
 // Output<>/generate().
@@ -24,6 +25,24 @@ public:
         return g;
     }
 };
+#else
+// Provide a placeholder here that uses generate(), just to allow this test to
+// succeed even if build() is disabled.
+class PartialBuildMethod : public Halide::Generator<PartialBuildMethod> {
+public:
+    GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+    Input<Buffer<float>> input{"input", 2};
+    Input<float> runtime_factor{"runtime_factor", 1.0};
+    Output<Buffer<int32_t>> output{"output", 2};
+
+    void generate() {
+        Var x, y;
+
+        output(x, y) = cast<int32_t>(input(x, y) * compiletime_factor * runtime_factor);
+    }
+};
+#endif
 
 }  // namespace
 

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -260,6 +260,7 @@ def test_complexstub():
             actual = b[x, y]
             assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
+# disabled because HALIDE_ALLOW_GENERATOR_BUILD_METHOD is off by default
 def test_partialbuildmethod():
     x, y, c = hl.Var(), hl.Var(), hl.Var()
     target = hl.get_jit_target_from_environment()
@@ -270,7 +271,7 @@ def test_partialbuildmethod():
     b_out = hl.Buffer(hl.Int(32), [2, 2])
 
     try:
-        f = partialbuildmethod.generate(target, b_in, 1)
+        f = partialbuildmethod.generate(target, b_in, 1.0)
     except RuntimeError as e:
         assert "Generators that use build() (instead of generate()+Output<>) are not supported in the Python bindings." in str(e)
     else:
@@ -294,5 +295,6 @@ if __name__ == "__main__":
     test_simplestub()
     test_looplevel()
     test_complexstub()
-    test_partialbuildmethod()
+    # disabled because HALIDE_ALLOW_GENERATOR_BUILD_METHOD is off by default
+    # test_partialbuildmethod()
     test_nobuildmethod()

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -674,6 +674,7 @@ std::vector<std::vector<Func>> GeneratorStub::generate(const GeneratorParamsMap 
 
     std::vector<std::vector<Func>> v;
     GeneratorParamInfo &pi = generator->param_info();
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     if (!pi.outputs().empty()) {
         for (auto *output : pi.outputs()) {
             v.push_back(get_outputs(output->name()));
@@ -684,6 +685,12 @@ std::vector<std::vector<Func>> GeneratorStub::generate(const GeneratorParamsMap 
             v.push_back(std::vector<Func>{output});
         }
     }
+#else
+    internal_assert(!pi.outputs().empty());
+    for (auto *output : pi.outputs()) {
+        v.push_back(get_outputs(output->name()));
+    }
+#endif
     return v;
 }
 
@@ -1113,8 +1120,13 @@ void GeneratorParamBase::check_value_readable() const {
         name() == "machine_params") {
         return;
     }
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     user_assert(generator && generator->phase >= GeneratorBase::ConfigureCalled)
         << "The GeneratorParam \"" << name() << "\" cannot be read before build() or configure()/generate() is called.\n";
+#else
+    user_assert(generator && generator->phase >= GeneratorBase::ConfigureCalled)
+        << "The GeneratorParam \"" << name() << "\" cannot be read before configure()/generate() is called.\n";
+#endif
 }
 
 void GeneratorParamBase::check_value_writable() const {
@@ -1122,7 +1134,13 @@ void GeneratorParamBase::check_value_writable() const {
     if (!generator) {
         return;
     }
-    user_assert(generator->phase < GeneratorBase::GenerateCalled) << "The GeneratorParam \"" << name() << "\" cannot be written after build() or generate() is called.\n";
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
+    user_assert(generator->phase < GeneratorBase::GenerateCalled)
+        << "The GeneratorParam \"" << name() << "\" cannot be written after build() or generate() is called.\n";
+#else
+    user_assert(generator->phase < GeneratorBase::GenerateCalled)
+        << "The GeneratorParam \"" << name() << "\" cannot be written after generate() is called.\n";
+#endif
 }
 
 void GeneratorParamBase::fail_wrong_type(const char *type) {
@@ -1449,6 +1467,7 @@ void GeneratorBase::post_schedule() {
     track_parameter_values(true);
 }
 
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
 void GeneratorBase::pre_build() {
     advance_phase(GenerateCalled);
     advance_phase(ScheduleCalled);
@@ -1466,6 +1485,7 @@ void GeneratorBase::pre_build() {
 void GeneratorBase::post_build() {
     track_parameter_values(true);
 }
+#endif
 
 Pipeline GeneratorBase::get_pipeline() {
     check_min_phase(GenerateCalled);
@@ -1900,8 +1920,13 @@ void GIOBase::check_gio_access() const {
     if (!generator) {
         return;
     }
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     user_assert(generator->phase > GeneratorBase::InputsSet)
         << "The " << input_or_output() << " \"" << name() << "\" cannot be examined before build() or generate() is called.\n";
+#else
+    user_assert(generator->phase > GeneratorBase::InputsSet)
+        << "The " << input_or_output() << " \"" << name() << "\" cannot be examined before generate() is called.\n";
+#endif
 }
 
 // If our dims are defined, ensure it matches the one passed in, asserting if not.
@@ -2181,6 +2206,7 @@ void generator_test() {
         // tester.sp2.set(202);  // This will assert-fail.
     }
 
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     // Verify that the Generator's internal phase actually prevents unsupported
     // order of operations (with old-style Generator)
     {
@@ -2247,6 +2273,7 @@ void generator_test() {
         // tester.gp2.set(2);  // This will assert-fail.
         // tester.sp2.set(202);  // This will assert-fail.
     }
+#endif
 
     // Verify that set_inputs() works properly, even if the specific subtype of Generator is not known.
     {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -304,7 +304,7 @@ void generator_test();
  * vectorization being unavailable.
  *
  * We do this by tracking the active values at entrance and exit to all user-provided
- * Generator methods (build()/generate()/schedule()); if we ever find more than two unique
+ * Generator methods (generate()/schedule()); if we ever find more than two unique
  * values active, we know we have a potential conflict. ("two" here because the first
  * value is the default value for a given constraint.)
  *
@@ -3132,7 +3132,7 @@ public:
 
     void emit_cpp_stub(const std::string &stub_file_path);
 
-    // Call build() and produce a Module for the result.
+    // Call generate() and produce a Module for the result.
     // If function_name is empty, generator_name() will be used for the function.
     Module build_module(const std::string &function_name = "",
                         LinkageType linkage_type = LinkageType::ExternalPlusMetadata);
@@ -3191,12 +3191,20 @@ public:
         get_pipeline().realize(r, get_target());
     }
 
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     // Return the Pipeline that has been built by the generate() method.
     // This method can only be used from a Generator that has a generate()
     // method (vs a build() method), and currently can only be called from
     // the schedule() method. (This may be relaxed in the future to allow
     // calling from generate() as long as all Outputs have been defined.)
     Pipeline get_pipeline();
+#else
+    // Return the Pipeline that has been built by the generate() method.
+    // This method can only be called from the schedule() method.
+    // (This may be relaxed in the future to allow calling from generate() as
+    // long as all Outputs have been defined.)
+    Pipeline get_pipeline();
+#endif
 
     // Create Input<Buffer> or Input<Func> with dynamic type
     template<typename T,
@@ -3324,10 +3332,15 @@ protected:
         // in AOT mode, this can be skipped, going Created->GenerateCalled directly.)
         InputsSet,
 
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
         // Generator has had its generate() method called. (For Generators with
         // a build() method instead of generate(), this phase will be skipped
         // and will advance directly to ScheduleCalled.)
         GenerateCalled,
+#else
+        // Generator has had its generate() method called.
+        GenerateCalled,
+#endif
 
         // Generator has had its schedule() method (if any) called.
         ScheduleCalled,
@@ -3568,7 +3581,7 @@ public:
     static std::unique_ptr<T> create(const Halide::GeneratorContext &context) {
         // We must have an object of type T (not merely GeneratorBase) to call a protected method,
         // because CRTP is a weird beast.
-        auto g = std::unique_ptr<T>(new T());
+        auto g = std::make_unique<T>();
         g->init_from_context(context);
         return g;
     }
@@ -3587,11 +3600,13 @@ public:
 
     template<typename... Args>
     void apply(const Args &...args) {
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
 #ifndef _MSC_VER
         // VS2015 apparently has some SFINAE issues, so this can inappropriately
         // trigger there. (We'll still fail when generate() is called, just
         // with a less-helpful error message.)
         static_assert(has_generate_method<T>::value, "apply() is not supported for old-style Generators.");
+#endif
 #endif
         call_configure();
         set_inputs(args...);
@@ -3623,9 +3638,7 @@ private:
     template<typename T2>
     struct has_schedule_method<T2, typename type_sink<decltype(std::declval<T2>().schedule())>::type> : std::true_type {};
 
-    template<typename T2 = T,
-             typename std::enable_if<!has_generate_method<T2>::value>::type * = nullptr>
-
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     // Implementations for build_pipeline_impl(), specialized on whether we
     // have build() or generate()/schedule() methods.
 
@@ -3635,9 +3648,16 @@ private:
     // many overloads as we can exist, and then use C++'s preference
     // for treating a 0 as an int rather than a double to choose one
     // of them.
+    template<typename T2 = T,
+             typename std::enable_if<!has_generate_method<T2>::value>::type * = nullptr>
+    HALIDE_ATTRIBUTE_DEPRECATED("The build() method is deprecated for Halide Generators and will be removed entirely in future versions of Halide. Please use a generate() method with Output<> members instead.")
     Pipeline build_pipeline_impl(double) {
         static_assert(!has_configure_method<T2>::value, "The configure() method is ignored if you define a build() method; use generate() instead.");
         static_assert(!has_schedule_method<T2>::value, "The schedule() method is ignored if you define a build() method; use generate() instead.");
+
+        user_warning << "The build() method is deprecated for Halide Generators and will be removed entirely in future versions of Halide. "
+                     << "Please use a generate() method with Output<> members instead.\n";
+
         pre_build();
         Pipeline p = ((T *)this)->build();
         post_build();
@@ -3729,8 +3749,51 @@ private:
         t->schedule();
         post_schedule();
     }
+#else
+    Pipeline build_pipeline_impl() {
+        T *t = (T *)this;
+        // No: configure() must be called prior to this
+        // (and in fact, prior to calling set_inputs).
+        //
+        // t->call_configure_impl();
+
+        t->call_generate_impl();
+        t->call_schedule_impl();
+        return get_pipeline();
+    }
+
+    void call_configure_impl() {
+        pre_configure();
+        if constexpr (has_configure_method<T>::value) {
+            T *t = (T *)this;
+            static_assert(std::is_void<decltype(t->configure())>::value, "configure() must return void");
+            t->configure();
+        }
+        post_configure();
+    }
+
+    void call_generate_impl() {
+        pre_generate();
+        static_assert(has_generate_method<T>::value, "Expected a generate() method here.");
+        T *t = (T *)this;
+        static_assert(std::is_void<decltype(t->generate())>::value, "generate() must return void");
+        t->generate();
+        post_generate();
+    }
+
+    void call_schedule_impl() {
+        pre_schedule();
+        if constexpr (has_schedule_method<T>::value) {
+            T *t = (T *)this;
+            static_assert(std::is_void<decltype(t->schedule())>::value, "schedule() must return void");
+            t->schedule();
+        }
+        post_schedule();
+    }
+#endif
 
 protected:
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     Pipeline build_pipeline() override {
         return this->build_pipeline_impl(0);
     }
@@ -3746,7 +3809,23 @@ protected:
     void call_schedule() override {
         this->call_schedule_impl(0, 0);
     }
+#else
+    Pipeline build_pipeline() override {
+        return this->build_pipeline_impl();
+    }
 
+    void call_configure() override {
+        this->call_configure_impl();
+    }
+
+    void call_generate() override {
+        this->call_generate_impl();
+    }
+
+    void call_schedule() override {
+        this->call_schedule_impl();
+    }
+#endif
 private:
     friend void ::Halide::Internal::generator_test();
     friend void ::Halide::Internal::generator_test();

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -292,10 +292,21 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
                 return llvm::DataLayout("e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:128-n8:16:32-S128");
             } else if (target.os == Target::IOS) {
                 return llvm::DataLayout("e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:128-n8:16:32-S128");
-            } else if (target.os == Target::Windows && !target.has_feature(Target::JIT)) {
-                return llvm::DataLayout("e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:32-n8:16:32-a:0:32-S32");
             } else if (target.os == Target::Windows) {
-                return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:32-n8:16:32-a:0:32-S32");
+#if LLVM_VERSION >= 140
+                // For 32-bit MSVC targets, alignment of f80 values is 16 bytes (see https://reviews.llvm.org/D115942)
+                if (!target.has_feature(Target::JIT)) {
+                    return llvm::DataLayout("e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32-a:0:32-S32");
+                } else {
+                    return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32-a:0:32-S32");
+                }
+#else
+                if (!target.has_feature(Target::JIT)) {
+                    return llvm::DataLayout("e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:32-n8:16:32-a:0:32-S32");
+                } else {
+                    return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:32-n8:16:32-a:0:32-S32");
+                }
+#endif
             } else {
                 // Linux/Android
                 return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128");

--- a/test/generator/buildmethod_generator.cpp
+++ b/test/generator/buildmethod_generator.cpp
@@ -2,6 +2,7 @@
 
 namespace {
 
+#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
 // This Generator exists solely to test old-style generators (using the
 // build() method, rather than generate()/schedule()).
 // Do not convert it to new-style until/unless we decide to entirely remove support
@@ -21,6 +22,24 @@ public:
         return g;
     }
 };
+#else
+// Provide a placeholder here that uses generate(), just to allow this test to
+// succeed even if build() is disabled.
+class BuildMethod : public Halide::Generator<BuildMethod> {
+public:
+    GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
+
+    Input<Buffer<float>> input{"input", 3};
+    Input<float> runtime_factor{"runtime_factor", 1.0};
+    Output<Buffer<int32_t>> output{"output", 3};
+
+    void generate() {
+        Var x, y, c;
+
+        output(x, y, c) = cast<int32_t>(input(x, y, c) * compiletime_factor * runtime_factor);
+    }
+};
+#endif
 
 }  // namespace
 


### PR DESCRIPTION
This makes the use of the `build()` method in Generators unsupported by default in Halide 14. The newer, `generate()` based approach has been preferred for quite some time, and it is believed that very few downstream users still have any code in that form. (Halide itself only has a couple of remaining uses, and they exist only to verify that the build() method still works.)

This hides all support for `build()` behind the `HALIDE_ALLOW_GENERATOR_BUILD_METHOD` preprocessor flag, which defaults to undefined -- Generators with build() methods won't compile in this state.

To allow downstream users time to adapt any remaining code, they can #define `HALIDE_ALLOW_GENERATOR_BUILD_METHOD` in their build system, which will allow the old code to compile (with deprecation warnings).

The intent here is to ship Halide 14 with this deprecation in place, then remove the support entirely in Halide 15.

(At this time LLVM 14 is scheduled to go final in roughly mid-March 2022, so it's likely that Halide 14 will follow in early April 2022 or so.)

