### PR TITLE
Future-proof 'processor` to `tune processor`

### DIFF
--- a/python_bindings/src/PyEnums.cpp
+++ b/python_bindings/src/PyEnums.cpp
@@ -83,7 +83,7 @@ void define_enums(py::module &m) {
         .value("WebAssembly", Target::Arch::WebAssembly);
 
     // Please keep sorted.
-    py::enum_<Target::Processor>(m, "TargetProcessor")
+    py::enum_<Target::Processor>(m, "TargetProcessorTune")
         .value("TuneAMDFam10", Target::Processor::AMDFam10)
         .value("TuneBdVer1", Target::Processor::BdVer1)
         .value("TuneBdVer2", Target::Processor::BdVer2)

--- a/python_bindings/src/PyTarget.cpp
+++ b/python_bindings/src/PyTarget.cpp
@@ -34,7 +34,7 @@ void define_target(py::module &m) {
             .def_readwrite("os", &Target::os)
             .def_readwrite("arch", &Target::arch)
             .def_readwrite("bits", &Target::bits)
-            .def_readwrite("processor", &Target::processor)
+            .def_readwrite("processor_tune", &Target::processor_tune)
 
             .def("__repr__", &target_repr)
             .def("__str__", &Target::to_string)

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -687,7 +687,7 @@ void CodeGen_X86::visit(const Store *op) {
 
 string CodeGen_X86::mcpu() const {
     // First, check if any explicit request for tuning exists.
-    switch (target.processor) {  // Please keep sorted.
+    switch (target.processor_tune) {  // Please keep sorted.
     case Target::Processor::AMDFam10:
         return "amdfam10";
     case Target::Processor::BdVer1:

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -615,7 +615,7 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
                 }
             }
             debug(1) << "Module.compile(): static_library " << output_files.at(OutputFileType::static_library) << "\n";
-            Target base_target(target().os, target().arch, target().bits, target().processor);
+            Target base_target(target().os, target().arch, target().bits, target().processor_tune);
             create_static_library(temp_dir.files(), base_target, output_files.at(OutputFileType::static_library));
         }
         if (contains(output_files, OutputFileType::assembly)) {
@@ -923,7 +923,7 @@ void compile_multitarget(const std::string &fn_name,
     // and add that to the result.
     if (!base_target.has_feature(Target::NoRuntime)) {
         // Start with a bare Target, set only the features we know are common to all.
-        Target runtime_target(base_target.os, base_target.arch, base_target.bits, base_target.processor);
+        Target runtime_target(base_target.os, base_target.arch, base_target.bits, base_target.processor_tune);
         for (int i = 0; i < Target::FeatureEnd; ++i) {
             // We never want NoRuntime set here.
             if (i == Target::NoRuntime) {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -517,7 +517,7 @@ bool merge_string(Target &t, const std::string &target) {
                 return false;
             }
             os_specified = true;
-        } else if (lookup_processor(tok, t.processor)) {
+        } else if (lookup_processor(tok, t.processor_tune)) {
             if (processor_specified) {
                 return false;
             }
@@ -675,9 +675,9 @@ std::string Target::to_string() const {
             break;
         }
     }
-    if (processor != ProcessorGeneric) {
+    if (processor_tune != ProcessorGeneric) {
         for (const auto &processor_entry : processor_name_map) {
-            if (processor_entry.second == processor) {
+            if (processor_entry.second == processor_tune) {
                 result += "-" + processor_entry.first;
                 break;
             }
@@ -1102,7 +1102,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // Union of features is computed through bitwise-or, and masked away by the features we care about
     // Intersection of features is computed through bitwise-and and masked away, too.
     // We merge the bits via bitwise or.
-    Target output = Target{os, arch, bits, processor};
+    Target output = Target{os, arch, bits, processor_tune};
     output.features = ((features | other.features) & union_mask) | ((features | other.features) & matching_mask) | ((features & other.features) & intersection_mask);
 
     // Pick tight lower bound for CUDA capability. Use fall-through to clear redundant features

--- a/src/Target.h
+++ b/src/Target.h
@@ -69,7 +69,7 @@ struct Target {
         ZnVer1,    /// Tune for AMD Zen   CPU (AMD Family 17h, launched 2017).
         ZnVer2,    /// Tune for AMD Zen 2 CPU (AMD Family 17h, launched 2019).
         ZnVer3,    /// Tune for AMD Zen 3 CPU (AMD Family 19h, launched 2020).
-    } processor = ProcessorGeneric;
+    } processor_tune = ProcessorGeneric;
 
     /** Optional features a target can have.
      * Corresponds to feature_name_map in Target.cpp.
@@ -157,8 +157,8 @@ struct Target {
         FeatureEnd = halide_target_feature_end
     };
     Target() = default;
-    Target(OS o, Arch a, int b, Processor p, const std::vector<Feature> &initial_features = std::vector<Feature>())
-        : os(o), arch(a), bits(b), processor(p) {
+    Target(OS o, Arch a, int b, Processor pt, const std::vector<Feature> &initial_features = std::vector<Feature>())
+        : os(o), arch(a), bits(b), processor_tune(pt) {
         for (const auto &f : initial_features) {
             set_feature(f);
         }
@@ -251,7 +251,7 @@ struct Target {
         return os == other.os &&
                arch == other.arch &&
                bits == other.bits &&
-               processor == other.processor &&
+               processor_tune == other.processor_tune &&
                features == other.features;
     }
 


### PR DESCRIPTION
This is mainly a future proofing.

#6655 added certain `processor` fields, which specify the CPU
for which we should tune, without implying features,
but the field name is awfully generic.

Once we want to add a second processor field,
that will mean features, such a field should have a name
of `processor`/`processor_target`, yet `processor` already means `tune`...

I'm not renaming the enum, i don't see why we'd need a second one.