### PR TITLE
Clean up python_binding Makefile

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -97,7 +97,7 @@ $(BIN)/generators/%.so: $(BIN)/%_PyStub.o $(BIN)/PyStubImpl.o $(BIN)/%_generator
 	@$(CXX) $^ $(LDFLAGS) -shared -o $@
 
 # Compile the generators:
-$(BIN)/%.gen: $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp correctness/%_generator.cpp $(LIBHALIDE)
+$(BIN)/%.gen: $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp $(BIN)/%_generator.o $(LIBHALIDE)
 	@echo Building $@...
 	@mkdir -p $(@D)
 	@$(CXX) $(CCFLAGS) $(LDFLAGS) $^ -o $@
@@ -122,7 +122,8 @@ target_features_user_context=-user_context-no_runtime
 # Make the generator generate a Python extension:
 $(BIN)/%.py.cpp $(BIN)/%.a $(BIN)/%.h: $(BIN)/%.gen
 	@echo Building $@...
-	@LD_LIBRARY_PATH=$(HALIDE_DISTRIB_PATH)/bin $< -e static_library,c_header,python_extension \
+	@LD_LIBRARY_PATH=$(HALIDE_DISTRIB_PATH)/bin $< \
+	    -e static_library,c_header,python_extension \
 	    -g $(notdir $(basename $<)) -o $(BIN) \
 	    target=host$(target_features_$(notdir $(basename $<)))
 
@@ -131,13 +132,34 @@ $(BIN)/%.py.o: $(BIN)/%.py.cpp
 	@echo Building $@...
 	@$(CXX) -c $(FPIC) $(CCFLAGS) $^ -o $@
 
+# Fake up a linker script that will export *just* the PyInit entry
+# point we want. (If we don't do this we can have interesting failures
+# when loading multiple of these Python extensions in the same space.)
+ifeq ($(UNAME), Darwin)
+$(BIN)/ext/%.ldscript:
+	@echo Building $@...
+	@mkdir -p $(@D)
+	@echo _PyInit_$* > $@
+
+PYEXT_LDSCRIPT_FLAG = -Wl,-exported_symbols_list %LDSCRIPT%
+else
+# Assume Desktop Linux
+$(BIN)/ext/%.ldscript:
+	@echo Building $@...
+	@mkdir -p $(@D)
+	@echo "{" > $@
+	@echo "  global: PyInit_$*;" >> $@
+	@echo "  local: *;" >> $@
+	@echo "};" >> $@
+PYEXT_LDSCRIPT_FLAG = -Wl,--version-script=%LDSCRIPT%
+endif
+
 # The Python extension of the generator is already in $(BIN), and is named
 # the same, so put the Python extension of the function into ext/.
-# TODO: Python extensions of generators should have a _generator suffix.
-$(BIN)/ext/%.so: $(BIN)/%.py.o $(BIN)/%.a $(BIN)/runtime.a
+$(BIN)/ext/%.so: $(BIN)/%.py.o $(BIN)/%.a $(BIN)/runtime.a $(BIN)/ext/%.ldscript
 	@echo Building $@...
-	@mkdir -p $(BIN)/ext
-	@$(CXX) $(LDFLAGS) $^ -shared -o $@
+	@mkdir -p $(@D)
+	@$(CXX) $(LDFLAGS) $(filter-out $(BIN)/ext/$*.ldscript,$^) -shared $(subst %LDSCRIPT%,$(BIN)/ext/$*.ldscript,$(PYEXT_LDSCRIPT_FLAG)) -o $@
 
 test_correctness_addconstant_test: $(BIN)/ext/addconstant.so
 test_correctness_bit_test: $(BIN)/ext/bit.so

--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -56,26 +56,30 @@ PY_OBJS=$(PY_SRCS:$(ROOT_DIR)/src/%.cpp=$(BIN)/src/%.o)
 MODULE=$(BIN)/halide$(SUFFIX)
 
 $(MODULE): $(PY_OBJS) $(LIBHALIDE)
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $^ $(LDFLAGS) -shared -o $@
+	@$(CXX) $^ $(LDFLAGS) -shared -o $@
 
 # We don't want any of this auto-deleted
 .SECONDARY:
 
 $(BIN)/src/%.o: $(ROOT_DIR)/src/%.cpp
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $(CCFLAGS) -c $< -o $@
+	@$(CXX) $(CCFLAGS) -c $< -o $@
 
 
 $(BIN)/%_generator.o: $(ROOT_DIR)/correctness/%_generator.cpp $(HALIDE_DISTRIB_PATH)/include/Halide.h
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $(CCFLAGS) -c $< -o $@
+	@$(CXX) $(CCFLAGS) -c $< -o $@
 
 $(BIN)/PyStubImpl.o: $(ROOT_DIR)/stub/PyStubImpl.cpp $(HALIDE_DISTRIB_PATH)/include/Halide.h
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $(CCFLAGS) -c $< -o $@
+	@$(CXX) $(CCFLAGS) -c $< -o $@
 
