### PR TITLE
Revise PyStub calling convention for GeneratorParams

### DIFF
--- a/python_bindings/Makefile
+++ b/python_bindings/Makefile
@@ -151,7 +151,8 @@ GENPARAMS_complex=\
 	array_input.type=uint8 \
 	int_arg.size=2 \
 	simple_input.type=uint8 \
-	untyped_buffer_input.type=uint8
+	untyped_buffer_input.type=uint8 \
+	untyped_buffer_output.type=uint8
 
 GENPARAMS_simple=\
 	func_input.type=uint8

--- a/python_bindings/correctness/generators/CMakeLists.txt
+++ b/python_bindings/correctness/generators/CMakeLists.txt
@@ -20,7 +20,8 @@ set(GENPARAMS_complex
     array_input.type=uint8
     int_arg.size=2
     simple_input.type=uint8
-    untyped_buffer_input.type=uint8)
+    untyped_buffer_input.type=uint8
+    untyped_buffer_output.type=uint8)
 
 set(GENPARAMS_simple
     func_input.type=uint8)

--- a/python_bindings/correctness/generators/complex_generator.cpp
+++ b/python_bindings/correctness/generators/complex_generator.cpp
@@ -17,7 +17,6 @@ Halide::Buffer<Type, 3> make_image(int extra) {
 
 class Complex : public Halide::Generator<Complex> {
 public:
-    GeneratorParam<Type> untyped_buffer_output_type{"untyped_buffer_output_type", Float(32)};
     GeneratorParam<bool> vectorize{"vectorize", true};
     GeneratorParam<LoopLevel> intermediate_level{"intermediate_level", LoopLevel::root()};
 
@@ -52,7 +51,7 @@ public:
         // assert-fail, because there is no type constraint set: the type
         // will end up as whatever we infer from the values put into it. We'll use an
         // explicit GeneratorParam to allow us to set it.
-        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output_type, untyped_buffer_input(x, y, c));
+        untyped_buffer_output(x, y, c) = cast(untyped_buffer_output.output_type(), untyped_buffer_input(x, y, c));
 
         // Gratuitous intermediate for the purpose of exercising
         // GeneratorParam<LoopLevel>

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -211,7 +211,7 @@ const Type &Func::output_type() const {
 const std::vector<Type> &Func::output_types() const {
     const auto &types = defined() ? func.output_types() : func.required_types();
     user_assert(!types.empty())
-        << "Can't call Func::output_type on Func \"" << name()
+        << "Can't call Func::output_types on Func \"" << name()
         << "\" because it is undefined or has no type requirements.\n";
     return types;
 }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -79,6 +79,11 @@ bool is_valid_name(const std::string &n) {
             return false;
         }
     }
+    // prohibit this specific string so that we can use it for
+    // passing GeneratorParams in Python.
+    if (n == "generator_params") {
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
This is a rethink of https://github.com/halide/Halide/pull/6661, trying to make it saner in anticipation of the ongoing Python Generator work.

TL;DR: instead of mixing GeneratorParams in with the rest of the keywords, segregate them into an optional `generator_params` keyword argument, which is a plain Python dict. This neatly solves a couple of problems:
- synthetic params with funky names aren't a problem anymore.
- error reporting is simpler because before an unknown keyword could have been intended to be a GP or an Input.
- GP values are now clear and distinct from Inputs, which is IMHO a good thing.

This is technically a breaking change, but I doubt anyone will notice; this is mainly here to get a sane convention in place for use with Python Generators as well.

Also, a drive-by change to Func::output_types() to fix the assertion error message.