### PR TITLE
Upgrade the PyStub code to handle synthetic GeneratorParams

### DIFF
--- a/python_bindings/correctness/complexstub_generator.cpp
+++ b/python_bindings/correctness/complexstub_generator.cpp
@@ -17,7 +17,6 @@ Halide::Buffer<Type, 3> make_image(int extra) {
 
 class ComplexStub : public Halide::Generator<ComplexStub> {
 public:
-    GeneratorParam<Type> untyped_buffer_output_type{"untyped_buffer_output_type", Float(32)};
     GeneratorParam<bool> vectorize{"vectorize", true};
     GeneratorParam<LoopLevel> intermediate_level{"intermediate_level", LoopLevel::root()};
 
@@ -47,11 +46,7 @@ public:
     void generate() {
         simple_output(x, y, c) = cast<float>(simple_input(x, y, c));
         typed_buffer_output(x, y, c) = cast<float>(typed_buffer_input(x, y, c));
-        // Note that if we are being invoked via a Stub, "untyped_buffer_output.type()" will
-        // assert-fail, because there is no type constraint set: the type
-        // will end up as whatever we infer from the values put into it. We'll use an
-        // explicit GeneratorParam to allow us to set it.
-        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output.type(), untyped_buffer_input(x, y, c));
 
         // Gratuitous intermediate for the purpose of exercising
         // GeneratorParam<LoopLevel>

--- a/python_bindings/correctness/pystub.py
+++ b/python_bindings/correctness/pystub.py
@@ -174,10 +174,27 @@ def test_complexstub():
                     simple_input=input,
                     array_input=[ input, input ],
                     float_arg=float_arg,
-                    int_arg=[ int_arg, int_arg ],
-                    untyped_buffer_output_type="uint8",
+                    int_arg=[int_arg, int_arg],
+                    # We can put GeneratorParams anywhere in the list we want;
+                    # they will be examined and applied before any inputs are
+                    # processed, and thus, any type/dimension constraints will be
+                    # enforced on inputs.
+                    #
+                    # Note that in Python, synthetic GeneratorParams
+                    # replace the '.' with a double underscore ('__'), so setting
+                    # untyped_buffer_output.type is accomplished like so:
+                    untyped_buffer_output__type="uint8",
                     extra_func_input=func_input,
-                    vectorize=True)
+                    vectorize=True,
+                    # Let's set some others, even though we don't need to here:
+                    # We can specify a halide Type via string or object here:
+                    simple_input__type=hl.UInt(8),
+                    untyped_buffer_input__type="uint8",
+                    # Can specify a list-of-types for Tuple output
+                    # tuple_output__type=[hl.Float(32), hl.Float(32)],
+                    # Alternately, we could specify comma-delimited string:
+                    tuple_output__type="float32,float32",
+                 )
 
     # return value is a tuple; unpack separately to avoid
     # making the callsite above unreadable

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -125,26 +125,54 @@ py::object generate_impl(const GeneratorFactory &factory, const GeneratorContext
 
     GeneratorParamsMap generator_params;
 
-    // Process the kwargs first.
+    // Process the GeneratorParams first, regardless of order;
+    // this allows us to rely on type/dim/etc constraints being in place
+    // before inputs are set.
     for (auto kw : kwargs) {
-        // If the kwarg is the name of a known input, stick it in the input
-        // vector. If not, stick it in the GeneratorParamsMap (if it's invalid,
-        // an error will be reported further downstream).
         std::string name = kw.first.cast<std::string>();
         py::handle value = kw.second;
         auto it = kw_inputs.find(name);
         if (it != kw_inputs.end()) {
-            _halide_user_assert(it->second.empty())
-                << "Generator Input named '" << it->first << "' was specified more than once.";
-            it->second = to_stub_inputs(py::cast<py::object>(value));
-            kw_inputs_specified++;
-        } else {
-            if (py::isinstance<LoopLevel>(value)) {
-                generator_params[name] = value.cast<LoopLevel>();
-            } else {
-                generator_params[name] = py::str(value).cast<std::string>();
-            }
+            continue;
         }
+
+        // In Python, synthetic params (eg "buffer.type") are specified
+        // by replacing the . with __ (this always works because user-specified
+        // names for GeneratorParams can never contain a double underscore).
+        // Translate those names back into the canonical dot form before doing the
+        // lookup!
+        name = Internal::replace_all(name, "__type", ".type");
+        name = Internal::replace_all(name, "__dim", ".dim");
+        name = Internal::replace_all(name, "__size", ".size");
+        if (py::isinstance<LoopLevel>(value)) {
+            generator_params[name] = value.cast<LoopLevel>();
+        } else if (py::isinstance<py::list>(value)) {
+            // Convert [hl.UInt(8), hl.Int(16)] -> uint8,int16
+            std::string v;
+            for (auto t : value) {
+                if (!v.empty()) {
+                    v += ",";
+                }
+                v += py::str(t).cast<std::string>();
+            }
+            generator_params[name] = v;
+        } else {
+            generator_params[name] = py::str(value).cast<std::string>();
+        }
+    }
+
+    // Now the inputs via kwargs.
+    for (auto kw : kwargs) {
+        std::string name = kw.first.cast<std::string>();
+        py::handle value = kw.second;
+        auto it = kw_inputs.find(name);
+        if (it == kw_inputs.end()) {
+            continue;
+        }
+        _halide_user_assert(it->second.empty())
+            << "Generator Input named '" << it->first << "' was specified more than once.";
+        it->second = to_stub_inputs(py::cast<py::object>(value));
+        kw_inputs_specified++;
     }
 
     std::vector<std::vector<StubInput>> inputs;


### PR DESCRIPTION
PyStub is the code that lets Python code call a (C++) Generator; this upgrades the code to allow passing in of 'synthetic' GeneratorParams (e.g. buffer.type), which it previously didn't handle.

At the moment this doesn't make a big difference (I'm not aware of ~any meaningful amount of code outside of the Python tests that use PyStub), but this will streamline some possible changes in an experimental branch and make future diffs less painful.