### PR TITLE
Remove `rounding_halving_sub` and non-existent arm rhsub instructions

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -297,14 +297,6 @@ const ArmIntrinsic intrinsic_defs[] = {
     {"vrhadds", "srhadd", Int(32, 2), "rounding_halving_add", {Int(32, 2), Int(32, 2)}, ArmIntrinsic::HalfWidth},
     {"vrhaddu", "urhadd", UInt(32, 2), "rounding_halving_add", {UInt(32, 2), UInt(32, 2)}, ArmIntrinsic::HalfWidth},
 
-    // SRHSUB, URHSUB - Halving sub with rounding
-    {"vrhsubs", "srhsub", Int(8, 8), "rounding_halving_sub", {Int(8, 8), Int(8, 8)}, ArmIntrinsic::HalfWidth},
-    {"vrhsubu", "urhsub", UInt(8, 8), "rounding_halving_sub", {UInt(8, 8), UInt(8, 8)}, ArmIntrinsic::HalfWidth},
-    {"vrhsubs", "srhsub", Int(16, 4), "rounding_halving_sub", {Int(16, 4), Int(16, 4)}, ArmIntrinsic::HalfWidth},
-    {"vrhsubu", "urhsub", UInt(16, 4), "rounding_halving_sub", {UInt(16, 4), UInt(16, 4)}, ArmIntrinsic::HalfWidth},
-    {"vrhsubs", "srhsub", Int(32, 2), "rounding_halving_sub", {Int(32, 2), Int(32, 2)}, ArmIntrinsic::HalfWidth},
-    {"vrhsubu", "urhsub", UInt(32, 2), "rounding_halving_sub", {UInt(32, 2), UInt(32, 2)}, ArmIntrinsic::HalfWidth},
-
     // SMIN, UMIN, FMIN - Min
     {"vmins", "smin", Int(8, 8), "min", {Int(8, 8), Int(8, 8)}, ArmIntrinsic::HalfWidth},
     {"vminu", "umin", UInt(8, 8), "min", {UInt(8, 8), UInt(8, 8)}, ArmIntrinsic::HalfWidth},

--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -447,16 +447,8 @@ protected:
                         rounding_halving_add(x, y),
                         is_x_same_int_or_uint) ||
 
-                rewrite(halving_add(widening_sub(x, y), 1),
-                        rounding_halving_sub(x, y),
-                        is_x_same_int_or_uint) ||
-
                 rewrite(rounding_shift_right(widening_add(x, y), 1),
                         rounding_halving_add(x, y),
-                        is_x_same_int_or_uint) ||
-
-                rewrite(rounding_shift_right(widening_sub(x, y), 1),
-                        rounding_halving_sub(x, y),
                         is_x_same_int_or_uint) ||
 
                 // Multiply-keep-high-bits patterns.
