### PR TITLE
Allow AMX instructions with K dimension larger than 4 bytes

### DIFF
--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -224,7 +224,13 @@ Tile<3> get_3d_rhs_tile_index(const Expr &e, int element_width) {
         return {};
     }
 
-    Expr base = base_stride_ramp->base.as<Broadcast>()->value;
+    const Broadcast *base_bc = base_stride_ramp->base.as<Broadcast>();
+
+    if (!base_bc) {
+        return {};
+    }
+
+    Expr base = base_bc->value;
     Expr stride;
 
     bool found_stride = false;

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -179,13 +179,6 @@ Tile<3> get_3d_rhs_tile_index(const Expr &e, int element_width) {
         return {};
     }
 
-    // (([x*y](ramp(0, 1, r) / [x*y*r](4)) + [x*y*r](rro*4)) * [x*y*r](rhs.stride.2)
-    const Mul *mul = add_lhs->a.as<Mul>();
-
-    if (!mul) {
-        return {};
-    }
-
     // obtain the x, y, r dimensions
     const Add *dim_expr = add_lhs->b.as<Add>();
 
@@ -211,13 +204,6 @@ Tile<3> get_3d_rhs_tile_index(const Expr &e, int element_width) {
     }
 
     int tile_r = r_ramp->lanes;
