### PR TITLE
Unbreak WABT again by using main instead of a commit

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -16,9 +16,9 @@ if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
 endif ()
 
 if (WITH_WABT)
-    # TODO: this commit hash is temporary until WABT produces
+    # TODO: using main is temporary until WABT produces
     # a new release tag with revised API
-    set(WABT_VER 09c40635207d42dd30ffaca22477fd3491dd9e7d)
+    set(WABT_VER main)
 
     message(STATUS "Fetching WABT ${WABT_VER}...")
     FetchContent_Declare(wabt


### PR DESCRIPTION
Commit 09c40635207d42dd30ffaca22477fd3491dd9e7d is no longer being recognized for WABT; rather than whack-a-mole, let's just use `main` temporarily (I've requested the WABT team make a new tag ASAP so we can standardize on the new API)