### PR TITLE
Update WasmExecutor for WABT API changes

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -16,7 +16,7 @@ if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
 endif ()
 
 if (WITH_WABT)
-    set(WABT_VER 1.0.25)
+    set(WABT_VER main)
 
     message(STATUS "Fetching WABT ${WABT_VER}...")
     FetchContent_Declare(wabt


### PR DESCRIPTION
The API for WABT has changed in top-of-tree. This fixes the incompatibilities. It also (temporarily) changes to pulling WABT from top-of-tree (rather than a known release) as the most recent labeled release doesn't have these changes. (We'll change back to a fixed WABT release when the next one is released.)