@@ -519,10 +511,6 @@ protected:
                 // Halving subtract patterns
                 rewrite(shift_right(cast(op_type_wide, widening_sub(x, y)), 1),
                         halving_sub(x, y),
-                        is_x_same_int_or_uint) ||
-
-                rewrite(rounding_shift_right(cast(op_type_wide, widening_sub(x, y)), 1),
-                        rounding_halving_sub(x, y),
                         is_x_same_int_or_uint) ||
 
                 false) {
@@ -592,13 +580,10 @@ protected:
             if (rewrite(halving_add(x + y, 1), rounding_halving_add(x, y)) ||
                 rewrite(halving_add(x, y + 1), rounding_halving_add(x, y)) ||
                 rewrite(halving_add(x + 1, y), rounding_halving_add(x, y)) ||
-                rewrite(halving_add(x - y, 1), rounding_halving_sub(x, y)) ||
-                rewrite(halving_sub(x + 1, y), rounding_halving_sub(x, y)) ||
                 rewrite(halving_add(x, 1), rounding_shift_right(x, 1)) ||
                 rewrite(shift_right(x + y, 1), halving_add(x, y)) ||
                 rewrite(shift_right(x - y, 1), halving_sub(x, y)) ||
                 rewrite(rounding_shift_right(x + y, 1), rounding_halving_add(x, y)) ||
-                rewrite(rounding_shift_right(x - y, 1), rounding_halving_sub(x, y)) ||
                 false) {
                 return mutate(rewrite.result);
             }
@@ -919,11 +904,6 @@ Expr lower_rounding_halving_add(const Expr &a, const Expr &b) {
     return (a >> 1) + (b >> 1) + (((a & 1) + (b & 1) + 1) >> 1);
 }
 
-Expr lower_rounding_halving_sub(const Expr &a, const Expr &b) {
-    internal_assert(a.type() == b.type());
-    return (a >> 1) - (b >> 1) + (((a & 1) - (b & 1) + 1) >> 1);
-}
-
 Expr lower_sorted_avg(const Expr &a, const Expr &b) {
     // b > a, so the following works without widening.
     return a + ((b - a) >> 1);
@@ -1040,9 +1020,6 @@ Expr lower_intrinsic(const Call *op) {
     } else if (op->is_intrinsic(Call::rounding_halving_add)) {
         internal_assert(op->args.size() == 2);
         return lower_rounding_halving_add(op->args[0], op->args[1]);
-    } else if (op->is_intrinsic(Call::rounding_halving_sub)) {
-        internal_assert(op->args.size() == 2);
-        return lower_rounding_halving_sub(op->args[0], op->args[1]);
     } else if (op->is_intrinsic(Call::rounding_mul_shift_right)) {
         internal_assert(op->args.size() == 3);
         return lower_rounding_mul_shift_right(op->args[0], op->args[1], op->args[2]);

--- a/src/FindIntrinsics.h
+++ b/src/FindIntrinsics.h
@@ -26,7 +26,6 @@ Expr lower_saturating_sub(const Expr &a, const Expr &b);
 Expr lower_halving_add(const Expr &a, const Expr &b);
 Expr lower_halving_sub(const Expr &a, const Expr &b);
 Expr lower_rounding_halving_add(const Expr &a, const Expr &b);
-Expr lower_rounding_halving_sub(const Expr &a, const Expr &b);
 
 Expr lower_mul_shift_right(const Expr &a, const Expr &b, const Expr &q);
 Expr lower_rounding_mul_shift_right(const Expr &a, const Expr &b, const Expr &q);

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -634,7 +634,6 @@ const char *const intrinsic_op_names[] = {
     "return_second",
     "rewrite_buffer",
     "rounding_halving_add",
-    "rounding_halving_sub",
     "rounding_mul_shift_right",
     "rounding_shift_left",
     "rounding_shift_right",

--- a/src/IR.h
+++ b/src/IR.h
@@ -543,7 +543,6 @@ struct Call : public ExprNode<Call> {
         return_second,
         rewrite_buffer,
         rounding_halving_add,
-        rounding_halving_sub,
         rounding_mul_shift_right,
         rounding_shift_left,
         rounding_shift_right,

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1437,8 +1437,6 @@ struct Intrin {
             return halving_sub(arg0, arg1);
         } else if (intrin == Call::rounding_halving_add) {
             return rounding_halving_add(arg0, arg1);
-        } else if (intrin == Call::rounding_halving_sub) {
-            return rounding_halving_sub(arg0, arg1);
         } else if (intrin == Call::shift_left) {
             return arg0 << arg1;
         } else if (intrin == Call::shift_right) {
@@ -1554,10 +1552,6 @@ auto halving_sub(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decl
 template<typename A, typename B>
 auto rounding_halving_add(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
     return {Call::rounding_halving_add, pattern_arg(a), pattern_arg(b)};
-}
-template<typename A, typename B>
-auto rounding_halving_sub(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {
-    return {Call::rounding_halving_sub, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
 auto shift_left(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decltype(pattern_arg(b))> {

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1249,13 +1249,6 @@ Expr halving_sub(Expr a, Expr b) {
     return Call::make(result_type, Call::halving_sub, {std::move(a), std::move(b)}, Call::PureIntrinsic);
 }
 
-Expr rounding_halving_sub(Expr a, Expr b) {
-    user_assert(a.defined() && b.defined()) << "rounding_halving_sub of undefined Expr\n";
-    match_types(a, b);
-    Type result_type = a.type();
-    return Call::make(result_type, Call::rounding_halving_sub, {std::move(a), std::move(b)}, Call::PureIntrinsic);
-}
-
 Expr mul_shift_right(Expr a, Expr b, Expr q) {
     user_assert(a.defined() && b.defined() && q.defined()) << "mul_shift_right of undefined Expr\n";
     user_assert(q.type().is_uint()) << "mul_shift_right shift must be unsigned\n";

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -375,8 +375,6 @@ Expr halving_add(Expr a, Expr b);
 Expr rounding_halving_add(Expr a, Expr b);
 /** Compute narrow((widen(a) - widen(b)) / 2) */
 Expr halving_sub(Expr a, Expr b);
-/** Compute narrow((widen(a) - widen(b) + 1) / 2) */
-Expr rounding_halving_sub(Expr a, Expr b);
 
 /** Compute saturating_narrow(shift_right(widening_mul(a, b), q)) */
 Expr mul_shift_right(Expr a, Expr b, Expr q);

--- a/test/correctness/intrinsics.cpp
+++ b/test/correctness/intrinsics.cpp
@@ -72,7 +72,6 @@ void check_intrinsics_over_range() {
                 {halving_add(a_expr, b_expr), (a + b) >> 1},
                 {rounding_halving_add(a_expr, b_expr), (a + b + 1) >> 1},
                 {halving_sub(a_expr, b_expr), (a - b) >> 1},
-                {rounding_halving_sub(a_expr, b_expr), (a - b + 1) >> 1},
             };
             for (const auto &p : intrinsics_with_reference_answer) {
                 Expr test = lower_intrinsics(p.first);
@@ -221,12 +220,6 @@ int main(int argc, char **argv) {
     check(i8((widening_add(i8x, i8y) + 1) / 2), rounding_halving_add(i8x, i8y));
     check(u8((widening_add(u8x, u8y) + 1) / 2), rounding_halving_add(u8x, u8y));
     check((i32x + i32y + 1) / 2, rounding_halving_add(i32x, i32y));
-
-    check(i8((i16(i8x) - i8y + 1) / 2), rounding_halving_sub(i8x, i8y));
-    check(u8((u16(u8x) - u8y + 1) / 2), rounding_halving_sub(u8x, u8y));
-    check(i8((widening_sub(i8x, i8y) + 1) / 2), rounding_halving_sub(i8x, i8y));
-    check(u8((widening_sub(u8x, u8y) + 1) / 2), rounding_halving_sub(u8x, u8y));
-    check((i32x - i32y + 1) / 2, rounding_halving_sub(i32x, i32y));
 
     // Check absd
     check(abs(i16(i8x) - i16(i8y)), u16(absd(i8x, i8y)));


### PR DESCRIPTION
These instructions don't seem to exist, they don't get produced when compiling for arm. https://github.com/gcc-mirror/gcc/commit/2e828dfe91a39a7a898ca6d8827048760e08b236 suggests that they were supposed to exist at some point, but were never implemented.