### PR TITLE
Make bounds of let visitor use unique_name()

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1503,8 +1503,8 @@ private:
         // them in as variables and add an outer let (to avoid
         // combinatorial explosion).
         Interval var;
-        string min_name = op->name + ".min";
-        string max_name = op->name + ".max";
+        const string min_name = unique_name(op->name + ".min");
+        const string max_name = unique_name(op->name + ".max");
 
         if (val.has_lower_bound()) {
             if (is_const(val.min)) {


### PR DESCRIPTION
The bounds visitor on a let should use `unique_name()` for the introduced variables. Without this change, Halide sometimes internally generates expressions of the form `(let x = (let x = ... in ...) in ...)` which can cause failures when substituting in lets and simplifying.