### PR TITLE
[CMake] Deduplicate `Halide_LLVM_VERSION` and `LLVM_PACKAGE_VERSION`

### DIFF
--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -20,9 +20,6 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 
-# LLVM_PACKAGE_VERSION does not propagate to higher scopes
-set(Halide_LLVM_VERSION ${LLVM_PACKAGE_VERSION} CACHE INTERNAL "Provided LLVM version")
-
 if (LLVM_PACKAGE_VERSION VERSION_LESS 12.0)
     message(FATAL_ERROR "LLVM version must be 12.0 or newer")
 endif ()

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -304,7 +304,7 @@ foreach (i IN LISTS RUNTIME_LL)
     # see https://llvm.org/docs/OpaquePointers.html)
 
     set(LL_TRANSFORMED "${LL}.transformed.ll")
-    if (Halide_LLVM_VERSION VERSION_LESS 14.0)
+    if (LLVM_PACKAGE_VERSION VERSION_LESS 14.0.0)
         add_custom_command(OUTPUT "${LL_TRANSFORMED}"
                            COMMAND regexp_replace "elementtype\\(i[0-9]+\\)" "" < "$<SHELL_PATH:${CMAKE_CURRENT_SOURCE_DIR}/${LL}>" > "${LL_TRANSFORMED}"
                            DEPENDS "${LL}" regexp_replace


### PR DESCRIPTION
As far as i can tell, they are always exactly identical,
and i don't believe the claim that `LLVM_PACKAGE_VERSION`
doesn't exist in upper scopes is valid.