### PR TITLE
Prefer accessing Generator's target, auto_schedule, and machine_params...

### DIFF
--- a/apps/HelloPyTorch/src/add_generator.cpp
+++ b/apps/HelloPyTorch/src/add_generator.cpp
@@ -30,7 +30,7 @@ public:
         output.set_estimates({{0, kEdge}, {0, kEdge}, {0, kEdge}, {0, kEdge}});
 
         // Schedule
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             Var tx("tx"), xy("xy"), cn("cn"), allvars("allvars");
             if (get_target().has_gpu_feature()) {
                 output
@@ -84,7 +84,7 @@ public:
         d_input_b.set_estimates({{0, kEdge}, {0, kEdge}, {0, kEdge}, {0, kEdge}});
 
         // Schedule
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             Var tx("tx"), xy("xy"), cn("cn"), allvars("allvars");
 
             if (get_target().has_gpu_feature()) {

--- a/apps/bgu/bgu_generator.cpp
+++ b/apps/bgu/bgu_generator.cpp
@@ -430,7 +430,7 @@ public:
             b(2, 2) += weighted_lambda * gain;
 
             // Now solve Ax = b
-            Matrix<3, 4> result = transpose(solve_symmetric(A, b, line, x, auto_schedule, get_target()));
+            Matrix<3, 4> result = transpose(solve_symmetric(A, b, line, x, get_auto_schedule(), get_target()));
 
             // Pack the resulting matrix into the output Func.
             line(x, y, z, c) = pack_channels(c, {result(0, 0),
@@ -509,7 +509,7 @@ public:
         output = slice;
 
         // Schedule
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             if (!get_target().has_gpu_feature()) {
                 // 7.09 ms on an Intel i9-9960X using 16 threads
                 //

--- a/apps/bilateral_grid/bilateral_grid_generator.cpp
+++ b/apps/bilateral_grid/bilateral_grid_generator.cpp
@@ -80,7 +80,7 @@ public:
         blury.set_estimate(z, 0, 12);
         bilateral_grid.set_estimates({{0, 1536}, {0, 2560}});
 
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // nothing
         } else if (get_target().has_gpu_feature()) {
             // 0.50ms on an RTX 2060

--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -154,7 +154,7 @@ public:
     void schedule() {
         Pipeline p(output);
 
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // blank
         } else if (get_target().has_gpu_feature()) {
             Var xi, yi;
@@ -270,7 +270,7 @@ Func CameraPipe::color_correct(Func input) {
     Expr val = (matrix_3200(x, y) * alpha + matrix_7000(x, y) * (1 - alpha));
     matrix(x, y) = cast<int16_t>(val * 256.0f);  // Q8.8 fixed point
 
-    if (!auto_schedule) {
+    if (!get_auto_schedule()) {
         matrix.compute_root();
         if (get_target().has_gpu_feature()) {
             matrix.gpu_single_thread();
@@ -331,7 +331,7 @@ Func CameraPipe::apply_curve(Func input) {
     // makeLUT add guard band outside of (minRaw, maxRaw]:
     curve(x) = select(x <= minRaw, 0, select(x > maxRaw, 255, val));
 
-    if (!auto_schedule) {
+    if (!get_auto_schedule()) {
         // It's a LUT, compute it once ahead of time.
         curve.compute_root();
         if (get_target().has_gpu_feature()) {
@@ -370,7 +370,7 @@ Func CameraPipe::sharpen(Func input) {
     // Convert the sharpening strength to 2.5 fixed point. This allows sharpening in the range [0, 4].
     Func sharpen_strength_x32("sharpen_strength_x32");
     sharpen_strength_x32() = u8_sat(sharpen_strength * 32);
-    if (!auto_schedule) {
+    if (!get_auto_schedule()) {
         sharpen_strength_x32.compute_root();
         if (get_target().has_gpu_feature()) {
             sharpen_strength_x32.gpu_single_thread();
@@ -439,12 +439,12 @@ void CameraPipe::generate() {
     processed.set_estimates({{0, 2592}, {0, 1968}, {0, 3}});
 
     // Schedule
-    if (auto_schedule) {
+    if (get_auto_schedule()) {
         // nothing
     } else if (get_target().has_gpu_feature()) {
 
         // We can generate slightly better code if we know the output is even-sized
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             // TODO: The autoscheduler really ought to be able to
             // accommodate bounds on the output Func.
             Expr out_width = processed.width();

--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -49,7 +49,7 @@ public:
 
         bias.dim(0).set_bounds(0, CO).set_stride(1);
 
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             input.dim(0).set_estimate(0, CI);
             input.dim(1).set_estimate(0, W + 2);
             input.dim(2).set_estimate(0, H + 2);

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -74,7 +74,7 @@ public:
         output(d, x, y, b) = max(pointwise_convolved(d, x, y, b), 0.f);
 
         // The schedule.
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // Second layer of MobileNet v2
             const int N = 4, CI = 32, CO = 16, CM = 1, W = 112, H = 112;
 
@@ -276,7 +276,7 @@ public:
                 .unroll(xi);
         }
 
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             // We're going to specialize both schedules for channel_multiplier = 1,
             // in which case it's nice to know that depthwise_filter
             // is dense across the second dimension.

--- a/apps/fft/fft_generator.cpp
+++ b/apps/fft/fft_generator.cpp
@@ -108,21 +108,21 @@ public:
                 Func in;
                 in(x, y) = input(x, y, 0);
 
-                complex_result = fft2d_r2c(in, size0, size1, target, desc);
+                complex_result = fft2d_r2c(in, size0, size1, get_target(), desc);
             } else {
                 ComplexFunc in;
                 in(x, y) = ComplexExpr(input(x, y, 0), 0);
 
-                complex_result = fft2d_c2c(in, size0, size1, sign, target, desc);
+                complex_result = fft2d_c2c(in, size0, size1, sign, get_target(), desc);
             }
         } else {
             ComplexFunc in;
             in(x, y) = ComplexExpr(input(x, y, 0), input(x, y, 1));
             if (output_number_type == FFTNumberType::Real &&
                 direction == FFTDirection::FrequencyToSamples) {
-                real_result = fft2d_c2r(in, size0, size1, target, desc);
+                real_result = fft2d_c2r(in, size0, size1, get_target(), desc);
             } else {
-                complex_result = fft2d_c2c(in, size0, size1, sign, target, desc);
+                complex_result = fft2d_c2c(in, size0, size1, sign, get_target(), desc);
             }
         }
 

--- a/apps/hannk/halide/depthwise_conv_generator.cpp
+++ b/apps/hannk/halide/depthwise_conv_generator.cpp
@@ -58,7 +58,7 @@ public:
 
         // For the shallow case, we need to know the vector size in the algorithm.
         int vector_size = natural_vector_size<uint8_t>();
-        if (get_register_count(target) < 32) {
+        if (get_register_count(get_target()) < 32) {
             vector_size = natural_vector_size<int16_t>();
         }
 
@@ -132,7 +132,7 @@ public:
 
         output_(c, x, y, b) =
             quantize_and_relu_u8(convolved(c, x, y, b), output_multiplier_, output_shift_,
-                                 output_zero_, output_min_, output_max_, target);
+                                 output_zero_, output_min_, output_max_, get_target());
 
         // Schedule.
         interpret_as_tensor(input_);

--- a/apps/harris/harris_generator.cpp
+++ b/apps/harris/harris_generator.cpp
@@ -72,7 +72,7 @@ public:
         }
 
         // Schedule
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             Var xi("xi"), yi("yi");
             if (get_target().has_gpu_feature()) {
                 // 0.253ms on a 2060 RTX

--- a/apps/hist/hist_generator.cpp
+++ b/apps/hist/hist_generator.cpp
@@ -64,7 +64,7 @@ public:
         }
 
         // Schedule
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             cdf.bound(x, 0, 256);
 
             Var xi("xi"), yi("yi");

--- a/apps/iir_blur/iir_blur_generator.cpp
+++ b/apps/iir_blur/iir_blur_generator.cpp
@@ -145,10 +145,10 @@ public:
         Expr height = input.height();
 
         // First, blur the columns of the input.
-        Func blury_T = blur_cols_transpose(input, height, alpha, auto_schedule, get_target());
+        Func blury_T = blur_cols_transpose(input, height, alpha, get_auto_schedule(), get_target());
 
         // Blur the columns again (the rows of the original).
-        Func blur = blur_cols_transpose(blury_T, width, alpha, auto_schedule, get_target());
+        Func blur = blur_cols_transpose(blury_T, width, alpha, get_auto_schedule(), get_target());
 
         // Scheduling is done inside blur_cols_transpose.
         output = blur;

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -72,7 +72,7 @@ public:
         normalize(x, y, c) = interpolated[0](x, y, c) / interpolated[0](x, y, 3);
 
         // Schedule
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             output = normalize;
         } else {
             // 0.86ms on a 2060 RTX

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -166,7 +166,7 @@ public:
         final.set_estimates({{0, 192}, {0, 320}, {0, 3}});
 
         /* THE SCHEDULE */
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // nothing
         } else if (get_target().has_gpu_feature()) {
             // Manual GPU schedule

--- a/apps/linear_algebra/src/blas_l1_generators.cpp
+++ b/apps/linear_algebra/src/blas_l1_generators.cpp
@@ -12,7 +12,6 @@ public:
     typedef Generator<AXPYGenerator<T>> Base;
     using Base::get_target;
     using Base::natural_vector_size;
-    using Base::target;
     template<typename T2>
     using Input = typename Base::template Input<T2>;
     template<typename T2>
@@ -77,7 +76,6 @@ public:
     typedef Generator<DotGenerator<T>> Base;
     using Base::get_target;
     using Base::natural_vector_size;
-    using Base::target;
     template<typename T2>
     using Input = typename Base::template Input<T2>;
     template<typename T2>
@@ -131,7 +129,6 @@ public:
     typedef Generator<AbsSumGenerator<T>> Base;
     using Base::get_target;
     using Base::natural_vector_size;
-    using Base::target;
     template<typename T2>
     using Input = typename Base::template Input<T2>;
     template<typename T2>

--- a/apps/linear_algebra/src/blas_l2_generators.cpp
+++ b/apps/linear_algebra/src/blas_l2_generators.cpp
@@ -12,7 +12,6 @@ public:
     typedef Generator<GEMVGenerator<T>> Base;
     using Base::get_target;
     using Base::natural_vector_size;
-    using Base::target;
     template<typename T2>
     using Input = typename Base::template Input<T2>;
     template<typename T2>
@@ -203,7 +202,6 @@ public:
     typedef Generator<GERGenerator<T>> Base;
     using Base::get_target;
     using Base::natural_vector_size;
-    using Base::target;
     template<typename T2>
     using Input = typename Base::template Input<T2>;
     template<typename T2>

--- a/apps/linear_algebra/src/blas_l3_generators.cpp
+++ b/apps/linear_algebra/src/blas_l3_generators.cpp
@@ -12,7 +12,6 @@ public:
     typedef Generator<GEMMGenerator<T>> Base;
     using Base::get_target;
     using Base::natural_vector_size;
-    using Base::target;
     template<typename T2>
     using Input = typename Base::template Input<T2>;
     template<typename T2>

--- a/apps/linear_blur/linear_blur_generator.cpp
+++ b/apps/linear_blur/linear_blur_generator.cpp
@@ -17,7 +17,7 @@ struct LinearBlur : public Halide::Generator<LinearBlur> {
         Func srgb = linear_to_srgb::generate(this, {blurred});
         output(x, y, c) = srgb(x, y, c);
 
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             input.set_estimates({{0, 1536}, {0, 2560}, {0, 4}});
             output.set_estimates({{0, 1536}, {0, 2560}, {0, 4}});
         } else {

--- a/apps/linear_blur/linear_to_srgb_generator.cpp
+++ b/apps/linear_blur/linear_to_srgb_generator.cpp
@@ -17,7 +17,7 @@ struct LinearTosRGB : public Halide::Generator<LinearTosRGB> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             const int W = 1536, H = 2560, C = 4;
             // Wart: Input<Func> are defined with Vars we don't know.
             // Might be x,y but might be _0,_1. Use the args() to work around.

--- a/apps/linear_blur/simple_blur_generator.cpp
+++ b/apps/linear_blur/simple_blur_generator.cpp
@@ -22,7 +22,7 @@ struct SimpleBlur : public Halide::Generator<SimpleBlur> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             const int W = 1536, H = 2560, C = 4;
             // Wart: Input<Func> are defined with Vars we don't know.
             // Might be x,y but might be _0,_1. Use the args() to work around.

--- a/apps/linear_blur/srgb_to_linear_generator.cpp
+++ b/apps/linear_blur/srgb_to_linear_generator.cpp
@@ -17,7 +17,7 @@ struct sRGBToLinear : public Halide::Generator<sRGBToLinear> {
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             const int W = 1536, H = 2560, C = 4;
             // Wart: Input<Func> are defined with Vars we don't know.
             // Might be x,y but might be _0,_1. Use the args() to work around.

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -98,7 +98,7 @@ public:
         output.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
 
         /* THE SCHEDULE */
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // Nothing.
         } else if (get_target().has_gpu_feature()) {
             // GPU schedule.

--- a/apps/max_filter/max_filter_generator.cpp
+++ b/apps/max_filter/max_filter_generator.cpp
@@ -64,7 +64,7 @@ public:
         }
 
         // Schedule
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             if (get_target().has_gpu_feature()) {
                 // 11.8ms on a 2060 RTX
 

--- a/apps/nl_means/nl_means_generator.cpp
+++ b/apps/nl_means/nl_means_generator.cpp
@@ -81,7 +81,7 @@ public:
         // Provide estimates on the output pipeline
         non_local_means.set_estimates({{0, 1536}, {0, 2560}, {0, 3}});
 
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // nothing
         } else if (get_target().has_gpu_feature()) {
             // 22 ms on a 2060 RTX

--- a/apps/stencil_chain/stencil_chain_generator.cpp
+++ b/apps/stencil_chain/stencil_chain_generator.cpp
@@ -45,7 +45,7 @@ public:
             output.set_estimates({{0, width}, {0, height}});
         }
 
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // nothing
         } else if (get_target().has_gpu_feature()) {
             // GPU schedule

--- a/apps/unsharp/unsharp_generator.cpp
+++ b/apps/unsharp/unsharp_generator.cpp
@@ -61,7 +61,7 @@ public:
         }
 
         // Schedule
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             // Some Intel Mac Minis have GPUs that require tile sizes smaller than 32x32
             // for this pipeline because they have too few registers. Drop to 16x16 to
             // avoid unexpected crashes in CI.

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -715,7 +715,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const MachineParams &p
             user_assert(sched.splits().empty())
                 << "The Func \"" << consumer.name() << "\" has scheduling directive(s) "
                 << "applied to it; you must remove these, or conditionalize them "
-                << "using `if (!auto_schedule)`, to use the autoscheduler on this pipeline.";
+                << "using `if (!get_auto_schedule())`, to use the autoscheduler on this pipeline.";
             stage.loop_nest_all_common_cases = true;
             for (size_t i = 0; i < sched.dims().size(); i++) {
                 const auto &d = sched.dims()[i];

--- a/src/autoschedulers/adams2019/cost_model_generator.cpp
+++ b/src/autoschedulers/adams2019/cost_model_generator.cpp
@@ -123,7 +123,7 @@ public:
     using Input = GeneratorInput<T>;
     template<typename T>
     using Output = GeneratorOutput<T>;
-    using Generator<CostModel<training>>::auto_schedule;
+    using Generator<CostModel<training>>::get_auto_schedule;
     using Generator<CostModel<training>>::get_pipeline;
 
     // Number of pipeline stages
@@ -482,9 +482,9 @@ public:
         true_runtime.set_estimates({{0, 80}});
 
         // SCHEDULE
-        if (training && !auto_schedule) {
+        if (training && !get_auto_schedule()) {
             do_cost_model_schedule(get_pipeline());
-        } else if (auto_schedule) {
+        } else if (get_auto_schedule()) {
             // Do nothing.
         } else {
             // We just write down a good schedule for

--- a/src/autoschedulers/adams2019/included_schedule_file_generator.cpp
+++ b/src/autoschedulers/adams2019/included_schedule_file_generator.cpp
@@ -37,7 +37,7 @@ struct IncludedScheduleFile : public Halide::Generator<IncludedScheduleFile> {
         relu.set_estimates({{0, CO}, {0, W}, {0, H}, {0, N}});
 
         // Schedule
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // nothing
         } else {
 #if defined(GENERATING_SCHEDULE)

--- a/test/generator/example_generator.cpp
+++ b/test/generator/example_generator.cpp
@@ -81,7 +81,7 @@ public:
         runtime_factor.set_estimate(1);
         output.set_estimates({{0, 32}, {0, 32}, {0, 3}});
 
-        if (!auto_schedule) {
+        if (!get_auto_schedule()) {
             output
                 .bound(c, 0, channels)
                 .reorder(c, x, y)

--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -69,7 +69,7 @@ public:
     }
 
     void schedule() {
-        if (auto_schedule) {
+        if (get_auto_schedule()) {
             // The auto-scheduler requires estimates on all the input/output
             // sizes and parameter values in order to compare different
             // alternatives and decide on a good schedule.


### PR DESCRIPTION
...via the existing getter methods, rather than the direct fieldnames.

The underlying GeneratorParams implementing them are going to (eventually) go away, in favor of the fields in GeneratorContext; this is a first step in cleaning up the code.