-# Produce a Python extension for the generator by compiling PyStub.cpp
+# Produce a Python extension for a C++ generator by compiling PyStub.cpp
 # (with HALIDE_PYSTUB_GENERATOR_NAME defined to the Generator's build name),
 # and linking with the generator's .o file, PyStubImpl.o, plus the same libHalide
 # being used by halide.so.
@@ -83,27 +87,32 @@ $(BIN)/PyStubImpl.o: $(ROOT_DIR)/stub/PyStubImpl.cpp $(HALIDE_DISTRIB_PATH)/incl
 # You can optionally also define HALIDE_PYSTUB_MODULE_NAME if you want the Python
 # module name to be something other than the Generator build name.
 $(BIN)/%_PyStub.o: $(ROOT_DIR)/stub/PyStub.cpp
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $(CCFLAGS) -DHALIDE_PYSTUB_GENERATOR_NAME=$* -c $< -o $@
+	@$(CXX) $(CCFLAGS) -DHALIDE_PYSTUB_GENERATOR_NAME=$* -c $< -o $@
 
-$(BIN)/%.so: $(BIN)/%_PyStub.o $(BIN)/PyStubImpl.o $(BIN)/%_generator.o $(LIBHALIDE)
+$(BIN)/generators/%.so: $(BIN)/%_PyStub.o $(BIN)/PyStubImpl.o $(BIN)/%_generator.o $(LIBHALIDE)
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $^ $(LDFLAGS) -shared -o $@
+	@$(CXX) $^ $(LDFLAGS) -shared -o $@
 
 # Compile the generators:
 $(BIN)/%.gen: $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp correctness/%_generator.cpp $(LIBHALIDE)
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $(CCFLAGS) $(LDFLAGS) $^ -o $@
+	@$(CXX) $(CCFLAGS) $(LDFLAGS) $^ -o $@
 
 # Special generator for generating a runtime:
 $(BIN)/runtime.gen: $(HALIDE_DISTRIB_PATH)/tools/GenGen.cpp $(LIBHALIDE)
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$(CXX) $(CCFLAGS) $(LDFLAGS) $^ -o $@
+	@$(CXX) $(CCFLAGS) $(LDFLAGS) $^ -o $@
 
 # Generate a runtime:
 $(BIN)/runtime.a: $(BIN)/runtime.gen
+	@echo Building $@...
 	@mkdir -p $(@D)
-	$< -r runtime -o $(BIN) target=host
+	@$< -r runtime -o $(BIN) target=host
 
 # Which target features to use for which test targets.
 target_features_addconstant=-no_runtime
@@ -112,31 +121,28 @@ target_features_user_context=-user_context-no_runtime
 
 # Make the generator generate a Python extension:
 $(BIN)/%.py.cpp $(BIN)/%.a $(BIN)/%.h: $(BIN)/%.gen
-	LD_LIBRARY_PATH=$(HALIDE_DISTRIB_PATH)/bin $< -e static_library,c_header,python_extension \
+	@echo Building $@...
+	@LD_LIBRARY_PATH=$(HALIDE_DISTRIB_PATH)/bin $< -e static_library,c_header,python_extension \
 	    -g $(notdir $(basename $<)) -o $(BIN) \
 	    target=host$(target_features_$(notdir $(basename $<)))
 
 # Compile the generated Python extension(s):
 $(BIN)/%.py.o: $(BIN)/%.py.cpp
-	$(CXX) -c $(FPIC) $(CCFLAGS) $^ -o $@
+	@echo Building $@...
+	@$(CXX) -c $(FPIC) $(CCFLAGS) $^ -o $@
 
 # The Python extension of the generator is already in $(BIN), and is named
 # the same, so put the Python extension of the function into ext/.
 # TODO: Python extensions of generators should have a _generator suffix.
 $(BIN)/ext/%.so: $(BIN)/%.py.o $(BIN)/%.a $(BIN)/runtime.a
+	@echo Building $@...
 	@mkdir -p $(BIN)/ext
-	$(CXX) $(LDFLAGS) $^ -shared -o $@
+	@$(CXX) $(LDFLAGS) $^ -shared -o $@
 
