### PR TITLE
Add a way to prohibit calls to ImageParam/Param::set

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1717,7 +1717,9 @@ public:
     operator ImageParam() const {
         this->check_gio_access();
         user_assert(!this->is_array()) << "Cannot convert an Input<Buffer<>[]> to an ImageParam; use an explicit subscript operator: " << this->name();
-        return ImageParam(this->parameters_.at(0), Func(*this));
+        ImageParam im(this->parameters_.at(0), Func(*this));
+        im.parameter().freeze();
+        return im;
     }
 
     template<typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
@@ -1729,13 +1731,17 @@ public:
     template<typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
     ImageParam operator[](size_t i) const {
         this->check_gio_access();
-        return ImageParam(this->parameters_.at(i), this->funcs().at(i));
+        ImageParam im(this->parameters_.at(i), this->funcs().at(i));
+        im.parameter().freeze();
+        return im;
     }
 
     template<typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>
     ImageParam at(size_t i) const {
         this->check_gio_access();
-        return ImageParam(this->parameters_.at(i), this->funcs().at(i));
+        ImageParam im(this->parameters_.at(i), this->funcs().at(i));
+        im.parameter().freeze();
+        return im;
     }
 
     template<typename T2 = T, typename std::enable_if<std::is_array<T2>::value>::type * = nullptr>

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -191,10 +191,6 @@ void Parameter::set_buffer(const Buffer<> &b) {
     contents->buffer = b;
 }
 
-    /** Disallow any future calls to `set_buffer()` for the Parameter; attempts to
-     * do so will assert-fail. Only relevant when jitting */
-    void freeze_buffer();
-
 const void *Parameter::scalar_address() const {
     check_is_scalar();
     return &contents->data;


### PR DESCRIPTION
The goal here is to allow us to 'freeze' an ImageParam (or Param) so that it is no longer legal to call set_scalar(), set_buffer(), etc on it. In normal JIT usage, it's unlikely you'd ever want to do this, but for Generators, it would be undesirable for Generator code to (say) cast an input to an ImageParam and bind a Buffer to it directly, since the meaning is only well-defined forJIT usage.

This is in the category of "I don't know of anyone misusing this right now, but I want to disallow it before anyone does, because Hyrum's Law exists."

Also, drive-by fixes for const-correctness and memcpy usage in Parameter.h.