### PR TITLE
Various fixes to static-dimensioned Buffer

### DIFF
--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -139,7 +139,7 @@ class Buffer {
         } else {
             // Don't delegate to
             // Runtime::Buffer<T>::assert_can_convert_from. It might
-            // not assert is NDEBUG is defined. user_assert is
+            // not assert if NDEBUG is defined. user_assert is
             // friendlier anyway because it reports line numbers when
             // debugging symbols are found, it throws an exception
             // when exceptions are enabled, and we can print the
@@ -147,8 +147,8 @@ class Buffer {
             using BufType = Runtime::Buffer<T, Dims>;  // alias because commas in user_assert() macro confuses compiler
             user_assert(BufType::can_convert_from(*(other.get())))
                 << "Type mismatch constructing Buffer. Can't construct Buffer<"
-                << Internal::buffer_type_name<T>() << "> from Buffer<"
-                << type_to_c_type(other.type(), false) << ">\n";
+                << Internal::buffer_type_name<T>() << ", " << Dims << "> from Buffer<"
+                << type_to_c_type(other.type(), false) << ", " << D2 << ">, dimensions() = " << other.dimensions() << "\n";
         }
     }
 
@@ -509,13 +509,13 @@ public:
 
     static constexpr bool has_static_halide_type = Runtime::Buffer<T, Dims>::has_static_halide_type;
 