-# Run the Python extension(s):
-%.run: $(ROOT_DIR)/correctness/%_test.py $(BIN)/ext/%.so
-	PYTHONPATH="$(BIN)/ext:$$PYTHONPATH" $(PYTHON) $<
-
-# TODO: In the optimal case, we'd do %.run on all our generators. Unfortunately,
-# every generator needs its own settings. See https://github.com/halide/Halide/issues/2977.
-test_correctness_addconstant_test: addconstant.run ;
-test_correctness_bit_test: bit.run ;
-test_correctness_user_context_test: user_context.run ;
-test_correctness_pystub: $(BIN)/simplestub.so $(BIN)/complexstub.so $(BIN)/partialbuildmethod.so $(BIN)/nobuildmethod.so
+test_correctness_addconstant_test: $(BIN)/ext/addconstant.so
+test_correctness_bit_test: $(BIN)/ext/bit.so
+test_correctness_user_context_test: $(BIN)/ext/user_context.so
+test_correctness_pystub: $(BIN)/generators/simplestub.so $(BIN)/generators/complexstub.so $(BIN)/generators/partialbuildmethod.so $(BIN)/generators/nobuildmethod.so
 
 APPS = $(shell ls $(ROOT_DIR)/apps/*.py)
 CORRECTNESS = $(shell ls $(ROOT_DIR)/correctness/*.py)
@@ -157,7 +163,7 @@ test_correctness: $(CORRECTNESS:$(ROOT_DIR)/correctness/%.py=test_correctness_%)
 test_correctness_%: $(ROOT_DIR)/correctness/%.py $(MODULE)
 	@echo Testing $*...
 	@mkdir -p $(TEST_TMP)
-	@cd $(TEST_TMP); PYTHONPATH="$(BIN):$$PYTHONPATH" $(PYTHON) $<
+	@cd $(TEST_TMP); PYTHONPATH="$(BIN)/ext:$(BIN)/generators:$$PYTHONPATH" $(PYTHON) $<
 
 .PHONY: test_tutorial
 test_tutorial: $(TUTORIAL:$(ROOT_DIR)/tutorial/%.py=test_tutorial_%)
@@ -172,7 +178,8 @@ test_tutorial_%: $(ROOT_DIR)/tutorial/%.py $(MODULE)
 test_tutorial_lesson_10_aot_compilation_run: $(TEST_TMP)/lesson_10_halide.so
 
 $(TEST_TMP)/lesson_10_halide.so: test_tutorial_lesson_10_aot_compilation_generate
-	$(CXX) $(CCFLAGS) $(LDFLAGS) $(FPIC) -shared \
+	@echo Building $@...
+	@$(CXX) $(CCFLAGS) $(LDFLAGS) $(FPIC) -shared \
 		$(TEST_TMP)/lesson_10_halide.py.cpp \
 		$(TEST_TMP)/lesson_10_halide.o \
 		-I $(TEST_TMP) -o $@

--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -163,7 +163,7 @@ test_correctness: $(CORRECTNESS:$(ROOT_DIR)/correctness/%.py=test_correctness_%)
 test_correctness_%: $(ROOT_DIR)/correctness/%.py $(MODULE)
 	@echo Testing $*...
 	@mkdir -p $(TEST_TMP)
-	@cd $(TEST_TMP); PYTHONPATH="$(BIN)/ext:$(BIN)/generators:$$PYTHONPATH" $(PYTHON) $<
+	@cd $(TEST_TMP); PYTHONPATH="$(BIN)/ext:$(BIN)/generators:$(BIN):$$PYTHONPATH" $(PYTHON) $<
 
 .PHONY: test_tutorial
 test_tutorial: $(TUTORIAL:$(ROOT_DIR)/tutorial/%.py=test_tutorial_%)

--- a/python_bindings/correctness/bit_test.py
+++ b/python_bindings/correctness/bit_test.py
@@ -1,4 +1,3 @@
-
 import array
 import bit
 import sys
@@ -19,12 +18,5 @@ def test():
         print("Expected Exception not raised.", file=sys.stderr)
         exit(1)
 
-
 if __name__ == "__main__":
-    if "darwin" in sys.platform:
-        # Don't run this test on Mac OS X.  It causes sporadic errors of the form
-        # "dyld: termination function 0x108fa45b0 not in mapped image bit.so".
-        # TODO: investigate why this is the case.
-        pass
-    else:
-        test()
+    test()


### PR DESCRIPTION
Some of the tests with Generator dependencies had deps set up in a weird way that made some downstream work painful. Cleaned up. Also vastly reduced build-time noise.