### PR TITLE
Fixes the Pytorch Wrapper Codegen for CPU-only machines.

### DIFF
--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -101,6 +101,8 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
         stream << get_indent() << "user_ctx.cuda_context = &ctx;\n";
         stream << get_indent() << "user_ctx.stream = &stream;\n";
         stream << get_indent() << "void* __user_context = (void*) &user_ctx;\n\n";
+    } else {
+        stream << get_indent() << "void* __user_context = nullptr;\n\n";
     }
 
     stream << get_indent() << "// Check tensors have contiguous memory and are on the correct device\n";
@@ -131,8 +133,15 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
         std::string tp = type_to_c_type(buffer_arg.type, false);
         stream
             << "Halide::Runtime::Buffer<" << tp << "> "
-            << c_print_name(buffer_arg.name)
-            << "_buffer = Halide::PyTorch::wrap<" << tp << ">("
+            << c_print_name(buffer_arg.name);
+        if (is_cuda) {
+            stream
+                << "_buffer = Halide::PyTorch::wrap_cuda<" << tp << ">(";
+        } else {
+            stream
+                << "_buffer = Halide::PyTorch::wrap<" << tp << ">(";
+        }
+        stream
             << c_print_name(buffer_arg.name)
             << ");\n";
     }

--- a/src/runtime/HalidePyTorchHelpers.h
+++ b/src/runtime/HalidePyTorchHelpers.h
@@ -15,7 +15,8 @@
 
 #include "HalideBuffer.h"
 
-#include "HalideRuntimeCuda.h"
+// Forward declare the cuda_device_interface, for tensor wrapper.
+const halide_device_interface_t *halide_cuda_device_interface();
 
 #define HLPT_CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
 #define HLPT_CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")
@@ -90,16 +91,29 @@ inline Buffer<scalar_t> wrap(at::Tensor &tensor) {
 #endif
     Buffer<scalar_t> buffer;
 
-    // TODO(mgharbi): force Halide to put input/output on GPU?
-    if (tensor.is_cuda()) {
-        buffer = Buffer<scalar_t>(dims);
-        const halide_device_interface_t *cuda_interface = halide_cuda_device_interface();
-        int err = buffer.device_wrap_native(cuda_interface, (uint64_t)pData);
-        AT_ASSERTM(err == 0, "(CUDA) halide_device_wrap failed");
-        buffer.set_device_dirty();
-    } else {
-        buffer = Buffer<scalar_t>(pData, dims);
-    }
+    buffer = Buffer<scalar_t>(pData, dims);
+
+    return buffer;
+}
+
+
+template<class scalar_t>
+inline Buffer<scalar_t> wrap_cuda(at::Tensor &tensor) {
+    check_type<scalar_t>(tensor);
+    std::vector<int> dims = get_dims(tensor);
+#if HL_PYTORCH_API_VERSION >= 13
+    scalar_t *pData = tensor.data_ptr<scalar_t>();
+#else
+    scalar_t *pData = tensor.data<scalar_t>();
+#endif
+    Buffer<scalar_t> buffer;
+
+    AT_ASSERTM(tensor.is_cuda(), "expected input tensor to be on a CUDA device.");
+    buffer = Buffer<scalar_t>(dims);
+    const halide_device_interface_t *cuda_interface = halide_cuda_device_interface();
+    int err = buffer.device_wrap_native(cuda_interface, (uint64_t)pData);
+    AT_ASSERTM(err == 0, "(CUDA) halide_device_wrap failed");
+    buffer.set_device_dirty();
 
     return buffer;
 }

--- a/src/runtime/HalidePyTorchHelpers.h
+++ b/src/runtime/HalidePyTorchHelpers.h
@@ -89,11 +89,7 @@ inline Buffer<scalar_t> wrap(at::Tensor &tensor) {
 #else
     scalar_t *pData = tensor.data<scalar_t>();
 #endif
-    Buffer<scalar_t> buffer;
-
-    buffer = Buffer<scalar_t>(pData, dims);
-
-    return buffer;
+    return Buffer<scalar_t>(pData, dims);
 }
 
 
@@ -106,13 +102,14 @@ inline Buffer<scalar_t> wrap_cuda(at::Tensor &tensor) {
 #else
     scalar_t *pData = tensor.data<scalar_t>();
 #endif
-    Buffer<scalar_t> buffer;
-
     AT_ASSERTM(tensor.is_cuda(), "expected input tensor to be on a CUDA device.");
-    buffer = Buffer<scalar_t>(dims);
+
+    Buffer<scalar_t> buffer(dims);
+
     const halide_device_interface_t *cuda_interface = halide_cuda_device_interface();
     int err = buffer.device_wrap_native(cuda_interface, (uint64_t)pData);
     AT_ASSERTM(err == 0, "(CUDA) halide_device_wrap failed");
+
     buffer.set_device_dirty();
 
     return buffer;

--- a/src/runtime/HalidePyTorchHelpers.h
+++ b/src/runtime/HalidePyTorchHelpers.h
@@ -92,7 +92,6 @@ inline Buffer<scalar_t> wrap(at::Tensor &tensor) {
     return Buffer<scalar_t>(pData, dims);
 }
 
-
 template<class scalar_t>
 inline Buffer<scalar_t> wrap_cuda(at::Tensor &tensor) {
     check_type<scalar_t>(tensor);

--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -132,6 +132,8 @@ const struct halide_filter_metadata_t *test1_metadata();
 
 HALIDE_FUNCTION_ATTRS
 inline int test1_th_(float _alpha, int32_t _beta, at::Tensor &_buf) {
+    void* __user_context = nullptr;
+
     // Check tensors have contiguous memory and are on the correct device
     HLPT_CHECK_CONTIGUOUS(_buf);
 
@@ -229,7 +231,7 @@ inline int test2_th_(float _alpha, int32_t _beta, at::Tensor &_buf) {
     HLPT_CHECK_DEVICE(_buf, device_id);
 
     // Wrap tensors in Halide buffers
-    Halide::Runtime::Buffer<int32_t> _buf_buffer = Halide::PyTorch::wrap<int32_t>(_buf);
+    Halide::Runtime::Buffer<int32_t> _buf_buffer = Halide::PyTorch::wrap_cuda<int32_t>(_buf);
 
     // Run Halide pipeline
     int err = test2(__user_context, _alpha, _beta, _buf_buffer);


### PR DESCRIPTION
This PR does two things:
1. split the helper function that wraps PyTorch tensors into Halide buffers into 2: one for CPU tensors, one for GPU tensors. Before the PR, the wrapper may fail on CPU-only machine because `halide_cuda_device_interface` is missing.
2. add a default `__user_context = nullptr` in CPU-only ops. The auto-scheduler can create intermediate functions that have a __user_context input. This case was not handled by the CodeGen, so compilation would fail. We now create a default null context instead. 