### PR TITLE
Deprecate the direct use of `target`, `auto_schedule`, `machine_params`

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1261,6 +1261,19 @@ std::vector<std::string> GeneratorRegistry::enumerate() {
     return result;
 }
 
+#ifdef HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#endif  // HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
+
 GeneratorBase::GeneratorBase(size_t size, const void *introspection_helper)
     : size(size) {
     ObjectInstanceRegistry::register_instance(this, size, ObjectInstanceRegistry::Generator, this, introspection_helper);
@@ -1269,6 +1282,17 @@ GeneratorBase::GeneratorBase(size_t size, const void *introspection_helper)
 GeneratorBase::~GeneratorBase() {
     ObjectInstanceRegistry::unregister_instance(this);
 }
+
+#ifdef HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#endif  // HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
 
 GeneratorParamInfo::GeneratorParamInfo(GeneratorBase *generator, const size_t size) {
     std::vector<void *> vf = ObjectInstanceRegistry::instances_in_range(
@@ -1393,18 +1417,52 @@ void GeneratorBase::set_generator_param_values(const GeneratorParamsMap &params)
 
 #ifdef HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
 GeneratorContext GeneratorBase::context() const {
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     return GeneratorContext(target, auto_schedule, machine_params, externs_map, value_tracker);
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 }
 #endif
 
 void GeneratorBase::init_from_context(const Halide::GeneratorContext &context) {
 #ifdef HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     target.set(context.target_);
     auto_schedule.set(context.auto_schedule_);
     machine_params.set(context.machine_params_);
 
     externs_map = context.externs_map_;
     value_tracker = context.value_tracker_;
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #else
     context_ = context;
 #endif

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -975,7 +975,7 @@ gengen
     args.suffixes = split_string(pop("target"), ",");
     args.targets = build_targets(args.suffixes);
     args.auto_schedule = auto_schedule_string == "true" || auto_schedule_string == "True";
-    args.machine_params = machine_params_string.empty() ? MachineParams::generic() :  MachineParams(machine_params_string);
+    args.machine_params = machine_params_string.empty() ? MachineParams::generic() : MachineParams(machine_params_string);
     args.output_dir = flags_info["-o"];
     args.output_types = build_output_types();
     args.generator_name = flags_info["-g"];

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -249,7 +249,7 @@
  * \endcode
  *
  * Note that a Generator is always executed with a specific Target assigned to it,
- * that you can access via the get_target() method. (You should *not* use the
+ * that you can access via the target() method. (You should *not* use the
  * global get_target_from_environment(), etc. methods provided in Target.h)
  *
  * (Note that there are older variations of Generator that differ from what's
@@ -385,9 +385,7 @@ template<typename First, typename... Rest>
 struct select_type : std::conditional<First::value, typename First::type, typename select_type<Rest...>::type> {};
 
 template<typename First>
-struct select_type<First> {
-    using type = typename std::conditional<First::value, typename First::type, void>::type;
-};
+struct select_type<First> { using type = typename std::conditional<First::value, typename First::type, void>::type; };
 
 class GeneratorParamInfo;
 
@@ -3580,13 +3578,13 @@ protected:
 
 #else
     Target get_target() const {
-        return context().get_target();
+        return context().target();
     }
     bool get_auto_schedule() const {
-        return context().get_auto_schedule();
+        return context().auto_schedule();
     }
     MachineParams get_machine_params() const {
-        return context().get_machine_params();
+        return context().machine_params();
     }
 #endif
 
@@ -4062,6 +4060,12 @@ struct ExecuteGeneratorArgs {
     // Target(s) to use when generating. Must not be empty.
     // If list contains multiple entries, a multitarget output will be produced.
     std::vector<Target> targets;
+
+    // If true, auto-schedule.
+    bool auto_schedule = false;
+
+    // MachineParams used for autoscheduling.
+    MachineParams machine_params = MachineParams::generic();
 
     // When generating multitarget output, use these as the suffixes for each Target
     // specified by the targets field. If empty, the canonical string form of

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -351,7 +351,9 @@ template<typename First, typename... Rest>
 struct select_type : std::conditional<First::value, typename First::type, typename select_type<Rest...>::type> {};
 
 template<typename First>
-struct select_type<First> { using type = typename std::conditional<First::value, typename First::type, void>::type; };
+struct select_type<First> {
+    using type = typename std::conditional<First::value, typename First::type, void>::type;
+};
 
 class GeneratorBase;
 class GeneratorParamInfo;
@@ -2103,7 +2105,9 @@ public:
 };
 
 template<typename>
-struct type_sink { typedef void type; };
+struct type_sink {
+    typedef void type;
+};
 
 template<typename T2, typename = void>
 struct has_static_halide_type_method : std::false_type {};
@@ -3403,6 +3407,16 @@ protected:
     void ensure_configure_has_been_called();
 
 #ifdef HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     Target get_target() const {
         return target;
     }
@@ -3412,6 +3426,14 @@ protected:
     MachineParams get_machine_params() const {
         return machine_params;
     }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #else
     Target get_target() const {
         return context().get_target();
@@ -3449,8 +3471,11 @@ protected:
 
 #ifdef HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS
     // These must remain here for legacy code that access the fields directly.
+    HALIDE_ATTRIBUTE_DEPRECATED("The `target` GeneratorParam is deprecated for Halide Generators and will be removed entirely in future versions of Halide. Please use get_target() instead.")
     GeneratorParam<Target> target{"target", Target()};
+    HALIDE_ATTRIBUTE_DEPRECATED("The `auto_schedule` GeneratorParam is deprecated for Halide Generators and will be removed entirely in future versions of Halide. Please use get_auto_schedule() instead.")
     GeneratorParam<bool> auto_schedule{"auto_schedule", false};
+    HALIDE_ATTRIBUTE_DEPRECATED("The `machine_params` GeneratorParam is deprecated for Halide Generators and will be removed entirely in future versions of Halide. Please use get_machine_params() instead.")
     GeneratorParam<MachineParams> machine_params{"machine_params", MachineParams::generic()};
 #endif
 
@@ -3725,7 +3750,9 @@ private:
     // std::is_member_function_pointer will fail if there is no member of that name,
     // so we use a little SFINAE to detect if there are method-shaped members.
     template<typename>
-    struct type_sink { typedef void type; };
+    struct type_sink {
+        typedef void type;
+    };
 
     template<typename T2, typename = void>
     struct has_configure_method : std::false_type {};


### PR DESCRIPTION
These GeneratorParams have been special-cased ~forever, and really need to be a part of GeneratorContext rather than their own GeneratorParams. This defaults to making them vanish entirely; code can opt-in to continue using it (with a deprecation warning) by defining `HALIDE_ALLOW_LEGACY_GENERATOR_PARAMS` at compiletime (similar to how we handled deprecation of the `build()` method last version).