### PR TITLE
Python Bindings: fix Python `bool` -> `Expr` implicit conversion

### DIFF
--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -1,3 +1,4 @@
+
 import halide as hl
 import numpy as np
 

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -1,6 +1,5 @@
 import halide as hl
 import numpy as np
-import random
 
 def test_compiletime_error():
     x = hl.Var('x')

--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -1,6 +1,6 @@
-
 import halide as hl
 import numpy as np
+import random
 
 def test_compiletime_error():
     x = hl.Var('x')
@@ -301,6 +301,13 @@ def test_scalar_funcs():
 
     g.compile_jit()
 
+def test_bool_conversion():
+    x = hl.Var('x')
+    f = hl.Func('f')
+    f[x] = x
+    s = bool(True)
+    # Verify that this doesn't fail with 'Argument passed to specialize must be of type bool'
+    f.compute_root().specialize(True)
 
 if __name__ == "__main__":
     test_compiletime_error()
@@ -317,3 +324,4 @@ if __name__ == "__main__":
     test_basics4()
     test_basics5()
     test_scalar_funcs()
+    test_bool_conversion()

--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -23,6 +23,9 @@ void define_expr(py::module &m) {
     auto expr_class =
         py::class_<Expr>(m, "Expr")
             .def(py::init<>())
+            .def(py::init([](bool b) {
+                return Internal::make_bool(b);
+            }))
             // PyBind11 searches in declared order,
             // int should be tried before float conversion
             .def(py::init<int>())
@@ -45,6 +48,7 @@ void define_expr(py::module &m) {
             .def("__nonzero__", to_bool)
 
             .def("type", &Expr::type)
+            .def("defined", &Expr::defined)
             .def("__repr__", [](const Expr &e) -> std::string {
                 std::ostringstream o;
                 o << "<halide.Expr of type " << halide_type_to_string(e.type()) << ": " << e << ">";
@@ -55,6 +59,7 @@ void define_expr(py::module &m) {
 
     // implicitly_convertible declaration order matters,
     // int should be tried before float conversion
+    py::implicitly_convertible<bool, Expr>();
     py::implicitly_convertible<int, Expr>();
     py::implicitly_convertible<float, Expr>();
     py::implicitly_convertible<double, Expr>();

--- a/python_bindings/src/PyExpr.cpp
+++ b/python_bindings/src/PyExpr.cpp
@@ -48,7 +48,6 @@ void define_expr(py::module &m) {
             .def("__nonzero__", to_bool)
 
             .def("type", &Expr::type)
-            .def("defined", &Expr::defined)
             .def("__repr__", [](const Expr &e) -> std::string {
                 std::ostringstream o;
                 o << "<halide.Expr of type " << halide_type_to_string(e.type()) << ": " << e << ">";


### PR DESCRIPTION
It was implicitly converting to a Halide `Int(32)` literal of value 1, but we want it to match Halide's boolean type of `UInt(1)`
