### PR TITLE
Smarten type_of<> for fn ptrs; fix async_parallel for C backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1198,9 +1198,6 @@ GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_msan,$(GENERATOR_AOTCPP_
 # https://github.com/halide/Halide/issues/2075
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_memory_profiler_mandelbrot,$(GENERATOR_AOTCPP_TESTS))
 
-# https://github.com/halide/Halide/issues/2093
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_async_parallel,$(GENERATOR_AOTCPP_TESTS))
-
 # https://github.com/halide/Halide/issues/4916
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_stubtest,$(GENERATOR_AOTCPP_TESTS))
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_stubuser,$(GENERATOR_AOTCPP_TESTS))
@@ -1213,7 +1210,6 @@ test_aotcpp_generator: $(GENERATOR_AOTCPP_TESTS)
 # not all will work directly (e.g. due to missing define_externs at link time), so we disable
 # those known to be broken for plausible reasons.
 GENERATOR_BUILD_RUNGEN_TESTS = $(GENERATOR_EXTERNAL_TEST_GENERATOR:$(ROOT_DIR)/test/generator/%_generator.cpp=$(FILTERS_DIR)/%.rungen)
-GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/async_parallel.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/cxx_mangling_define_extern.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/define_extern_opencl.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/msan.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))

--- a/Makefile
+++ b/Makefile
@@ -1210,6 +1210,7 @@ test_aotcpp_generator: $(GENERATOR_AOTCPP_TESTS)
 # not all will work directly (e.g. due to missing define_externs at link time), so we disable
 # those known to be broken for plausible reasons.
 GENERATOR_BUILD_RUNGEN_TESTS = $(GENERATOR_EXTERNAL_TEST_GENERATOR:$(ROOT_DIR)/test/generator/%_generator.cpp=$(FILTERS_DIR)/%.rungen)
+GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/async_parallel.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/cxx_mangling_define_extern.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/define_extern_opencl.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))
 GENERATOR_BUILD_RUNGEN_TESTS := $(filter-out $(FILTERS_DIR)/msan.rungen,$(GENERATOR_BUILD_RUNGEN_TESTS))

