### PR TITLE
Wild match object should not be foldable

### DIFF
--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -486,30 +486,7 @@ struct Wild {
         return state.get_binding(i);
     }
 
-    constexpr static bool foldable = true;
-    HALIDE_ALWAYS_INLINE
-    void make_folded_const(halide_scalar_value_t &val, halide_type_t &ty, MatcherState &state) const noexcept {
-        const auto *e = state.get_binding(i);
-        ty = e->type;
-        switch (e->node_type) {
-        case IRNodeType::UIntImm:
-            val.u.u64 = ((const UIntImm *)e)->value;
-            return;
-        case IRNodeType::IntImm:
-            val.u.i64 = ((const IntImm *)e)->value;
-            return;
-        case IRNodeType::FloatImm:
-            val.u.f64 = ((const FloatImm *)e)->value;
-            return;
-        default:
-            // The function is noexcept, so silent failure. You
-            // shouldn't be calling this if you haven't already
-            // checked it's going to be a constant (e.g. with
-            // is_const, or because you manually bound a constant Expr
-            // to the state).
-            val.u.u64 = 0;
-        }
-    }
+    constexpr static bool foldable = false;
 };
 
 template<int i>


### PR DESCRIPTION
`Wild` objects should not be foldable, `WildConst` should be used when matching against constants. There are no use cases of a `Wild` object being folded, so this should be removed unless there is a relevant use-case.