### PR TITLE
Add static-dimension annotations to Buffer usage in python_bindings and tutorials

### DIFF
--- a/python_bindings/correctness/addconstant_generator.cpp
+++ b/python_bindings/correctness/addconstant_generator.cpp
@@ -16,31 +16,31 @@ public:
     Input<float> constant_float{"constant_float"};
     Input<double> constant_double{"constant_double"};
 
-    Input<Buffer<uint8_t>> input_uint8{"input_uint8", 1};
-    Input<Buffer<uint16_t>> input_uint16{"input_uint16", 1};
-    Input<Buffer<uint32_t>> input_uint32{"input_uint32", 1};
-    Input<Buffer<uint64_t>> input_uint64{"input_uint64", 1};
-    Input<Buffer<int8_t>> input_int8{"input_int8", 1};
-    Input<Buffer<int16_t>> input_int16{"input_int16", 1};
-    Input<Buffer<int32_t>> input_int32{"input_int32", 1};
-    Input<Buffer<int64_t>> input_int64{"input_int64", 1};
-    Input<Buffer<float>> input_float{"input_float", 1};
-    Input<Buffer<double>> input_double{"input_double", 1};
-    Input<Buffer<int8_t>> input_2d{"input_2d", 2};
-    Input<Buffer<int8_t>> input_3d{"input_3d", 3};
+    Input<Buffer<uint8_t, 1>> input_uint8{"input_uint8"};
+    Input<Buffer<uint16_t, 1>> input_uint16{"input_uint16"};
+    Input<Buffer<uint32_t, 1>> input_uint32{"input_uint32"};
+    Input<Buffer<uint64_t, 1>> input_uint64{"input_uint64"};
+    Input<Buffer<int8_t, 1>> input_int8{"input_int8"};
+    Input<Buffer<int16_t, 1>> input_int16{"input_int16"};
+    Input<Buffer<int32_t, 1>> input_int32{"input_int32"};
+    Input<Buffer<int64_t, 1>> input_int64{"input_int64"};
+    Input<Buffer<float, 1>> input_float{"input_float"};
+    Input<Buffer<double, 1>> input_double{"input_double"};
+    Input<Buffer<int8_t, 2>> input_2d{"input_2d"};
+    Input<Buffer<int8_t, 3>> input_3d{"input_3d"};
 
-    Output<Buffer<uint8_t>> output_uint8{"output_uint8", 1};
-    Output<Buffer<uint16_t>> output_uint16{"output_uint16", 1};
-    Output<Buffer<uint32_t>> output_uint32{"output_uint32", 1};
-    Output<Buffer<uint64_t>> output_uint64{"output_uint64", 1};
-    Output<Buffer<int8_t>> output_int8{"output_int8", 1};
-    Output<Buffer<int16_t>> output_int16{"output_int16", 1};
-    Output<Buffer<int32_t>> output_int32{"output_int32", 1};
-    Output<Buffer<int64_t>> output_int64{"output_int64", 1};
-    Output<Buffer<float>> output_float{"output_float", 1};
-    Output<Buffer<double>> output_double{"output_double", 1};
-    Output<Buffer<int8_t>> output_2d{"buffer_2d", 2};
-    Output<Buffer<int8_t>> output_3d{"buffer_3d", 3};
+    Output<Buffer<uint8_t, 1>> output_uint8{"output_uint8"};
+    Output<Buffer<uint16_t, 1>> output_uint16{"output_uint16"};
+    Output<Buffer<uint32_t, 1>> output_uint32{"output_uint32"};
+    Output<Buffer<uint64_t, 1>> output_uint64{"output_uint64"};
+    Output<Buffer<int8_t, 1>> output_int8{"output_int8"};
+    Output<Buffer<int16_t, 1>> output_int16{"output_int16"};
+    Output<Buffer<int32_t, 1>> output_int32{"output_int32"};
+    Output<Buffer<int64_t, 1>> output_int64{"output_int64"};
+    Output<Buffer<float, 1>> output_float{"output_float"};
+    Output<Buffer<double, 1>> output_double{"output_double"};
+    Output<Buffer<int8_t, 2>> output_2d{"buffer_2d"};
+    Output<Buffer<int8_t, 3>> output_3d{"buffer_3d"};
 
     Var x, y, z;
 

