### PR TITLE
Define an AbstractGenerator interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -576,6 +576,7 @@ SOURCE_FILES = \
 # Don't include anything here that includes llvm headers.
 # Keep this list sorted in alphabetical order.
 HEADER_FILES = \
+  AbstractGenerator.h \
   AddAtomicMutex.h \
   AddImageChecks.h \
   AddParameterChecks.h \

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -112,7 +112,7 @@ def test_simplestub():
         # Bad input name
         f = simplestub.generate(target, buffer_input=b_in, float_arg=3.5, offset=k, funk_input=f_in)
     except RuntimeError as e:
-        assert "Expected exactly 3 keyword args for inputs, but saw 2." in str(e)
+        assert "Generator simplestub has no GeneratorParam named: funk_input" in str(e)
     else:
         assert False, 'Did not see expected exception!'
 
@@ -298,3 +298,4 @@ if __name__ == "__main__":
     # disabled because HALIDE_ALLOW_GENERATOR_BUILD_METHOD is off by default
     # test_partialbuildmethod()
     test_nobuildmethod()
+

--- a/python_bindings/stub/PyStub.cpp
+++ b/python_bindings/stub/PyStub.cpp
@@ -45,7 +45,7 @@ static_assert(PY_MAJOR_VERSION >= 3, "Python bindings for Halide require Python 
 
 namespace halide_register_generator {
 namespace HALIDE_CONCAT(HALIDE_PYSTUB_GENERATOR_NAME, _ns) {
-    extern std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext &context);
+    extern std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext &context);
 }  // namespace HALIDE_CONCAT(HALIDE_PYSTUB_GENERATOR_NAME,_ns)
 }  // namespace halide_register_generator
 

--- a/src/AbstractGenerator.h
+++ b/src/AbstractGenerator.h
@@ -109,7 +109,7 @@ public:
      */
     virtual std::vector<ArgInfo> get_output_arginfos() = 0;
 
