### PR TITLE
Add a CTAD for PrintTypeList

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -467,6 +467,9 @@ target_compile_options(
         # This warning was removed in Clang 13
         $<$<AND:$<CXX_COMPILER_ID:Clang,AppleClang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,13.0>>:-Wno-return-std-move-in-c++11>
 
+        # This warning was added in Clang 13 -- some downstream code will complain without it
+        $<$<AND:$<CXX_COMPILER_ID:Clang,AppleClang>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,13.0>>:-Wctad-maybe-unsupported>
+
         $<$<CXX_COMPILER_ID:MSVC>:/W3>
         $<$<CXX_COMPILER_ID:MSVC>:/wd4018>  # 4018: disable "signed/unsigned mismatch"
         $<$<CXX_COMPILER_ID:MSVC>:/wd4141>  # 4141: 'inline' used more than once

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -362,8 +362,13 @@ struct PrintTypeList {
     }
 };
 
-// Add an explicit CTAD here just in case we are compiling in an environment with a
-// warning like `-Wctad-maybe-unsupported` enabled.
+// Add an explicit (user-defined) deduction guide here, just in case we are
+// compiling in an environment with a warning like `-Wctad-maybe-unsupported` enabled.
+//
+// See:
+//
+//      https://en.cppreference.com/w/cpp/language/class_template_argument_deduction
+//      https://reviews.llvm.org/D56731?id=181972
 template<typename T>
 PrintTypeList(const std::vector<T> &) -> PrintTypeList<T>;
 

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -362,11 +362,8 @@ struct PrintTypeList {
     }
 };
 
-// Some compilers will (inexplicably) complain:
-//
-//    'PrintTypeList' may not intend to support class template argument deduction
-//
-// ...so add a CTAD to deal with this.
+// Add an explicit CTAD here just in case we are compiling in an environment with a
+// warning like `-Wctad-maybe-unsupported` enabled.
 template<typename T>
 PrintTypeList(const std::vector<T> &) -> PrintTypeList<T>;
 

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -362,6 +362,14 @@ struct PrintTypeList {
     }
 };
 
+// Some compilers will (inexplicably) complain:
+//
+//    'PrintTypeList' may not intend to support class template argument deduction
+//
+// ...so add a CTAD to deal with this.
+template<typename T>
+PrintTypeList(const std::vector<T> &) -> PrintTypeList<T>;
+
 bool types_match(const std::vector<Type> &types, const std::vector<Expr> &exprs) {
     size_t n = types.size();
     if (n != exprs.size()) {


### PR DESCRIPTION
This smells like a compiler bug to me, because I don't see any ambiguity, but this is needed to eliminate a downstream issue, and should be harmless to conforming C++17 compilers.