### PR TITLE
Add synthetic GeneratorParams to stubs (both C++ and Python)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1549,6 +1549,7 @@ STUBTEST_GENERATOR_ARGS=\
 	array_input.type=float32 array_input.size=2 \
 	int_arg.size=2 \
 	tuple_output.type=float32,float32 \
+	untyped_buffer_output.type=float32 \
 	vectorize=true
 
 $(FILTERS_DIR)/stubtest.a: $(BIN_DIR)/stubtest.generator

--- a/python_bindings/correctness/complexstub_generator.cpp
+++ b/python_bindings/correctness/complexstub_generator.cpp
@@ -17,7 +17,6 @@ Halide::Buffer<Type, 3> make_image(int extra) {
 
 class ComplexStub : public Halide::Generator<ComplexStub> {
 public:
-    GeneratorParam<Type> untyped_buffer_output_type{"untyped_buffer_output_type", Float(32)};
     GeneratorParam<bool> vectorize{"vectorize", true};
     GeneratorParam<LoopLevel> intermediate_level{"intermediate_level", LoopLevel::root()};
 
@@ -47,11 +46,7 @@ public:
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));
         typed_buffer_output(x, y, c) = cast<float>(typed_buffer_input(x, y, c));
-        // Note that if we are being invoked via a Stub, "untyped_buffer_output.type()" will
-        // assert-fail, because there is no type constraint set: the type
-        // will end up as whatever we infer from the values put into it. We'll use an
-        // explicit GeneratorParam to allow us to set it.
-        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output.type(), untyped_buffer_input(x, y, c));
 
         // Gratuitous intermediate for the purpose of exercising
         // GeneratorParam<LoopLevel>

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -174,10 +174,21 @@ def test_complexstub():
                     simple_input=input,
                     array_input=[ input, input ],
                     float_arg=float_arg,
-                    int_arg=[ int_arg, int_arg ],
-                    untyped_buffer_output_type="uint8",
+                    int_arg=[int_arg, int_arg],
+                    # We can put GeneratorParams anywhere in the list we want;
+                    # they will be examined and applied before anything else.
+                    untyped_buffer_output__type="uint8",
                     extra_func_input=func_input,
-                    vectorize=True)
+                    vectorize=True,
+                    # Let's set some others, even though we don't need to here:
+                    # We can specify a halide Type via string or object here
+                    simple_input__type=hl.UInt(8),
+                    untyped_buffer_input__type="uint8",
+                    # Can specify a list-of-types for Tuple output
+                    # tuple_output__type=[hl.Float(32), hl.Float(32)],
+                    # Alternately, we could specify comma-delimited string:
+                    tuple_output__type="float32,float32",
+                 )
 
     # return value is a tuple; unpack separately to avoid
     # making the callsite above unreadable

--- a/test/generator/stubtest_generator.cpp
+++ b/test/generator/stubtest_generator.cpp
@@ -20,7 +20,6 @@ Halide::Buffer<Type, 3> make_image(int extra) {
 
 class StubTest : public Halide::Generator<StubTest> {
 public:
-    GeneratorParam<Type> untyped_buffer_output_type{"untyped_buffer_output_type", Float(32)};
     GeneratorParam<float> float_param{"float_param", 3.1415926535f};
     GeneratorParam<std::string> str_param{"str_param", ""};
     GeneratorParam<BagType> bag_type{"bag_type",
@@ -56,11 +55,7 @@ public:
         bfloat16_output(x, y, c) = cast<Halide::bfloat16_t>(simple_input(x, y, c));
 
         typed_buffer_output(x, y, c) = cast<float>(typed_buffer_input(x, y, c));
-        // Note that if we are being invoked via a Stub, "untyped_buffer_output.type()" will
-        // assert-fail, because there is no type constraint set: the type
-        // will end up as whatever we infer from the values put into it. We'll use an
-        // explicit GeneratorParam to allow us to set it.
-        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output.type(), untyped_buffer_input(x, y, c));
 
         tupled_output(x, y, c) = Tuple(simple_output(x, y, c), cast<int32_t>(simple_output(x, y, c)) + 1);
 

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -63,6 +63,7 @@ int main(int argc, char **argv) {
     // Pass in a set of GeneratorParams: even though we aren't customizing
     // the values, we can set the LoopLevel values after-the-fact.
     StubTest::GeneratorParams gp;
+    gp.untyped_buffer_output__type = Float(32);
     auto gen = StubTest::generate(
         GeneratorContext(get_jit_target_from_environment()),
         // Use aggregate-initialization syntax to fill in an Inputs struct.

--- a/test/generator/stubuser_generator.cpp
+++ b/test/generator/stubuser_generator.cpp
@@ -53,7 +53,10 @@ public:
         inputs.int_arg = {int_arg};
 
         StubTest::GeneratorParams gp;
-        gp.untyped_buffer_output_type = int32_buffer_output.type();
+        // In GeneratorParams structs, synthetic params replace the "."
+        // with "__" in order to make a legal identifier, thus this
+        // is actually setting untyped_buffer_output.type
+        gp.untyped_buffer_output__type = int32_buffer_output.type();
         gp.intermediate_level.set(LoopLevel(calculated_output, Var("y")));
         gp.vectorize = true;
         gp.str_param = "2 x * y +";


### PR DESCRIPTION
Currently, there is no way to set 'synthetic' GeneratorParams via a GeneratorStub. ('synthetic' == things like "fieldname.type" for an input Buffer with an undefined static type.)

C++ GeneratorStubs are rarely used, but the Python stubs are useful, and (more importantly) revising this behavior to be possible will make some future work on Python generators more consistent.

Note that this should (in theory) have no effect on any existing C++ stub users; the new fields added to the stubs all have unique names, and aren't added to the default signatures.