### PR TITLE
Reenable warning about unscheduled update definitions

### DIFF
--- a/apps/HelloMatlab/iir_blur.cpp
+++ b/apps/HelloMatlab/iir_blur.cpp
@@ -45,6 +45,8 @@ Func blur_cols_transpose(Func input, Expr height, Expr alpha) {
     blur.compute_at(transpose, yo);
 
     // Vectorize computations within the strips.
+    blur.update(0)
+        .vectorize(x);
     blur.update(1)
         .reorder(x, ry)
         .vectorize(x);

--- a/apps/fft/fft.cpp
+++ b/apps/fft/fft.cpp
@@ -871,6 +871,10 @@ ComplexFunc fft2d_r2c(Func r,
     dft.update(4).allow_race_conditions().vectorize(n0z1, vector_size);
     dft.update(5).allow_race_conditions().vectorize(n0z2, vector_size);
 
+    // Intentionally serial
+    dft.update(0);
+    dft.update(3);
+
     // Our result is undefined outside these bounds.
     dft.bound(n0, 0, N0);
     dft.bound(n1, 0, (N1 + 1) / 2 + 1);

--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -60,6 +60,7 @@ public:
             Var ii("ii");
             result_.update().vectorize(vecs, vec_size);
         }
+        result_.update(1);  // Leave the tail unvectorized
 
         result_.bound(i, 0, x_.width());
         result_.dim(0).set_bounds(0, x_.width());

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -1808,7 +1808,7 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
         // If previous update has a different set of reduction variables,
         // don't merge
         const vector<ReductionVariable> &rvars =
-            func_to_update.update(update_id).get_schedule().rvars();
+            func_to_update.function().update(update_id).schedule().rvars();
         if (!merged_r.defined()) {
             return rvars.empty();
         }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -344,6 +344,7 @@ bool is_const_assignment(const string &func_name, const vector<Expr> &args, cons
 }  // namespace
 
 void Stage::set_dim_type(const VarOrRVar &var, ForType t) {
+    definition.schedule().touched() = true;
     bool found = false;
     vector<Dim> &dims = definition.schedule().dims();
     for (auto &dim : dims) {
@@ -407,6 +408,7 @@ void Stage::set_dim_type(const VarOrRVar &var, ForType t) {
 }
 
 void Stage::set_dim_device_api(const VarOrRVar &var, DeviceAPI device_api) {
+    definition.schedule().touched() = true;
     bool found = false;
     vector<Dim> &dims = definition.schedule().dims();
     for (auto &dim : dims) {
@@ -662,11 +664,14 @@ bool apply_split_directive(const Split &s, vector<ReductionVariable> &rvars,
 }  // anonymous namespace
 
 Func Stage::rfactor(const RVar &r, const Var &v) {
+    definition.schedule().touched() = true;
     return rfactor({{r, v}});
 }
 
 Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
     user_assert(!definition.is_init()) << "rfactor() must be called on an update definition\n";
+
+    definition.schedule().touched() = true;
 
     const string &func_name = function.name();
     vector<Expr> &args = definition.args();
@@ -969,6 +974,8 @@ void Stage::split(const string &old, const string &outer, const string &inner, c
              << outer << " and " << inner << " with factor of " << factor << "\n";
     vector<Dim> &dims = definition.schedule().dims();
 
+    definition.schedule().touched() = true;
+
     // Check that the new names aren't already in the dims list.
     for (auto &dim : dims) {
         string new_names[2] = {inner, outer};
@@ -1116,6 +1123,7 @@ void Stage::split(const string &old, const string &outer, const string &inner, c
 }
 
 Stage &Stage::split(const VarOrRVar &old, const VarOrRVar &outer, const VarOrRVar &inner, const Expr &factor, TailStrategy tail) {
+    definition.schedule().touched() = true;
     if (old.is_rvar) {
         user_assert(outer.is_rvar) << "Can't split RVar " << old.name() << " into Var " << outer.name() << "\n";
         user_assert(inner.is_rvar) << "Can't split RVar " << old.name() << " into Var " << inner.name() << "\n";
@@ -1128,6 +1136,7 @@ Stage &Stage::split(const VarOrRVar &old, const VarOrRVar &outer, const VarOrRVa
 }
 
 Stage &Stage::fuse(const VarOrRVar &inner, const VarOrRVar &outer, const VarOrRVar &fused) {
+    definition.schedule().touched() = true;
     if (!fused.is_rvar) {
         user_assert(!outer.is_rvar) << "Can't fuse Var " << fused.name()
                                     << " from RVar " << outer.name() << "\n";
@@ -1211,6 +1220,8 @@ protected:
 Stage Stage::specialize(const Expr &condition) {
     user_assert(condition.type().is_bool()) << "Argument passed to specialize must be of type bool\n";
 
+    definition.schedule().touched() = true;
+
     // The condition may not depend on Vars or RVars
     Internal::CheckForFreeVars check;
     condition.accept(&check);
@@ -1242,6 +1253,9 @@ void Stage::specialize_fail(const std::string &message) {
     const vector<Specialization> &specializations = definition.specializations();
     user_assert(specializations.empty() || specializations.back().failure_message.empty())
         << "Only one specialize_fail() may be defined per Stage.";
+
+    definition.schedule().touched() = true;
+
     (void)definition.add_specialization(const_true());
     Specialization &s = definition.specializations().back();
     s.failure_message = message;
@@ -1383,6 +1397,8 @@ void Stage::remove(const string &var) {
 }
 
 Stage &Stage::rename(const VarOrRVar &old_var, const VarOrRVar &new_var) {
+    definition.schedule().touched() = true;
+
     if (old_var.is_rvar) {
         user_assert(new_var.is_rvar)
             << "In schedule for " << name()
@@ -1472,11 +1488,13 @@ Stage &Stage::rename(const VarOrRVar &old_var, const VarOrRVar &new_var) {
 }
 
 Stage &Stage::allow_race_conditions() {
+    definition.schedule().touched() = true;
     definition.schedule().allow_race_conditions() = true;
     return *this;
 }
 
 Stage &Stage::atomic(bool override_associativity_test) {
+    definition.schedule().touched() = true;
     definition.schedule().atomic() = true;
     definition.schedule().override_atomic_associativity_test() = override_associativity_test;
     return *this;
@@ -1600,6 +1618,7 @@ Stage &Stage::tile(const std::vector<VarOrRVar> &previous,
 }
 
 Stage &Stage::reorder(const std::vector<VarOrRVar> &vars) {
+    definition.schedule().touched() = true;
     const string &func_name = function.name();
     vector<Expr> &args = definition.args();
     vector<Expr> &values = definition.values();
@@ -1839,18 +1858,21 @@ Stage &Stage::hexagon(const VarOrRVar &x) {
 }
 
 Stage &Stage::prefetch(const Func &f, const VarOrRVar &at, const VarOrRVar &from, Expr offset, PrefetchBoundStrategy strategy) {
+    definition.schedule().touched() = true;
     PrefetchDirective prefetch = {f.name(), at.name(), from.name(), std::move(offset), strategy, Parameter()};
     definition.schedule().prefetches().push_back(prefetch);
     return *this;
 }
 
 Stage &Stage::prefetch(const Internal::Parameter &param, const VarOrRVar &at, const VarOrRVar &from, Expr offset, PrefetchBoundStrategy strategy) {
+    definition.schedule().touched() = true;
     PrefetchDirective prefetch = {param.name(), at.name(), from.name(), std::move(offset), strategy, param};
     definition.schedule().prefetches().push_back(prefetch);
     return *this;
 }
 
 Stage &Stage::compute_with(LoopLevel loop_level, const map<string, LoopAlignStrategy> &align) {
+    definition.schedule().touched() = true;
     loop_level.lock();
     user_assert(!loop_level.is_inlined() && !loop_level.is_root())
         << "Undefined loop level to compute with\n";
@@ -2738,7 +2760,9 @@ void Func::debug_to_file(const string &filename) {
 Stage Func::update(int idx) {
     user_assert(idx < num_update_definitions()) << "Call to update with index larger than last defined update stage for Func \"" << name() << "\".\n";
     invalidate_cache();
-    return Stage(func, func.update(idx), idx + 1);
+    Definition d = func.update(idx);
+    d.schedule().touched() = true;
+    return Stage(func, d, idx + 1);
 }
 
 Func::operator Stage() const {

--- a/src/Func.h
+++ b/src/Func.h
@@ -94,7 +94,6 @@ public:
     Stage(Internal::Function f, Internal::Definition d, size_t stage_index)
         : function(std::move(f)), definition(std::move(d)), stage_index(stage_index) {
         internal_assert(definition.defined());
-        definition.schedule().touched() = true;
 
         dim_vars.reserve(function.args().size());
         for (const auto &arg : function.args()) {

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -2078,10 +2078,10 @@ bool validate_schedule(Function f, const Stmt &s, const Target &target, bool is_
             const Definition &r = f.update((int)i);
             if (!r.schedule().touched()) {
                 user_warning
-                    << "Warning: Update step " << i
+                    << "Update definition " << i
                     << " of function " << f.name()
                     << " has not been scheduled, even though some other"
-                    << " steps have been. You may have forgotten to"
+                    << " definitions have been. You may have forgotten to"
                     << " schedule it. If this was intentional, call "
                     << f.name() << ".update(" << i << ") to suppress"
                     << " this warning.\n";

--- a/src/autoschedulers/adams2019/cost_model_generator.cpp
+++ b/src/autoschedulers/adams2019/cost_model_generator.cpp
@@ -533,7 +533,7 @@ public:
             };
 
             // Pipeline features processing
-            conv1_stage1.compute_root().vectorize(c);
+            conv1_stage1.compute_root().vectorize(c).update().vectorize(c);
             squashed_head1_filter.compute_root().vectorize(c);
 
             // Schedule features processing. The number of schedule

--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -242,6 +242,9 @@ int multiple_fuse_group_test() {
         p.fuse(x, y, t).parallel(t);
         h.fuse(x, y, t).parallel(t);
         h.compute_with(p, t);
+        h.update(0);  // unfused
+        h.update(1);  // unfused
+        h.update(2);  // unfused
 
         f.update(0).compute_with(g, y, LoopAlignStrategy::AlignEnd);
         f.compute_with(g, x);
@@ -1278,6 +1281,8 @@ int update_stage_test() {
         f.compute_root();
 
         f.update(1).compute_with(g.update(0), y);
+        f.update(0);  // unfused
+        g.update(1);  // unfused
 
         g.bound(x, 0, g_size).bound(y, 0, g_size);
         f.bound(x, 0, f_size).bound(y, 0, f_size);
@@ -1351,6 +1356,7 @@ int update_stage2_test() {
 
         f.update(0).compute_with(g.update(0), y);
         f.update(1).compute_with(g.update(0), y);
+        g.update(1);  // unfused
 
         g.bound(x, 0, g_size).bound(y, 0, g_size);
         f.bound(x, 0, f_size).bound(y, 0, f_size);
@@ -1659,6 +1665,8 @@ int update_stage_diagonal_test() {
 
         f.update(1).compute_with(g.update(0), y);
         g.update(0).compute_with(h, y);
+        f.update(0);
+        g.update(1);
 
         g.bound(x, 0, g_size).bound(y, 0, g_size);
         f.bound(x, 0, f_size).bound(y, 0, f_size);

--- a/test/correctness/extern_bounds_inference.cpp
+++ b/test/correctness/extern_bounds_inference.cpp
@@ -118,6 +118,7 @@ int main(int argc, char **argv) {
         f1.compute_at(g, y);
         f2.compute_at(g, x);
         g.reorder(y, x).vectorize(y, 4);
+        g.update();
 
         g.infer_input_bounds({W, H});
 

--- a/test/correctness/named_updates.cpp
+++ b/test/correctness/named_updates.cpp
@@ -41,6 +41,8 @@ int main(int argc, char **argv) {
         more_updates.a.vectorize(r, 4);
         more_updates.b.vectorize(r, 4);
         more_updates.c.vectorize(r, 4);
+
+        f.update();  // fix_first isn't scheduled
     }
 
     // Define the same thing without all the weird syntax and without

--- a/test/correctness/tuple_reduction.cpp
+++ b/test/correctness/tuple_reduction.cpp
@@ -61,14 +61,13 @@ int main(int argc, char **argv) {
             f.hexagon(y).vectorize(x, 32);
         }
         for (int i = 0; i < 10; i++) {
+            f.update(i);
             if (i & 1) {
                 if (target.has_gpu_feature()) {
                     f.update(i).gpu_tile(x, y, xo, yo, xi, yi, 16, 16);
                 } else if (target.has_feature(Target::HVX)) {
                     f.update(i).hexagon(y).vectorize(x, 32);
                 }
-            } else {
-                f.update(i);
             }
         }
 
@@ -103,14 +102,13 @@ int main(int argc, char **argv) {
 
         // Schedule the even update steps on the gpu
         for (int i = 0; i < 10; i++) {
+            f.update(i);
             if (i & 1) {
                 if (target.has_gpu_feature()) {
                     f.update(i).gpu_tile(x, y, xo, yo, xi, yi, 16, 16);
                 } else if (target.has_feature(Target::HVX)) {
                     f.update(i).hexagon(y).vectorize(x, 32);
                 }
-            } else {
-                f.update(i);
             }
         }
 
@@ -146,9 +144,8 @@ int main(int argc, char **argv) {
 
         // Schedule the even update steps on the gpu
         for (int i = 0; i < 10; i++) {
-            if (i & 1) {
-                f.update(i);
-            } else {
+            f.update(i);
+            if ((i & 1) == 0) {
                 if (target.has_gpu_feature()) {
                     f.update(i).gpu_tile(x, y, xo, yo, xi, yi, 16, 16);
                 } else if (target.has_feature(Target::HVX)) {

--- a/test/warning/CMakeLists.txt
+++ b/test/warning/CMakeLists.txt
@@ -3,6 +3,7 @@ tests(GROUPS warning
       hidden_pure_definition.cpp
       require_const_false.cpp
       sliding_vectors.cpp
+      unscheduled_update_def.cpp
       )
 
 # Don't look for "Success!" in warning tests, look for "Warning:" instead.

--- a/test/warning/unscheduled_update_def.cpp
+++ b/test/warning/unscheduled_update_def.cpp
@@ -1,0 +1,17 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f;
+    Var x;
+
+    f(x) = 0;
+    f(x) += 5;
+
+    f.vectorize(x, 8);
+
+    f.realize({1024});
+
+    return 0;
+}


### PR DESCRIPTION
and fix associated issues in the tests and apps.

This is an old warning that stopped triggering because it wasn't tested.
We should either remove it, fix the trigger conditions, or perhaps make
it an error. This PR fixes the trigger conditions and fixes all
instances of the warning in our tests and apps.

The warning triggers if you schedule some but not all of the update
definitions of a Func. It's to protect against the common error of only
scheduling the pure definition of something like a summation. The
warning can be suppressed by inserting a call to func.update(idx).