### PR TITLE
python_bindings: Fix SIGSEGV in HalidePythonCompileTimeErrorReporter

### DIFF
--- a/python_bindings/correctness/CMakeLists.txt
+++ b/python_bindings/correctness/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TESTS
     multipass_constraints.py
     pystub.py
     rdom.py
+    realize_warnings.py
     target.py
     tuple_select.py
     type.py

--- a/python_bindings/correctness/realize_warnings.py
+++ b/python_bindings/correctness/realize_warnings.py
@@ -1,0 +1,28 @@
+import halide as hl
+from io import StringIO
+from contextlib import redirect_stdout
+
+
+def test_warnings():
+    i = hl.Var()
+    f = hl.Func("f")
+    f[i] = 0.0
+    f.bound(i, 0, 127)
+
+    g = hl.Func("g")
+    g[i] = f[i * i]
+
+    expected_warning = "Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] because " \
+                       "the function is scheduled inline.\n"
+
+    buffer = StringIO()
+    with redirect_stdout(buffer):
+        g.realize([16])
+
+    buffer.seek(0)
+    stdout_lines = buffer.readlines()
+    assert stdout_lines == [expected_warning] * 3
+
+
+if __name__ == '__main__':
+    test_warnings()

--- a/python_bindings/src/PyError.cpp
+++ b/python_bindings/src/PyError.cpp
@@ -17,7 +17,7 @@ void halide_python_print(JITUserContext *, const char *msg) {
 class HalidePythonCompileTimeErrorReporter : public CompileTimeErrorReporter {
 public:
     void warning(const char *msg) override {
-        py::print(msg, py::arg("end") = "");
+        halide_python_print(nullptr, msg);
     }
 
     void error(const char *msg) override {


### PR DESCRIPTION
When I realize `g` in the snippet below, I get a SIGSEGV in `PyErr_Occurred`. This example is run with python bindings from `release/13.x` branch.

**Expected**: I see the warning

> Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] 
> because the function is scheduled inline.

**Actual**: SIGSEGV

I added a `py::gil_scoped_acquire` before printing similar to `halide_python_print()` in `PyError.cpp` and this fixes the output. Should I release the GIL?

```py
buffer = Buffer(np.arange(2048))
i = Var()
f = Func("f")
f[i] = buffer[i]
f.bound(i, 0, 127)

g = Func("g")
g[i] = f[i * i]
g.realize([16])
```

```
Thread 1 "python" received signal SIGSEGV, Segmentation fault.
0x00007fa43811932e in PyErr_Occurred () from /usr/lib/libpython3.9.so.1.0
(gdb) bt
#0  0x00007fa43811932e in PyErr_Occurred () from /usr/lib/libpython3.9.so.1.0
#1  0x00007fa43725600b in pybind11::arg_v::arg_v<char const (&) [1]> (this=0x7fa408f31e88, base=..., x={...}, descr=0x0) at Halide/cmake-build-debug/_deps/pybind11-src/include/pybind11/cast.h:1902
#2  0x00007fa437255f4b in pybind11::arg_v::arg_v<char const (&) [1]> (this=0x7fa408f31e88, base=..., x={...}, descr=0x0) at Halide/cmake-build-debug/_deps/pybind11-src/include/pybind11/cast.h:1916
#3  0x00007fa437235a09 in pybind11::arg::operator=<char const (&) [1]> (this=0x7fa408f31e78, value={...}) at Halide/cmake-build-debug/_deps/pybind11-src/include/pybind11/cast.h:1945
#4  0x00007fa4372db272 in Halide::PythonBindings::(anonymous namespace)::HalidePythonCompileTimeErrorReporter::warning (this=0x7fa437847f98 <Halide::PythonBindings::define_error(pybind11::module_&)::reporter>, msg=0x558ddf3937c0 "Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] because the function is scheduled inline.\n") at Halide/python_bindings/src/PyError.cpp:20
#5  0x00007fa4328d5d4f in Halide::Internal::ErrorReport::~ErrorReport (this=0x7fa408f32578) at Halide/src/Error.cpp:110
#6  0x00007fa432a9e949 in Halide::Internal::validate_schedule_inlined_function (f=...) at Halide/src/Inline.cpp:80
#7  0x00007fa432d03719 in Halide::Internal::(anonymous namespace)::validate_schedule (f=..., s=..., target=..., is_output=false, env=std::map with 2 elements = {...}) at Halide/src/ScheduleFunctions.cpp:2194
#8  0x00007fa432d0101e in Halide::Internal::schedule_functions (outputs=std::vector of length 1, capacity 1 = {...}, fused_groups=std::vector of length 2, capacity 2 = {...}, env=std::map with 2 elements = {...}, target=..., any_memoized=@0x7fa408f3624f: false) at Halide/src/ScheduleFunctions.cpp:2442
#9  0x00007fa432c085f6 in Halide::Internal::(anonymous namespace)::lower_impl (output_funcs=std::vector of length 1, capacity 1 = {...}, pipeline_name="g", t=..., args=std::vector of length 2, capacity 2 = {...}, linkage_type=Halide::LinkageType::ExternalPlusMetadata, requirements=std::vector of length 0, capacity 0, trace_pipeline=false, custom_passes=std::vector of length 0, capacity 0, result_module=...) at Halide/src/Lower.cpp:143
#10 0x00007fa432c081c4 in Halide::Internal::lower(std::vector<Halide::Internal::Function, std::allocator<Halide::Internal::Function> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Halide::Target const&, std::vector<Halide::Argument, std::allocator<Halide::Argument> > const&, Halide::LinkageType, std::vector<Halide::Internal::Stmt, std::allocator<Halide::Internal::Stmt> > const&, bool, std::vector<Halide::Internal::IRMutator*, std::allocator<Halide::Internal::IRMutator*> > const&)::$_0::operator()() const (this=0x558ddf5e4eb0) at Halide/src/Lower.cpp:539
#11 0x00007fa432c0814d in std::__invoke_impl<void, Halide::Internal::lower(std::vector<Halide::Internal::Function, std::allocator<Halide::Internal::Function> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Halide::Target const&, std::vector<Halide::Argument, std::allocator<Halide::Argument> > const&, Halide::LinkageType, std::vector<Halide::Internal::Stmt, std::allocator<Halide::Internal::Stmt> > const&, bool, std::vector<Halide::Internal::IRMutator*, std::allocator<Halide::Internal::IRMutator*> > const&)::$_0&>(std::__invoke_other, Halide::Internal::lower(std::vector<Halide::Internal::Function, std::allocator<Halide::Internal::Function> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Halide::Target const&, std::vector<Halide::Argument, std::allocator<Halide::Argument> > const&, Halide::LinkageType, std::vector<Halide::Internal::Stmt, std::allocator<Halide::Internal::Stmt> > const&, bool, std::vector<Halide::Internal::IRMutator*, std::allocator<Halide::Internal::IRMutator*> > const&)::$_0&) (__f=...) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../include/c++/11.2.0/bits/invoke.h:61
#12 0x00007fa432c080fd in std::__invoke_r<void, Halide::Internal::lower(std::vector<Halide::Internal::Function, std::allocator<Halide::Internal::Function> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Halide::Target const&, std::vector<Halide::Argument, std::allocator<Halide::Argument> > const&, Halide::LinkageType, std::vector<Halide::Internal::Stmt, std::allocator<Halide::Internal::Stmt> > const&, bool, std::vector<Halide::Internal::IRMutator*, std::allocator<Halide::Internal::IRMutator*> > const&)::$_0&>(Halide::Internal::lower(std::vector<Halide::Internal::Function, std::allocator<Halide::Internal::Function> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Halide::Target const&, std::vector<Halide::Argument, std::allocator<Halide::Argument> > const&, Halide::LinkageType, std::vector<Halide::Internal::Stmt, std::allocator<Halide::Internal::Stmt> > const&, bool, std::vector<Halide::Internal::IRMutator*, std::allocator<Halide::Internal::IRMutator*> > const&)::$_0&) (__fn=...) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../include/c++/11.2.0/bits/invoke.h:111
#13 0x00007fa432c07fcd in std::_Function_handler<void (), Halide::Internal::lower(std::vector<Halide::Internal::Function, std::allocator<Halide::Internal::Function> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Halide::Target const&, std::vector<Halide::Argument, std::allocator<Halide::Argument> > const&, Halide::LinkageType, std::vector<Halide::Internal::Stmt, std::allocator<Halide::Internal::Stmt> > const&, bool, std::vector<Halide::Internal::IRMutator*, std::allocator<Halide::Internal::IRMutator*> > const&)::$_0>::_M_invoke(std::_Any_data const&) (__functor=...) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../include/c++/11.2.0/bits/std_function.h:291
#14 0x00007fa432c9a725 in std::function<void ()>::operator()() const (this=0x7fff64d856d0) at /usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../include/c++/11.2.0/bits/std_function.h:560
#15 0x00007fa43385afac in Halide::Internal::run_with_large_stack(std::function<void ()> const&)::$_0::operator()() const (this=0x7fff64d85200) at Halide/src/Util.cpp:730
#16 0x00007fa43385af69 in Halide::Internal::run_with_large_stack(std::function<void ()> const&)::$_0::__invoke() () at Halide/src/Util.cpp:727
#17 0x00007fa437f066d0 in ?? () from /usr/lib/libc.so.6
```

**After the fix**

```
python reprod.py
Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] because the function is scheduled inline.
Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] because the function is scheduled inline.
Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] because the function is scheduled inline.

Process finished with exit code 0
```
