### PR TITLE
Avoid double narrowing in widening_add/widening_sub if type is 8-bit

### DIFF
--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -614,7 +614,7 @@ protected:
             if (narrow_a.defined() && narrow_b.defined()) {
                 return mutate(Cast::make(op->type, widening_mul(narrow_a, narrow_b)));
             }
-        } else if (op->is_intrinsic(Call::widening_add)) {
+        } else if (op->is_intrinsic(Call::widening_add) && (op->type.bits() >= 16)) {
             internal_assert(op->args.size() == 2);
             for (halide_type_code_t t : {op->type.code(), halide_type_uint}) {
                 Type narrow_t = op->type.narrow().narrow().with_code(t);
@@ -624,7 +624,7 @@ protected:
                     return mutate(Cast::make(op->type, widening_add(narrow_a, narrow_b)));
                 }
             }
-        } else if (op->is_intrinsic(Call::widening_sub)) {
+        } else if (op->is_intrinsic(Call::widening_sub) && (op->type.bits() >= 16)) {
             internal_assert(op->args.size() == 2);
             for (halide_type_code_t t : {op->type.code(), halide_type_uint}) {
                 Type narrow_t = op->type.narrow().narrow().with_code(t);


### PR DESCRIPTION
#6622, specifically making narrowing of uint1 an error broke some of our internal tests. The simplest reproducer would be an expression like `u8(x > 0) + u8(y > 0)`, which would get replaced by `widening_add(x > 0 + y > 0)` where type of `widened_add` is `uint8`, which later at https://github.com/halide/Halide/blob/main/src/FindIntrinsics.cpp#L620 will get narrowed twice and cause u8->u1->error. 

Here I just looked for all places where narrow().narrow() happens and added a check to make sure that type has at least 16-bit, which seems to fix all failing tests I was seeing.