--- a/src/LowerParallelTasks.cpp
+++ b/src/LowerParallelTasks.cpp
@@ -249,15 +249,18 @@ struct LowerParallelTasks : public IRMutator {
                 //
                 //   typedef int (*halide_task_t)(void *user_context, int task_number, uint8_t *closure);
                 //
+                closure_function_type = type_of<halide_task_t>();
+
                 closure_args[1] = make_scalar_arg<int32_t>(t.loop_var);
                 closure_args[2] = closure_arg;
                 // closure_task_parent remains undefined here.
-                closure_function_type = type_of<halide_task_t>();
             } else {
                 // The closure will be a halide_loop_task_t, with arguments like:
                 //
                 //   typedef int (*halide_loop_task_t)(void *user_context, int min, int extent, uint8_t *closure, void *task_parent);
                 //
+                closure_function_type = type_of<halide_loop_task_t>();
+
                 const std::string closure_task_parent_name = unique_name("__task_parent");
                 closure_task_parent = Variable::make(type_of<void *>(), closure_task_parent_name);
                 // We peeled off a loop. Wrap a new loop around the body
@@ -278,8 +281,6 @@ struct LowerParallelTasks : public IRMutator {
                 closure_args[2] = make_scalar_arg<int32_t>(loop_extent_name);
                 closure_args[3] = closure_arg;
                 closure_args[4] = make_scalar_arg<void *>(closure_task_parent_name);
-
-                closure_function_type = type_of<halide_loop_task_t>();
             }
 
             {

--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -299,7 +299,7 @@ std::string type_to_c_type(Type type, bool include_space, bool c_plus_plus) {
                     oss << " restrict";
                 }
                 if ((modifier & halide_handle_cplusplus_type::Pointer) &&
-                    !(modifier & halide_handle_cplusplus_type::FunctionPointer)) {
+                    !(modifier & halide_handle_cplusplus_type::FunctionTypedef)) {
                     oss << " *";
                 }
             }

--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -298,7 +298,8 @@ std::string type_to_c_type(Type type, bool include_space, bool c_plus_plus) {
                 if (modifier & halide_handle_cplusplus_type::Restrict) {
                     oss << " restrict";
                 }
-                if (modifier & halide_handle_cplusplus_type::Pointer) {
+                if ((modifier & halide_handle_cplusplus_type::Pointer) &&
+                    !(modifier & halide_handle_cplusplus_type::FunctionPointer)) {
                     oss << " *";
                 }
             }

--- a/src/Type.h
+++ b/src/Type.h
@@ -88,7 +88,7 @@ struct halide_handle_cplusplus_type {
         Volatile = 1 << 1,         ///< Bitmask flag for "volatile"
         Restrict = 1 << 2,         ///< Bitmask flag for "restrict"
         Pointer = 1 << 3,          ///< Bitmask flag for a pointer "*"
-        FunctionPointer = 1 << 4,  ///< Bitmask flag for a function pointer (if set, Pointer will also be set)
+        FunctionTypedef = 1 << 4,  ///< Bitmask flag for a function typedef; when this is set, Pointer should also always be set
     };
 
     /// Qualifiers and indirections on type. 0 is innermost.
@@ -210,7 +210,7 @@ template<typename T>
     constexpr bool is_volatile = std::is_volatile<TBase>::value;
 
     constexpr uint8_t modifiers = static_cast<uint8_t>(
-        (is_function_pointer ? halide_handle_cplusplus_type::FunctionPointer : 0) |
+        (is_function_pointer ? halide_handle_cplusplus_type::FunctionTypedef : 0) |
         (is_ptr ? halide_handle_cplusplus_type::Pointer : 0) |
         (is_const ? halide_handle_cplusplus_type::Const : 0) |
         (is_volatile ? halide_handle_cplusplus_type::Volatile : 0));

--- a/src/Type.h
+++ b/src/Type.h
@@ -84,10 +84,11 @@ struct halide_handle_cplusplus_type {
     /// One set of modifiers on a type.
     /// The const/volatile/restrict properties are "inside" the pointer property.
     enum Modifier : uint8_t {
-        Const = 1 << 0,     ///< Bitmask flag for "const"
-        Volatile = 1 << 1,  ///< Bitmask flag for "volatile"
-        Restrict = 1 << 2,  ///< Bitmask flag for "restrict"
-        Pointer = 1 << 3,   ///< Bitmask flag for a pointer "*"
+        Const = 1 << 0,            ///< Bitmask flag for "const"
+        Volatile = 1 << 1,         ///< Bitmask flag for "volatile"
+        Restrict = 1 << 2,         ///< Bitmask flag for "restrict"
+        Pointer = 1 << 3,          ///< Bitmask flag for a pointer "*"
+        FunctionPointer = 1 << 4,  ///< Bitmask flag for a function pointer (if set, Pointer will also be set)
     };
 
     /// Qualifiers and indirections on type. 0 is innermost.
@@ -163,6 +164,8 @@ HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(int64_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(uint64_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(Halide::float16_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(Halide::bfloat16_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(halide_task_t);
+HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(halide_loop_task_t);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(float);
 HALIDE_DECLARE_EXTERN_SIMPLE_TYPE(double);
 HALIDE_DECLARE_EXTERN_STRUCT_TYPE(halide_buffer_t);
@@ -196,11 +199,18 @@ template<typename T>
     constexpr bool is_lvalue_reference = std::is_lvalue_reference<T>::value;
     constexpr bool is_rvalue_reference = std::is_rvalue_reference<T>::value;
 
-    using TBase = typename std::remove_pointer<typename std::remove_reference<T>::type>::type;
+    using TNoRef = typename std::remove_reference<T>::type;
+    using TNoRefNoPtr = typename std::remove_pointer<TNoRef>::type;
+    constexpr bool is_function_pointer = std::is_pointer<TNoRef>::value &&
+                                         std::is_function<TNoRefNoPtr>::value;
+
+    // Don't remove the pointer-ness from a function pointer.
+    using TBase = typename std::conditional<is_function_pointer, TNoRef, TNoRefNoPtr>::type;
     constexpr bool is_const = std::is_const<TBase>::value;
     constexpr bool is_volatile = std::is_volatile<TBase>::value;
 
     constexpr uint8_t modifiers = static_cast<uint8_t>(
+        (is_function_pointer ? halide_handle_cplusplus_type::FunctionPointer : 0) |
         (is_ptr ? halide_handle_cplusplus_type::Pointer : 0) |
         (is_const ? halide_handle_cplusplus_type::Const : 0) |
         (is_volatile ? halide_handle_cplusplus_type::Volatile : 0));


### PR DESCRIPTION
(Fixes #2093)

This basically just adds the right type annotations to make the parallel code produced by the C backend compile properly. This could have been fixed by inserted some brute-force void* casting into the C backend, but this felt a lot cleaner.

The one thing here I'm a little unsure about is how I extended the Type code to be able to handle function-pointer types correctly; it works but doesn't feel very elegant.