### PR TITLE
Fix regression from #6734

### DIFF
--- a/test/error/func_expr_update_type_mismatch.cpp
+++ b/test/error/func_expr_update_type_mismatch.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     Func f(Float(32), 2, "f");
 
     f(x, y) = 0.f;
-    f(x, y) += cast<uint8_t>(0);
+    f(x, y) = cast<uint8_t>(0);
 
     f.realize({100, 100});
 

--- a/test/error/func_tuple_update_types_mismatch.cpp
+++ b/test/error/func_tuple_update_types_mismatch.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     Func f({UInt(8), Float(64)}, 2, "f");
 
     f(x, y) = {cast<uint8_t>(0), cast<double>(0)};
-    f(x, y) += {cast<int>(0), cast<float>(0)};
+    f(x, y) = {cast<int>(0), cast<float>(0)};
 
     f.realize({100, 100});
 


### PR DESCRIPTION
That change inadvertently required the RHS of an update stage that used `+=` (or similar operators) to match the LHS type, which should be required (implicit casting of the RHS is expected). Restructured to remove this, but still ensure that auto-injection of a pure definition matches the required types (if any), and updated tests.