### PR TITLE
Closure functions for parallel tasks should be internal, not external

### DIFF
--- a/src/LowerParallelTasks.cpp
+++ b/src/LowerParallelTasks.cpp
@@ -292,7 +292,7 @@ struct LowerParallelTasks : public IRMutator {
 
                 // TODO(zvookin): Figure out how we want to handle name mangling of closures.
                 // For now, the C++ backend makes them extern "C" so they have to be NameMangling::C.
-                LoweredFunc closure_func{new_function_name, closure_args, std::move(wrapped_body), LinkageType::External, NameMangling::C};
+                LoweredFunc closure_func{new_function_name, closure_args, std::move(wrapped_body), LinkageType::Internal, NameMangling::C};
                 if (target.has_feature(Target::Debug)) {
                     debug_arguments(&closure_func, target);
                 }


### PR DESCRIPTION
Minor optimization.