### PR TITLE
Remove deprecated JIT handler setters

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3309,33 +3309,6 @@ void set_handler(A &a, B b) {
 }
 }  // namespace
 
-// Deprecated setters for JIT handlers
-void Func::set_error_handler(void (*handler)(void *, const char *)) {
-    set_handler(jit_handlers().custom_error, handler);
-}
-
-void Func::set_custom_allocator(void *(*cust_malloc)(void *, size_t),
-                                void (*cust_free)(void *, void *)) {
-    set_handler(jit_handlers().custom_malloc, cust_malloc);
-    set_handler(jit_handlers().custom_free, cust_free);
-}
-
-void Func::set_custom_do_par_for(int (*cust_do_par_for)(void *, int (*)(void *, int, uint8_t *), int, int, uint8_t *)) {
-    set_handler(jit_handlers().custom_do_par_for, cust_do_par_for);
-}
-
-void Func::set_custom_do_task(int (*cust_do_task)(void *, int (*)(void *, int, uint8_t *), int, uint8_t *)) {
-    set_handler(jit_handlers().custom_do_task, cust_do_task);
-}
-
-void Func::set_custom_trace(int (*trace_fn)(void *, const halide_trace_event_t *)) {
-    set_handler(jit_handlers().custom_trace, trace_fn);
-}
-
-void Func::set_custom_print(void (*cust_print)(void *, const char *)) {
-    set_handler(jit_handlers().custom_print, cust_print);
-}
-
 void Func::add_custom_lowering_pass(IRMutator *pass, std::function<void()> deleter) {
     pipeline().add_custom_lowering_pass(pass, std::move(deleter));
 }

--- a/src/Func.h
+++ b/src/Func.h
@@ -1053,29 +1053,6 @@ public:
      */
     void compile_jit(const Target &target = get_jit_target_from_environment());
 
-    /** Deprecated variants of the above that use a void pointer
-     * instead of a JITUserContext pointer. */
-    // @{
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_error_handler(void (*handler)(void *, const char *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_allocator(void *(*malloc)(void *, size_t),
-                              void (*free)(void *, void *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_do_task(
-        int (*custom_do_task)(void *, int (*)(void *, int, uint8_t *),
-                              int, uint8_t *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_do_par_for(
-        int (*custom_do_par_for)(void *, int (*)(void *, int, uint8_t *), int,
-                                 int, uint8_t *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_trace(int (*trace_fn)(void *, const halide_trace_event_t *));
-
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_print(void (*handler)(void *, const char *));
-    // @}
-
     /** Get a struct containing the currently set custom functions
      * used by JIT. This can be mutated. Changes will take effect the
      * next time this Func is realized. */

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -640,43 +640,6 @@ void Pipeline::compile_jit(const Target &target_arg) {
     contents->jit_module = jit_module;
 }
 
-template<typename A, typename B>
-void set_handler(A &a, B b) {
-    a = (A)b;
-}
-
-void Pipeline::set_error_handler(void (*handler)(void *, const char *)) {
-    user_assert(defined()) << "Pipeline is undefined\n";
-    set_handler(contents->jit_handlers.custom_error, handler);
-}
-
-void Pipeline::set_custom_allocator(void *(*cust_malloc)(void *, size_t),
-                                    void (*cust_free)(void *, void *)) {
-    user_assert(defined()) << "Pipeline is undefined\n";
-    set_handler(contents->jit_handlers.custom_malloc, cust_malloc);
-    set_handler(contents->jit_handlers.custom_free, cust_free);
-}
-
-void Pipeline::set_custom_do_par_for(int (*cust_do_par_for)(void *, int (*)(void *, int, uint8_t *), int, int, uint8_t *)) {
-    user_assert(defined()) << "Pipeline is undefined\n";
-    set_handler(contents->jit_handlers.custom_do_par_for, cust_do_par_for);
-}
-
-void Pipeline::set_custom_do_task(int (*cust_do_task)(void *, int (*)(void *, int, uint8_t *), int, uint8_t *)) {
-    user_assert(defined()) << "Pipeline is undefined\n";
-    set_handler(contents->jit_handlers.custom_do_task, cust_do_task);
-}
-
-void Pipeline::set_custom_trace(int (*trace_fn)(void *, const halide_trace_event_t *)) {
-    user_assert(defined()) << "Pipeline is undefined\n";
-    set_handler(contents->jit_handlers.custom_trace, trace_fn);
-}
-
-void Pipeline::set_custom_print(void (*cust_print)(void *, const char *)) {
-    user_assert(defined()) << "Pipeline is undefined\n";
-    set_handler(contents->jit_handlers.custom_print, cust_print);
-}
-
 void Pipeline::set_jit_externs(const std::map<std::string, JITExtern> &externs) {
     user_assert(defined()) << "Pipeline is undefined\n";
     contents->jit_externs = externs;

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -349,28 +349,6 @@ public:
      */
     void compile_jit(const Target &target = get_jit_target_from_environment());
 
-    /** Deprecated variants of the above that use a void pointer
-     * instead of a JITUserContext pointer. */
-    // @{
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_error_handler(void (*handler)(void *, const char *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_allocator(void *(*malloc)(void *, size_t),
-                              void (*free)(void *, void *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_do_task(
-        int (*custom_do_task)(void *, int (*)(void *, int, uint8_t *),
-                              int, uint8_t *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_do_par_for(
-        int (*custom_do_par_for)(void *, int (*)(void *, int, uint8_t *), int,
-                                 int, uint8_t *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_trace(int (*trace_fn)(void *, const halide_trace_event_t *));
-    HALIDE_ATTRIBUTE_DEPRECATED("Custom handlers should by set by modifying the struct returned by jit_handlers()")
-    void set_custom_print(void (*handler)(void *, const char *));
-    // @}
-
     /** Install a set of external C functions or Funcs to satisfy
      * dependencies introduced by HalideExtern and define_extern
      * mechanisms. These will be used by calls to realize,


### PR DESCRIPTION
These were deprecated in Halide 14; let's remove them now.