### PR TITLE
Remove halide_config.cmake from Makefile build. Fixes #6615

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2289,7 +2289,6 @@ $(DISTRIB_DIR)/lib/libHalide.$(SHARED_EXT): \
                            $(INCLUDE_DIR)/Halide.h \
                            $(RUNTIME_EXPORTED_INCLUDES) \
                            $(ROOT_DIR)/README*.md \
-                           $(BUILD_DIR)/halide_config.cmake \
                            $(BUILD_DIR)/halide_config.make
 	rm -rf $(DISTRIB_DIR)
 	mkdir -p $(DISTRIB_DIR)/include \

--- a/tools/halide_config.cmake.tpl
+++ b/tools/halide_config.cmake.tpl
@@ -1,3 +1,0 @@
-# Machine-Generated: Do Not Edit
-set(HALIDE_SYSTEM_LIBS @HALIDE_SYSTEM_LIBS_RAW@)
-set(HALIDE_RTTI @HALIDE_RTTI_RAW@)


### PR DESCRIPTION
What it says on the tin. I didn't remove the pattern rules for the possibility of there eventually being _other_ build `halide_config.*.tpl` files we want to generate.