### PR TITLE
Fix ctors for Realization

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -127,7 +127,7 @@ void define_func(py::module &m) {
                 "realize",
                 [](Func &f, std::vector<Buffer<>> buffers, const Target &t) -> void {
                     py::gil_scoped_release release;
-                    f.realize(Realization(buffers), t);
+                    f.realize(Realization(std::move(buffers)), t);
                 },
                 py::arg("dst"), py::arg("target") = Target())
 
@@ -260,7 +260,7 @@ void define_func(py::module &m) {
 
                     try {
                         std::vector<Buffer<>> v = dst.cast<std::vector<Buffer<>>>();
-                        f.infer_input_bounds(Realization(v), target);
+                        f.infer_input_bounds(Realization(std::move(v)), target);
                         return;
                     } catch (...) {
                         // fall thru

--- a/python_bindings/src/PyPipeline.cpp
+++ b/python_bindings/src/PyPipeline.cpp
@@ -105,7 +105,7 @@ void define_pipeline(py::module &m) {
             .def(
                 "realize", [](Pipeline &p, std::vector<Buffer<>> buffers, const Target &t) -> void {
                     py::gil_scoped_release release;
-                    p.realize(Realization(buffers), t);
+                    p.realize(Realization(std::move(buffers)), t);
                 },
                 py::arg("dst"), py::arg("target") = Target())
 
@@ -133,7 +133,7 @@ void define_pipeline(py::module &m) {
 
                     try {
                         std::vector<Buffer<>> v = dst.cast<std::vector<Buffer<>>>();
-                        p.infer_input_bounds(Realization(v), target);
+                        p.infer_input_bounds(Realization(std::move(v)), target);
                         return;
                     } catch (...) {
                         // fall thru

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3157,7 +3157,7 @@ void Func::infer_input_bounds(JITUserContext *context,
         Buffer<> im(func.output_types()[i], nullptr, sizes);
         outputs[i] = std::move(im);
     }
-    Realization r(outputs);
+    Realization r(std::move(outputs));
     infer_input_bounds(context, r, target, param_map);
 }
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -729,7 +729,7 @@ Realization Pipeline::realize(JITUserContext *context,
             bufs.emplace_back(t, nullptr, sizes);
         }
     }
-    Realization r(bufs);
+    Realization r(std::move(bufs));
     // Do an output bounds query if we can. Otherwise just assume the
     // output size is good.
     if (!target.has_feature(Target::NoBoundsQuery)) {
@@ -1308,7 +1308,7 @@ void Pipeline::infer_input_bounds(JITUserContext *context,
     for (Type t : contents->outputs[0].output_types()) {
         bufs.emplace_back(t, sizes);
     }
-    Realization r(bufs);
+    Realization r(std::move(bufs));
     infer_input_bounds(context, r, target, param_map);
 }
 

--- a/src/Realization.cpp
+++ b/src/Realization.cpp
@@ -5,36 +5,30 @@
 
 namespace Halide {
 
-/** The number of images in the Realization. */
 size_t Realization::size() const {
     return images.size();
 }
 
-/** Get a const reference to one of the images. */
 const Buffer<void> &Realization::operator[](size_t x) const {
     user_assert(x < images.size()) << "Realization access out of bounds\n";
     return images[x];
 }
 
-/** Get a reference to one of the images. */
 Buffer<void> &Realization::operator[](size_t x) {
     user_assert(x < images.size()) << "Realization access out of bounds\n";
     return images[x];
 }
 
-/** Construct a Realization that refers to the buffers in an
- * existing vector of Buffer<> */
-Realization::Realization(std::vector<Buffer<void>> &e)
+Realization::Realization(const std::vector<Buffer<void>> &e)
     : images(e) {
-    user_assert(!e.empty()) << "Realizations must have at least one element\n";
+    user_assert(!images.empty()) << "Realizations must have at least one element\n";
 }
 
-/** Call device_sync() for all Buffers in the Realization.
- * If one of the calls returns an error, subsequent Buffers won't have
- * device_sync called; thus callers should consider a nonzero return
- * code to mean that potentially all of the Buffers are in an indeterminate
- * state of sync.
- * Calling this explicitly should rarely be necessary, except for profiling. */
+Realization::Realization(std::vector<Buffer<void>> &&e)
+    : images(std::move(e)) {
+    user_assert(!images.empty()) << "Realizations must have at least one element\n";
+}
+
 int Realization::device_sync(void *ctx) {
     for (auto &b : images) {
         int result = b.device_sync(ctx);

--- a/src/Realization.h
+++ b/src/Realization.h
@@ -49,7 +49,10 @@ public:
 
     /** Construct a Realization that refers to the buffers in an
      * existing vector of Buffer<> */
-    explicit Realization(std::vector<Buffer<void>> &e);
+    // @{
+    explicit Realization(const std::vector<Buffer<void>> &e);
+    explicit Realization(std::vector<Buffer<void>> &&e);
+    // @}
 
     /** Call device_sync() for all Buffers in the Realization.
      * If one of the calls returns an error, subsequent Buffers won't have


### PR DESCRIPTION
For vector-of-Buffers, the ctor took a non-const ref to the argument, which was weird and nonsensical. Replaced with a const-ref version and and an rvalue-ref version; it turns out that literally *all* of the internal calls were able to use the latter, trivially saving some copies.