### PR TITLE
Add optional runtime H::R::Buffer access checks

### DIFF
--- a/apps/bgu/Makefile
+++ b/apps/bgu/Makefile
@@ -6,6 +6,10 @@ build: $(BIN)/$(HL_TARGET)/filter
 
 test: $(BIN)/$(HL_TARGET)/out.png
 
+# .SECONDARY with no prerequisites causes all targets to be treated as secondary
+# (i.e., no target is removed because it is considered intermediate).
+.SECONDARY:
+
 $(GENERATOR_BIN)/bgu.generator: bgu_generator.cpp $(GENERATOR_DEPS)
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) -g $(filter %.cpp,$^) -o $@ $(LIBHALIDE_LDFLAGS)

--- a/apps/bgu/filter.cpp
+++ b/apps/bgu/filter.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
     low_res_in.for_each_element([&](int x, int y, int c) {
         float val;
         // Sharpen, ignoring edges
-        if (x == 0 || x == W - 1 || y == 0 || y == H - 1) {
+        if (x == 0 || x == low_res_in.width() - 1 || y == 0 || y == low_res_in.height() - 1) {
             val = low_res_in(x, y, c);
         } else {
             val =

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -35,6 +35,10 @@
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
+#ifndef HALIDE_RUNTIME_BUFFER_CHECK_INDICES
+#define HALIDE_RUNTIME_BUFFER_CHECK_INDICES 0
+#endif
+
 namespace Halide {
 namespace Runtime {
 
@@ -1882,6 +1886,10 @@ private:
     HALIDE_ALWAYS_INLINE
         ptrdiff_t
         offset_of(int d, int first, Args... rest) const {
+        #if HALIDE_RUNTIME_BUFFER_CHECK_INDICES
+        assert(first >= this->buf.dim[d].min);
+        assert(first < this->buf.dim[d].min + this->buf.dim[d].extent);
+        #endif
         return offset_of(d + 1, rest...) + (ptrdiff_t)this->buf.dim[d].stride * (first - this->buf.dim[d].min);
     }
 
@@ -1905,6 +1913,10 @@ private:
     ptrdiff_t offset_of(const int *pos) const {
         ptrdiff_t offset = 0;
         for (int i = this->dimensions() - 1; i >= 0; i--) {
+            #if HALIDE_RUNTIME_BUFFER_CHECK_INDICES
+            assert(pos[i] >= this->buf.dim[i].min);
+            assert(pos[i] < this->buf.dim[i].min + this->buf.dim[i].extent);
+            #endif
             offset += (ptrdiff_t)this->buf.dim[i].stride * (pos[i] - this->buf.dim[i].min);
         }
         return offset;

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1886,10 +1886,10 @@ private:
     HALIDE_ALWAYS_INLINE
         ptrdiff_t
         offset_of(int d, int first, Args... rest) const {
-        #if HALIDE_RUNTIME_BUFFER_CHECK_INDICES
+#if HALIDE_RUNTIME_BUFFER_CHECK_INDICES
         assert(first >= this->buf.dim[d].min);
         assert(first < this->buf.dim[d].min + this->buf.dim[d].extent);
-        #endif
+#endif
         return offset_of(d + 1, rest...) + (ptrdiff_t)this->buf.dim[d].stride * (first - this->buf.dim[d].min);
     }
 
@@ -1913,10 +1913,10 @@ private:
     ptrdiff_t offset_of(const int *pos) const {
         ptrdiff_t offset = 0;
         for (int i = this->dimensions() - 1; i >= 0; i--) {
-            #if HALIDE_RUNTIME_BUFFER_CHECK_INDICES
+#if HALIDE_RUNTIME_BUFFER_CHECK_INDICES
             assert(pos[i] >= this->buf.dim[i].min);
             assert(pos[i] < this->buf.dim[i].min + this->buf.dim[i].extent);
-            #endif
+#endif
             offset += (ptrdiff_t)this->buf.dim[i].stride * (pos[i] - this->buf.dim[i].min);
         }
         return offset;

--- a/test/performance/fast_pow.cpp
+++ b/test/performance/fast_pow.cpp
@@ -69,22 +69,22 @@ int main(int argc, char **argv) {
 
     int timing_N = timing_scratch.width() * timing_scratch.height() * 10;
     int correctness_N = fast_result.width() * fast_result.height();
-    fast_err(0) = sqrt(fast_err(0) / correctness_N);
-    faster_err(0) = sqrt(faster_err(0) / correctness_N);
+    fast_err() = sqrt(fast_err() / correctness_N);
+    faster_err() = sqrt(faster_err() / correctness_N);
 
     printf("powf: %f ns per pixel\n"
            "Halide's pow: %f ns per pixel (rms error = %0.10f)\n"
            "Halide's fast_pow: %f ns per pixel (rms error = %0.10f)\n",
            1000000 * t1 / timing_N,
-           1000000 * t2 / timing_N, fast_err(0),
-           1000000 * t3 / timing_N, faster_err(0));
+           1000000 * t2 / timing_N, fast_err(),
+           1000000 * t3 / timing_N, faster_err());
 
-    if (fast_err(0) > 0.000001) {
+    if (fast_err() > 0.000001) {
         printf("Error for pow too large\n");
         return -1;
     }
 
-    if (faster_err(0) > 0.0001) {
+    if (faster_err() > 0.0001) {
         printf("Error for fast_pow too large\n");
         return -1;
     }


### PR DESCRIPTION
This adds some optional `assert()` checks to HRB's `operator()` and friends. They are only enabled if `HALIDE_RUNTIME_BUFFER_CHECK_INDICES=1` is defined at compile time.

Also fixes errors found by enabling these assertions and running tests.
