### PR TITLE
Allow `make test_apps` to work with ASAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2087,7 +2087,7 @@ build_python_bindings: distrib $(BIN_DIR)/host/runtime.a
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 		BIN=$(CURDIR)/$(BIN_DIR)/python3_bindings \
 		PYTHON=$(PYTHON) \
-		OPTIMIZE=$(OPTIMIZE)
+		OPTIMIZE="$(OPTIMIZE)"
 
 .PHONY: test_python
 test_python: distrib $(BIN_DIR)/host/runtime.a build_python_bindings
@@ -2097,7 +2097,7 @@ test_python: distrib $(BIN_DIR)/host/runtime.a build_python_bindings
 		HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR) \
 		BIN=$(CURDIR)/$(BIN_DIR)/python3_bindings \
 		PYTHON=$(PYTHON) \
-		OPTIMIZE=$(OPTIMIZE)
+		OPTIMIZE="$(OPTIMIZE)"
 
 # It's just for compiling the runtime, so earlier clangs *might* work,
 # but best to peg it to the minimum llvm version.


### PR DESCRIPTION
With asan or tsan in the target, there is a space in the OPTIMIZE var, so it needs to be quoted.