-    /** Return the names for all known Constants (aka GeneratorParams) in this Generator.
+    /** Return the names for all known GeneratorParams in this Generator.
      * (Synthetic params are excluded and will never be returned here.)
      * Always legal to call on any AbstractGenerator instance, regardless of what other methods
      * have been called. Note that while the results are returned in a vector, the order of
@@ -180,9 +180,6 @@ public:
      * This call is infrequently used, and is only useful in JIT or Stub situations;
      * this allows you to bind the inputs to be Funcs, Buffers, etc from another Halide code
      * fragment, allowing inlining of multiple fragments together.
-     *
-     * Note that there is no way to rebind individual inputs. (This could be added but
-     * is unlikely to be useful, as all existing usage is all-or-none.)
      *
      * CALL-AFTER: n/a
      * CALL-BEFORE: build_pipeline

--- a/src/AbstractGenerator.h
+++ b/src/AbstractGenerator.h
@@ -1,0 +1,217 @@
+#ifndef HALIDE_ABSTRACT_GENERATOR_H_
+#define HALIDE_ABSTRACT_GENERATOR_H_
+
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "Expr.h"
+#include "Func.h"
+#include "Parameter.h"
+#include "Pipeline.h"
+#include "Schedule.h"
+#include "Target.h"
+#include "Type.h"
+
+namespace Halide {
+
+class GeneratorContext;
+
+namespace Internal {
+
+enum class IOKind { Scalar,
+                    Function,
+                    Buffer };
+
+using ExternsMap = std::map<std::string, ExternalCode>;
+
+/**
+ * AbstractGenerator is an ABC that defines the API a Generator must provide
+ * to work with the existing Generator infrastructure (GenGen, RunGen,
+ * Generator Stubs). The existing Generator<>-based instances all implement
+ * this API, but any other code that implements this (and uses RegisterGenerator
+ * to register itself) should be indistinguishable from a user perspective.
+ *
+ * An AbstractGenerator is meant to be "single-use"; typically lifetimes will be
+ * something like:
+ * - create an instance (with a specific Target)
+ * - optionally set GeneratorParam values
+ * - optionally re-bind inputs (if using in JIT or Stub modes)
+ * - call build_pipeline()
+ * - optionally call get_funcs_for_output() to get the output(s) (if using in JIT or Stub modes)
+ * - discard the instance
+ *
+ * AbstractGenerators should be fairly cheap to instantiate! Don't try to re-use
+ * one by re-setting inputs and calling build_pipeline() multiple times.
+ *
+ * Note that an AbstractGenerator instance is (generally) stateful in terms of the order
+ * that methods should be called; calling the methods out of order may cause
+ * assert-fails or other undesirable behavior. Read the method notes carefully!
+ */
+class AbstractGenerator {
+public:
+    virtual ~AbstractGenerator() = default;
+
+    /** ArgInfo is a struct to contain name-and-type information for the inputs and outputs to
+     * the Pipeline that build_pipeline() will return.
+     *
+     * Note that this looks quite similar to Halide::Argument, but unfortunately
+     * that is not a good fit here, as it cannot represent Func inputs (only
+     * Buffer and Scalar). Rather than extend Argument to handle that (and risk
+     * confusing the public API), we'll create this (which is only for internal
+     * use).
+     *
+     * TODO: name is suboptimal. Is there a better one?
+     */
+    struct ArgInfo {
+        std::string name;
+        IOKind kind = IOKind::Scalar;
+        // Note that this can have multiple entries for Tuple-valued Inputs or Outputs
+        std::vector<Type> types;
+        int dimensions = 0;
+    };
+
+    /** Return the name of this Generator. (This should always be the name
+     * used to register it.) */
+    virtual std::string get_name() = 0;
+
+    /** Return the Target, autoscheduler flag, and MachineParams that this Generator
+     * was created with. Always legal to call on any AbstractGenerator instance,
+     * regardless of what other methods have been called. (All AbstractGenerator instances
+     * are expected to be created with immutable values for these, which can't be
+     * changed for a given instance.)
+     *
+     * CALL-AFTER: any
+     * CALL-BEFORE: any
+     */
+    virtual GeneratorContext context() const = 0;
+
+    /** Return a list of the names for inputs, in the correct order.
+     * All input and output names will be unique within a given Generator instance.
+     * If this is called after add_input(), the added inputs will be returned.
+     * Always legal to call on any AbstractGenerator instance, regardless of what other methods
+     * have been called.
+     *
+     * CALL-AFTER: any
+     * CALL-BEFORE: any
+     */
+    virtual std::vector<ArgInfo> get_input_arginfos() = 0;
+
+    /** Return a list of the names for outputs, in the correct order.
+     * All input and output names will be unique within a given Generator instance.
+     * If this is called after add_output(), the added outputs will be returned.
+     * Always legal to call on any AbstractGenerator instance, regardless of what other methods
+     * have been called.
+     *
+     * CALL-AFTER: any
+     * CALL-BEFORE: any
+     */
+    virtual std::vector<ArgInfo> get_output_arginfos() = 0;
+
+    /** Return the names for all known Constants (aka GeneratorParams) in this Generator.
+     * (Synthetic params are excluded and will never be returned here.)
+     * Always legal to call on any AbstractGenerator instance, regardless of what other methods
+     * have been called. Note that while the results are returned in a vector, the order of
+     * names in the result aren't important (unlike for inputs and outputs, where order matters).
+     *
+     * CALL-AFTER: any
+     * CALL-BEFORE: any
+     */
+    virtual std::vector<std::string> get_generatorparam_names() = 0;
+
+    /** Set the value for a specific GeneratorParam for an AbstractGenerator instance.
+     *
+     * Names that aren't in the list returned by get_generatorparam_names() will assert-fail.
+     *
+     * Values that can't be parsed for the specific GeneratorParam (e.g. passing "foo" where
+     * an integer is expected) should assert-fail at some point (either immediately, or when
+     * build_pipeline() is called)
+     *
+     * This can be called multiple times, but only prior to build_pipeline().
+     *
+     * CALL-AFTER: nona
+     * CALL-BEFORE: build_pipeline
+     */
+    // @{
+    virtual void set_generatorparam_value(const std::string &name, const std::string &value) = 0;
+    virtual void set_generatorparam_value(const std::string &name, const LoopLevel &loop_level) = 0;
+    // @}
+
+    /** Build and return the Pipeline for this AbstractGenerator. This method should be called
+     * only once per instance.
+     *
+     * CALL-AFTER: set_generatorparam_value, bind_input
+     * CALL-BEFORE: get_parameters_for_input, get_funcs_for_output, get_external_code_map
+     */
+    virtual Pipeline build_pipeline() = 0;
+
+    /** Given the name of an input, return the Parameter(s) for that input.
+     * (Most inputs will have exactly one, but inputs that are declared as arrays
+     * will have multiple.)
+     *
+     * CALL-AFTER: build_pipeline
+     * CALL-BEFORE: none
+     */
+    virtual std::vector<Parameter> get_parameters_for_input(const std::string &name) = 0;
+
+    /** Given the name of an output, return the Func(s) for that output.
+     * (Most outputs will have exactly one, but outputs that are declared as arrays, or that return Tuples,
+     * will have multiple.)
+     *
+     * Must be called after build_pipeline(), since the output Funcs will be undefined prior to that.
+     *
+     * CALL-AFTER: build_pipeline()
+     * CALL-BEFORE: none
+     */
+    virtual std::vector<Func> get_funcs_for_output(const std::string &name) = 0;
+
+    /** Return the ExternsMap for the Generator, if any.
+     *
+     * CALL-AFTER: build_pipeline()
+     * CALL-BEFORE: n/a
+     */
+    virtual ExternsMap get_external_code_map() = 0;
+
+    /** Rebind all the inputs in a single call. The vector of StubInputs is assumed to have
+     * the same size and ordering as the list of inputs. Basic type-checking is done to ensure
+     * that inputs are still sane (e.g. types, dimensions, etc must match expectations).
+     *
+     * This call is infrequently used, and is only useful in JIT or Stub situations;
+     * this allows you to bind the inputs to be Funcs, Buffers, etc from another Halide code
+     * fragment, allowing inlining of multiple fragments together.
+     *
+     * Note that there is no way to rebind individual inputs. (This could be added but
+     * is unlikely to be useful, as all existing usage is all-or-none.)
+     *
+     * CALL-AFTER: n/a
+     * CALL-BEFORE: build_pipeline
+     */
+    // @{
+    virtual void bind_input(const std::string &name, const std::vector<Parameter> &v) = 0;
+    virtual void bind_input(const std::string &name, const std::vector<Func> &v) = 0;
+    virtual void bind_input(const std::string &name, const std::vector<Expr> &v) = 0;
+    // @}
+
+    /** Emit a Generator Stub (.stub.h) file to the given path. Not all Generators support this.
+     *
+     * If you call this method, you should not call any other AbstractGenerator methods
+     * on this instance, before or after this call.
+     *
+     * If the Generator is capable of emitting a Stub, do so and return true. (Errors
+     * during stub emission should assert-fail rather than returning false.)
+     *
+     * If the Generator is not capable of emitting a Stub, do nothing and return false.
+     *
+     * CALL-AFTER: none
+     * CALL-BEFORE: none
+     */
+    virtual bool emit_cpp_stub(const std::string &stub_file_path) = 0;
+};
+
+using AbstractGeneratorPtr = std::unique_ptr<AbstractGenerator>;
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@
 # The externally-visible header files that go into making Halide.h.
 # Don't include anything here that includes llvm headers.
 set(HEADER_FILES
+    AbstractGenerator.h
     AddAtomicMutex.h
     AddImageChecks.h
     AddParameterChecks.h

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -1940,6 +1940,15 @@ Func Derivative::operator()(const Param<> &param) const {
     return it->second;
 }
 
+Func Derivative::operator()(const std::string &name) const {
+    auto it = adjoints.find(FuncKey{name, -1});
+    if (it == adjoints.end()) {
+        Internal::debug(1) << "Could not find name: " << name << "\n";
+        return Func();
+    }
+    return it->second;
+}
+
 Derivative propagate_adjoints(const Func &output,
                               const Func &adjoint,
                               const Region &output_bounds) {

--- a/src/Derivative.h
+++ b/src/Derivative.h
@@ -35,6 +35,7 @@ public:
     Func operator()(const Func &func, int update_id = -1) const;
     Func operator()(const Buffer<> &buffer) const;
     Func operator()(const Param<> &param) const;
+    Func operator()(const std::string &name) const;
 
 private:
     const std::map<FuncKey, Func> adjoints;

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -341,25 +341,6 @@ void StubEmitter::emit_generator_params_struct() {
         stream << "\n";
     }
 
-    stream << get_indent() << "inline HALIDE_NO_USER_CODE_INLINE Halide::Internal::GeneratorParamsMap to_generator_params_map() const {\n";
-    indent_level++;
-    stream << get_indent() << "return {\n";
-    indent_level++;
-    std::string comma = "";
-    for (auto *p : v) {
-        stream << get_indent() << comma << "{\"" << p->name() << "\", ";
-        if (p->is_looplevel_param()) {
-            stream << p->name() << "}\n";
-        } else {
-            stream << p->call_to_string(p->name()) << "}\n";
-        }
-        comma = ", ";
-    }
-    indent_level--;
-    stream << get_indent() << "};\n";
-    indent_level--;
-    stream << get_indent() << "}\n";
-
     indent_level--;
     stream << get_indent() << "};\n";
     stream << "\n";
@@ -438,11 +419,17 @@ void StubEmitter::emit() {
     for (auto *output : outputs) {
         std::string c_type = output->get_c_type();
         const bool is_func = (c_type == "Func");
-        std::string getter = is_func ? "get_outputs" : "get_output_buffers<" + c_type + ">";
-        std::string getter_suffix = output->is_array() ? "" : ".at(0)";
+        std::string getter = "generator->get_funcs_for_output(\"" + output->name() + "\")";
+        if (!is_func) {
+            getter = c_type + "::to_output_buffers(" + getter + ", generator)";
+        }
+        if (!output->is_array()) {
+            getter = getter + ".at(0)";
+        }
+
         out_info.push_back({output->name(),
                             output->is_array() ? "std::vector<" + c_type + ">" : c_type,
-                            getter + "(\"" + output->name() + "\")" + getter_suffix});
+                            getter});
         if (c_type != "Func") {
             all_outputs_are_func = false;
         }
@@ -463,6 +450,7 @@ void StubEmitter::emit() {
     stream << "\n";
 
     stream << get_indent() << "#include <cassert>\n";
+    stream << get_indent() << "#include <iterator>\n";
     stream << get_indent() << "#include <map>\n";
     stream << get_indent() << "#include <memory>\n";
     stream << get_indent() << "#include <string>\n";
@@ -474,7 +462,7 @@ void StubEmitter::emit() {
 
     stream << "namespace halide_register_generator {\n";
     stream << "namespace " << generator_registered_name << "_ns {\n";
-    stream << "extern std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext& context);\n";
+    stream << "extern std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext& context);\n";
     stream << "}  // namespace halide_register_generator\n";
     stream << "}  // namespace " << generator_registered_name << "\n";
     stream << "\n";
@@ -618,29 +606,48 @@ void StubEmitter::emit() {
     stream << get_indent() << ")\n";
     stream << get_indent() << "{\n";
     indent_level++;
-    stream << get_indent() << "using Stub = Halide::Internal::GeneratorStub;\n";
-    stream << get_indent() << "Stub stub(\n";
-    indent_level++;
-    stream << get_indent() << "context,\n";
-    stream << get_indent() << "halide_register_generator::" << generator_registered_name << "_ns::factory,\n";
-    stream << get_indent() << "generator_params.to_generator_params_map(),\n";
-    stream << get_indent() << "{\n";
-    indent_level++;
-    for (auto *input : inputs) {
-        stream << get_indent() << "Stub::to_stub_input_vector(inputs." << input->name() << ")";
-        stream << ",\n";
+    stream << get_indent() << "std::shared_ptr<Halide::Internal::AbstractGenerator> generator = halide_register_generator::" << generator_registered_name << "_ns::factory(context);\n";
+    for (auto *p : generator_params) {
+        stream << get_indent();
+        if (p->is_looplevel_param()) {
+            stream << "generator->set_generatorparam_value(";
+        } else {
+            stream << "generator->set_generatorparam_value(";
+        }
+        stream << "\"" << p->name() << "\", ";
+        if (p->is_looplevel_param()) {
+            stream << "generator_params." << p->name();
+        } else {
+            stream << p->call_to_string("generator_params." + p->name());
+        }
+        stream << ");\n";
     }
-    indent_level--;
-    stream << get_indent() << "}\n";
-    indent_level--;
-    stream << get_indent() << ");\n";
 
+    for (auto *p : inputs) {
+        stream << get_indent() << "generator->bind_input("
+               << "\"" << p->name() << "\", ";
+        if (p->kind() == IOKind::Buffer) {
+            stream << "Halide::Internal::StubInputBuffer<>::to_parameter_vector(inputs." << p->name() << ")";
+        } else {
+            // Func or Expr
+            if (!p->is_array()) {
+                stream << "{";
+            }
+            stream << "inputs." << p->name();
+            if (!p->is_array()) {
+                stream << "}";
+            }
+        }
+        stream << ");\n";
+    }
+
+    stream << get_indent() << "generator->build_pipeline();\n";
     stream << get_indent() << "return {\n";
     indent_level++;
     for (const auto &out : out_info) {
-        stream << get_indent() << "stub." << out.getter << ",\n";
+        stream << get_indent() << out.getter << ",\n";
     }
-    stream << get_indent() << "stub.generator->context().get_target()\n";
+    stream << get_indent() << "generator->context().target\n";
     indent_level--;
     stream << get_indent() << "};\n";
     indent_level--;
@@ -689,68 +696,6 @@ void StubEmitter::emit() {
     stream << "\n";
 
     stream << get_indent() << "#endif  // " << guard.str() << "\n";
-}
-
-GeneratorStub::GeneratorStub(const GeneratorContext &context,
-                             const GeneratorFactory &generator_factory)
-    : generator(generator_factory(context)) {
-}
-
-GeneratorStub::GeneratorStub(const GeneratorContext &context,
-                             const GeneratorFactory &generator_factory,
-                             const GeneratorParamsMap &generator_params,
-                             const std::vector<std::vector<Internal::StubInput>> &inputs)
-    : GeneratorStub(context, generator_factory) {
-    generate(generator_params, inputs);
-}
-
-// Return a vector of all Outputs of this Generator; non-array outputs are returned
-// as a vector-of-size-1. This method is primarily useful for code that needs
-// to iterate through the outputs of unknown, arbitrary Generators (e.g.,
-// the Python bindings).
-std::vector<std::vector<Func>> GeneratorStub::generate(const GeneratorParamsMap &generator_params,
-                                                       const std::vector<std::vector<Internal::StubInput>> &inputs) {
-    generator->set_generator_param_values(generator_params);
-    generator->ensure_configure_has_been_called();
-    generator->set_inputs_vector(inputs);
-    Pipeline p = generator->build_pipeline();
-
-    std::vector<std::vector<Func>> v;
-    GeneratorParamInfo &pi = generator->param_info();
-#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
-    if (!pi.outputs().empty()) {
-        for (auto *output : pi.outputs()) {
-            v.push_back(get_outputs(output->name()));
-        }
-    } else {
-        // Generators with build() method can't have Output<>, hence can't have array outputs
-        for (const auto &output : p.outputs()) {
-            v.push_back(std::vector<Func>{output});
-        }
-    }
-#else
-    internal_assert(!pi.outputs().empty());
-    for (auto *output : pi.outputs()) {
-        v.push_back(get_outputs(output->name()));
-    }
-#endif
-    return v;
-}
-
-GeneratorStub::Names GeneratorStub::get_names() const {
-    generator->ensure_configure_has_been_called();
-    auto &pi = generator->param_info();
-    Names names;
-    for (auto *o : pi.generator_params()) {
-        names.generator_params.push_back(o->name());
-    }
-    for (auto *o : pi.inputs()) {
-        names.inputs.push_back(o->name());
-    }
-    for (auto *o : pi.outputs()) {
-        names.outputs.push_back(o->name());
-    }
-    return names;
 }
 
 const std::map<std::string, Type> &get_halide_type_enum_map() {
@@ -803,7 +748,215 @@ std::string halide_type_to_c_type(const Type &t) {
 
 namespace {
 
-int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output) {
+Module build_module(AbstractGenerator &g, const std::string &function_name) {
+    const LinkageType linkage_type = LinkageType::ExternalPlusMetadata;
+
+    Pipeline pipeline = g.build_pipeline();
+
+    AutoSchedulerResults auto_schedule_results;
+    const auto context = g.context();
+    if (context.get_auto_schedule()) {
+        auto_schedule_results = pipeline.auto_schedule(context.get_target(), context.get_machine_params());
+    }
+
+    std::vector<Argument> filter_arguments;
+    for (const auto &a : g.get_input_arginfos()) {
+        for (const auto &p : g.get_parameters_for_input(a.name)) {
+            filter_arguments.push_back(to_argument(p));
+        }
+    }
+
+    Module result = pipeline.compile_to_module(filter_arguments, function_name, context.get_target(), linkage_type);
+    for (const auto &map_entry : g.get_external_code_map()) {
+        result.append(map_entry.second);
+    }
+
+    for (const auto &output_info : g.get_output_arginfos()) {
+        const std::vector<Func> output_funcs = g.get_funcs_for_output(output_info.name);
+        for (size_t i = 0; i < output_funcs.size(); ++i) {
+            const Func &f = output_funcs[i];
+
+            const std::string &from = f.name();
+            std::string to = output_info.name;
+            if (output_funcs.size() > 1) {
+                to += "_" + std::to_string(i);
+            }
+
+            const int tuple_size = f.outputs();
+            for (int t = 0; t < tuple_size; ++t) {
+                const std::string suffix = (tuple_size > 1) ? ("." + std::to_string(t)) : "";
+                result.remap_metadata_name(from + suffix, to + suffix);
+            }
+        }
+    }
+
+    result.set_auto_scheduler_results(auto_schedule_results);
+
+    return result;
+}
+
+/**
+ * Build a module that is suitable for using for gradient descent calculation in TensorFlow or PyTorch.
+ *
+ * Essentially:
+ *   - A new Pipeline is synthesized from the current Generator (according to the rules below)
+ *   - The new Pipeline is autoscheduled (if autoscheduling is requested, but it would be odd not to do so)
+ *   - The Pipeline is compiled to a Module and returned
+ *
+ * The new Pipeline is adjoint to the original; it has:
+ *   - All the same inputs as the original, in the same order
+ *   - Followed by one grad-input for each original output
+ *   - Followed by one output for each unique pairing of original-output + original-input.
+ *     (For the common case of just one original-output, this amounts to being one output for each original-input.)
+ */
+Module build_gradient_module(Halide::Internal::AbstractGenerator &g, const std::string &function_name) {
+    constexpr int DBG = 1;
+
+    // I doubt these ever need customizing; if they do, we can make them arguments to this function.
+    const std::string grad_input_pattern = "_grad_loss_for_$OUT$";
+    const std::string grad_output_pattern = "_grad_loss_$OUT$_wrt_$IN$";
+    const LinkageType linkage_type = LinkageType::ExternalPlusMetadata;
+
+    user_assert(!function_name.empty()) << "build_gradient_module(): function_name cannot be empty\n";
+
+    Pipeline original_pipeline = g.build_pipeline();
+
+    std::vector<Func> original_outputs = original_pipeline.outputs();
+
+    // Construct the adjoint pipeline, which has:
+    // - All the same inputs as the original, in the same order
+    // - Followed by one grad-input for each original output
+    // - Followed by one output for each unique pairing of original-output + original-input.
+
+    // First: the original inputs. Note that scalar inputs remain scalar,
+    // rather being promoted into zero-dimensional buffers.
+    std::vector<Argument> gradient_inputs;
+    for (const auto &a : g.get_input_arginfos()) {
+        for (const auto &p : g.get_parameters_for_input(a.name)) {
+            gradient_inputs.push_back(to_argument(p));
+            debug(DBG) << "    gradient copied input is: " << gradient_inputs.back().name << "\n";
+        }
+    }
+
+    // Next: add a grad-input for each *original* output; these will
+    // be the same shape as the output (so we should copy estimates from
+    // those outputs onto these estimates).
+    // - If an output is an Array, we'll have a separate input for each array element.
+
+    std::vector<ImageParam> d_output_imageparams;
+    for (const auto &i : g.get_output_arginfos()) {
+        for (const auto &f : g.get_funcs_for_output(i.name)) {
+            const Parameter &p = f.output_buffer().parameter();
+            const std::string &output_name = p.name();
+            // output_name is something like "funcname_i"
+            const std::string grad_in_name = replace_all(grad_input_pattern, "$OUT$", output_name);
+            // TODO(srj): does it make sense for gradient to be a non-float type?
+            // For now, assume it's always float32 (unless the output is already some float).
+            const Type grad_in_type = p.type().is_float() ? p.type() : Float(32);
+            const int grad_in_dimensions = p.dimensions();
+            const ArgumentEstimates grad_in_estimates = p.get_argument_estimates();
+            internal_assert((int)grad_in_estimates.buffer_estimates.size() == grad_in_dimensions);
+
+            ImageParam d_im(grad_in_type, grad_in_dimensions, grad_in_name);
+            for (int d = 0; d < grad_in_dimensions; d++) {
+                d_im.parameter().set_min_constraint_estimate(d, grad_in_estimates.buffer_estimates.at(d).min);
+                d_im.parameter().set_extent_constraint_estimate(d, grad_in_estimates.buffer_estimates.at(d).extent);
+            }
+            d_output_imageparams.push_back(d_im);
+            gradient_inputs.push_back(to_argument(d_im.parameter()));
+
+            debug(DBG) << "    gradient synthesized input is: " << gradient_inputs.back().name << "\n";
+        }
+    }
+
+    // Finally: define the output Func(s), one for each unique output/input pair.
+    // Note that original_outputs.size() != pi.outputs().size() if any outputs are arrays.
+    internal_assert(original_outputs.size() == d_output_imageparams.size());
+    internal_assert(original_outputs.size() == d_output_imageparams.size());
+    std::vector<Func> gradient_outputs;
+    for (size_t i = 0; i < original_outputs.size(); ++i) {
+        const Func &original_output = original_outputs.at(i);
+        const ImageParam &d_output = d_output_imageparams.at(i);
+        Region bounds;
+        for (int i = 0; i < d_output.dimensions(); i++) {
+            bounds.emplace_back(d_output.dim(i).min(), d_output.dim(i).extent());
+        }
+        Func adjoint_func = BoundaryConditions::constant_exterior(d_output, make_zero(d_output.type()));
+        Derivative d = propagate_adjoints(original_output, adjoint_func, bounds);
+
+        const std::string &output_name = original_output.name();
+        for (const auto &a : g.get_input_arginfos()) {
+            for (const auto &p : g.get_parameters_for_input(a.name)) {
+                const std::string &input_name = p.name();
+
+                if (!p.is_buffer()) {
+                    // Not sure if skipping scalar inputs is correct, but that's
+                    // what the previous version of this code did, so we'll continue for now.
+                    debug(DBG) << "    Skipping scalar input " << output_name << " wrt input " << input_name << "\n";
+                    continue;
+                }
+
+                // Note that Derivative looks up by name; we don't have the original
+                // Func, and we can't create a new one with an identical name (since
+                // Func's ctor will uniquify the name for us). Let's just look up
+                // by the original string instead.
+                Func d_f = d(input_name + "_im");
+
+                std::string grad_out_name = replace_all(replace_all(grad_output_pattern, "$OUT$", output_name), "$IN$", input_name);
+                if (!d_f.defined()) {
+                    grad_out_name = "_dummy" + grad_out_name;
+                }
+
+                Func d_out_wrt_in(grad_out_name);
+                if (d_f.defined()) {
+                    d_out_wrt_in(Halide::_) = d_f(Halide::_);
+                } else {
+                    debug(DBG) << "    No Derivative found for output " << output_name << " wrt input " << input_name << "\n";
+                    // If there was no Derivative found, don't skip the output;
+                    // just replace with a dummy Func that is all zeros. This ensures
+                    // that the signature of the Pipeline we produce is always predictable.
+                    std::vector<Var> vars;
+                    for (int i = 0; i < d_output.dimensions(); i++) {
+                        vars.push_back(Var::implicit(i));
+                    }
+                    d_out_wrt_in(vars) = make_zero(d_output.type());
+                }
+
+                d_out_wrt_in.set_estimates(p.get_argument_estimates().buffer_estimates);
+
+                // Useful for debugging; ordinarily better to leave out
+                // debug(0) << "\n\n"
+                //          << "output:\n" << FuncWithDependencies(original_output) << "\n"
+                //          << "d_output:\n" << FuncWithDependencies(adjoint_func) << "\n"
+                //          << "input:\n" << FuncWithDependencies(f) << "\n"
+                //          << "d_out_wrt_in:\n" << FuncWithDependencies(d_out_wrt_in) << "\n";
+
+                gradient_outputs.push_back(d_out_wrt_in);
+                debug(DBG) << "    gradient output is: " << d_out_wrt_in.name() << "\n";
+            }
+        }
+    }
+
+    Pipeline grad_pipeline = Pipeline(gradient_outputs);
+
+    AutoSchedulerResults auto_schedule_results;
+    const auto context = g.context();
+    if (context.get_auto_schedule()) {
+        auto_schedule_results = grad_pipeline.auto_schedule(context.get_target(), context.get_machine_params());
+    } else {
+        user_warning << "Autoscheduling is not enabled in build_gradient_module(), so the resulting "
+                        "gradient module will be unscheduled; this is very unlikely to be what you want.\n";
+    }
+
+    Module result = grad_pipeline.compile_to_module(gradient_inputs, function_name, context.get_target(), linkage_type);
+    user_assert(g.get_external_code_map().empty())
+        << "Building a gradient-descent module for a Generator with ExternalCode is not supported.\n";
+
+    result.set_auto_scheduler_results(auto_schedule_results);
+    return result;
+}
+
+int generate_filter_main_inner(int argc, char **argv, std::ostream &error_output, const GeneratorsForMain &generators_for_main) {
     static const char kUsage[] = R"INLINE_CODE(
 gengen
   [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME]
@@ -855,7 +1008,7 @@ gengen
         {"-s", ""},
         {"-t", "900"},  // 15 minutes
     };
-    GeneratorParamsMap generator_args;
+    std::map<std::string, std::string> generator_args;
 
     for (int i = 1; i < argc; ++i) {
         if (argv[i][0] != '-') {
@@ -895,7 +1048,7 @@ gengen
         error_output << kUsage;
         return 1;
     }
-    const int build_gradient_module = flags_info["-d"] == "1";
+    const int do_build_gradient_module = flags_info["-d"] == "1";
 
     std::string autoscheduler_name = flags_info["-s"];
     if (!autoscheduler_name.empty()) {
@@ -904,7 +1057,7 @@ gengen
 
     std::string runtime_name = flags_info["-r"];
 
-    std::vector<std::string> generator_names = GeneratorRegistry::enumerate();
+    std::vector<std::string> generator_names = generators_for_main.enumerate();
     if (generator_names.empty() && runtime_name.empty()) {
         error_output << "No generators have been registered and not compiling a standalone runtime\n";
         error_output << kUsage;
@@ -964,7 +1117,7 @@ gengen
     // it's OK for file_base_name to be empty: filename will be based on function name
     std::string file_base_name = flags_info["-n"];
 
-    auto target_strings = split_string(generator_args["target"].string_value, ",");
+    auto target_strings = split_string(generator_args["target"], ",");
     std::vector<Target> targets;
     for (const auto &s : target_strings) {
         targets.emplace_back(s);
@@ -1033,8 +1186,8 @@ gengen
             if (it.first == "target") {
                 continue;
             }
-            std::string quote = it.second.string_value.find(' ') != std::string::npos ? "\\\"" : "";
-            generator_args_string += sep + it.first + "=" + quote + it.second.string_value + quote;
+            std::string quote = it.second.find(' ') != std::string::npos ? "\\\"" : "";
+            generator_args_string += sep + it.first + "=" + quote + it.second + quote;
             sep = " ";
         }
         std::unique_ptr<JSONCompilerLogger> t(new JSONCompilerLogger(
@@ -1111,27 +1264,54 @@ gengen
         compile_standalone_runtime(output_files, gcd_target);
     }
 
+    const auto create_or_die = [&generator_names, &generators_for_main](const std::string &name,
+                                                                        const Halide::GeneratorContext &context) -> AbstractGeneratorPtr {
+        auto g = generators_for_main.create(name, context);
+        if (!g) {
+            std::ostringstream o;
+            o << "Generator not found: " << name << "\n";
+            o << "Did you mean:\n";
+            for (const auto &n : generator_names) {
+                o << "    " << n << "\n";
+            }
+            user_error << o.str();
+        }
+        return g;
+    };
+
     if (!generator_name.empty()) {
         std::string base_path = compute_base_path(output_dir, function_name, file_base_name);
         debug(1) << "Generator " << generator_name << " has base_path " << base_path << "\n";
         if (outputs.count(OutputFileType::cpp_stub)) {
             // When generating cpp_stub, we ignore all generator args passed in, and supply a fake Target.
             // (CompilerLogger is never enabled for cpp_stub, for now anyway.)
-            auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(Target()));
+            auto gen = create_or_die(generator_name, GeneratorContext(Target()));
             auto stub_file_path = base_path + output_info[OutputFileType::cpp_stub].extension;
-            gen->emit_cpp_stub(stub_file_path);
+            if (!gen->emit_cpp_stub(stub_file_path)) {
+                error_output << "Generator '" << generator_name << "' is not capable of generating Stubs.\n";
+                return -1;
+            }
         }
 
         // Don't bother with this if we're just emitting a cpp_stub.
         if (!stub_only) {
             auto output_files = compute_output_files(targets[0], base_path, outputs);
-            auto module_factory = [&generator_name, &generator_args, build_gradient_module](const std::string &name, const Target &target) -> Module {
-                auto sub_generator_args = generator_args;
-                sub_generator_args.erase("target");
+            auto module_factory = [&generator_name, &generator_args, &create_or_die, do_build_gradient_module](const std::string &name, const Target &target) -> Module {
                 // Must re-create each time since each instance will have a different Target.
-                auto gen = GeneratorRegistry::create(generator_name, GeneratorContext(target));
-                gen->set_generator_param_values(sub_generator_args);
-                return build_gradient_module ? gen->build_gradient_module(name) : gen->build_module(name);
+                const std::string &auto_schedule_string = generator_args["auto_schedule"];
+                const std::string &machine_params_string = generator_args["machine_params"];
+                const bool auto_schedule = auto_schedule_string == "true" || auto_schedule_string == "True";
+                const MachineParams machine_params = machine_params_string.empty() ? MachineParams::generic() : MachineParams(machine_params_string);
+                auto gen = create_or_die(generator_name, GeneratorContext(target, auto_schedule, machine_params));
+                for (const auto &kv : generator_args) {
+                    if (kv.first == "target" ||
+                        kv.first == "auto_schedule" ||
+                        kv.first == "machine_params") {
+                        continue;
+                    }
+                    gen->set_generatorparam_value(kv.first, kv.second);
+                }
+                return do_build_gradient_module ? build_gradient_module(*gen, name) : build_module(*gen, name);
             };
             compile_multitarget(function_name, output_files, targets, target_strings, module_factory, compiler_logger_factory);
         }
@@ -1142,18 +1322,26 @@ gengen
 
 }  // namespace
 
+std::vector<std::string> GeneratorsForMain::enumerate() const {
+    return GeneratorRegistry::enumerate();
+}
+
+AbstractGeneratorPtr GeneratorsForMain::create(const std::string &name, const Halide::GeneratorContext &context) const {
+    return GeneratorRegistry::create(name, context);
+}
+
 #ifdef HALIDE_WITH_EXCEPTIONS
-int generate_filter_main(int argc, char **argv, std::ostream &error_output) {
+int generate_filter_main(int argc, char **argv, std::ostream &error_output, const GeneratorsForMain &generators_for_main) {
     try {
-        return generate_filter_main_inner(argc, argv, error_output);
+        return generate_filter_main_inner(argc, argv, error_output, generators_for_main);
     } catch (std::runtime_error &err) {
         error_output << "Unhandled exception: " << err.what() << "\n";
         return -1;
     }
 }
 #else
-int generate_filter_main(int argc, char **argv, std::ostream &error_output) {
-    return generate_filter_main_inner(argc, argv, error_output);
+int generate_filter_main(int argc, char **argv, std::ostream &error_output, const GeneratorsForMain &generators_for_main) {
+    return generate_filter_main_inner(argc, argv, error_output, generators_for_main);
 }
 #endif
 
@@ -1168,19 +1356,7 @@ GeneratorParamBase::~GeneratorParamBase() {
 }
 
 void GeneratorParamBase::check_value_readable() const {
-    // These are always readable.
-    if (name() == "target" ||
-        name() == "auto_schedule" ||
-        name() == "machine_params") {
-        return;
-    }
-#ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
-    user_assert(generator && generator->phase >= GeneratorBase::ConfigureCalled)
-        << "The GeneratorParam \"" << name() << "\" cannot be read before build() or configure()/generate() is called.\n";
-#else
-    user_assert(generator && generator->phase >= GeneratorBase::ConfigureCalled)
-        << "The GeneratorParam \"" << name() << "\" cannot be read before configure()/generate() is called.\n";
-#endif
+    // GeneratorParams are now always readable.
 }
 
 void GeneratorParamBase::check_value_writable() const {
@@ -1228,21 +1404,16 @@ void GeneratorRegistry::unregister_factory(const std::string &name) {
 }
 
 /* static */
-std::unique_ptr<GeneratorBase> GeneratorRegistry::create(const std::string &name,
-                                                         const GeneratorContext &context) {
+AbstractGeneratorPtr GeneratorRegistry::create(const std::string &name,
+                                               const GeneratorContext &context) {
     GeneratorRegistry &registry = get_registry();
     std::lock_guard<std::mutex> lock(registry.mutex);
     auto it = registry.factories.find(name);
     if (it == registry.factories.end()) {
-        std::ostringstream o;
-        o << "Generator not found: " << name << "\n";
-        o << "Did you mean:\n";
-        for (const auto &n : registry.factories) {
-            o << "    " << n.first << "\n";
-        }
-        user_error << o.str();
+        return nullptr;
     }
-    std::unique_ptr<GeneratorBase> g = it->second(context);
+    GeneratorFactory f = it->second;
+    AbstractGeneratorPtr g = f(context);
     internal_assert(g != nullptr);
     return g;
 }
@@ -1341,28 +1512,29 @@ GeneratorParamInfo &GeneratorBase::param_info() {
     return *param_info_ptr;
 }
 
-std::vector<Func> GeneratorBase::get_outputs(const std::string &n) {
-    check_min_phase(GenerateCalled);
-    auto *output = find_output_by_name(n);
-    // Call for the side-effect of asserting if the value isn't defined.
-    (void)output->array_size();
-    for (const auto &f : output->funcs()) {
-        user_assert(f.defined()) << "Output " << n << " was not fully defined.\n";
+namespace {
+    template<typename T>
+    T *find_by_name(const std::string &name, const std::vector<T *> &v) {
+        for (T *t : v) {
+            if (t->name() == name) {
+                return t;
+            }
+        }
+        return nullptr;
     }
-    return output->funcs();
+
+}  // namespace
+
+GeneratorInputBase *GeneratorBase::find_input_by_name(const std::string &name) {
+    auto *t = find_by_name(name, param_info().inputs());
+    internal_assert(t != nullptr) << "Input " << name << " not found.";
+    return t;
 }
 
-// Find output by name. If not found, assert-fail. Never returns null.
 GeneratorOutputBase *GeneratorBase::find_output_by_name(const std::string &name) {
-    // There usually are very few outputs, so a linear search is fine
-    GeneratorParamInfo &pi = param_info();
-    for (GeneratorOutputBase *output : pi.outputs()) {
-        if (output->name() == name) {
-            return output;
-        }
-    }
-    internal_error << "Output " << name << " not found.";
-    return nullptr;  // not reached
+    auto *t = find_by_name(name, param_info().outputs());
+    internal_assert(t != nullptr) << "Output " << name << " not found.";
+    return t;
 }
 
 void GeneratorBase::set_generator_param_values(const GeneratorParamsMap &params) {
@@ -1415,8 +1587,8 @@ void GeneratorBase::set_generator_names(const std::string &registered_name, cons
 }
 
 void GeneratorBase::set_inputs_vector(const std::vector<std::vector<StubInput>> &inputs) {
+    ensure_configure_has_been_called();
     advance_phase(InputsSet);
-    internal_assert(!inputs_set) << "set_inputs_vector() must be called at most once per Generator instance.\n";
     GeneratorParamInfo &pi = param_info();
     user_assert(inputs.size() == pi.inputs().size())
         << "Expected exactly " << pi.inputs().size()
@@ -1424,7 +1596,6 @@ void GeneratorBase::set_inputs_vector(const std::vector<std::vector<StubInput>> 
     for (size_t i = 0; i < pi.inputs().size(); ++i) {
         pi.inputs()[i]->set_inputs(inputs[i]);
     }
-    inputs_set = true;
 }
 
 void GeneratorBase::track_parameter_values(bool include_outputs) {
@@ -1467,13 +1638,13 @@ void GeneratorBase::check_exact_phase(Phase expected_phase) const {
 void GeneratorBase::advance_phase(Phase new_phase) {
     switch (new_phase) {
     case Created:
-        internal_error << "Impossible";
+        internal_error;
         break;
     case ConfigureCalled:
         internal_assert(phase == Created);
         break;
     case InputsSet:
-        internal_assert(phase == Created || phase == ConfigureCalled);
+        internal_assert(phase == Created || phase == ConfigureCalled || phase == InputsSet);
         break;
     case GenerateCalled:
         // It's OK to advance directly to GenerateCalled.
@@ -1506,11 +1677,8 @@ void GeneratorBase::pre_generate() {
     user_assert(!pi.outputs().empty()) << "Must use Output<> with generate() method.";
     user_assert(get_target() != Target()) << "The Generator target has not been set.";
 
-    if (!inputs_set) {
-        for (auto *input : pi.inputs()) {
-            input->init_internals();
-        }
-        inputs_set = true;
+    for (auto *input : pi.inputs()) {
+        input->init_internals();
     }
     for (auto *output : pi.outputs()) {
         output->init_internals();
@@ -1537,11 +1705,8 @@ void GeneratorBase::pre_build() {
     advance_phase(ScheduleCalled);
     GeneratorParamInfo &pi = param_info();
     user_assert(pi.outputs().empty()) << "May not use build() method with Output<>.";
-    if (!inputs_set) {
-        for (auto *input : pi.inputs()) {
-            input->init_internals();
-        }
-        inputs_set = true;
+    for (auto *input : pi.inputs()) {
+        input->init_internals();
     }
     track_parameter_values(false);
 }
@@ -1585,223 +1750,6 @@ Pipeline GeneratorBase::get_pipeline() {
     return pipeline;
 }
 
-Module GeneratorBase::build_module(const std::string &function_name,
-                                   const LinkageType linkage_type) {
-    AutoSchedulerResults auto_schedule_results;
-    ensure_configure_has_been_called();
-    Pipeline pipeline = build_pipeline();
-    if (get_auto_schedule()) {
-        auto_schedule_results = pipeline.auto_schedule(get_target(), get_machine_params());
-    }
-
-    const GeneratorParamInfo &pi = param_info();
-    std::vector<Argument> filter_arguments;
-    for (const auto *input : pi.inputs()) {
-        for (const auto &p : input->parameters_) {
-            filter_arguments.push_back(to_argument(p));
-        }
-    }
-
-    Module result = pipeline.compile_to_module(filter_arguments, function_name, get_target(), linkage_type);
-    std::shared_ptr<GeneratorContext::ExternsMap> externs_map = get_externs_map();
-    for (const auto &map_entry : *externs_map) {
-        result.append(map_entry.second);
-    }
-
-    for (const auto *output : pi.outputs()) {
-        for (size_t i = 0; i < output->funcs().size(); ++i) {
-            auto from = output->funcs()[i].name();
-            auto to = output->array_name(i);
-            size_t tuple_size = output->types_defined() ? output->types().size() : 1;
-            for (size_t t = 0; t < tuple_size; ++t) {
-                std::string suffix = (tuple_size > 1) ? ("." + std::to_string(t)) : "";
-                result.remap_metadata_name(from + suffix, to + suffix);
-            }
-        }
-    }
-
-    result.set_auto_scheduler_results(auto_schedule_results);
-
-    return result;
-}
-
-Module GeneratorBase::build_gradient_module(const std::string &function_name) {
-    constexpr int DBG = 1;
-
-    // I doubt these ever need customizing; if they do, we can make them arguments to this function.
-    const std::string grad_input_pattern = "_grad_loss_for_$OUT$";
-    const std::string grad_output_pattern = "_grad_loss_$OUT$_wrt_$IN$";
-    const LinkageType linkage_type = LinkageType::ExternalPlusMetadata;
-
-    user_assert(!function_name.empty()) << "build_gradient_module(): function_name cannot be empty\n";
-
-    ensure_configure_has_been_called();
-    Pipeline original_pipeline = build_pipeline();
-    std::vector<Func> original_outputs = original_pipeline.outputs();
-
-    // Construct the adjoint pipeline, which has:
-    // - All the same inputs as the original, in the same order
-    // - Followed by one grad-input for each original output
-    // - Followed by one output for each unique pairing of original-output + original-input.
-
-    const GeneratorParamInfo &pi = param_info();
-
-    // Even though propagate_adjoints() supports Funcs-of-Tuples just fine,
-    // we aren't going to support them here (yet); AFAICT, neither PyTorch nor
-    // TF support Tensors with Tuples-as-values, so we'd have to split the
-    // tuples up into separate Halide inputs and outputs anyway; since Generator
-    // doesn't support Tuple-valued Inputs at all, and Tuple-valued Outputs
-    // are quite rare, we're going to just fail up front, with the assumption
-    // that the coder will explicitly adapt their code as needed. (Note that
-    // support for Tupled outputs could be added with some effort, so if this
-    // is somehow deemed critical, go for it)
-    for (const auto *input : pi.inputs()) {
-        const size_t tuple_size = input->types_defined() ? input->types().size() : 1;
-        // Note: this should never happen
-        internal_assert(tuple_size == 1) << "Tuple Inputs are not yet supported by build_gradient_module()";
-    }
-    for (const auto *output : pi.outputs()) {
-        const size_t tuple_size = output->types_defined() ? output->types().size() : 1;
-        internal_assert(tuple_size == 1) << "Tuple Outputs are not yet supported by build_gradient_module";
-    }
-
-    std::vector<Argument> gradient_inputs;
-
-    // First: the original inputs. Note that scalar inputs remain scalar,
-    // rather being promoted into zero-dimensional buffers.
-    for (const auto *input : pi.inputs()) {
-        // There can be multiple Funcs/Parameters per input if the
-        // input is an Array.
-        if (input->is_array()) {
-            internal_assert(input->parameters_.size() == input->funcs_.size());
-        }
-        for (const auto &p : input->parameters_) {
-            gradient_inputs.push_back(to_argument(p));
-            debug(DBG) << "    gradient copied input is: " << gradient_inputs.back().name << "\n";
-        }
-    }
-
-    // Next: add a grad-input for each *original* output; these will
-    // be the same shape as the output (so we should copy estimates from
-    // those outputs onto these estimates).
-    // - If an output is an Array, we'll have a separate input for each array element.
-
-    std::vector<ImageParam> d_output_imageparams;
-    for (const auto *output : pi.outputs()) {
-        for (size_t i = 0; i < output->funcs().size(); ++i) {
-            const Func &f = output->funcs()[i];
-            const std::string output_name = output->array_name(i);
-            // output_name is something like "funcname_i"
-            const std::string grad_in_name = replace_all(grad_input_pattern, "$OUT$", output_name);
-            // TODO(srj): does it make sense for gradient to be a non-float type?
-            // For now, assume it's always float32 (unless the output is already some float).
-            const Type grad_in_type = output->type().is_float() ? output->type() : Float(32);
-            const int grad_in_dimensions = f.dimensions();
-            const ArgumentEstimates grad_in_estimates = f.output_buffer().parameter().get_argument_estimates();
-            internal_assert((int)grad_in_estimates.buffer_estimates.size() == grad_in_dimensions);
-
-            ImageParam d_im(grad_in_type, grad_in_dimensions, grad_in_name);
-            for (int d = 0; d < grad_in_dimensions; d++) {
-                d_im.parameter().set_min_constraint_estimate(d, grad_in_estimates.buffer_estimates[i].min);
-                d_im.parameter().set_extent_constraint_estimate(d, grad_in_estimates.buffer_estimates[i].extent);
-            }
-            d_output_imageparams.push_back(d_im);
-            gradient_inputs.push_back(to_argument(d_im.parameter()));
-
-            debug(DBG) << "    gradient synthesized input is: " << gradient_inputs.back().name << "\n";
-        }
-    }
-
-    // Finally: define the output Func(s), one for each unique output/input pair.
-    // Note that original_outputs.size() != pi.outputs().size() if any outputs are arrays.
-    internal_assert(original_outputs.size() == d_output_imageparams.size());
-    std::vector<Func> gradient_outputs;
-    for (size_t i = 0; i < original_outputs.size(); ++i) {
-        const Func &original_output = original_outputs.at(i);
-        const ImageParam &d_output = d_output_imageparams.at(i);
-        Region bounds;
-        for (int i = 0; i < d_output.dimensions(); i++) {
-            bounds.emplace_back(d_output.dim(i).min(), d_output.dim(i).extent());
-        }
-        Func adjoint_func = BoundaryConditions::constant_exterior(d_output, make_zero(d_output.type()));
-        Derivative d = propagate_adjoints(original_output, adjoint_func, bounds);
-
-        const std::string &output_name = original_output.name();
-        for (const auto *input : pi.inputs()) {
-            for (size_t i = 0; i < input->funcs_.size(); ++i) {
-                const std::string input_name = input->array_name(i);
-                const auto &f = input->funcs_[i];
-                const auto &p = input->parameters_[i];
-
-                Func d_f = d(f);
-
-                std::string grad_out_name = replace_all(replace_all(grad_output_pattern, "$OUT$", output_name), "$IN$", input_name);
-                if (!d_f.defined()) {
-                    grad_out_name = "_dummy" + grad_out_name;
-                }
-
-                Func d_out_wrt_in(grad_out_name);
-                if (d_f.defined()) {
-                    d_out_wrt_in(Halide::_) = d_f(Halide::_);
-                } else {
-                    debug(DBG) << "    No Derivative found for output " << output_name << " wrt input " << input_name << "\n";
-                    // If there was no Derivative found, don't skip the output;
-                    // just replace with a dummy Func that is all zeros. This ensures
-                    // that the signature of the Pipeline we produce is always predictable.
-                    std::vector<Var> vars;
-                    for (int i = 0; i < d_output.dimensions(); i++) {
-                        vars.push_back(Var::implicit(i));
-                    }
-                    d_out_wrt_in(vars) = make_zero(d_output.type());
-                }
-
-                d_out_wrt_in.set_estimates(p.get_argument_estimates().buffer_estimates);
-
-                // Useful for debugging; ordinarily better to leave out
-                // debug(0) << "\n\n"
-                //          << "output:\n" << FuncWithDependencies(original_output) << "\n"
-                //          << "d_output:\n" << FuncWithDependencies(adjoint_func) << "\n"
-                //          << "input:\n" << FuncWithDependencies(f) << "\n"
-                //          << "d_out_wrt_in:\n" << FuncWithDependencies(d_out_wrt_in) << "\n";
-
-                gradient_outputs.push_back(d_out_wrt_in);
-                debug(DBG) << "    gradient output is: " << d_out_wrt_in.name() << "\n";
-            }
-        }
-    }
-
-    Pipeline grad_pipeline = Pipeline(gradient_outputs);
-
-    AutoSchedulerResults auto_schedule_results;
-    if (get_auto_schedule()) {
-        auto_schedule_results = grad_pipeline.auto_schedule(get_target(), get_machine_params());
-    } else {
-        user_warning << "Autoscheduling is not enabled in build_gradient_module(), so the resulting "
-                        "gradient module will be unscheduled; this is very unlikely to be what you want.\n";
-    }
-
-    Module result = grad_pipeline.compile_to_module(gradient_inputs, function_name, get_target(), linkage_type);
-    user_assert(get_externs_map()->empty())
-        << "Building a gradient-descent module for a Generator with ExternalCode is not supported.\n";
-
-    result.set_auto_scheduler_results(auto_schedule_results);
-
-    return result;
-}
-
-void GeneratorBase::emit_cpp_stub(const std::string &stub_file_path) {
-    user_assert(!generator_registered_name.empty() && !generator_stub_name.empty()) << "Generator has no name.\n";
-    // Make sure we call configure() so that extra inputs/outputs are added as necessary.
-    ensure_configure_has_been_called();
-    // StubEmitter will want to access the GP/SP values, so advance the phase to avoid assert-fails.
-    advance_phase(GenerateCalled);
-    advance_phase(ScheduleCalled);
-    GeneratorParamInfo &pi = param_info();
-    std::ofstream file(stub_file_path);
-    StubEmitter emit(file, generator_registered_name, generator_stub_name, pi.generator_params(), pi.inputs(), pi.outputs());
-    emit.emit();
-}
-
 void GeneratorBase::check_scheduled(const char *m) const {
     check_min_phase(ScheduleCalled);
 }
@@ -1819,6 +1767,175 @@ void GeneratorBase::check_input_is_array(Internal::GeneratorInputBase *in) {
 void GeneratorBase::check_input_kind(Internal::GeneratorInputBase *in, Internal::IOKind kind) {
     user_assert(in->kind() == kind)
         << "Input " << in->name() << " cannot be set with the type specified.";
+}
+
+std::vector<std::string> GeneratorBase::get_generatorparam_names() {
+    std::vector<std::string> v;
+    for (auto *g : param_info().generator_params()) {
+        if (g->is_synthetic_param()) {
+            continue;
+        }
+        const auto &n = g->name();
+        if (n == "target" ||
+            n == "auto_schedule" ||
+            n == "machine_params") {
+            continue;
+        }
+        v.push_back(n);
+    }
+
+    return v;
+}
+
+void GeneratorBase::set_generatorparam_value(const std::string &name, const std::string &value) {
+    if (name == "target" ||
+        name == "auto_schedule" ||
+        name == "machine_params") {
+        user_error
+            << "The GeneratorParam named " << name << " cannot be set by set_generatorparam_value().\n";
+    }
+
+    GeneratorParamInfo &pi = param_info();
+
+    for (auto *g : pi.generator_params()) {
+        if (g->name() != name) {
+            continue;
+        }
+        g->set_from_string(value);
+        return;
+    }
+    user_error
+        << "Generator " << generator_registered_name << " has no GeneratorParam named: " << name << "\n";
+}
+
+void GeneratorBase::set_generatorparam_value(const std::string &name, const LoopLevel &value) {
+    GeneratorParamInfo &pi = param_info();
+    for (auto *g : pi.generator_params()) {
+        if (g->name() != name) {
+            continue;
+        }
+        user_assert(g->is_looplevel_param()) << "GeneratorParam " << name << " is not a LoopLevel and cannot be set this way.";
+        g->set(value);
+        return;
+    }
+    user_error
+        << "Generator " << generator_registered_name << " has no GeneratorParam named: " << name << "\n";
+}
+
+std::string GeneratorBase::get_name() {
+    return generator_registered_name;
+}
+
+namespace {
+    // Note that this deliberately ignores inputs/outputs with multiple array values
+    // (ie, one name per input or output, regardless of array_size())
+    template<typename T>
+    std::vector<AbstractGenerator::ArgInfo> get_arguments(const T &t) {
+        std::vector<AbstractGenerator::ArgInfo> args;
+        args.reserve(t.size());
+        for (auto *e : t) {
+            args.push_back({e->name(),
+                            e->kind(),
+                            e->types_defined() ? e->types() : std::vector<Type>{},
+                            e->dims_defined() ? e->dims() : 0});
+        }
+        return args;
+    }
+
+}  // namespace
+
+std::vector<AbstractGenerator::ArgInfo> GeneratorBase::get_input_arginfos() {
+    ensure_configure_has_been_called();
+    return get_arguments(param_info().inputs());
+}
+
+std::vector<AbstractGenerator::ArgInfo> GeneratorBase::get_output_arginfos() {
+    ensure_configure_has_been_called();
+    return get_arguments(param_info().outputs());
+}
+
+std::vector<Parameter> GeneratorBase::get_parameters_for_input(const std::string &name) {
+    auto *input = find_input_by_name(name);
+
+    std::vector<Parameter> params;
+    // TODO: replicated code, yuck
+    if (input->kind() == IOKind::Scalar) {
+        internal_assert(input->funcs_.empty() && input->exprs_.size() == input->parameters_.size());
+        for (size_t i = 0; i < input->exprs_.size(); ++i) {
+            const auto &p = input->parameters_[i];
+            internal_assert(!p.is_buffer());
+            internal_assert(p.name() == input->array_name(i)) << "input name was " << p.name() << " expected " << input->array_name(i);
+            internal_assert(p.dimensions() == 0) << "input dimensions was " << p.dimensions() << " expected " << 0;
+            internal_assert(p.type() == input->type()) << "input type was " << p.name() << " expected " << input->type();
+            params.push_back(p);
+        }
+    } else {
+        internal_assert(input->exprs_.empty() && input->funcs_.size() == input->parameters_.size());
+        for (size_t i = 0; i < input->funcs_.size(); ++i) {
+            const auto &f = input->funcs_[i];
+            const auto &p = input->parameters_[i];
+            internal_assert(p.is_buffer());
+            internal_assert(p.name() == input->array_name(i)) << "input name was " << p.name() << " expected " << input->array_name(i);
+            internal_assert(p.dimensions() == f.dimensions()) << "input dimensions was " << p.dimensions() << " expected " << f.dimensions();
+            internal_assert(p.type() == input->type()) << "input type was " << p.name() << " expected " << input->type();
+            params.push_back(p);
+        }
+    }
+    return params;
+}
+
+std::vector<Func> GeneratorBase::get_funcs_for_output(const std::string &n) {
+    check_min_phase(GenerateCalled);
+    auto *output = find_output_by_name(n);
+    // Call for the side-effect of asserting if the value isn't defined.
+    (void)output->array_size();
+    for (const auto &f : output->funcs()) {
+        user_assert(f.defined()) << "Output " << n << " was not fully defined.\n";
+    }
+    return output->funcs();
+}
+
+ExternsMap GeneratorBase::get_external_code_map() {
+    // get_externs_map() returns a std::shared_ptr<ExternsMap>
+    return *get_externs_map();
+}
+
+void GeneratorBase::bind_input(const std::string &name, const std::vector<Parameter> &v) {
+    ensure_configure_has_been_called();
+    advance_phase(InputsSet);
+    std::vector<StubInput> si;
+    std::copy(v.begin(), v.end(), std::back_inserter(si));
+    find_input_by_name(name)->set_inputs(si);
+}
+
+void GeneratorBase::bind_input(const std::string &name, const std::vector<Func> &v) {
+    ensure_configure_has_been_called();
+    advance_phase(InputsSet);
+    std::vector<StubInput> si;
+    std::copy(v.begin(), v.end(), std::back_inserter(si));
+    find_input_by_name(name)->set_inputs(si);
+}
+
+void GeneratorBase::bind_input(const std::string &name, const std::vector<Expr> &v) {
+    ensure_configure_has_been_called();
+    advance_phase(InputsSet);
+    std::vector<StubInput> si;
+    std::copy(v.begin(), v.end(), std::back_inserter(si));
+    find_input_by_name(name)->set_inputs(si);
+}
+
+bool GeneratorBase::emit_cpp_stub(const std::string &stub_file_path) {
+    user_assert(!generator_registered_name.empty() && !generator_stub_name.empty()) << "Generator has no name.\n";
+    // Make sure we call configure() so that extra inputs/outputs are added as necessary.
+    ensure_configure_has_been_called();
+    // StubEmitter will want to access the GP/SP values, so advance the phase to avoid assert-fails.
+    advance_phase(GenerateCalled);
+    advance_phase(ScheduleCalled);
+    GeneratorParamInfo &pi = param_info();
+    std::ofstream file(stub_file_path);
+    StubEmitter emit(file, generator_registered_name, generator_stub_name, pi.generator_params(), pi.inputs(), pi.outputs());
+    emit.emit();
+    return true;
 }
 
 GIOBase::GIOBase(size_t array_size,
@@ -2053,6 +2170,10 @@ void GeneratorInputBase::verify_internals() {
 }
 
 void GeneratorInputBase::init_internals() {
+    if (inputs_set) {
+        return;
+    }
+
     // Call these for the side-effect of asserting if the values aren't defined.
     (void)array_size();
     (void)types();
@@ -2113,6 +2234,7 @@ void GeneratorInputBase::set_inputs(const std::vector<StubInput> &inputs) {
 
     set_def_min_max();
     verify_internals();
+    inputs_set = true;
 }
 
 void GeneratorInputBase::set_estimate_impl(const Var &var, const Expr &min, const Expr &extent) {
@@ -2194,12 +2316,8 @@ void GeneratorOutputBase::resize(size_t size) {
 
 StubOutputBufferBase::StubOutputBufferBase() = default;
 
-StubOutputBufferBase::StubOutputBufferBase(const Func &f, const std::shared_ptr<GeneratorBase> &generator)
+StubOutputBufferBase::StubOutputBufferBase(const Func &f, const std::shared_ptr<AbstractGenerator> &generator)
     : f(f), generator(generator) {
-}
-
-void StubOutputBufferBase::check_scheduled(const char *m) const {
-    generator->check_scheduled(m);
 }
 
 Realization StubOutputBufferBase::realize(std::vector<int32_t> sizes) {
@@ -2207,7 +2325,7 @@ Realization StubOutputBufferBase::realize(std::vector<int32_t> sizes) {
 }
 
 Target StubOutputBufferBase::get_target() const {
-    return generator->get_target();
+    return generator->context().get_target();
 }
 
 RegisterGenerator::RegisterGenerator(const char *registered_name, GeneratorFactory generator_factory) {

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -271,6 +271,7 @@
 #include <utility>
 #include <vector>
 
+#include "AbstractGenerator.h"
 #include "ExternalCode.h"
 #include "Func.h"
 #include "ImageParam.h"
@@ -283,6 +284,9 @@
 #endif
 
 namespace Halide {
+
+class GeneratorContext;
+
 namespace Internal {
 
 void generator_test();
@@ -322,10 +326,25 @@ std::string halide_type_to_c_source(const Type &t);
 // e.g., Int(32) -> "int32_t"
 std::string halide_type_to_c_type(const Type &t);
 
+class GeneratorsForMain {
+public:
+    GeneratorsForMain() = default;
+    virtual ~GeneratorsForMain() = default;
+
+    virtual std::vector<std::string> enumerate() const;
+    virtual AbstractGeneratorPtr create(const std::string &name,
+                                        const Halide::GeneratorContext &context) const;
+
+    GeneratorsForMain(const GeneratorsForMain &) = delete;
+    GeneratorsForMain &operator=(const GeneratorsForMain &) = delete;
+    GeneratorsForMain(GeneratorsForMain &&) = delete;
+    GeneratorsForMain &operator=(GeneratorsForMain &&) = delete;
+};
+
 /** generate_filter_main() is a convenient wrapper for GeneratorRegistry::create() +
  * compile_to_files(); it can be trivially wrapped by a "real" main() to produce a
  * command-line utility for ahead-of-time filter compilation. */
-int generate_filter_main(int argc, char **argv, std::ostream &cerr);
+int generate_filter_main(int argc, char **argv, std::ostream &cerr, const GeneratorsForMain &generators_for_main = GeneratorsForMain());
 
 // select_type<> is to std::conditional as switch is to if:
 // it allows a multiway compile-time type definition via the form
@@ -1223,10 +1242,6 @@ namespace Internal {
 template<typename T2>
 class GeneratorInput_Buffer;
 
-enum class IOKind { Scalar,
-                    Function,
-                    Buffer };
-
 /**
  * StubInputBuffer is the placeholder that a Stub uses when it requires
  * a Buffer for an input (rather than merely a Func or Expr). It is constructed
@@ -1241,6 +1256,8 @@ class StubInputBuffer {
     friend class StubInput;
     template<typename T2>
     friend class GeneratorInput_Buffer;
+    template<typename T2, int D2>
+    friend class StubInputBuffer;
 
     Parameter parameter_;
 
@@ -1273,31 +1290,45 @@ public:
     StubInputBuffer(const Buffer<T2, D2> &b)
         : parameter_(parameter_from_buffer(b)) {
     }
+
+    template<typename T2>
+    static std::vector<Parameter> to_parameter_vector(const StubInputBuffer<T2> &t) {
+        return {t.parameter_};
+    }
+
+    template<typename T2>
+    static std::vector<Parameter> to_parameter_vector(const std::vector<StubInputBuffer<T2>> &v) {
+        std::vector<Parameter> r;
+        r.reserve(v.size());
+        for (const auto &s : v) {
+            r.push_back(s.parameter_);
+        }
+        return r;
+    }
 };
+
+class AbstractGenerator;
 
 class StubOutputBufferBase {
 protected:
     Func f;
-    std::shared_ptr<GeneratorBase> generator;
+    std::shared_ptr<AbstractGenerator> generator;
 
-    void check_scheduled(const char *m) const;
     Target get_target() const;
 
     StubOutputBufferBase();
-    explicit StubOutputBufferBase(const Func &f, const std::shared_ptr<GeneratorBase> &generator);
+    explicit StubOutputBufferBase(const Func &f, const std::shared_ptr<AbstractGenerator> &generator);
 
 public:
     Realization realize(std::vector<int32_t> sizes);
 
     template<typename... Args>
     Realization realize(Args &&...args) {
-        check_scheduled("realize");
         return f.realize(std::forward<Args>(args)..., get_target());
     }
 
     template<typename Dst>
     void realize(Dst dst) {
-        check_scheduled("realize");
         f.realize(dst, get_target());
     }
 };
@@ -1318,13 +1349,21 @@ template<typename T = void>
 class StubOutputBuffer : public StubOutputBufferBase {
     template<typename T2>
     friend class GeneratorOutput_Buffer;
-    friend class GeneratorStub;
-    explicit StubOutputBuffer(const Func &f, const std::shared_ptr<GeneratorBase> &generator)
+    explicit StubOutputBuffer(const Func &f, const std::shared_ptr<AbstractGenerator> &generator)
         : StubOutputBufferBase(f, generator) {
     }
 
 public:
     StubOutputBuffer() = default;
+
+    static std::vector<StubOutputBuffer<T>> to_output_buffers(const std::vector<Func> &v,
+                                                              const std::shared_ptr<AbstractGenerator> &generator) {
+        std::vector<StubOutputBuffer<T>> result;
+        for (const Func &f : v) {
+            result.push_back(StubOutputBuffer<T>(f, generator));
+        }
+        return result;
+    }
 };
 
 // This is a union-like class that allows for convenient initialization of Stub Inputs
@@ -1344,15 +1383,15 @@ public:
     StubInput(const StubInputBuffer<T2> &b)
         : kind_(IOKind::Buffer), parameter_(b.parameter_), func_(), expr_() {
     }
+    StubInput(const Parameter &p)
+        : kind_(IOKind::Buffer), parameter_(p), func_(), expr_() {
+    }
     StubInput(const Func &f)
         : kind_(IOKind::Function), parameter_(), func_(f), expr_() {
     }
     StubInput(const Expr &e)
         : kind_(IOKind::Scalar), parameter_(), func_(), expr_(e) {
     }
-
-private:
-    friend class GeneratorInputBase;
 
     IOKind kind() const {
         return kind_;
@@ -1503,6 +1542,7 @@ protected:
 
     void init_internals();
     void set_inputs(const std::vector<StubInput> &inputs);
+    bool inputs_set = false;
 
     virtual void set_def_min_max();
 
@@ -2892,8 +2932,6 @@ private:
     const std::string error_msg;
 };
 
-class GeneratorStub;
-
 }  // namespace Internal
 
 /** GeneratorContext is a class that is used when using Generators (or Stubs) directly;
@@ -3045,11 +3083,9 @@ struct NoRealizations<T, Args...> {
     static const bool value = !std::is_convertible<T, Realization>::value && NoRealizations<Args...>::value;
 };
 
-class GeneratorStub;
-
 // Note that these functions must never return null:
 // if they cannot return a valid Generator, they must assert-fail.
-using GeneratorFactory = std::function<std::unique_ptr<GeneratorBase>(const GeneratorContext &)>;
+using GeneratorFactory = std::function<AbstractGeneratorPtr(const GeneratorContext &context)>;
 
 struct StringOrLoopLevel {
     std::string string_value;
@@ -3105,9 +3141,9 @@ public:
     }
 };
 
-class GeneratorBase : public NamesInterface {
+class GeneratorBase : public NamesInterface, public AbstractGenerator {
 public:
-    virtual ~GeneratorBase();
+    ~GeneratorBase() override;
 
     void set_generator_param_values(const GeneratorParamsMap &params);
 
@@ -3123,29 +3159,6 @@ public:
     int natural_vector_size() const {
         return get_target().natural_vector_size<data_t>();
     }
-
-    void emit_cpp_stub(const std::string &stub_file_path);
-
-    // Call generate() and produce a Module for the result.
-    // If function_name is empty, generator_name() will be used for the function.
-    Module build_module(const std::string &function_name = "",
-                        LinkageType linkage_type = LinkageType::ExternalPlusMetadata);
-
-    /**
-     * Build a module that is suitable for using for gradient descent calculation in TensorFlow or PyTorch.
-     *
-     * Essentially:
-     *   - A new Pipeline is synthesized from the current Generator (according to the rules below)
-     *   - The new Pipeline is autoscheduled (if autoscheduling is requested, but it would be odd not to do so)
-     *   - The Pipeline is compiled to a Module and returned
-     *
-     * The new Pipeline is adjoint to the original; it has:
-     *   - All the same inputs as the original, in the same order
-     *   - Followed by one grad-input for each original output
-     *   - Followed by one output for each unique pairing of original-output + original-input.
-     *     (For the common case of just one original-output, this amounts to being one output for each original-input.)
-     */
-    Module build_gradient_module(const std::string &function_name);
 
     /**
      * set_inputs is a variadic wrapper around set_inputs_vector, which makes usage much simpler
@@ -3340,15 +3353,12 @@ public:
         get_pipeline().trace_pipeline();
     }
 
-    GeneratorContext context() const;
-
 protected:
     GeneratorBase(size_t size, const void *introspection_helper);
     void set_generator_names(const std::string &registered_name, const std::string &stub_name);
 
     void init_from_context(const Halide::GeneratorContext &context);
 
-    virtual Pipeline build_pipeline() = 0;
     virtual void call_configure() = 0;
     virtual void call_generate() = 0;
     virtual void call_schedule() = 0;
@@ -3446,7 +3456,6 @@ private:
     friend class GeneratorInputBase;
     friend class GeneratorOutputBase;
     friend class GeneratorParamInfo;
-    friend class GeneratorStub;
     friend class StubOutputBufferBase;
 
     const size_t size;
@@ -3457,13 +3466,13 @@ private:
     // Do not access directly: use the param_info() getter.
     std::unique_ptr<GeneratorParamInfo> param_info_ptr;
 
-    bool inputs_set{false};
     std::string generator_registered_name, generator_stub_name;
     Pipeline pipeline;
 
     // Return our GeneratorParamInfo.
     GeneratorParamInfo &param_info();
 
+    Internal::GeneratorInputBase *find_input_by_name(const std::string &name);
     Internal::GeneratorOutputBase *find_output_by_name(const std::string &name);
 
     void check_scheduled(const char *m) const;
@@ -3476,12 +3485,6 @@ private:
     void get_host_target();
     void get_jit_target_from_environment();
     void get_target_from_environment();
-
-    // Return the output with the given name.
-    // If the output is singular (a non-array), return a vector of size 1.
-    // If no such name exists (or is non-array), assert.
-    // This method never returns undefined Funcs.
-    std::vector<Func> get_outputs(const std::string &n);
 
     void set_inputs_vector(const std::vector<std::vector<StubInput>> &inputs);
 
@@ -3621,6 +3624,30 @@ private:
     }
 
 public:
+    // AbstractGenerator methods
+    std::string get_name() override;
+    GeneratorContext context() const override;
+    std::vector<ArgInfo> get_input_arginfos() override;
+    std::vector<ArgInfo> get_output_arginfos() override;
+    std::vector<std::string> get_generatorparam_names() override;
+
+    void set_generatorparam_value(const std::string &name, const std::string &value) override;
+    void set_generatorparam_value(const std::string &name, const LoopLevel &loop_level) override;
+
+    std::vector<Parameter> get_parameters_for_input(const std::string &name) override;
+    std::vector<Func> get_funcs_for_output(const std::string &name) override;
+
+    ExternsMap get_external_code_map() override;
+
+    // This is overridden in the concrete Generator<> subclass.
+    // Pipeline build_pipeline() override;
+
+    void bind_input(const std::string &name, const std::vector<Parameter> &v) override;
+    void bind_input(const std::string &name, const std::vector<Func> &v) override;
+    void bind_input(const std::string &name, const std::vector<Expr> &v) override;
+
+    bool emit_cpp_stub(const std::string &stub_file_path) override;
+
     GeneratorBase(const GeneratorBase &) = delete;
     GeneratorBase &operator=(const GeneratorBase &) = delete;
     GeneratorBase(GeneratorBase &&that) = delete;
@@ -3634,8 +3661,8 @@ public:
     static std::vector<std::string> enumerate();
     // Note that this method will never return null:
     // if it cannot return a valid Generator, it should assert-fail.
-    static std::unique_ptr<GeneratorBase> create(const std::string &name,
-                                                 const Halide::GeneratorContext &context);
+    static AbstractGeneratorPtr create(const std::string &name,
+                                       const Halide::GeneratorContext &context);
 
 private:
     using GeneratorFactoryMap = std::map<const std::string, GeneratorFactory>;
@@ -3891,6 +3918,7 @@ private:
 protected:
 #ifdef HALIDE_ALLOW_GENERATOR_BUILD_METHOD
     Pipeline build_pipeline() override {
+        ensure_configure_has_been_called();
         return this->build_pipeline_impl(0);
     }
 
@@ -3907,6 +3935,7 @@ protected:
     }
 #else
     Pipeline build_pipeline() override {
+        ensure_configure_has_been_called();
         return this->build_pipeline_impl();
     }
 
@@ -3941,61 +3970,6 @@ public:
     RegisterGenerator(const char *registered_name, GeneratorFactory generator_factory);
 };
 
-class GeneratorStub : public NamesInterface {
-public:
-    GeneratorStub(const GeneratorContext &context,
-                  const GeneratorFactory &generator_factory);
-
-    GeneratorStub(const GeneratorContext &context,
-                  const GeneratorFactory &generator_factory,
-                  const GeneratorParamsMap &generator_params,
-                  const std::vector<std::vector<Internal::StubInput>> &inputs);
-    std::vector<std::vector<Func>> generate(const GeneratorParamsMap &generator_params,
-                                            const std::vector<std::vector<Internal::StubInput>> &inputs);
-
-    // Output(s)
-    std::vector<Func> get_outputs(const std::string &n) const {
-        return generator->get_outputs(n);
-    }
-
-    template<typename T2>
-    std::vector<T2> get_output_buffers(const std::string &n) const {
-        auto v = generator->get_outputs(n);
-        std::vector<T2> result;
-        for (auto &o : v) {
-            result.push_back(T2(o, generator));
-        }
-        return result;
-    }
-
-    static std::vector<StubInput> to_stub_input_vector(const Expr &e) {
-        return {StubInput(e)};
-    }
-
-    static std::vector<StubInput> to_stub_input_vector(const Func &f) {
-        return {StubInput(f)};
-    }
-
-    template<typename T = void>
-    static std::vector<StubInput> to_stub_input_vector(const StubInputBuffer<T> &b) {
-        return {StubInput(b)};
-    }
-
-    template<typename T>
-    static std::vector<StubInput> to_stub_input_vector(const std::vector<T> &v) {
-        std::vector<StubInput> r;
-        std::copy(v.begin(), v.end(), std::back_inserter(r));
-        return r;
-    }
-
-    struct Names {
-        std::vector<std::string> generator_params, inputs, outputs;
-    };
-    Names get_names() const;
-
-    std::shared_ptr<GeneratorBase> generator;
-};
-
 }  // namespace Internal
 
 }  // namespace Halide
@@ -4011,8 +3985,8 @@ struct halide_global_ns;
     namespace halide_register_generator {                                                                                           \
     struct halide_global_ns;                                                                                                        \
     namespace GEN_REGISTRY_NAME##_ns {                                                                                              \
-        std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext &context);                          \
-        std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext &context) {                         \
+        std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext &context);                      \
+        std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext &context) {                     \
             using GenType = std::remove_pointer<decltype(new GEN_CLASS_NAME)>::type; /* NOLINT(bugprone-macro-parentheses) */       \
             return GenType::create(context, #GEN_REGISTRY_NAME, #FULLY_QUALIFIED_STUB_NAME);                                        \
         }                                                                                                                           \
@@ -4073,13 +4047,15 @@ struct halide_global_ns;
     namespace halide_register_generator {                                                                                           \
     struct halide_global_ns;                                                                                                        \
     namespace ORIGINAL_REGISTRY_NAME##_ns {                                                                                         \
-        std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext &context);                          \
+        std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext &context);                      \
     }                                                                                                                               \
     namespace GEN_REGISTRY_NAME##_ns {                                                                                              \
-        std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext &context);                          \
-        std::unique_ptr<Halide::Internal::GeneratorBase> factory(const Halide::GeneratorContext &context) {                         \
+        std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext &context) {                     \
             auto g = ORIGINAL_REGISTRY_NAME##_ns::factory(context);                                                                 \
-            g->set_generator_param_values(__VA_ARGS__);                                                                             \
+            const std::map<std::string, std::string> m = __VA_ARGS__;                                                               \
+            for (const auto &c : m) {                                                                                               \
+                g->set_generatorparam_value(c.first, c.second);                                                                     \
+            }                                                                                                                       \
             return g;                                                                                                               \
         }                                                                                                                           \
     }                                                                                                                               \

--- a/src/exported_symbols.ldscript
+++ b/src/exported_symbols.ldscript
@@ -9,6 +9,8 @@
         _Z?6Halide* ;
         _Z??6Halide* ;
         _Z???6Halide* ;
+        # non-virtual thunks
+        _ZThn???_N6Halide* ;
 
     local: *;
 };

--- a/src/exported_symbols.osx
+++ b/src/exported_symbols.osx
@@ -5,3 +5,5 @@ halide_*
 __Z?6Halide*
 __Z??6Halide*
 __Z???6Halide*
+# non-virtual thunks
+__ZThn???_N6Halide*

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -171,6 +171,10 @@ if (TARGET generator_aot_autograd)
     target_link_libraries(generator_aot_autograd PRIVATE autograd_grad)
 endif ()
 
+# abstractgeneratortest_aottest.cpp
+# abstractgeneratortest_generator.cpp
+halide_define_aot_test(abstractgeneratortest)
+
 # bit_operations_aottest.cpp
 # bit_operations_generator.cpp
 halide_define_aot_test(bit_operations)

--- a/test/generator/abstractgeneratortest_aottest.cpp
+++ b/test/generator/abstractgeneratortest_aottest.cpp
@@ -1,0 +1,46 @@
+#include "HalideBuffer.h"
+#include "HalideRuntime.h"
+
+#include <math.h>
+#include <stdio.h>
+
+#include "abstractgeneratortest.h"
+
+using namespace Halide::Runtime;
+
+const int kSize = 4;
+
+void verify(const Buffer<int32_t> &img, float compiletime_factor, float runtime_factor, int channels) {
+    img.for_each_element([=](int x, int y, int c) {
+        int expected = (int32_t)(compiletime_factor * runtime_factor * c * (x > y ? x : y));
+        int actual = img(x, y, c);
+        assert(expected == actual);
+    });
+}
+
+int main(int argc, char **argv) {
+
+    const int32_t scaling = 2;  // GeneratorParam
+
+    Buffer<int32_t> input(kSize, kSize);
+    const int32_t offset = 32;
+
+    input.for_each_element([&](int x, int y) {
+        input(x, y) = (x + y);
+    });
+
+    Buffer<int32_t> output(kSize, kSize);
+    abstractgeneratortest(input, offset, output);
+
+    output.for_each_element([&](int x, int y) {
+        int expected = (x + y) * scaling + offset;
+        int actual = output(x, y);
+        if (expected != actual) {
+            fprintf(stderr, "at %d %d, expected %d, actual %d\n", x, y, expected, actual);
+            exit(-1);
+        }
+    });
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/generator/abstractgeneratortest_generator.cpp
+++ b/test/generator/abstractgeneratortest_generator.cpp
@@ -1,0 +1,164 @@
+#include "Halide.h"
+
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace Halide::Internal;
+
+namespace Halide {
+namespace {
+
+// Note to reader: this test is meant as a simple way to verify that arbitrary
+// implementations of AbstractGenerator work properly. That said, we recommend
+// that you don't imitate this code; AbstractGenerator is an *internal*
+// abtraction, intended for Halide to build on internally. If you use AbstractGenerator
+// directly, you'll almost certainly have more work maintaining your code
+// on your own.
+
+const char *const AbstractGeneratorTestName = "abstractgeneratortest";
+
+// We could use std::stoi() here, but we explicitly want to assert-fail
+// if we can't parse the string as a valid int.
+int string_to_int(const std::string &s) {
+    std::istringstream iss(s);
+    int i;
+    iss >> i;
+    _halide_user_assert(!iss.fail() && iss.get() == EOF) << "Unable to parse: " << s;
+    return i;
+}
+
+class AbstractGeneratorTest : public AbstractGenerator {
+    // Boilerplate
+    const GeneratorContext context_;
+
+    // Constants (aka GeneratorParams)
+    std::map<std::string, std::string> constants_ = {
+        {"scaling", "2"},
+    };
+
+    // Inputs
+    ImageParam input_{Int(32), 2, "input"};
+    Param<int32_t> offset_{"offset"};
+
+    // Outputs
+    Func output_{"output"};
+
+    // Misc
+    Pipeline pipeline_;
+
+public:
+    explicit AbstractGeneratorTest(const GeneratorContext &context)
+        : context_(context) {
+    }
+
+    std::string get_name() override {
+        return AbstractGeneratorTestName;
+    }
+
+    GeneratorContext context() const override {
+        return context_;
+    }
+
+    std::vector<ArgInfo> get_input_arginfos() override {
+        return {
+            {"input", IOKind::Buffer, {Int(32)}, 2},
+            {"offset", IOKind::Scalar, {Int(32)}, 0},
+        };
+    }
+
+    std::vector<ArgInfo> get_output_arginfos() override {
+        return {
+            {"output", IOKind::Buffer, {Int(32)}, 2},
+        };
+    }
+
+    std::vector<std::string> get_generatorparam_names() override {
+        std::vector<std::string> v;
+        for (const auto &c : constants_) {
+            v.push_back(c.first);
+        }
+        return v;
+    }
+
+    void set_generatorparam_value(const std::string &name, const std::string &value) override {
+        _halide_user_assert(!pipeline_.defined());
+        _halide_user_assert(constants_.count(name) == 1) << "Unknown Constant: " << name;
+        constants_[name] = value;
+    }
+
+    void set_generatorparam_value(const std::string &name, const LoopLevel &value) override {
+        _halide_user_assert(!pipeline_.defined());
+        _halide_user_assert(constants_.count(name) == 1) << "Unknown Constant: " << name;
+        _halide_user_assert(false) << "This Generator has no LoopLevel constants.";
+    }
+
+    Pipeline build_pipeline() override {
+        _halide_user_assert(!pipeline_.defined());
+
+        const int scaling = string_to_int(constants_.at("scaling"));
+
+        Var x, y;
+        output_(x, y) = input_(x, y) * scaling + offset_;
+        output_.compute_root();
+
+        pipeline_ = output_;
+        return pipeline_;
+    }
+
+    std::vector<Parameter> get_parameters_for_input(const std::string &name) override {
+        _halide_user_assert(pipeline_.defined());
+        if (name == "input") {
+            return {input_.parameter()};
+        }
+        if (name == "offset") {
+            return {offset_.parameter()};
+        }
+        _halide_user_assert(false) << "Unknown input: " << name;
+        return {};
+    }
+
+    std::vector<Func> get_funcs_for_output(const std::string &name) override {
+        _halide_user_assert(pipeline_.defined());
+        if (name == "output") {
+            return {output_};
+        }
+        _halide_user_assert(false) << "Unknown output: " << name;
+        return {};
+    }
+
+    ExternsMap get_external_code_map() override {
+        // none
+        return {};
+    }
+
+    void bind_input(const std::string &name, const std::vector<Parameter> &v) override {
+        _halide_user_assert(false) << "OOPS";
+    }
+
+    // void bind_input(const std::string &name, const std::vector<Buffer<void>> &v) override {
+    //     _halide_user_assert(false) << "OOPS";
+    // }
+
+    void bind_input(const std::string &name, const std::vector<Func> &v) override {
+        _halide_user_assert(false) << "OOPS";
+    }
+
+    void bind_input(const std::string &name, const std::vector<Expr> &v) override {
+        _halide_user_assert(false) << "OOPS";
+    }
+
+    bool emit_cpp_stub(const std::string & /*stub_file_path*/) override {
+        // not supported
+        return false;
+    }
+};
+
+RegisterGenerator register_something(AbstractGeneratorTestName,
+                                     [](const GeneratorContext &context) -> AbstractGeneratorPtr {
+                                         return std::unique_ptr<AbstractGeneratorTest>(new AbstractGeneratorTest(context));
+                                     });
+
+}  // namespace
+}  // namespace Halide


### PR DESCRIPTION
This PR refactors the Generator infrastructure to introduce the AbstractGenerator interface; this provides a relatively clean API that can be used to introduce alternate "Generator" syntaxes/implementations that still participate in the build infrastructure in the same way as existing Generators. 

The impetus for this was originally some experimental work to allow a more functional-style Generator binding in C++; that work is on hold indefinitely, but this work has proved useful in the ongoing work to add Generators to the Python bindings. I've maintained this as a private branch for a year or so (!) but at this point I think landing it will make further development simpler. PTAL.
