### PR TITLE
Deprecate GeneratorContext getters with `get_` prefix

### DIFF
--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -649,7 +649,7 @@ void StubEmitter::emit() {
     for (const auto &out : out_info) {
         stream << get_indent() << "stub." << out.getter << ",\n";
     }
-    stream << get_indent() << "stub.generator->context().get_target()\n";
+    stream << get_indent() << "stub.generator->context().target()\n";
     indent_level--;
     stream << get_indent() << "};\n";
     indent_level--;

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2949,12 +2949,25 @@ public:
     GeneratorContext(GeneratorContext &&) = default;
     GeneratorContext &operator=(GeneratorContext &&) = default;
 
+    const Target &target() const {
+        return target_;
+    }
+    bool auto_schedule() const {
+        return auto_schedule_;
+    }
+    const MachineParams &machine_params() const {
+        return machine_params_;
+    }
+
+    HALIDE_ATTRIBUTE_DEPRECATED("Call GeneratorContext::target() instead of GeneratorContext::get_target().")
     const Target &get_target() const {
         return target_;
     }
+    HALIDE_ATTRIBUTE_DEPRECATED("Call GeneratorContext::auto_schedule() instead of GeneratorContext::get_auto_schedule().")
     bool get_auto_schedule() const {
         return auto_schedule_;
     }
+    HALIDE_ATTRIBUTE_DEPRECATED("Call GeneratorContext::machine_params() instead of GeneratorContext::get_machine_params().")
     const MachineParams &get_machine_params() const {
         return machine_params_;
     }


### PR DESCRIPTION
Minor hygiene: most getters in Halide don't have a `get_` prefix. These are very rarely used (only one instance in our test suite I could find) but, hey, cleanliness.