-
-    // [x*y*r](rhs.stride.2)
-    const Broadcast *stride_bc = mul->b.as<Broadcast>();
-
-    if (!stride_bc) {
-        return {};
-    }
 
     // get the base and stride
     const Broadcast *base_stride_bc = add_lhs->b.as<Add>()->b.as<Broadcast>();

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -56,7 +56,16 @@ const auto wild_i32x = Variable::make(Int(32, 0), "*");
 
 Tile<1> get_1d_tile_index(const Expr &e) {
     if (const auto *r1 = e.as<Ramp>()) {
-        return {true, r1->base, {r1->stride}, {r1->lanes}};
+        Expr pattern = ((wild_i32 * wild_i32) + wild_i32) * wild_i32;
+
+        std::vector<Expr> results;
+        if (!expr_match(pattern, r1->base, results)) {
+            return {};
+        }
+
+        auto stride = std::move(results[1]);
+
+        return {true, std::move(r1->base), {std::move(stride)}, {r1->lanes}};
     }
 
     return {};

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -303,7 +303,9 @@ BaseStride get_rhs_tile_index(const Expr &index, int element_width, int tile_x, 
                 return {};
             }
 
-            // times 4 because of the rhs layout
+            // times 4 because of the rhs layout, each vector used by AMX is 4 bytes in size.
+            // For the 4 gets divided by the element width which means each vector has 4 elements in u8/i8 and
+            // 2 elements for bf16.
             return {true, rhs_tile1.base, rhs_tile1.stride[0] * (4 / element_width)};
         }
     } else {

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -374,6 +374,20 @@ Matmul convert_to_matmul(const Store *op, const string &new_name, AMXOpType op_t
 
     if (lhs_load && !rhs_broadcast) {
         // now working on a larger k dimension
+        // with a K dimension of 4 (or 2) with bf16 all the elements in the right-hand matrix are 
+        // layed out in a way that multiplying with a column can be done in a single dot product.
+        // Therefore the indexing can be reused with a broadcast,
+        // with higher K dimensions this can no longer be done and the broadcast won't exist.
+        // ┌──┐
+        // │1 │
+        // │2 │
+        // │3 │   ┌────────┐
+        // │4 │   │1234    │
+        // │5 │   │5678    │
+        // │6 │   └────────┘
+        // │7 │
+        // │8 │
+        // └──┘
         rhs_cast = matches[1].as<Cast>();
     } else {
         rhs_cast = rhs_broadcast->value.as<Cast>();

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -182,11 +182,23 @@ Tile<3> get_3d_rhs_tile_index(const Expr &e, int element_width) {
     // obtain the x, y, r dimensions
     const Add *dim_expr = add_lhs->b.as<Add>();
 
-    const Broadcast *y_bc = dim_expr->b.as<Broadcast>();
+    if (!dim_expr) {
+        return {};
+    }
 
-    int tile_y = y_bc->lanes;
+    const Broadcast *base_stride_bc = dim_expr->b.as<Broadcast>();
+
+    if (!base_stride_bc) {
+        return {};
+    }
+
+    int tile_y = base_stride_bc->lanes;
 
     const Mod *mod = dim_expr->a.as<Mod>();
+
+    if (!mod) {
+        return {};
+    }
 
     const Broadcast *bc_ramp = mod->a.as<Broadcast>();
 
@@ -206,12 +218,6 @@ Tile<3> get_3d_rhs_tile_index(const Expr &e, int element_width) {
     int tile_r = r_ramp->lanes;
 
     // get the base and stride
-    const Broadcast *base_stride_bc = add_lhs->b.as<Add>()->b.as<Broadcast>();
-
-    if (!base_stride_bc) {
-        return {};
-    }
-
     const Ramp *base_stride_ramp = base_stride_bc->value.as<Ramp>();
 
     if (!base_stride_ramp) {

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -73,6 +73,9 @@ Tile<1> get_1d_tile_index(const Expr &e) {
         for (const auto &pattern : patterns) {
             if (expr_match(pattern, r1->base, matches)) {
                 auto stride = std::move(matches["stride"]);
+                if (!stride.as<IntImm>()) {
+                    return {};
+                }
                 return {true, r1->base, {std::move(stride)}, {r1->lanes}};
             }
         }

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -384,12 +384,12 @@ Matmul convert_to_matmul(const Store *op, const string &new_name, AMXOpType op_t
     }
 
     if (rhs_cast) {
-        if (op_type == AMXOpType::Int8) {
-            if (!(rhs_cast->value.type().element_of() == Int(8) || rhs_cast->value.type().element_of() == UInt(8))) {
-                user_error << "Expected rhs cast of i8/u8, got " << rhs_cast->value.type();
-            }
-        } else {  // AMXOpType::Bfloat16
-            user_assert(rhs_cast->value.type().element_of() == BFloat(16)) << "Expected rhs cast of bf16";
+        bool is_i8_u8 = rhs_cast->value.type().element_of() == Int(8) || rhs_cast->value.type().element_of() == UInt(8);
+        bool is_bf16 = rhs_cast->value.type().element_of() == BFloat(16);
+
+        if ((op_type == AMXOpType::Int8 && !is_i8_u8) || (op_type == AMXOpType::Bfloat16 && !is_bf16)) {
+            user_error << "Expected rhs type of " << (op_type == AMXOpType::Int8 ? "i8/u8" : "bf16")
+                       << ", got " << rhs_cast->value.type() << " instead.\nIn Expression: " << Expr(rhs_cast);
         }
     } else {
         return {};

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -64,7 +64,7 @@ Tile<1> get_1d_tile_index(const Expr &e) {
 
         Expr patterns[] = {
             ((v1 * stride_var) + v2) * v3,
-            v3 * ((v1 * stride_var) + wild_i32),
+            v3 * ((v1 * stride_var) + v2),
             (v2 + (v1 * stride_var)) * v3,
             v3 * (v2 + (v1 * stride_var)),
         };

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -65,7 +65,7 @@ Tile<1> get_1d_tile_index(const Expr &e) {
 
         auto stride = std::move(results[1]);
 
-        return {true, std::move(r1->base), {std::move(stride)}, {r1->lanes}};
+        return {true, r1->base, {std::move(stride)}, {r1->lanes}};
     }
 
     return {};
@@ -233,7 +233,7 @@ Tile<3> get_3d_rhs_tile_index(const Expr &e, int element_width) {
     }
 
     if (!found_stride) {
-        stride_pattern = (Broadcast::make(Ramp::make(0, 1, tile_r), tile_x * tile_y) / Broadcast::make((4/ element_width), tile_x * tile_y * tile_r) + wild_i32) * Broadcast::make(wild_i32, tile_x * tile_y * tile_r);
+        stride_pattern = (Broadcast::make(Ramp::make(0, 1, tile_r), tile_x * tile_y) / Broadcast::make((4 / element_width), tile_x * tile_y * tile_r) + wild_i32) * Broadcast::make(wild_i32, tile_x * tile_y * tile_r);
         if (expr_match(stride_pattern, add_lhs->a, results)) {
             found_stride = true;
             stride = std::move(results[1]);

--- a/test/correctness/tiled_matmul.cpp
+++ b/test/correctness/tiled_matmul.cpp
@@ -50,14 +50,14 @@ bool equal_eps(float lhs, float rhs, float eps) {
 
 struct make_uint_t {
     template<typename... Args>
-    Type operator()(Args &&... args) const {
+    Type operator()(Args &&...args) const {
         return UInt(static_cast<Args &&>(args)...);
     }
 };
 
 struct make_int_t {
     template<typename... Args>
-    Type operator()(Args &&... args) const {
+    Type operator()(Args &&...args) const {
         return Int(static_cast<Args &&>(args)...);
     }
 };

--- a/test/correctness/tiled_matmul.cpp
+++ b/test/correctness/tiled_matmul.cpp
@@ -50,24 +50,45 @@ bool equal_eps(float lhs, float rhs, float eps) {
 
 struct make_uint_t {
     template<typename... Args>
-    Type operator()(Args &&...args) const {
+    Type operator()(Args &&... args) const {
         return UInt(static_cast<Args &&>(args)...);
     }
 };
 
 struct make_int_t {
     template<typename... Args>
-    Type operator()(Args &&...args) const {
+    Type operator()(Args &&... args) const {
         return Int(static_cast<Args &&>(args)...);
     }
 };
 
-template<typename LhsInt8, typename RhsInt8>
-bool matmul() {
-    constexpr int row = 16;
-    constexpr int col = 16;
-    constexpr int acc = 16;
+template<typename T>
+void print_mat(const Buffer<T> &buf, int rows, int cols) {
+    using cast_T = std::conditional_t<std::is_integral_v<T>, int, T>;
+    for (int j = 0; j != rows; ++j) {
+        for (int i = 0; i != cols; ++i) {
+            std::cout << static_cast<cast_T>(buf(i, j)) << " ";
+        }
+        std::cout << std::endl;
+    }
+}
 
+template<typename T>
+void print_mat_rhs(const Buffer<T> &buf, int rows, int cols) {
+    using cast_T = std::conditional_t<std::is_integral_v<T>, int, T>;
+    for (int j = 0; j != (rows / (4 / sizeof(T))); ++j) {
+        for (int k = 0; k != (4 / sizeof(T)); ++k) {
+            for (int i = 0; i != cols; ++i) {
+                std::cout << static_cast<cast_T>(buf(k, i, j)) << " ";
+            }
+
+            std::cout << std::endl;
+        }
+    }
+}
+
+template<typename LhsInt8, typename RhsInt8>
+bool matmul(int row, int col, int acc, int tile_x, int tile_y, int tile_r) {
     Buffer<LhsInt8> A_buf(acc, row);
     Buffer<RhsInt8> B_buf(4, col, acc / 4);
 
@@ -77,10 +98,6 @@ bool matmul() {
     Func mm("matmul");
     mm(x, y) = cast<int32_t>(0);
     mm(x, y) += cast<int32_t>(A_buf(r, y)) * cast<int32_t>(B_buf(r % 4, x, r / 4));
-
-    constexpr int tile_x = 8;
-    constexpr int tile_y = 8;
-    constexpr int tile_r = 4;
 
     Var rxi("rxi"), ryi("ryi");
     RVar rri("rri"), rro("rro");
@@ -118,6 +135,15 @@ bool matmul() {
 
     result.realize(out);
 
+    // uncomment to check the matrices
+    // std::cout << "Matrix A\n";
+    // print_mat(A_buf, row, acc);
+    // std::cout << "Matrix B\n";
+    // print_mat_rhs(B_buf, acc, col);
+
+    // std::cout << "result\n";
+    // print_mat(out, row, col);
+
     for (int j = 0; j < row; ++j) {
         for (int i = 0; i < col; ++i) {
             int32_t val = 0;
@@ -126,21 +152,18 @@ bool matmul() {
             }
             if (val != out(i, j)) {
                 std::cerr << "Invalid result at " << i << ", " << j << "\n"
-                          << out(i, j) << " != " << val << "\n";
+                          << out(i, j) << " != " << val << "\n"
+                          << "Matrix dims: " << row << "x" << col << "x" << acc << "\nTile dims: " << tile_x << "x" << tile_y << "x" << tile_r << "\n";
                 return false;
             }
         }
     }
 
+    std::cout << "Success\n";
     return true;
 }
 
-bool matmul_bf16() {
-    // lhs: 32x16, rhs: 16x32
-    const int row = 32;
-    const int col = 32;
-    const int acc = 16;
-
+bool matmul_bf16(int row, int col, int acc, int tile_x, int tile_y, int tile_r) {
     Var x("x"), y("y");
     Buffer<bfloat16_t> A(acc, row);
     Buffer<bfloat16_t> B(2, col, acc / 2);
@@ -150,10 +173,6 @@ bool matmul_bf16() {
     Func mm("matmul");
     mm(x, y) = cast<float>(0);
     mm(x, y) += cast<float>(cast<float>(A(r.x, y))) * cast<float>(B(r.x % 2, x, r.x / 2));
-
-    int tile_x = 8;
-    int tile_y = 8;
-    int tile_r = 2;
 
     Var rxi("rxi"), ryi("ryi");
     RVar rri("rri"), rro("rro");
@@ -195,20 +214,31 @@ bool matmul_bf16() {
 
     result.realize(out);
 
+    // uncomment to check the matrices
+    // std::cout << "Matrix A\n";
+    // print_mat(A, row, acc);
+    // std::cout << "Matrix B\n";
+    // print_mat_rhs(B, acc, col);
+
+    // std::cout << "result\n";
+    // print_mat(out, row, col);
+
     for (int j = 0; j < row; ++j) {
         for (int i = 0; i < col; ++i) {
             float val = 0.f;
             for (int k = 0; k < acc; ++k) {
                 val += static_cast<float>(A(k, j)) * static_cast<float>(B(k % 2, i, k / 2));
             }
-            if (!equal_eps(val, out(i, j), 0.01f)) {
+            if (!equal_eps(val, out(i, j), 0.03f)) {
                 std::cerr << "Invalid result at " << i << ", " << j << "\n"
-                          << out(i, j) << " != " << val << "\n";
+                          << out(i, j) << " != " << val << "\n"
+                          << "Matrix dims: " << row << "x" << col << "x" << acc << "\nTile dims: " << tile_x << "x" << tile_y << "x" << tile_r << "\n";
                 return false;
             }
         }
     }
 
+    std::cout << "Success!\n";
     return true;
 }
 
@@ -216,6 +246,10 @@ auto matmul_ss = &matmul<int8_t, int8_t>;
 auto matmul_us = &matmul<uint8_t, int8_t>;
 auto matmul_su = &matmul<int8_t, uint8_t>;
 auto matmul_uu = &matmul<uint8_t, uint8_t>;
+
+bool run_tests(bool (*fn)(int, int, int, int, int, int), int element_width) {
+    return fn(2, 2, 16, 2, 2, 8 / element_width) && fn(4, 4, 8, 4, 4, 8 / element_width) && fn(32, 32, 32, 8, 8, 8 / element_width) && fn(32, 32, 32, 8, 8, 4 / element_width);
+}
 
 int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
@@ -225,38 +259,31 @@ int main(int argc, char **argv) {
     }
 
     printf("Running AMX matmul (signed/signed)\n");
-    if (!matmul_ss()) {
+    if (!run_tests(matmul_ss, 1)) {
         return -1;
-    } else {
-        printf("Success!\n");
     }
 
-    printf("Running AMX matmul (signed/unsigned)\n");
-    if (!matmul_su()) {
-        return -1;
-    } else {
-        printf("Success!\n");
-    }
+    // llvm >= 13.0 is required for unsigned and float AMX instructions
+    if (Halide::Internal::get_llvm_version() >= 130) {
+        printf("Running AMX matmul (signed/unsigned)\n");
+        if (!run_tests(matmul_su, 1)) {
+            return -1;
+        }
 
-    printf("Running AMX matmul (unsigned/signed)\n");
-    if (!matmul_us()) {
-        return -1;
-    } else {
-        printf("Success!\n");
-    }
+        printf("Running AMX matmul (unsigned/signed)\n");
+        if (!run_tests(matmul_us, 1)) {
+            return -1;
+        }
 
-    printf("Running AMX matmul (unsigned/unsigned)\n");
-    if (!matmul_uu()) {
-        return -1;
-    } else {
-        printf("Success!\n");
-    }
+        printf("Running AMX matmul (unsigned/unsigned)\n");
+        if (!run_tests(matmul_uu, 1)) {
+            return -1;
+        }
 
-    printf("Running AMX matmul (bf16)\n");
-    if (!matmul_bf16()) {
-        return -1;
-    } else {
-        printf("Success!\n");
+        printf("Running AMX matmul (bf16)\n");
+        if (!run_tests(matmul_bf16, 2)) {
+            return -1;
+        }
     }
     return 0;
 }

--- a/test/correctness/tiled_matmul.cpp
+++ b/test/correctness/tiled_matmul.cpp
@@ -50,14 +50,14 @@ bool equal_eps(float lhs, float rhs, float eps) {
 
 struct make_uint_t {
     template<typename... Args>
-    Type operator()(Args &&...args) const {
+    Type operator()(Args &&... args) const {
         return UInt(static_cast<Args &&>(args)...);
     }
 };
 
 struct make_int_t {
     template<typename... Args>
-    Type operator()(Args &&...args) const {
+    Type operator()(Args &&... args) const {
         return Int(static_cast<Args &&>(args)...);
     }
 };
@@ -263,27 +263,25 @@ int main(int argc, char **argv) {
         return -1;
     }
 
-    // llvm >= 13.0 is required for unsigned and float AMX instructions
-    if (Halide::Internal::get_llvm_version() >= 130) {
-        printf("Running AMX matmul (signed/unsigned)\n");
-        if (!run_tests(matmul_su, 1)) {
-            return -1;
-        }
-
-        printf("Running AMX matmul (unsigned/signed)\n");
-        if (!run_tests(matmul_us, 1)) {
-            return -1;
-        }
-
-        printf("Running AMX matmul (unsigned/unsigned)\n");
-        if (!run_tests(matmul_uu, 1)) {
-            return -1;
-        }
-
-        printf("Running AMX matmul (bf16)\n");
-        if (!run_tests(matmul_bf16, 2)) {
-            return -1;
-        }
+    printf("Running AMX matmul (signed/unsigned)\n");
+    if (!run_tests(matmul_su, 1)) {
+        return -1;
     }
+
+    printf("Running AMX matmul (unsigned/signed)\n");
+    if (!run_tests(matmul_us, 1)) {
+        return -1;
+    }
+
+    printf("Running AMX matmul (unsigned/unsigned)\n");
+    if (!run_tests(matmul_uu, 1)) {
+        return -1;
+    }
+
+    printf("Running AMX matmul (bf16)\n");
+    if (!run_tests(matmul_bf16, 2)) {
+        return -1;
+    }
+
     return 0;
 }

--- a/test/correctness/tiled_matmul.cpp
+++ b/test/correctness/tiled_matmul.cpp
@@ -159,7 +159,7 @@ bool matmul(int row, int col, int acc, int tile_x, int tile_y, int tile_r) {
         }
     }
 
-    std::cout << "Success\n";
+    std::cout << "Success!\n";
     return true;
 }
 


### PR DESCRIPTION
Addresses #6054 
The current version of AMX can only handle K dimensions which are 4 bytes in size. This is because the way the right hand side (rhs) matrix is laid out is different from the left hand side (lhs). Where the lhs matrix is a regular MxK matrix the rhs is instead K/4xNx4 for i8/u8 and K/2xNx2 for bf16. To handle this an extra `get_3d_rhs_tile_index` function was added.
The correctness tests have been further expanded to handle a variety of cases.
* tile K dimension of 4 bytes
This tests the previous code, using 2d/1d tile index pattern matcher
* tile K dimension larger than 4 bytes but equal to the matrix's K dimension
This handles one of the 2 patterns checked for
* tile K dimension larger than 4 bytes and not equal to the matrix's K dimension
This handles the other pattern which is important for getting the correct offset