### PR TITLE
Remove the last remaining call to getPointerElementType()

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -999,21 +999,16 @@ void CodeGen_ARM::visit(const Store *op) {
         // Declare the function
         std::ostringstream instr;
         vector<llvm::Type *> arg_types;
-        llvm::Type *intrin_llvm_type = llvm_type_of(intrin_type);
-#if LLVM_VERSION >= 150
-        const bool is_opaque = llvm::PointerType::get(intrin_llvm_type, 0)->isOpaque();
-#else
-        const bool is_opaque = false;
-#endif
         if (target.bits == 32) {
+            const char *type_annotation = (LLVM_VERSION < 150) ? ".p0i8" : ".p0";
             instr << "llvm.arm.neon.vst"
                   << num_vecs
-                  << (is_opaque ? ".p0" : ".p0i8")
+                  << type_annotation
                   << ".v"
                   << intrin_type.lanes()
                   << (t.is_float() ? 'f' : 'i')
                   << t.bits();
-            arg_types = vector<llvm::Type *>(num_vecs + 2, intrin_llvm_type);
+            arg_types = vector<llvm::Type *>(num_vecs + 2, llvm_type_of(intrin_type));
             arg_types.front() = i8_t->getPointerTo();
             arg_types.back() = i32_t;
         } else {
@@ -1024,10 +1019,11 @@ void CodeGen_ARM::visit(const Store *op) {
                   << (t.is_float() ? 'f' : 'i')
                   << t.bits()
                   << ".p0";
-            if (!is_opaque) {
-                instr << (t.is_float() ? 'f' : 'i') << t.bits();
+            if (LLVM_VERSION < 150) {
+                instr << (t.is_float() ? 'f' : 'i')
+                      << t.bits();
             }
-            arg_types = vector<llvm::Type *>(num_vecs + 1, intrin_llvm_type);
+            arg_types = vector<llvm::Type *>(num_vecs + 1, llvm_type_of(intrin_type));
             arg_types.back() = llvm_type_of(intrin_type.element_of())->getPointerTo();
         }
         llvm::FunctionType *fn_type = FunctionType::get(llvm::Type::getVoidTy(*context), arg_types, false);

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -667,7 +667,7 @@ void CodeGen_X86::visit(const Load *op) {
         const Ramp *ramp = op->index.as<Ramp>();
         internal_assert(ramp) << "Expected AMXTile to have index ramp\n";
         Value *ptr = codegen_buffer_pointer(op->name, op->type, ramp->base);
-        LoadInst *load = builder->CreateAlignedLoad(ptr->getType()->getPointerElementType(), ptr, llvm::Align(op->type.bytes()));
+        LoadInst *load = builder->CreateAlignedLoad(llvm_type_of(upgrade_type_for_storage(op->type)), ptr, llvm::Align(op->type.bytes()));
         add_tbaa_metadata(load, op->name, op->index);
         value = load;
         return;


### PR DESCRIPTION
LLVM is moving to opaque pointers, we must have missed this one in previous work