--- a/python_bindings/correctness/bit_generator.cpp
+++ b/python_bindings/correctness/bit_generator.cpp
@@ -4,10 +4,9 @@ using namespace Halide;
 
 class BitGenerator : public Halide::Generator<BitGenerator> {
 public:
-    Input<Buffer<bool>> bit_input{"input_uint1", 1};
+    Input<Buffer<bool, 1>> bit_input{"input_uint1"};
     Input<bool> bit_constant{"constant_uint1"};
-
-    Output<Buffer<bool>> bit_output{"output_uint1", 1};
+    Output<Buffer<bool, 1>> bit_output{"output_uint1"};
 
     Var x, y, z;
 

--- a/python_bindings/correctness/complexstub_generator.cpp
+++ b/python_bindings/correctness/complexstub_generator.cpp
@@ -3,8 +3,8 @@
 namespace {
 
 template<typename Type, int size = 4, int dim = 1>
-Halide::Buffer<Type> make_image(int extra) {
-    Halide::Buffer<Type> im(size, size, dim);
+Halide::Buffer<Type, 3> make_image(int extra) {
+    Halide::Buffer<Type, 3> im(size, size, dim);
     for (int x = 0; x < size; x++) {
         for (int y = 0; y < size; y++) {
             for (int c = 0; c < dim; c++) {
@@ -21,8 +21,8 @@ public:
     GeneratorParam<bool> vectorize{"vectorize", true};
     GeneratorParam<LoopLevel> intermediate_level{"intermediate_level", LoopLevel::root()};
 
-    Input<Buffer<uint8_t>> typed_buffer_input{"typed_buffer_input", 3};
-    Input<Buffer<>> untyped_buffer_input{"untyped_buffer_input"};
+    Input<Buffer<uint8_t, 3>> typed_buffer_input{"typed_buffer_input"};
+    Input<Buffer<void, 3>> untyped_buffer_input{"untyped_buffer_input"};
     Input<Func> simple_input{"simple_input", 3};  // require a 3-dimensional Func but leave Type unspecified
     Input<Func[]> array_input{"array_input", 3};  // require a 3-dimensional Func but leave Type and ArraySize unspecified
     // Note that Input<Func> does not (yet) support Tuples
@@ -32,9 +32,9 @@ public:
     Output<Func> simple_output{"simple_output", Float(32), 3};
     Output<Func> tuple_output{"tuple_output", 3};             // require a 3-dimensional Func but leave Type(s) unspecified
     Output<Func[]> array_output{"array_output", Int(16), 2};  // leave ArraySize unspecified
-    Output<Buffer<float>> typed_buffer_output{"typed_buffer_output"};
-    Output<Buffer<>> untyped_buffer_output{"untyped_buffer_output"};
-    Output<Buffer<uint8_t>> static_compiled_buffer_output{"static_compiled_buffer_output", 3};
+    Output<Buffer<float, 3>> typed_buffer_output{"typed_buffer_output"};
+    Output<Buffer<void, 3>> untyped_buffer_output{"untyped_buffer_output"};
+    Output<Buffer<uint8_t, 3>> static_compiled_buffer_output{"static_compiled_buffer_output"};
 
     void configure() {
         // Pointers returned by add_input() are managed by the Generator;
@@ -68,7 +68,7 @@ public:
 
         // This should be compiled into the Generator product itself,
         // and not produce another input for the Stub or AOT filter.
-        Buffer<uint8_t> static_compiled_buffer = make_image<uint8_t>(42);
+        Buffer<uint8_t, 3> static_compiled_buffer = make_image<uint8_t>(42);
         static_compiled_buffer_output = static_compiled_buffer;
 
         (*extra_func_output)(x, y) = cast<double>((*extra_func_input)(x, y, 0) + 1);

--- a/python_bindings/correctness/nobuildmethod_generator.cpp
+++ b/python_bindings/correctness/nobuildmethod_generator.cpp
@@ -7,10 +7,9 @@ class NoBuildMethod : public Halide::Generator<NoBuildMethod> {
 public:
     GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
 
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float, 2>> input{"input"};
     Input<float> runtime_factor{"runtime_factor", 1.0};
-
-    Output<Buffer<int32_t>> output{"output", 2};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/python_bindings/correctness/partialbuildmethod_generator.cpp
+++ b/python_bindings/correctness/partialbuildmethod_generator.cpp
@@ -13,7 +13,7 @@ class PartialBuildMethod : public Halide::Generator<PartialBuildMethod> {
 public:
     GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
 
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float, 2>> input{"input"};
     Input<float> runtime_factor{"runtime_factor", 1.0};
 
     Func build() {
@@ -32,9 +32,9 @@ class PartialBuildMethod : public Halide::Generator<PartialBuildMethod> {
 public:
     GeneratorParam<float> compiletime_factor{"compiletime_factor", 1, 0, 100};
 
-    Input<Buffer<float>> input{"input", 2};
+    Input<Buffer<float, 2>> input{"input"};
     Input<float> runtime_factor{"runtime_factor", 1.0};
-    Output<Buffer<int32_t>> output{"output", 2};
+    Output<Buffer<int32_t, 2>> output{"output"};
 
     void generate() {
         Var x, y;

--- a/python_bindings/correctness/simplestub_generator.cpp
+++ b/python_bindings/correctness/simplestub_generator.cpp
@@ -7,7 +7,7 @@ public:
     GeneratorParam<int> offset{"offset", 0};
     GeneratorParam<LoopLevel> compute_level{"compute_level", LoopLevel::root()};
 
-    Input<Buffer<uint8_t>> buffer_input{"buffer_input", 2};
+    Input<Buffer<uint8_t, 2>> buffer_input{"buffer_input"};
     Input<Func> func_input{"func_input", 2};  // require a 2-dimensional Func but leave Type unspecified
     Input<float> float_arg{"float_arg", 1.0f, 0.0f, 100.0f};
 

--- a/python_bindings/correctness/user_context_generator.cpp
+++ b/python_bindings/correctness/user_context_generator.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 class UserContextGenerator : public Halide::Generator<UserContextGenerator> {
 public:
     Input<uint8_t> constant{"constant"};
-    Output<Buffer<uint8_t>> output{"output", 1};
+    Output<Buffer<uint8_t, 1>> output{"output"};
 
     Var x;
 

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -139,7 +139,7 @@ class Buffer {
         } else {
             // Don't delegate to
             // Runtime::Buffer<T>::assert_can_convert_from. It might
-            // not assert is NDEBUG is defined. user_assert is
+            // not assert if NDEBUG is defined. user_assert is
             // friendlier anyway because it reports line numbers when
             // debugging symbols are found, it throws an exception
             // when exceptions are enabled, and we can print the
@@ -147,8 +147,8 @@ class Buffer {
             using BufType = Runtime::Buffer<T, Dims>;  // alias because commas in user_assert() macro confuses compiler
             user_assert(BufType::can_convert_from(*(other.get())))
                 << "Type mismatch constructing Buffer. Can't construct Buffer<"
-                << Internal::buffer_type_name<T>() << "> from Buffer<"
-                << type_to_c_type(other.type(), false) << ">\n";
+                << Internal::buffer_type_name<T>() << ", " << Dims << "> from Buffer<"
+                << type_to_c_type(other.type(), false) << ", " << D2 << ">, dimensions() = " << other.dimensions() << "\n";
         }
     }
 
@@ -509,13 +509,13 @@ public:
 
     static constexpr bool has_static_halide_type = Runtime::Buffer<T, Dims>::has_static_halide_type;
 
-    static halide_type_t static_halide_type() {
+    static constexpr halide_type_t static_halide_type() {
         return Runtime::Buffer<T, Dims>::static_halide_type();
     }
 
     static constexpr bool has_static_dimensions = Runtime::Buffer<T, Dims>::has_static_dimensions;
 
-    static int static_dimensions() {
+    static constexpr int static_dimensions() {
         return Runtime::Buffer<T, Dims>::static_dimensions();
     }
 
@@ -533,7 +533,7 @@ public:
     }
 
     template<typename T2, int D2 = Dims>
-    Buffer<T2, Dims> as() const {
+    Buffer<T2, D2> as() const {
         return Buffer<T2, D2>(*this);
     }
 

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -113,17 +113,17 @@ public:
         RealizationArg(halide_buffer_t *buf)
             : buf(buf) {
         }
-        template<typename T, int D>
-        RealizationArg(Runtime::Buffer<T, D> &dst)
+        template<typename T, int Dims>
+        RealizationArg(Runtime::Buffer<T, Dims> &dst)
             : buf(dst.raw_buffer()) {
         }
-        template<typename T>
-        HALIDE_NO_USER_CODE_INLINE RealizationArg(Buffer<T> &dst)
+        template<typename T, int Dims>
+        HALIDE_NO_USER_CODE_INLINE RealizationArg(Buffer<T, Dims> &dst)
             : buf(dst.raw_buffer()) {
         }
-        template<typename T, typename... Args,
+        template<typename T, int Dims, typename... Args,
                  typename = typename std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>::type>
-        RealizationArg(Buffer<T> &a, Args &&...args)
+        RealizationArg(Buffer<T, Dims> &a, Args &&...args)
             : buffer_list(std::make_unique<std::vector<Buffer<>>>(std::initializer_list<Buffer<>>{a, std::forward<Args>(args)...})) {
         }
         RealizationArg(RealizationArg &&from) = default;

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1919,14 +1919,14 @@ bool save_tiff(ImageType &im, const std::string &filename) {
     }
 
     // Otherwise, write it out via manual traversal.
-#define HANDLE_CASE(CODE, BITS, TYPE)                    \
-    case halide_type_t(CODE, BITS).as_u32(): {           \
-        ElemWriter<TYPE> ew(&f);                         \
+#define HANDLE_CASE(CODE, BITS, TYPE)                                       \
+    case halide_type_t(CODE, BITS).as_u32(): {                              \
+        ElemWriter<TYPE> ew(&f);                                            \
         im.template as<const TYPE, DimsUnconstrained>().for_each_value(ew); \
-        if (!check(ew.ok, "TIFF write failed")) {        \
-            return false;                                \
-        }                                                \
-        break;                                           \
+        if (!check(ew.ok, "TIFF write failed")) {                           \
+            return false;                                                   \
+        }                                                                   \
+        break;                                                              \
     }
 
     switch (im_type.element_of().as_u32()) {

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -694,11 +694,13 @@ struct FileOpener {
     FILE *const f;
 };
 
+constexpr int DimsUnconstrained = -1;
+
 // Read a row of ElemTypes from a byte buffer and copy them into a specific image row.
 // Multibyte elements are assumed to be big-endian.
 template<typename ElemType, typename ImageType>
 void read_big_endian_row(const uint8_t *src, int y, ImageType *im) {
-    auto im_typed = im->template as<ElemType>();
+    auto im_typed = im->template as<ElemType, DimsUnconstrained>();
     const int xmin = im_typed.dim(0).min();
     const int xmax = im_typed.dim(0).max();
     if (im_typed.dimensions() > 2) {
@@ -722,7 +724,7 @@ void read_big_endian_row(const uint8_t *src, int y, ImageType *im) {
 // Multibyte elements are written in big-endian layout.
 template<typename ElemType, typename ImageType>
 void write_big_endian_row(const ImageType &im, int y, uint8_t *dst) {
-    auto im_typed = im.template as<typename std::add_const<ElemType>::type>();
+    auto im_typed = im.template as<typename std::add_const<ElemType>::type, DimsUnconstrained>();
     const int xmin = im_typed.dim(0).min();
     const int xmax = im_typed.dim(0).max();
     if (im_typed.dimensions() > 2) {
@@ -1920,7 +1922,7 @@ bool save_tiff(ImageType &im, const std::string &filename) {
 #define HANDLE_CASE(CODE, BITS, TYPE)                    \
     case halide_type_t(CODE, BITS).as_u32(): {           \
         ElemWriter<TYPE> ew(&f);                         \
-        im.template as<const TYPE>().for_each_value(ew); \
+        im.template as<const TYPE, DimsUnconstrained>().for_each_value(ew); \
         if (!check(ew.ok, "TIFF write failed")) {        \
             return false;                                \
         }                                                \
@@ -1949,22 +1951,22 @@ bool save_tiff(ImageType &im, const std::string &filename) {
     return true;
 }
 
-// Given something like ImageType<Foo, 2>, produce typedef ImageType<Foo, -1>
+// Given something like ImageType<Foo, 2>, produce typedef ImageType<Foo, DimsUnconstrained>
 template<typename ImageType>
 struct ImageTypeWithDynamicDims {
-    using type = decltype(std::declval<ImageType>().template as<typename ImageType::ElemType, -1>());
+    using type = decltype(std::declval<ImageType>().template as<typename ImageType::ElemType, DimsUnconstrained>());
 };
 
-// Given something like ImageType<Foo>, produce typedef ImageType<Bar, -1>
-template<typename ImageType, typename ElemType = void>
+// Given something like ImageType<Foo>, produce typedef ImageType<Bar, DimsUnconstrained>
+template<typename ImageType, typename ElemType>
 struct ImageTypeWithElemType {
-    using type = decltype(std::declval<ImageType>().template as<ElemType, -1>());
+    using type = decltype(std::declval<ImageType>().template as<ElemType, DimsUnconstrained>());
 };
 
-// Given something like ImageType<Foo>, produce typedef ImageType<const Bar, -1>
+// Given something like ImageType<Foo>, produce typedef ImageType<const Bar, DimsUnconstrained>
 template<typename ImageType, typename ElemType>
 struct ImageTypeWithConstElemType {
-    using type = decltype(std::declval<ImageType>().template as<typename std::add_const<ElemType>::type, -1>());
+    using type = decltype(std::declval<ImageType>().template as<typename std::add_const<ElemType>::type, DimsUnconstrained>());
 };
 
 template<typename ImageType, Internal::CheckFunc check>
@@ -2088,31 +2090,32 @@ struct ImageTypeConversion {
         // as documentation and a backstop against breakage.
         static_assert(!ImageType::has_static_halide_type,
                       "This variant of convert_image() requires a dynamically-typed image");
+        constexpr int DimsUnconstrained = Internal::DimsUnconstrained;
 
         const halide_type_t src_type = src.type();
         switch (src_type.element_of().as_u32()) {
         case halide_type_t(halide_type_float, 32).as_u32():
-            return convert_image<DstElemType>(src.template as<float>());
+            return convert_image<DstElemType>(src.template as<float, DimsUnconstrained>());
         case halide_type_t(halide_type_float, 64).as_u32():
-            return convert_image<DstElemType>(src.template as<double>());
+            return convert_image<DstElemType>(src.template as<double, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 8).as_u32():
-            return convert_image<DstElemType>(src.template as<int8_t>());
+            return convert_image<DstElemType>(src.template as<int8_t, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 16).as_u32():
-            return convert_image<DstElemType>(src.template as<int16_t>());
+            return convert_image<DstElemType>(src.template as<int16_t, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 32).as_u32():
-            return convert_image<DstElemType>(src.template as<int32_t>());
+            return convert_image<DstElemType>(src.template as<int32_t, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 64).as_u32():
-            return convert_image<DstElemType>(src.template as<int64_t>());
+            return convert_image<DstElemType>(src.template as<int64_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 1).as_u32():
-            return convert_image<DstElemType>(src.template as<bool>());
+            return convert_image<DstElemType>(src.template as<bool, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 8).as_u32():
-            return convert_image<DstElemType>(src.template as<uint8_t>());
+            return convert_image<DstElemType>(src.template as<uint8_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 16).as_u32():
-            return convert_image<DstElemType>(src.template as<uint16_t>());
+            return convert_image<DstElemType>(src.template as<uint16_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 32).as_u32():
-            return convert_image<DstElemType>(src.template as<uint32_t>());
+            return convert_image<DstElemType>(src.template as<uint32_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 64).as_u32():
-            return convert_image<DstElemType>(src.template as<uint64_t>());
+            return convert_image<DstElemType>(src.template as<uint64_t, DimsUnconstrained>());
         default:
             assert(false && "Unsupported type");
             using DstImageType = typename Internal::ImageTypeWithElemType<ImageType, DstElemType>::type;
@@ -2177,6 +2180,7 @@ struct ImageTypeConversion {
         // as documentation and a backstop against breakage.
         static_assert(!ImageType::has_static_halide_type,
                       "This variant of convert_image() requires a dynamically-typed image");
+        constexpr int DimsUnconstrained = Internal::DimsUnconstrained;
 
         // Sniff the runtime type of src, coerce it to that type using as<>(),
         // and call the static-to-dynamic variant of this method. (Note that
@@ -2185,27 +2189,27 @@ struct ImageTypeConversion {
         const halide_type_t src_type = src.type();
         switch (src_type.element_of().as_u32()) {
         case halide_type_t(halide_type_float, 32).as_u32():
-            return convert_image(src.template as<float>(), dst_type);
+            return convert_image(src.template as<float, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_float, 64).as_u32():
-            return convert_image(src.template as<double>(), dst_type);
+            return convert_image(src.template as<double, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 8).as_u32():
-            return convert_image(src.template as<int8_t>(), dst_type);
+            return convert_image(src.template as<int8_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 16).as_u32():
-            return convert_image(src.template as<int16_t>(), dst_type);
+            return convert_image(src.template as<int16_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 32).as_u32():
-            return convert_image(src.template as<int32_t>(), dst_type);
+            return convert_image(src.template as<int32_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 64).as_u32():
-            return convert_image(src.template as<int64_t>(), dst_type);
+            return convert_image(src.template as<int64_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 1).as_u32():
-            return convert_image(src.template as<bool>(), dst_type);
+            return convert_image(src.template as<bool, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 8).as_u32():
-            return convert_image(src.template as<uint8_t>(), dst_type);
+            return convert_image(src.template as<uint8_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 16).as_u32():
-            return convert_image(src.template as<uint16_t>(), dst_type);
+            return convert_image(src.template as<uint16_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 32).as_u32():
-            return convert_image(src.template as<uint32_t>(), dst_type);
+            return convert_image(src.template as<uint32_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 64).as_u32():
-            return convert_image(src.template as<uint64_t>(), dst_type);
+            return convert_image(src.template as<uint64_t, DimsUnconstrained>(), dst_type);
         default:
             assert(false && "Unsupported type");
             using RetImageType = typename Internal::ImageTypeWithDynamicDims<ImageType>::type;
@@ -2238,7 +2242,7 @@ bool load(const std::string &filename, ImageType *im) {
             return false;
         }
     }
-    *im = im_d.template as<typename ImageType::ElemType>();
+    *im = im_d.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>();
     im->set_host_dirty();
     return true;
 }
@@ -2259,7 +2263,7 @@ bool save(ImageType &im, const std::string &filename) {
 
     // Allow statically-typed images to be passed in, but quietly pass them on
     // as dynamically-typed images.
-    auto im_d = im.template as<const void>();
+    auto im_d = im.template as<const void, Internal::DimsUnconstrained>();
     return imageio.save(im_d, filename);
 }
 
@@ -2300,7 +2304,7 @@ public:
         Internal::CheckFail(ImageType::can_convert_from(im_d),
                             "Type mismatch assigning the result of load_image. "
                             "Did you mean to use load_and_convert_image?");
-        return im_d.template as<typename ImageType::ElemType>();
+        return im_d.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>();
     }
 
 private:
@@ -2322,7 +2326,7 @@ public:
         (void)load<DynamicImageType, Internal::CheckFail>(filename, &im_d);
         const halide_type_t expected_type = ImageType::static_halide_type();
         if (im_d.type() == expected_type) {
-            return im_d.template as<typename ImageType::ElemType>();
+            return im_d.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>();
         } else {
             return ImageTypeConversion::convert_image<typename ImageType::ElemType>(im_d);
         }
@@ -2343,7 +2347,8 @@ private:
 // a runtime error will occur.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckFail>
 void save_image(ImageType &im, const std::string &filename) {
-    (void)save<typename Internal::ImageTypeWithDynamicDims<ImageType>::type, check>(im, filename);
+    auto im_d = im.template as<void, Internal::DimsUnconstrained>();
+    (void)save<decltype(im_d), check>(im_d, filename);
 }
 
 // Like save_image, but quietly convert the saved image to a type that the
@@ -2360,7 +2365,7 @@ void convert_and_save_image(ImageType &im, const std::string &filename) {
     if (best.type == im.type() && best.dimensions == im.dimensions()) {
         // It's an exact match, we can save as-is.
         using DynamicImageDims = typename Internal::ImageTypeWithDynamicDims<ImageType>::type;
-        (void)save<DynamicImageDims, check>(im.template as<typename ImageType::ElemType, -1>(), filename);
+        (void)save<DynamicImageDims, check>(im.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>(), filename);
     } else {
         using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
         DynamicImageType im_converted = ImageTypeConversion::convert_image(im, best.type);

--- a/tutorial/lesson_01_basics.cpp
+++ b/tutorial/lesson_01_basics.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
     // resolution of the output image. Halide.h also provides a basic
     // templatized image type we can use. We'll make an 800 x 600
     // image.
-    Halide::Buffer<int32_t> output = gradient.realize({800, 600});
+    Halide::Buffer<int32_t, 2> output = gradient.realize({800, 600});
 
     // Halide does type inference for you. Var objects represent
     // 32-bit integers, so the Expr object 'x + y' also represents a

--- a/tutorial/lesson_02_input_image.cpp
+++ b/tutorial/lesson_02_input_image.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     // brightens an image.
 
     // First we'll load the input image we wish to brighten.
-    Halide::Buffer<uint8_t> input = load_image("images/rgb.png");
+    Halide::Buffer<uint8_t, 3> input = load_image("images/rgb.png");
 
     // See figures/lesson_02_input.jpg for a smaller version.
 
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     // smaller size. If we request a larger size Halide will throw an
     // error at runtime telling us we're trying to read out of bounds
     // on the input image.
-    Halide::Buffer<uint8_t> output =
+    Halide::Buffer<uint8_t, 3> output =
         brighter.realize({input.width(), input.height(), input.channels()});
 
     // Save the output for inspection. It should look like a bright parrot.

--- a/tutorial/lesson_03_debugging_1.cpp
+++ b/tutorial/lesson_03_debugging_1.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 
     // Realize the function to produce an output image. We'll keep it
     // very small for this lesson.
-    Buffer<int> output = gradient.realize({8, 8});
+    Buffer<int, 2> output = gradient.realize({8, 8});
 
     // That line compiled and ran the pipeline. Try running this
     // lesson with the environment variable HL_DEBUG_CODEGEN set to

--- a/tutorial/lesson_04_debugging_2.cpp
+++ b/tutorial/lesson_04_debugging_2.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
         // Realize the function over an 8x8 region.
         printf("Evaluating gradient\n");
-        Buffer<int> output = gradient.realize({8, 8});
+        Buffer<int, 2> output = gradient.realize({8, 8});
 
         // This will print out all the times gradient(x, y) gets
         // evaluated.

--- a/tutorial/lesson_05_scheduling_1.cpp
+++ b/tutorial/lesson_05_scheduling_1.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
         // slowly. x is the column and y is the row, so this is a
         // row-major traversal.
         printf("Evaluating gradient row-major\n");
-        Buffer<int> output = gradient.realize({4, 4});
+        Buffer<int, 2> output = gradient.realize({4, 4});
 
         // See figures/lesson_05_row_major.gif for a visualization of
         // what this did.
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         // traversal.
 
         printf("Evaluating gradient column-major\n");
-        Buffer<int> output = gradient.realize({4, 4});
+        Buffer<int, 2> output = gradient.realize({4, 4});
 
         // See figures/lesson_05_col_major.gif for a visualization of
         // what this did.
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
         // also added within the loops.
 
         printf("Evaluating gradient with x split into x_outer and x_inner \n");
-        Buffer<int> output = gradient.realize({4, 4});
+        Buffer<int, 2> output = gradient.realize({4, 4});
 
         printf("Equivalent C:\n");
         for (int y = 0; y < 4; y++) {
@@ -168,7 +168,7 @@ int main(int argc, char **argv) {
         gradient.fuse(x, y, fused);
 
         printf("Evaluating gradient with x and y fused\n");
-        Buffer<int> output = gradient.realize({4, 4});
+        Buffer<int, 2> output = gradient.realize({4, 4});
 
         printf("Equivalent C:\n");
         for (int fused = 0; fused < 4 * 4; fused++) {
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
         // gradient.tile(x, y, x_outer, y_outer, x_inner, y_inner, 4, 4);
 
         printf("Evaluating gradient in 4x4 tiles\n");
-        Buffer<int> output = gradient.realize({8, 8});
+        Buffer<int, 2> output = gradient.realize({8, 8});
 
         // See figures/lesson_05_tiled.gif for a visualization of this
         // schedule.
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
         // This time we'll evaluate over an 8x4 box, so that we have
         // more than one vector of work per scanline.
         printf("Evaluating gradient with x_inner vectorized \n");
-        Buffer<int> output = gradient.realize({8, 4});
+        Buffer<int, 2> output = gradient.realize({8, 4});
 
         // See figures/lesson_05_vectors.gif for a visualization.
 
@@ -320,7 +320,7 @@ int main(int argc, char **argv) {
         // gradient.unroll(x, 2);
 
         printf("Evaluating gradient unrolled by a factor of two\n");
-        Buffer<int> result = gradient.realize({4, 4});
+        Buffer<int, 2> result = gradient.realize({4, 4});
 
         printf("Equivalent C:\n");
         for (int y = 0; y < 4; y++) {
@@ -362,7 +362,7 @@ int main(int argc, char **argv) {
         gradient.split(x, x_outer, x_inner, 3);
 
         printf("Evaluating gradient over a 7x2 box with x split by three \n");
-        Buffer<int> output = gradient.realize({7, 2});
+        Buffer<int, 2> output = gradient.realize({7, 2});
 
         // See figures/lesson_05_split_7_by_3.gif for a visualization
         // of what happened. Note that some points get evaluated more
@@ -448,7 +448,7 @@ int main(int argc, char **argv) {
         //     .parallel(tile_index);
 
         printf("Evaluating gradient tiles in parallel\n");
-        Buffer<int> output = gradient.realize({8, 8});
+        Buffer<int, 2> output = gradient.realize({8, 8});
 
         // The tiles should occur in arbitrary order, but within each
         // tile the pixels will be traversed in row-major order. See
@@ -509,7 +509,7 @@ int main(int argc, char **argv) {
         // If you like you can turn on tracing, but it's going to
         // produce a lot of printfs. Instead we'll compute the answer
         // both in C and Halide and see if the answers match.
-        Buffer<int> result = gradient_fast.realize({350, 250});
+        Buffer<int, 2> result = gradient_fast.realize({350, 250});
 
         // See figures/lesson_05_fast.mp4 for a visualization.
 

--- a/tutorial/lesson_06_realizing_over_shifted_domains.cpp
+++ b/tutorial/lesson_06_realizing_over_shifted_domains.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     // way. We can pass it an image we would like it to fill in. The
     // following evaluates our Func into an existing image:
     printf("Evaluating gradient from (0, 0) to (7, 7)\n");
-    Buffer<int> result(8, 8);
+    Buffer<int, 2> result(8, 8);
     gradient.realize(result);
 
     // Let's check it did what we expect:
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     // from (100, 50) to (104, 56) inclusive.
 
     // We start by creating an image that represents that rectangle:
-    Buffer<int> shifted(5, 7);  // In the constructor we tell it the size.
+    Buffer<int, 2> shifted(5, 7);  // In the constructor we tell it the size.
     shifted.set_min(100, 50);   // Then we tell it the top-left corner.
 
     printf("Evaluating gradient from (100, 50) to (104, 56)\n");

--- a/tutorial/lesson_07_multi_stage_pipelines.cpp
+++ b/tutorial/lesson_07_multi_stage_pipelines.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     // first horizontally, and then vertically.
     {
         // Take a color 8-bit input
-        Buffer<uint8_t> input = load_image("images/rgb.png");
+        Buffer<uint8_t, 3> input = load_image("images/rgb.png");
 
         // Upgrade it to 16-bit, so we can do math without it overflowing.
         Func input_16("input_16");
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
 
         // Now let's realize it...
 
-        // Buffer<uint8_t> result = output.realize({input.width(), input.height(), 3});
+        // Buffer<uint8_t, 3> result = output.realize({input.width(), input.height(), 3});
 
         // Except that the line above is not going to work. Uncomment
         // it to see what happens.
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
         // over a domain shifted inwards by one pixel, we won't be
         // asking the Halide routine to read out of bounds. We saw how
         // to do this in the previous lesson:
-        Buffer<uint8_t> result(input.width() - 2, input.height() - 2, 3);
+        Buffer<uint8_t, 3> result(input.width() - 2, input.height() - 2, 3);
         result.set_min(1, 1);
         output.realize(result);
 
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
     // The same pipeline, with a boundary condition on the input.
     {
         // Take a color 8-bit input
-        Buffer<uint8_t> input = load_image("images/rgb.png");
+        Buffer<uint8_t, 3> input = load_image("images/rgb.png");
 
         // This time, we'll wrap the input in a Func that prevents
         // reading out of bounds:
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
 
         // This time it's safe to evaluate the output over the same
         // domain as the input, because we have a boundary condition.
-        Buffer<uint8_t> result = output.realize({input.width(), input.height(), 3});
+        Buffer<uint8_t, 3> result = output.realize({input.width(), input.height(), 3});
 
         // Save the result. It should look like a slightly blurry
         // parrot, but this time it will be the same size as the

--- a/tutorial/lesson_08_scheduling_2.cpp
+++ b/tutorial/lesson_08_scheduling_2.cpp
@@ -586,7 +586,7 @@ int main(int argc, char **argv) {
         // consumer.trace_stores();
         // producer.trace_stores();
 
-        Buffer<float> halide_result = consumer.realize({160, 160});
+        Buffer<float, 2> halide_result = consumer.realize({160, 160});
 
         // See figures/lesson_08_mixed.mp4 for a visualization.
 

--- a/tutorial/lesson_09_update_definitions.cpp
+++ b/tutorial/lesson_09_update_definitions.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     Var x("x"), y("y");
 
     // Load a grayscale image to use as an input.
-    Buffer<uint8_t> input = load_image("images/gray.png");
+    Buffer<uint8_t, 2> input = load_image("images/gray.png");
 
     // You can define a Func in multiple passes. Let's see a toy
     // example first.
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
         // domain" and using it inside an update definition:
         RDom r(0, 50);
         f(x, r) = f(x, r) * f(x, r);
-        Buffer<float> halide_result = f.realize({100, 100});
+        Buffer<float, 2> halide_result = f.realize({100, 100});
 
         // See figures/lesson_09_update_rdom.mp4 for a visualization.
 
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
         // input image at that point.
         histogram(input(r.x, r.y)) += 1;
 
-        Buffer<int> halide_result = histogram.realize({256});
+        Buffer<int, 1> halide_result = histogram.realize({256});
 
         // The equivalent C is:
         int c_result[256];
@@ -263,7 +263,7 @@ int main(int argc, char **argv) {
         Var yo, yi;
         f.update(1).split(y, yo, yi, 4).parallel(yo);
 
-        Buffer<int> halide_result = f.realize({16, 16});
+        Buffer<int, 2> halide_result = f.realize({16, 16});
 
         // See figures/lesson_09_update_schedule.mp4 for a visualization.
 
@@ -324,7 +324,7 @@ int main(int argc, char **argv) {
         producer(x) = x * 2;
         producer(x) += 10;
         consumer(x) = 2 * producer(x);
-        Buffer<int> halide_result = consumer.realize({10});
+        Buffer<int, 1> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_inline_reduction.gif for a visualization.
 
@@ -383,7 +383,7 @@ int main(int argc, char **argv) {
 
         producer.compute_at(consumer, x);
 
-        Buffer<int> halide_result = consumer.realize({10});
+        Buffer<int, 1> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_pure.gif for a visualization.
 
@@ -435,7 +435,7 @@ int main(int argc, char **argv) {
         // the Vars of a Func are shared across the pure and
         // update steps.
 
-        Buffer<int> halide_result = consumer.realize({10});
+        Buffer<int, 1> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_update.gif for a visualization.
 
@@ -478,7 +478,7 @@ int main(int argc, char **argv) {
         // redundant work occurs.
         producer.compute_at(consumer, x);
 
-        Buffer<int> halide_result = consumer.realize({10});
+        Buffer<int, 1> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_pure_and_update.gif for a visualization.
 
@@ -545,7 +545,7 @@ int main(int argc, char **argv) {
         producer_1.compute_at(consumer_2, x);
         producer_2.compute_at(consumer_2, y);
 
-        Buffer<int> halide_result = consumer_2.realize({10, 10});
+        Buffer<int, 2> halide_result = consumer_2.realize({10, 10});
 
         // See figures/lesson_09_compute_at_multiple_updates.mp4 for a visualization.
 
@@ -601,7 +601,7 @@ int main(int argc, char **argv) {
 
         producer.compute_at(consumer, r);
 
-        Buffer<int> halide_result = consumer.realize({10});
+        Buffer<int, 1> halide_result = consumer.realize({10});
 
         // See figures/lesson_09_compute_at_rvar.gif for a visualization.
 
@@ -658,7 +658,7 @@ int main(int argc, char **argv) {
         Func blurry;
         blurry(x, y) = cast<uint8_t>(local_sum(x, y) / 25);
 
-        Buffer<uint8_t> halide_result = blurry.realize({input.width(), input.height()});
+        Buffer<uint8_t, 2> halide_result = blurry.realize({input.width(), input.height()});
 
         // The default schedule will inline 'clamped' into the update
         // step of 'local_sum', because clamped only has a pure
@@ -667,7 +667,7 @@ int main(int argc, char **argv) {
         // because the default schedule for reductions is
         // compute-innermost. Here's the equivalent C:
 
-        Buffer<uint8_t> c_result(input.width(), input.height());
+        Buffer<uint8_t, 2> c_result(input.width(), input.height());
         for (int y = 0; y < input.height(); y++) {
             for (int x = 0; x < input.width(); x++) {
                 int local_sum[1];
@@ -720,8 +720,8 @@ int main(int argc, char **argv) {
         // pure function. The reduction domain has been swallowed to
         // define the inner anonymous reduction.
 
-        Buffer<int> halide_result_1 = f1.realize({10});
-        Buffer<int> halide_result_2 = f2.realize({10});
+        Buffer<int, 1> halide_result_1 = f1.realize({10});
+        Buffer<int, 1> halide_result_2 = f2.realize({10});
 
         // The equivalent C is:
         int c_result[10];
@@ -783,7 +783,7 @@ int main(int argc, char **argv) {
         // as we need it in a circular buffer (see lesson 08).
         clamped.store_at(spread, yo).compute_at(spread, yi);
 
-        Buffer<uint8_t> halide_result = spread.realize({input.width(), input.height()});
+        Buffer<uint8_t, 2> halide_result = spread.realize({input.width(), input.height()});
 
 // The C equivalent is almost too horrible to contemplate (and
 // took me a long time to debug). This time I want to time
@@ -793,7 +793,7 @@ int main(int argc, char **argv) {
 // similar to get correct timing).
 #ifdef __SSE2__
         // Don't include the time required to allocate the output buffer.
-        Buffer<uint8_t> c_result(input.width(), input.height());
+        Buffer<uint8_t, 2> c_result(input.width(), input.height());
 
 #ifdef _OPENMP
         double t1 = current_time();

--- a/tutorial/lesson_10_aot_compilation_run.cpp
+++ b/tutorial/lesson_10_aot_compilation_run.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     // zero on success.
 
     // Let's make a buffer for our input and output.
-    Halide::Runtime::Buffer<uint8_t> input(640, 480), output(640, 480);
+    Halide::Runtime::Buffer<uint8_t, 2> input(640, 480), output(640, 480);
 
     // Halide::Runtime::Buffer also has constructors that wrap
     // existing data instead of allocating new memory. Use these if

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -40,9 +40,9 @@ Var x, y, c, i, ii, xo, yo, xi, yi;
 class MyPipeline {
 public:
     Func lut, padded, padded16, sharpen, curved;
-    Buffer<uint8_t> input;
+    Buffer<uint8_t, 3> input;
 
-    MyPipeline(Buffer<uint8_t> in)
+    MyPipeline(Buffer<uint8_t, 3> in)
         : input(in) {
         // For this lesson, we'll use a two-stage pipeline that sharpens
         // and then applies a look-up-table (LUT).
@@ -196,7 +196,7 @@ public:
     void test_performance() {
         // Test the performance of the scheduled MyPipeline.
 
-        Buffer<uint8_t> output(input.width(), input.height(), input.channels());
+        Buffer<uint8_t, 3> output(input.width(), input.height(), input.channels());
 
         // Run the filter once to initialize any GPU runtime state.
         curved.realize(output);
@@ -226,8 +226,8 @@ public:
         printf("%1.4f milliseconds\n", best_time);
     }
 
-    void test_correctness(Buffer<uint8_t> reference_output) {
-        Buffer<uint8_t> output =
+    void test_correctness(Buffer<uint8_t, 3> reference_output) {
+        Buffer<uint8_t, 3> output =
             curved.realize({input.width(), input.height(), input.channels()});
 
         // Check against the reference output.
@@ -250,10 +250,10 @@ public:
 
 int main(int argc, char **argv) {
     // Load an input image.
-    Buffer<uint8_t> input = load_image("images/rgb.png");
+    Buffer<uint8_t, 3> input = load_image("images/rgb.png");
 
     // Allocated an image that will store the correct output
-    Buffer<uint8_t> reference_output(input.width(), input.height(), input.channels());
+    Buffer<uint8_t, 3> reference_output(input.width(), input.height(), input.channels());
 
     printf("Running pipeline on CPU:\n");
     MyPipeline p1(input);

--- a/tutorial/lesson_13_tuples.cpp
+++ b/tutorial/lesson_13_tuples.cpp
@@ -93,8 +93,8 @@ int main(int argc, char **argv) {
     {
         Realization r = multi_valued.realize({80, 60});
         assert(r.size() == 2);
-        Buffer<int> im0 = r[0];
-        Buffer<float> im1 = r[1];
+        Buffer<int, 2> im0 = r[0];
+        Buffer<float, 2> im1 = r[1];
         assert(im0(30, 40) == 30 + 40);
         assert(im1(30, 40) == sinf(30 * 40));
     }
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
         // First we create a Buffer to take the argmax over.
         Func input_func;
         input_func(x) = sin(x);
-        Buffer<float> input = input_func.realize({100});
+        Buffer<float, 1> input = input_func.realize({100});
 
         // Then we define a 2-valued Tuple which tracks the index of
         // the maximum value and the value itself.
@@ -184,10 +184,10 @@ int main(int argc, char **argv) {
         // value and index.
         {
             Realization r = arg_max.realize();
-            Buffer<int> r0 = r[0];
-            Buffer<float> r1 = r[1];
-            assert(arg_max_0 == r0(0));
-            assert(arg_max_1 == r1(0));
+            Buffer<int, 0> r0 = r[0];
+            Buffer<float, 0> r1 = r[1];
+            assert(arg_max_0 == r0());
+            assert(arg_max_1 == r1());
         }
 
         // Halide provides argmax and argmin as built-in reductions
@@ -284,7 +284,7 @@ int main(int argc, char **argv) {
         escape(x, y) = first_escape[0];
 
         // Realize the pipeline and print the result as ascii art.
-        Buffer<int> result = escape.realize({61, 25});
+        Buffer<int, 2> result = escape.realize({61, 25});
         const char *code = " .:-~*={}&%#@";
         for (int y = 0; y < result.height(); y++) {
             for (int x = 0; x < result.width(); x++) {

--- a/tutorial/lesson_15_generators.cpp
+++ b/tutorial/lesson_15_generators.cpp
@@ -32,10 +32,10 @@ public:
     // member variables. They'll appear in the signature of our generated
     // function in the same order as we declare them.
     Input<uint8_t> offset{"offset"};
-    Input<Buffer<uint8_t>> input{"input", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
 
     // We also declare the Outputs as public member variables.
-    Output<Buffer<uint8_t>> brighter{"brighter", 2};
+    Output<Buffer<uint8_t, 2>> brighter{"brighter"};
 
     // Typically you declare your Vars at this scope as well, so that
     // they can be used in any helper methods you add later.
@@ -97,12 +97,12 @@ public:
 
     // We'll use the same Inputs as before:
     Input<uint8_t> offset{"offset"};
-    Input<Buffer<uint8_t>> input{"input", 2};
+    Input<Buffer<uint8_t, 2>> input{"input"};
 
     // And a similar Output. Note that we don't specify a type for the Buffer:
     // at compile-time, we must specify an explicit type via the "output.type"
     // GeneratorParam (which is implicitly defined for this Output).
-    Output<Buffer<>> output{"output", 2};
+    Output<Buffer<void, 2>> output{"output"};
 
     // And we'll declare our Vars here as before.
     Var x, y;

--- a/tutorial/lesson_16_rgb_generate.cpp
+++ b/tutorial/lesson_16_rgb_generate.cpp
@@ -33,7 +33,7 @@ public:
     // We declare a three-dimensional input image. The first two
     // dimensions will be x, and y, and the third dimension will be
     // the color channel.
-    Input<Buffer<uint8_t>> input{"input", 3};
+    Input<Buffer<uint8_t, 3>> input{"input"};
 
     // We will compile this generator in several ways to accept
     // several different memory layouts for the input and output. This
@@ -56,7 +56,7 @@ public:
     Input<uint8_t> offset{"offset"};
 
     // Declare our outputs
-    Output<Buffer<uint8_t>> brighter{"brighter", 3};
+    Output<Buffer<uint8_t, 3>> brighter{"brighter"};
 
     // Declare our Vars
     Var x, y, c;

--- a/tutorial/lesson_16_rgb_run.cpp
+++ b/tutorial/lesson_16_rgb_run.cpp
@@ -33,12 +33,12 @@ int main(int argc, char **argv) {
 
     // Let's make some images stored with interleaved and planar
     // memory. Halide::Runtime::Buffer is planar by default.
-    Halide::Runtime::Buffer<uint8_t> planar_input(1024, 768, 3);
-    Halide::Runtime::Buffer<uint8_t> planar_output(1024, 768, 3);
-    Halide::Runtime::Buffer<uint8_t> interleaved_input =
-        Halide::Runtime::Buffer<uint8_t>::make_interleaved(1024, 768, 3);
-    Halide::Runtime::Buffer<uint8_t> interleaved_output =
-        Halide::Runtime::Buffer<uint8_t>::make_interleaved(1024, 768, 3);
+    Halide::Runtime::Buffer<uint8_t, 3> planar_input(1024, 768, 3);
+    Halide::Runtime::Buffer<uint8_t, 3> planar_output(1024, 768, 3);
+    Halide::Runtime::Buffer<uint8_t, 3> interleaved_input =
+        Halide::Runtime::Buffer<uint8_t, 3>::make_interleaved(1024, 768, 3);
+    Halide::Runtime::Buffer<uint8_t, 3> interleaved_output =
+        Halide::Runtime::Buffer<uint8_t, 3>::make_interleaved(1024, 768, 3);
 
     // Let's check the strides are what we expect, given the
     // constraints we set up in the generator.

--- a/tutorial/lesson_17_predicated_rdom.cpp
+++ b/tutorial/lesson_17_predicated_rdom.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
         // After defining the predicate, we then define the update.
         circle(r.x, r.y) *= 2;
 
-        Buffer<int> halide_result = circle.realize({7, 7});
+        Buffer<int, 2> halide_result = circle.realize({7, 7});
 
         // See figures/lesson_17_rdom_circular.mp4 for a visualization of
         // what this did.
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
         // Then define the update.
         triangle(r.x, r.y) *= 2;
 
-        Buffer<int> halide_result = triangle.realize({10, 10});
+        Buffer<int, 2> halide_result = triangle.realize({10, 10});
 
         // See figures/lesson_17_rdom_triangular.mp4 for a
         // visualization of what this did.
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
         r2.where(f(r2.x, r2.y) < 1);
         g(r2.x, r2.y) += 17;
 
-        Buffer<int> halide_result_g = g.realize({5, 5});
+        Buffer<int, 2> halide_result_g = g.realize({5, 5});
 
         // See figures/lesson_17_rdom_calls_in_predicate.mp4 for a
         // visualization of what this did.

--- a/tutorial/lesson_18_parallel_associative_reductions.cpp
+++ b/tutorial/lesson_18_parallel_associative_reductions.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
     Var x("x"), y("y"), i("i"), u("u"), v("v");
 
     // Create an input with random values.
-    Buffer<uint8_t> input(8, 8, "input");
+    Buffer<uint8_t, 2> input(8, 8, "input");
     for (int y = 0; y < 8; ++y) {
         for (int x = 0; x < 8; ++x) {
             input(x, y) = (rand() % 256);
@@ -156,7 +156,7 @@ int main(int argc, char **argv) {
         // can't prove the associativity of a reduction, it will throw
         // an error.
 
-        Buffer<int> halide_result = histogram.realize({8});
+        Buffer<int, 1> halide_result = histogram.realize({8});
 
         // See figures/lesson_18_hist_rfactor_par.mp4 for a
         // visualization of what this does.
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
         intermediate.vectorize(x, 8);
         histogram.vectorize(x, 8);
 
-        Buffer<int> halide_result = histogram.realize({8});
+        Buffer<int, 1> halide_result = histogram.realize({8});
 
         // See figures/lesson_18_hist_rfactor_vec.mp4 for a
         // visualization of what this does.
@@ -294,7 +294,7 @@ int main(int argc, char **argv) {
         intermediate.vectorize(x, 8);
         histogram.vectorize(x, 8);
 
-        Buffer<int> halide_result = histogram.realize({8});
+        Buffer<int, 1> halide_result = histogram.realize({8});
 
         // See figures/lesson_18_hist_rfactor_tile.mp4 for a visualization of
         // what this does.

--- a/tutorial/lesson_19_wrapper_funcs.cpp
+++ b/tutorial/lesson_19_wrapper_funcs.cpp
@@ -306,7 +306,7 @@ int main(int argc, char **argv) {
         }
 
         // Create an interesting input image to use.
-        Buffer<int> input(258, 258);
+        Buffer<int, 2> input(258, 258);
         input.set_min(-1, -1);
         for (int y = input.top(); y <= input.bottom(); y++) {
             for (int x = input.left(); x <= input.right(); x++) {
@@ -316,7 +316,7 @@ int main(int argc, char **argv) {
 
         img.set(input);
         blur.compile_jit(target);
-        Buffer<int> out = blur.realize({256, 256});
+        Buffer<int, 2> out = blur.realize({256, 256});
 
         // Check the output is what we expected
         for (int y = out.top(); y <= out.bottom(); y++) {

--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -29,11 +29,10 @@ using namespace Halide;
 // We will define a generator to auto-schedule.
 class AutoScheduled : public Halide::Generator<AutoScheduled> {
 public:
-    Input<Buffer<float>> input{"input", 3};
+    Input<Buffer<float, 3>> input{"input"};
     Input<float> factor{"factor"};
-
-    Output<Buffer<float>> output1{"output1", 2};
-    Output<Buffer<float>> output2{"output2", 2};
+    Output<Buffer<float, 2>> output1{"output1"};
+    Output<Buffer<float, 2>> output2{"output2"};
 
     Expr sum3x3(Func f, Var x, Var y) {
         return f(x - 1, y - 1) + f(x - 1, y) + f(x - 1, y + 1) +

--- a/tutorial/lesson_21_auto_scheduler_run.cpp
+++ b/tutorial/lesson_21_auto_scheduler_run.cpp
@@ -22,7 +22,7 @@
 
 int main(int argc, char **argv) {
     // Let's declare and initialize the input images
-    Halide::Runtime::Buffer<float> input(1024, 1024, 3);
+    Halide::Runtime::Buffer<float, 3> input(1024, 1024, 3);
 
     for (int c = 0; c < input.channels(); ++c) {
         for (int y = 0; y < input.height(); ++y) {
@@ -32,8 +32,8 @@ int main(int argc, char **argv) {
         }
     }
 
-    Halide::Runtime::Buffer<float> output1(1024, 1024);
-    Halide::Runtime::Buffer<float> output2(1024, 1024);
+    Halide::Runtime::Buffer<float, 2> output1(1024, 1024);
+    Halide::Runtime::Buffer<float, 2> output2(1024, 1024);
     // Run each version of the codes (with no auto-schedule and with
     // auto-schedule) multiple times for benchmarking.
     double auto_schedule_off = Halide::Tools::benchmark(2, 5, [&]() {


### PR DESCRIPTION
Plus more fixes to corner cases in src/ and halide_image_io that I missed earlier