-    static halide_type_t static_halide_type() {
+    static constexpr halide_type_t static_halide_type() {
         return Runtime::Buffer<T, Dims>::static_halide_type();
     }
 
     static constexpr bool has_static_dimensions = Runtime::Buffer<T, Dims>::has_static_dimensions;
 
-    static int static_dimensions() {
+    static constexpr int static_dimensions() {
         return Runtime::Buffer<T, Dims>::static_dimensions();
     }
 
@@ -533,7 +533,7 @@ public:
     }
 
     template<typename T2, int D2 = Dims>
-    Buffer<T2, Dims> as() const {
+    Buffer<T2, D2> as() const {
         return Buffer<T2, D2>(*this);
     }
 

--- a/src/ExternFuncArgument.h
+++ b/src/ExternFuncArgument.h
@@ -30,8 +30,8 @@ struct ExternFuncArgument {
         : arg_type(FuncArg), func(std::move(f)) {
     }
 
-    template<typename T>
-    ExternFuncArgument(Buffer<T> b)
+    template<typename T, int Dims>
+    ExternFuncArgument(Buffer<T, Dims> b)
         : arg_type(BufferArg), buffer(b) {
     }
     ExternFuncArgument(Expr e)

--- a/src/Func.h
+++ b/src/Func.h
@@ -740,8 +740,8 @@ public:
     explicit Func(Internal::Function f);
 
     /** Construct a new Func to wrap a Buffer. */
-    template<typename T>
-    HALIDE_NO_USER_CODE_INLINE explicit Func(Buffer<T> &im)
+    template<typename T, int Dims>
+    HALIDE_NO_USER_CODE_INLINE explicit Func(Buffer<T, Dims> &im)
         : Func() {
         (*this)(_) = im(_);
     }
@@ -2560,7 +2560,7 @@ HALIDE_NO_USER_CODE_INLINE T evaluate(JITUserContext *ctx, const Expr &e) {
         << " as a scalar of type " << type_of<T>() << "\n";
     Func f;
     f() = e;
-    Buffer<T> im = f.realize(ctx);
+    Buffer<T, 0> im = f.realize(ctx);
     return im();
 }
 
@@ -2615,7 +2615,7 @@ HALIDE_NO_USER_CODE_INLINE T evaluate_may_gpu(const Expr &e) {
     Func f;
     f() = e;
     Internal::schedule_scalar(f);
-    Buffer<T> im = f.realize();
+    Buffer<T, 0> im = f.realize();
     return im();
 }
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3275,7 +3275,7 @@ public:
     template<typename T,
              typename std::enable_if<!std::is_arithmetic<T>::value && !std::is_same<T, Halide::Func>::value>::type * = nullptr>
     GeneratorInput<T> *add_input(const std::string &name, const Type &t, int dimensions) {
-        static_assert(!T::has_static_dimensions, "You can only call this version of add_input() for a Buffer<T, D> where T is void or omitted .");
+        static_assert(!T::has_static_halide_type, "You can only call this version of add_input() for a Buffer<T, D> where T is void or omitted .");
         static_assert(!T::has_static_dimensions, "You can only call this version of add_input() for a Buffer<T, D> where D is -1 or omitted.");
         check_exact_phase(GeneratorBase::ConfigureCalled);
         auto *p = new GeneratorInput<T>(name, t, dimensions);
@@ -3303,7 +3303,7 @@ public:
     template<typename T,
              typename std::enable_if<!std::is_arithmetic<T>::value && !std::is_same<T, Halide::Func>::value>::type * = nullptr>
     GeneratorInput<T> *add_input(const std::string &name) {
-        static_assert(T::has_static_dimensions, "You can only call this version of add_input() for a Buffer<T, D> where T is not void.");
+        static_assert(T::has_static_halide_type, "You can only call this version of add_input() for a Buffer<T, D> where T is not void.");
         static_assert(T::has_static_dimensions, "You can only call this version of add_input() for a Buffer<T, D> where D is not -1.");
         check_exact_phase(GeneratorBase::ConfigureCalled);
         auto *p = new GeneratorInput<T>(name);
@@ -3352,7 +3352,7 @@ public:
     template<typename T,
              typename std::enable_if<!std::is_arithmetic<T>::value && !std::is_same<T, Halide::Func>::value>::type * = nullptr>
     GeneratorOutput<T> *add_output(const std::string &name, const Type &t, int dimensions) {
-        static_assert(!T::has_static_dimensions, "You can only call this version of add_output() for a Buffer<T, D> where T is void or omitted .");
+        static_assert(!T::has_static_halide_type, "You can only call this version of add_output() for a Buffer<T, D> where T is void or omitted .");
         static_assert(!T::has_static_dimensions, "You can only call this version of add_output() for a Buffer<T, D> where D is -1 or omitted.");
         check_exact_phase(GeneratorBase::ConfigureCalled);
         auto *p = new GeneratorOutput<T>(name, t, dimensions);
@@ -3380,7 +3380,7 @@ public:
     template<typename T,
              typename std::enable_if<!std::is_arithmetic<T>::value && !std::is_same<T, Halide::Func>::value>::type * = nullptr>
     GeneratorOutput<T> *add_output(const std::string &name) {
-        static_assert(T::has_static_dimensions, "You can only call this version of add_output() for a Buffer<T, D> where T is not void.");
+        static_assert(T::has_static_halide_type, "You can only call this version of add_output() for a Buffer<T, D> where T is not void.");
         static_assert(T::has_static_dimensions, "You can only call this version of add_output() for a Buffer<T, D> where D is not -1.");
         check_exact_phase(GeneratorBase::ConfigureCalled);
         auto *p = new GeneratorOutput<T>(name);

--- a/src/ParamMap.h
+++ b/src/ParamMap.h
@@ -33,8 +33,8 @@ public:
             : image_param(&p), buf(buf), buf_out_param(nullptr) {
         }
 
-        template<typename T>
-        ParamMapping(const ImageParam &p, Buffer<T> &buf)
+        template<typename T, int Dims>
+        ParamMapping(const ImageParam &p, Buffer<T, Dims> &buf)
             : image_param(&p), buf(buf), buf_out_param(nullptr) {
         }
 
@@ -42,8 +42,8 @@ public:
             : image_param(&p), buf_out_param(buf_ptr) {
         }
 
-        template<typename T>
-        ParamMapping(const ImageParam &p, Buffer<T> *buf_ptr)
+        template<typename T, int Dims>
+        ParamMapping(const ImageParam &p, Buffer<T, Dims> *buf_ptr)
             : image_param(&p), buf_out_param((Buffer<> *)buf_ptr) {
         }
     };

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -113,17 +113,17 @@ public:
         RealizationArg(halide_buffer_t *buf)
             : buf(buf) {
         }
-        template<typename T, int D>
-        RealizationArg(Runtime::Buffer<T, D> &dst)
+        template<typename T, int Dims>
+        RealizationArg(Runtime::Buffer<T, Dims> &dst)
             : buf(dst.raw_buffer()) {
         }
-        template<typename T>
-        HALIDE_NO_USER_CODE_INLINE RealizationArg(Buffer<T> &dst)
+        template<typename T, int Dims>
+        HALIDE_NO_USER_CODE_INLINE RealizationArg(Buffer<T, Dims> &dst)
             : buf(dst.raw_buffer()) {
         }
-        template<typename T, typename... Args,
+        template<typename T, int Dims, typename... Args,
                  typename = typename std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>::type>
-        RealizationArg(Buffer<T> &a, Args &&...args)
+        RealizationArg(Buffer<T, Dims> &a, Args &&...args)
             : buffer_list(std::make_unique<std::vector<Buffer<>>>(std::initializer_list<Buffer<>>{a, std::forward<Args>(args)...})) {
         }
         RealizationArg(RealizationArg &&from) = default;

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1493,7 +1493,7 @@ public:
 
     /** Make a lower-dimensional buffer that refers to one slice of
      * this buffer. */
-    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims - 1), InClassDimStorage>
+    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims - 1)>
     sliced(int d, int pos) const {
         static_assert(Dims == BufferDimsUnconstrained || Dims > 0, "Cannot slice a 0-dimensional buffer");
         assert(dimensions() > 0);
@@ -1514,7 +1514,7 @@ public:
 
     /** Make a lower-dimensional buffer that refers to one slice of this
      * buffer at the dimension's minimum. */
-    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims - 1), InClassDimStorage>
+    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims - 1)>
     sliced(int d) const {
         static_assert(Dims == BufferDimsUnconstrained || Dims > 0, "Cannot slice a 0-dimensional buffer");
         assert(dimensions() > 0);
@@ -1557,7 +1557,7 @@ public:
      &im(x, y, c) == &im2(x, 17, y, c);
      \endcode
      */
-    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims + 1), InClassDimStorage>
+    Buffer<T, (Dims == BufferDimsUnconstrained ? BufferDimsUnconstrained : Dims + 1)>
     embedded(int d, int pos = 0) const {
         Buffer<T, BufferDimsUnconstrained, InClassDimStorage> im(*this);
         im.embed(d, pos);

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -694,11 +694,13 @@ struct FileOpener {
     FILE *const f;
 };
 
+constexpr int DimsUnconstrained = -1;
+
 // Read a row of ElemTypes from a byte buffer and copy them into a specific image row.
 // Multibyte elements are assumed to be big-endian.
 template<typename ElemType, typename ImageType>
 void read_big_endian_row(const uint8_t *src, int y, ImageType *im) {
-    auto im_typed = im->template as<ElemType>();
+    auto im_typed = im->template as<ElemType, DimsUnconstrained>();
     const int xmin = im_typed.dim(0).min();
     const int xmax = im_typed.dim(0).max();
     if (im_typed.dimensions() > 2) {
@@ -722,7 +724,7 @@ void read_big_endian_row(const uint8_t *src, int y, ImageType *im) {
 // Multibyte elements are written in big-endian layout.
 template<typename ElemType, typename ImageType>
 void write_big_endian_row(const ImageType &im, int y, uint8_t *dst) {
-    auto im_typed = im.template as<typename std::add_const<ElemType>::type>();
+    auto im_typed = im.template as<typename std::add_const<ElemType>::type, DimsUnconstrained>();
     const int xmin = im_typed.dim(0).min();
     const int xmax = im_typed.dim(0).max();
     if (im_typed.dimensions() > 2) {
@@ -1917,14 +1919,14 @@ bool save_tiff(ImageType &im, const std::string &filename) {
     }
 
     // Otherwise, write it out via manual traversal.
-#define HANDLE_CASE(CODE, BITS, TYPE)                    \
-    case halide_type_t(CODE, BITS).as_u32(): {           \
-        ElemWriter<TYPE> ew(&f);                         \
-        im.template as<const TYPE>().for_each_value(ew); \
-        if (!check(ew.ok, "TIFF write failed")) {        \
-            return false;                                \
-        }                                                \
-        break;                                           \
+#define HANDLE_CASE(CODE, BITS, TYPE)                                       \
+    case halide_type_t(CODE, BITS).as_u32(): {                              \
+        ElemWriter<TYPE> ew(&f);                                            \
+        im.template as<const TYPE, DimsUnconstrained>().for_each_value(ew); \
+        if (!check(ew.ok, "TIFF write failed")) {                           \
+            return false;                                                   \
+        }                                                                   \
+        break;                                                              \
     }
 
     switch (im_type.element_of().as_u32()) {
@@ -1949,22 +1951,22 @@ bool save_tiff(ImageType &im, const std::string &filename) {
     return true;
 }
 
-// Given something like ImageType<Foo, 2>, produce typedef ImageType<Foo, -1>
+// Given something like ImageType<Foo, 2>, produce typedef ImageType<Foo, DimsUnconstrained>
 template<typename ImageType>
 struct ImageTypeWithDynamicDims {
-    using type = decltype(std::declval<ImageType>().template as<typename ImageType::ElemType, -1>());
+    using type = decltype(std::declval<ImageType>().template as<typename ImageType::ElemType, DimsUnconstrained>());
 };
 
-// Given something like ImageType<Foo>, produce typedef ImageType<Bar, -1>
-template<typename ImageType, typename ElemType = void>
+// Given something like ImageType<Foo>, produce typedef ImageType<Bar, DimsUnconstrained>
+template<typename ImageType, typename ElemType>
 struct ImageTypeWithElemType {
-    using type = decltype(std::declval<ImageType>().template as<ElemType, -1>());
+    using type = decltype(std::declval<ImageType>().template as<ElemType, DimsUnconstrained>());
 };
 
-// Given something like ImageType<Foo>, produce typedef ImageType<const Bar, -1>
+// Given something like ImageType<Foo>, produce typedef ImageType<const Bar, DimsUnconstrained>
 template<typename ImageType, typename ElemType>
 struct ImageTypeWithConstElemType {
-    using type = decltype(std::declval<ImageType>().template as<typename std::add_const<ElemType>::type, -1>());
+    using type = decltype(std::declval<ImageType>().template as<typename std::add_const<ElemType>::type, DimsUnconstrained>());
 };
 
 template<typename ImageType, Internal::CheckFunc check>
@@ -2088,31 +2090,32 @@ struct ImageTypeConversion {
         // as documentation and a backstop against breakage.
         static_assert(!ImageType::has_static_halide_type,
                       "This variant of convert_image() requires a dynamically-typed image");
+        constexpr int DimsUnconstrained = Internal::DimsUnconstrained;
 
         const halide_type_t src_type = src.type();
         switch (src_type.element_of().as_u32()) {
         case halide_type_t(halide_type_float, 32).as_u32():
-            return convert_image<DstElemType>(src.template as<float>());
+            return convert_image<DstElemType>(src.template as<float, DimsUnconstrained>());
         case halide_type_t(halide_type_float, 64).as_u32():
-            return convert_image<DstElemType>(src.template as<double>());
+            return convert_image<DstElemType>(src.template as<double, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 8).as_u32():
-            return convert_image<DstElemType>(src.template as<int8_t>());
+            return convert_image<DstElemType>(src.template as<int8_t, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 16).as_u32():
-            return convert_image<DstElemType>(src.template as<int16_t>());
+            return convert_image<DstElemType>(src.template as<int16_t, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 32).as_u32():
-            return convert_image<DstElemType>(src.template as<int32_t>());
+            return convert_image<DstElemType>(src.template as<int32_t, DimsUnconstrained>());
         case halide_type_t(halide_type_int, 64).as_u32():
-            return convert_image<DstElemType>(src.template as<int64_t>());
+            return convert_image<DstElemType>(src.template as<int64_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 1).as_u32():
-            return convert_image<DstElemType>(src.template as<bool>());
+            return convert_image<DstElemType>(src.template as<bool, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 8).as_u32():
-            return convert_image<DstElemType>(src.template as<uint8_t>());
+            return convert_image<DstElemType>(src.template as<uint8_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 16).as_u32():
-            return convert_image<DstElemType>(src.template as<uint16_t>());
+            return convert_image<DstElemType>(src.template as<uint16_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 32).as_u32():
-            return convert_image<DstElemType>(src.template as<uint32_t>());
+            return convert_image<DstElemType>(src.template as<uint32_t, DimsUnconstrained>());
         case halide_type_t(halide_type_uint, 64).as_u32():
-            return convert_image<DstElemType>(src.template as<uint64_t>());
+            return convert_image<DstElemType>(src.template as<uint64_t, DimsUnconstrained>());
         default:
             assert(false && "Unsupported type");
             using DstImageType = typename Internal::ImageTypeWithElemType<ImageType, DstElemType>::type;
@@ -2177,6 +2180,7 @@ struct ImageTypeConversion {
         // as documentation and a backstop against breakage.
         static_assert(!ImageType::has_static_halide_type,
                       "This variant of convert_image() requires a dynamically-typed image");
+        constexpr int DimsUnconstrained = Internal::DimsUnconstrained;
 
         // Sniff the runtime type of src, coerce it to that type using as<>(),
         // and call the static-to-dynamic variant of this method. (Note that
@@ -2185,27 +2189,27 @@ struct ImageTypeConversion {
         const halide_type_t src_type = src.type();
         switch (src_type.element_of().as_u32()) {
         case halide_type_t(halide_type_float, 32).as_u32():
-            return convert_image(src.template as<float>(), dst_type);
+            return convert_image(src.template as<float, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_float, 64).as_u32():
-            return convert_image(src.template as<double>(), dst_type);
+            return convert_image(src.template as<double, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 8).as_u32():
-            return convert_image(src.template as<int8_t>(), dst_type);
+            return convert_image(src.template as<int8_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 16).as_u32():
-            return convert_image(src.template as<int16_t>(), dst_type);
+            return convert_image(src.template as<int16_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 32).as_u32():
-            return convert_image(src.template as<int32_t>(), dst_type);
+            return convert_image(src.template as<int32_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_int, 64).as_u32():
-            return convert_image(src.template as<int64_t>(), dst_type);
+            return convert_image(src.template as<int64_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 1).as_u32():
-            return convert_image(src.template as<bool>(), dst_type);
+            return convert_image(src.template as<bool, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 8).as_u32():
-            return convert_image(src.template as<uint8_t>(), dst_type);
+            return convert_image(src.template as<uint8_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 16).as_u32():
-            return convert_image(src.template as<uint16_t>(), dst_type);
+            return convert_image(src.template as<uint16_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 32).as_u32():
-            return convert_image(src.template as<uint32_t>(), dst_type);
+            return convert_image(src.template as<uint32_t, DimsUnconstrained>(), dst_type);
         case halide_type_t(halide_type_uint, 64).as_u32():
-            return convert_image(src.template as<uint64_t>(), dst_type);
+            return convert_image(src.template as<uint64_t, DimsUnconstrained>(), dst_type);
         default:
             assert(false && "Unsupported type");
             using RetImageType = typename Internal::ImageTypeWithDynamicDims<ImageType>::type;
@@ -2238,7 +2242,7 @@ bool load(const std::string &filename, ImageType *im) {
             return false;
         }
     }
-    *im = im_d.template as<typename ImageType::ElemType>();
+    *im = im_d.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>();
     im->set_host_dirty();
     return true;
 }
@@ -2259,7 +2263,7 @@ bool save(ImageType &im, const std::string &filename) {
 
     // Allow statically-typed images to be passed in, but quietly pass them on
     // as dynamically-typed images.
-    auto im_d = im.template as<const void>();
+    auto im_d = im.template as<const void, Internal::DimsUnconstrained>();
     return imageio.save(im_d, filename);
 }
 
@@ -2300,7 +2304,7 @@ public:
         Internal::CheckFail(ImageType::can_convert_from(im_d),
                             "Type mismatch assigning the result of load_image. "
                             "Did you mean to use load_and_convert_image?");
-        return im_d.template as<typename ImageType::ElemType>();
+        return im_d.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>();
     }
 
 private:
@@ -2322,7 +2326,7 @@ public:
         (void)load<DynamicImageType, Internal::CheckFail>(filename, &im_d);
         const halide_type_t expected_type = ImageType::static_halide_type();
         if (im_d.type() == expected_type) {
-            return im_d.template as<typename ImageType::ElemType>();
+            return im_d.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>();
         } else {
             return ImageTypeConversion::convert_image<typename ImageType::ElemType>(im_d);
         }
@@ -2343,7 +2347,8 @@ private:
 // a runtime error will occur.
 template<typename ImageType, Internal::CheckFunc check = Internal::CheckFail>
 void save_image(ImageType &im, const std::string &filename) {
-    (void)save<typename Internal::ImageTypeWithDynamicDims<ImageType>::type, check>(im, filename);
+    auto im_d = im.template as<void, Internal::DimsUnconstrained>();
+    (void)save<decltype(im_d), check>(im_d, filename);
 }
 
 // Like save_image, but quietly convert the saved image to a type that the
@@ -2360,7 +2365,7 @@ void convert_and_save_image(ImageType &im, const std::string &filename) {
     if (best.type == im.type() && best.dimensions == im.dimensions()) {
         // It's an exact match, we can save as-is.
         using DynamicImageDims = typename Internal::ImageTypeWithDynamicDims<ImageType>::type;
-        (void)save<DynamicImageDims, check>(im.template as<typename ImageType::ElemType, -1>(), filename);
+        (void)save<DynamicImageDims, check>(im.template as<typename ImageType::ElemType, Internal::DimsUnconstrained>(), filename);
     } else {
         using DynamicImageType = typename Internal::ImageTypeWithElemType<ImageType, void>::type;
         DynamicImageType im_converted = ImageTypeConversion::convert_image(im, best.type);


### PR DESCRIPTION
More details that should have been in #6574:
- Buffer needed to make some methods constexpr, and also had a broken return value for `as<>()`
- Various templated methods needed to add `int Dims` as a parameter
- Generator::add_input() and add_output() needed specializations for static-buffer types
- sliced() and embedded() should use the default values for InClassDimStorage
- halide_image_io should use a named constant