### PR TITLE
Add Func::output_type() method

### DIFF
--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -159,6 +159,7 @@ void define_func(py::module &m) {
             })
             .def("defined", &Func::defined)
             .def("outputs", &Func::outputs)
+            .def("output_type", &Func::output_type)
             .def("output_types", &Func::output_types)
 
             .def("bound", &Func::bound, py::arg("var"), py::arg("min"), py::arg("extent"))

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -188,7 +188,18 @@ void Func::define_extern(const std::string &function_name,
 }
 
 /** Get the types of the buffers returned by an extern definition. */
+const Type &Func::output_type() const {
+    user_assert(defined())
+        << "Can't access output buffer of undefined Func.\n";
+    user_assert(func.output_types().size() == 1)
+        << "Can't call Func::output_type on Func \"" << name()
+        << "\" because it returns a Tuple.\n";
+    return func.output_types()[0];
+}
+
 const std::vector<Type> &Func::output_types() const {
+    user_assert(defined())
+        << "Can't access output buffer of undefined Func.\n";
     return func.output_types();
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -1191,7 +1191,10 @@ public:
     // @}
 
     /** Get the types of the outputs of this Func. */
+    // @{
+    const Type &output_type() const;
     const std::vector<Type> &output_types() const;
+    // @}
 
     /** Get the number of outputs of this Func. Corresponds to the
      * size of the Tuple this Func was defined to return. */


### PR DESCRIPTION
Basically this mirrors the existing `output_buffer()` vs `output_buffers()` call -- the singular versions assert that the Func returns an Expr and not a Tuple. Also, add assertion to output_buffer() that checks if the Func is defined, to give a gentler failure mode.