### PR TITLE
Fix bug in mul_shift_right matching

### DIFF
--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -380,6 +380,8 @@ protected:
             Type signed_type_wide = op_type_wide.with_code(halide_type_int);
             Type unsigned_type = op->type.with_code(halide_type_uint);
 
+            // Give concise names to various predicates we want to use in
+            // rewrite rules below.
             int bits = op->type.bits();
             auto is_x_same_int = op->type.is_int() && is_int(x, bits);
             auto is_x_same_uint = op->type.is_uint() && is_uint(x, bits);

--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -384,6 +384,7 @@ protected:
             auto is_x_same_int = op->type.is_int() && is_int(x, bits);
             auto is_x_same_uint = op->type.is_uint() && is_uint(x, bits);
             auto is_x_same_int_or_uint = is_x_same_int || is_x_same_uint;
+            auto x_y_same_sign = (is_int(x) && is_int(y)) || (is_uint(x) && is_uint(y));
             auto is_y_narrow_uint = op->type.is_uint() && is_uint(y, bits / 2);
             if (
                 // Saturating patterns
@@ -457,42 +458,42 @@ protected:
                         is_x_same_int_or_uint) ||
 
                 // Multiply-keep-high-bits patterns.
-
                 rewrite(max(min(shift_right(widening_mul(x, y), z), upper), lower),
                         mul_shift_right(x, y, cast(unsigned_type, z)),
-                        is_x_same_int_or_uint && is_uint(z)) ||
+                        is_x_same_int_or_uint && x_y_same_sign && is_uint(z)) ||
 
                 rewrite(max(min(rounding_shift_right(widening_mul(x, y), z), upper), lower),
                         rounding_mul_shift_right(x, y, cast(unsigned_type, z)),
-                        is_x_same_int_or_uint && is_uint(z)) ||
+                        is_x_same_int_or_uint && x_y_same_sign && is_uint(z)) ||
 
                 rewrite(min(shift_right(widening_mul(x, y), z), upper),
                         mul_shift_right(x, y, cast(unsigned_type, z)),
-                        is_x_same_uint && is_uint(z)) ||
+                        is_x_same_uint && x_y_same_sign && is_uint(z)) ||
 
                 rewrite(min(rounding_shift_right(widening_mul(x, y), z), upper),
                         rounding_mul_shift_right(x, y, cast(unsigned_type, z)),
-                        is_x_same_uint && is_uint(z)) ||
+                        is_x_same_uint && x_y_same_sign && is_uint(z)) ||
 
                 // We don't need saturation for the full upper half of a multiply.
                 // For signed integers, this is almost true, except for when x and y
                 // are both the most negative value. For these, we only need saturation
                 // at the upper bound.
+
                 rewrite(min(shift_right(widening_mul(x, y), c0), upper),
                         mul_shift_right(x, y, cast(unsigned_type, c0)),
-                        is_x_same_int && c0 >= bits - 1) ||
+                        is_x_same_int && x_y_same_sign && c0 >= bits - 1) ||
 
                 rewrite(min(rounding_shift_right(widening_mul(x, y), c0), upper),
                         rounding_mul_shift_right(x, y, cast(unsigned_type, c0)),
-                        is_x_same_int && c0 >= bits - 1) ||
+                        is_x_same_int && x_y_same_sign && c0 >= bits - 1) ||
 
                 rewrite(shift_right(widening_mul(x, y), c0),
                         mul_shift_right(x, y, cast(unsigned_type, c0)),
-                        is_x_same_int_or_uint && c0 >= bits) ||
+                        is_x_same_int_or_uint && x_y_same_sign && c0 >= bits) ||
 
                 rewrite(rounding_shift_right(widening_mul(x, y), c0),
                         rounding_mul_shift_right(x, y, cast(unsigned_type, c0)),
-                        is_x_same_int_or_uint && c0 >= bits) ||
+                        is_x_same_int_or_uint && x_y_same_sign && c0 >= bits) ||
 
                 // We can also match on smaller shifts if one of the args is
                 // narrow. We don't do this for signed (yet), because the

--- a/test/correctness/intrinsics.cpp
+++ b/test/correctness/intrinsics.cpp
@@ -311,6 +311,9 @@ int main(int argc, char **argv) {
     // Multiplication of mixed-width integers
     check(u16(u32(u16x) * u32(u8y) >> 8), mul_shift_right(u16x, u16(u8y), 8));
 
+    // Multiplication of mixed-sign integers shouldn't use mul_shift_right
+    check(i32(i64(u32x) * i64(i32y) >> 32), i32(widening_mul(u32x, i32y) >> 32));
+
     check(i8_sat(rounding_shift_right(i16(i8x) * i16(i8y), 7)), rounding_mul_shift_right(i8x, i8y, 7));
     check(i8(min(rounding_shift_right(i16(i8x) * i16(i8y), 7), 127)), rounding_mul_shift_right(i8x, i8y, 7));
     check(i8_sat(rounding_shift_right(i16(i8x) * i16(i8y), 8)), rounding_mul_shift_right(i8x, i8y, 8));


### PR DESCRIPTION
widening_mul handles mixed-signedness args, but mul_shift_right doesn't.
We shouldn't map a mixed-signedness widening_mul to a mul_shift_right.