### PR TITLE
Combine string constants in combine_strings()

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -62,6 +62,10 @@ Expr stringify(const std::vector<Expr> &args) {
 }
 
 Expr combine_strings(const std::vector<Expr> &args) {
+    if (args.empty()) {
+        return Expr("");
+    }
+
     // Insert spaces between each expr.
     std::vector<Expr> strings(args.size() * 2);
     for (size_t i = 0; i < args.size(); i++) {

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -73,6 +73,20 @@ Expr combine_strings(const std::vector<Expr> &args) {
         }
     }
 
+    // Now combine all adjacent string literals, which is
+    // useful to reduce emitted code size when printing
+    size_t i = 0;
+    while (i < strings.size() - 1) {
+        const auto *cur_str = strings[i].as<Internal::StringImm>();
+        const auto *next_str = strings[i + 1].as<Internal::StringImm>();
+        if (cur_str && next_str) {
+            strings[i] = Internal::StringImm::make(cur_str->value + next_str->value);
+            strings.erase(strings.begin() + i + 1);
+            continue;
+        }
+        i++;
+    }
+
     return stringify(strings);
 }
 


### PR DESCRIPTION
This is a pretty trivial optimization, but when printing (or enabling `debug`), it cuts the number of `halide_string_to_string()` calls we generate by ~half.