### PR TITLE
Augment Halide::Func to allow for constraining Type and Dimensionality

### DIFF
--- a/python_bindings/correctness/basics.py
+++ b/python_bindings/correctness/basics.py
@@ -309,11 +309,44 @@ def test_bool_conversion():
     # Verify that this doesn't fail with 'Argument passed to specialize must be of type bool'
     f.compute_root().specialize(True)
 
+def test_typed_funcs():
+    x = hl.Var('x')
+    y = hl.Var('y')
+
+    f = hl.Func(hl.Int(32), 1, 'f')
+    try:
+        f[x, y] = hl.i32(0);
+        f.realize([10, 10])
+    except RuntimeError as e:
+        assert 'is constrained to have exactly 1 dimensions, but is defined with 2 dimensions' in str(e)
+    else:
+        assert False, 'Did not see expected exception!'
+
+    f = hl.Func(hl.Int(32), 2, 'f')
+    try:
+        f[x, y] = hl.i16(0);
+        f.realize([10, 10])
+    except RuntimeError as e:
+        assert 'is constrained to only hold values of type int32 but is defined with values of type int16' in str(e)
+    else:
+        assert False, 'Did not see expected exception!'
+
+    f = hl.Func((hl.Int(32), hl.Float(32)), 2, 'f')
+    try:
+        f[x, y] = (hl.i16(0), hl.f64(0))
+        f.realize([10, 10])
+    except RuntimeError as e:
+        assert 'is constrained to only hold values of type (int32, float32) but is defined with values of type (int16, float64)' in str(e)
+    else:
+        assert False, 'Did not see expected exception!'
+
+
 if __name__ == "__main__":
     test_compiletime_error()
     test_runtime_error()
     test_misused_and()
     test_misused_or()
+    test_typed_funcs()
     test_float_or_int()
     test_operator_order()
     test_int_promotion()

