### PR TITLE
Add ldscript code for Python extensions in CMake

### DIFF
--- a/python_bindings/correctness/ext/CMakeLists.txt
+++ b/python_bindings/correctness/ext/CMakeLists.txt
@@ -25,14 +25,10 @@ foreach (GEN IN ITEMS addconstant bit user_context)
     #
     # TODO: How to do this for Windows as well?
     if (APPLE)
-        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript"
-             "_PyInit_${GEN}\n"
-        )
+        configure_file(ext.ldscript.apple.in "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
         target_link_options(py_${GEN} PRIVATE "-Wl,-exported_symbols_list,${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
     elseif (UNIX)
-        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript"
-             "{\nglobal: PyInit_${GEN};\nlocal: *;\n};\n"
-        )
+        configure_file(ext.ldscript.linux.in "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
         target_link_options(py_${GEN} PRIVATE "-Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
     endif()
 

--- a/python_bindings/correctness/ext/CMakeLists.txt
+++ b/python_bindings/correctness/ext/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(TargetExportScript)
+
 set(FEATURES_user_context user_context)
 
 foreach (GEN IN ITEMS addconstant bit user_context)
@@ -24,12 +26,12 @@ foreach (GEN IN ITEMS addconstant bit user_context)
     # when loading multiple of these Python extensions in the same space.)
     #
     # TODO: How to do this for Windows as well?
-    if (APPLE)
-        configure_file(ext.ldscript.apple.in "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
-        target_link_options(py_${GEN} PRIVATE "-Wl,-exported_symbols_list,${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
-    elseif (UNIX)
-        configure_file(ext.ldscript.linux.in "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
-        target_link_options(py_${GEN} PRIVATE "-Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
-    endif()
+    configure_file(ext.ldscript.apple.in "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript.apple")
+    configure_file(ext.ldscript.linux.in "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
+    target_export_script(
+        py_${GEN}
+        APPLE_LD "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript.apple"
+        GNU_LD "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript"
+    )
 
 endforeach ()

--- a/python_bindings/correctness/ext/CMakeLists.txt
+++ b/python_bindings/correctness/ext/CMakeLists.txt
@@ -18,4 +18,22 @@ foreach (GEN IN ITEMS addconstant bit user_context)
     Python3_add_library(py_${GEN} MODULE ${${GEN}_py_cpp})
     target_link_libraries(py_${GEN} PRIVATE ext_${GEN})
     set_target_properties(py_${GEN} PROPERTIES OUTPUT_NAME ${GEN}) # Python3_add_library adds target info to name.
+
+    # Fake up a linker script that will export *just* the PyInit entry
+    # point we want. (If we don't do this we can have interesting failures
+    # when loading multiple of these Python extensions in the same space.)
+    #
+    # TODO: How to do this for Windows as well?
+    if (APPLE)
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript"
+             "_PyInit_${GEN}\n"
+        )
+        target_link_options(py_${GEN} PRIVATE "-Wl,-exported_symbols_list,${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
+    elseif (UNIX)
+        file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript"
+             "{\nglobal: PyInit_${GEN};\nlocal: *;\n};\n"
+        )
+        target_link_options(py_${GEN} PRIVATE "-Wl,--version-script,${CMAKE_CURRENT_BINARY_DIR}/${GEN}.ldscript")
+    endif()
+
 endforeach ()

--- a/python_bindings/correctness/ext/ext.ldscript.apple.in
+++ b/python_bindings/correctness/ext/ext.ldscript.apple.in
@@ -1,0 +1,1 @@
+_PyInit_${GEN}

--- a/python_bindings/correctness/ext/ext.ldscript.linux.in
+++ b/python_bindings/correctness/ext/ext.ldscript.linux.in
@@ -1,0 +1,4 @@
+{
+global: PyInit_${GEN};
+local: *;
+};


### PR DESCRIPTION
We added ldscripts to the Makefile for Python extensions (to restrict exported symbols to just the PyInit_foo symbol), but neglected to do so for CMake. This corrects that.