--- a/python_bindings/src/PyFunc.cpp
+++ b/python_bindings/src/PyFunc.cpp
@@ -108,6 +108,8 @@ void define_func(py::module &m) {
         py::class_<Func>(m, "Func")
             .def(py::init<>())
             .def(py::init<std::string>())
+            .def(py::init<Type, int, std::string>(), py::arg("required_type"), py::arg("required_dimensions"), py::arg("name"))
+            .def(py::init<std::vector<Type>, int, std::string>(), py::arg("required_types"), py::arg("required_dimensions"), py::arg("name"))
             .def(py::init<Expr>())
             .def(py::init([](Buffer<> &b) -> Func { return Func(b); }))
 

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -8,7 +8,9 @@
 
 namespace Halide {
 
-template<typename T = void, int Dims = Halide::Runtime::AnyDims>
+constexpr int AnyDims = Halide::Runtime::AnyDims;  // -1
+
+template<typename T = void, int Dims = AnyDims>
 class Buffer;
 
 struct JITUserContext;
@@ -153,7 +155,7 @@ class Buffer {
     }
 
 public:
-    static constexpr int AnyDims = Halide::Runtime::AnyDims;
+    static constexpr int AnyDims = Halide::AnyDims;
     static_assert(Dims == AnyDims || Dims >= 0);
 
     typedef T ElemType;

--- a/src/Func.h
+++ b/src/Func.h
@@ -715,6 +715,19 @@ public:
     /** Declare a new undefined function with the given name */
     explicit Func(const std::string &name);
 
+    /** Declare a new undefined function with the given name.
+     * The function will be constrained to represent Exprs of required_type.
+     * If required_dims is not AnyDims, the function will be constrained to exactly
+     * that many dimensions. */
+    explicit Func(const Type &required_type, int required_dims, const std::string &name);
+
+    /** Declare a new undefined function with the given name.
+     * If required_types is not empty, the function will be constrained to represent
+     * Tuples of the same arity and types. (If required_types is empty, there is no constraint.)
+     * If required_dims is not AnyDims, the function will be constrained to exactly
+     * that many dimensions. */
+    explicit Func(const std::vector<Type> &required_types, int required_dims, const std::string &name);
+
     /** Declare a new undefined function with an
      * automatically-generated unique name */
     Func();

--- a/src/Function.h
+++ b/src/Function.h
@@ -17,6 +17,7 @@
 namespace Halide {
 
 struct ExternFuncArgument;
+class Tuple;
 
 class Var;
 
@@ -56,6 +57,13 @@ public:
 
     /** Construct a new function with the given name */
     explicit Function(const std::string &n);
+
+    /** Construct a new function with the given name,
+     * with a requirement that it can only represent Expr(s) of the given type(s),
+     * and must have exactly the give nnumber of dimensions.
+     * required_types.empty() means there are no constraints on the type(s).
+     * required_dims == AnyDims means there are no constraints on the dimensions. */
+    explicit Function(const std::vector<Type> &required_types, int required_dims, const std::string &n);
 
     /** Construct a Function from an existing FunctionContents pointer. Must be non-null */
     explicit Function(const FunctionPtr &);
@@ -292,6 +300,18 @@ public:
 
     /** Return true iff the name matches one of the Function's pure args. */
     bool is_pure_arg(const std::string &name) const;
+
+    /** If the Function has type requirements, check that the given argument
+     * is compatible with them. If not, assert-fail. (If there are no type requirements, do nothing.) */
+    void check_types(const Expr &e) const;
+    void check_types(const Tuple &t) const;
+    void check_types(const Type &t) const;
+    void check_types(const std::vector<Expr> &exprs) const;
+    void check_types(const std::vector<Type> &types) const;
+
+    /** If the Function has dimension requirements, check that the given argument
+     * is compatible with them. If not, assert-fail. (If there are no dimension requirements, do nothing.) */
+    void check_dims(int dims) const;
 };
 
 /** Deep copy an entire Function DAG. */

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -687,6 +687,8 @@ Realization Pipeline::realize(JITUserContext *context,
     user_assert(defined()) << "Pipeline is undefined\n";
     vector<Buffer<>> bufs;
     for (auto &out : contents->outputs) {
+        user_assert((int)sizes.size() == out.dimensions())
+            << "Func " << out.name() << " is defined with " << out.dimensions() << " dimensions, but realize() is requesting a realization with " << sizes.size() << " dimensions.\n";
         user_assert(out.has_pure_definition() || out.has_extern_definition()) << "Can't realize Pipeline with undefined output Func: " << out.name() << ".\n";
         for (Type t : out.output_types()) {
             bufs.emplace_back(t, nullptr, sizes);

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -44,6 +44,14 @@ tests(GROUPS error
       five_d_gpu_buffer.cpp
       float_arg.cpp
       forward_on_undefined_buffer.cpp
+      func_expr_dim_mismatch.cpp
+      func_expr_type_mismatch.cpp
+      func_expr_update_type_mismatch.cpp
+      func_extern_dim_mismatch.cpp
+      func_extern_type_mismatch.cpp
+      func_tuple_dim_mismatch.cpp
+      func_tuple_types_mismatch.cpp
+      func_tuple_update_types_mismatch.cpp
       implicit_args.cpp
       impossible_constraints.cpp
       init_def_should_be_all_vars.cpp

--- a/test/error/func_expr_dim_mismatch.cpp
+++ b/test/error/func_expr_dim_mismatch.cpp
@@ -1,0 +1,17 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f(Int(32), 1, "f");
+
+    f(x, y) = cast<int>(0);
+
+    f.realize({100, 100});
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/func_expr_type_mismatch.cpp
+++ b/test/error/func_expr_type_mismatch.cpp
@@ -1,0 +1,17 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f(Float(32), 1, "f");
+
+    f(x, y) = cast<int>(0);
+
+    f.realize({100, 100});
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/func_expr_update_type_mismatch.cpp
+++ b/test/error/func_expr_update_type_mismatch.cpp
@@ -1,0 +1,18 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f(Float(32), 2, "f");
+
+    f(x, y) = 0.f;
+    f(x, y) += cast<uint8_t>(0);
+
+    f.realize({100, 100});
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/func_extern_dim_mismatch.cpp
+++ b/test/error/func_extern_dim_mismatch.cpp
@@ -1,0 +1,14 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f(Float(32), 1, "f");
+    f.define_extern("test", {}, Float(32), {x, y});
+    f.realize({100, 100});
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/func_extern_type_mismatch.cpp
+++ b/test/error/func_extern_type_mismatch.cpp
@@ -1,0 +1,14 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f({UInt(8), Float(64)}, 2, "f");
+    f.define_extern("test", {}, {Int(32), Float(32)}, {x, y});
+    f.realize({100, 100});
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/func_tuple_dim_mismatch.cpp
+++ b/test/error/func_tuple_dim_mismatch.cpp
@@ -1,0 +1,17 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f({Int(32), Float(32)}, 1, "f");
+
+    f(x, y) = {cast<int>(0), cast<float>(0)};
+
+    f.realize({100, 100});
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/func_tuple_types_mismatch.cpp
+++ b/test/error/func_tuple_types_mismatch.cpp
@@ -1,0 +1,17 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f({UInt(8), Float(64)}, 2, "f");
+
+    f(x, y) = {cast<int>(0), cast<float>(0)};
+
+    f.realize({100, 100});
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/func_tuple_update_types_mismatch.cpp
+++ b/test/error/func_tuple_update_types_mismatch.cpp
@@ -1,0 +1,18 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y");
+    Func f({UInt(8), Float(64)}, 2, "f");
+
+    f(x, y) = {cast<uint8_t>(0), cast<double>(0)};
+    f(x, y) += {cast<int>(0), cast<float>(0)};
+
+    f.realize({100, 100});
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
This enhances Func by allowing you to (optionally) constrain the type(s) of Exprs that the Func can contain, and/or the dimensionality of the Func. (Attempting to violate either of these will assert-fail.)

There are a few goals here:
- Enhanced code readability; in cases where a Func's values may not be obvious from the code flow, this can allow an in-code way of declaring it (rather than via comments)
- Enhanced type enforcement; specifying constraints allows us to fail in type-mismatched compilations somewhat sooner, with somewhat better error messages.
- Better symmetry for AOT/JIT code generation with ImageParam, in which the inputs (ImageParam) have a way to specify the required concrete type, but the outputs (Funcs) don't.

If this is accepted, then subsequent changes will likely add uses where it makes sense (e.g., the Func associated with an ImageParam should always have both type and dimensionality specified since it will always be well-known).

Note that this doesn't add any C++ template class for static declarations (e.g. `FuncT<float, 2>` -> `Func(Float(32), 2)`); these could be added later if desired.