### PR TITLE
AOT `_metadata()` getters should be multitarget-aware

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1050,7 +1050,7 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
         /* num_arguments */ ConstantInt::get(i32_t, num_args),
         /* arguments */ ConstantExpr::getInBoundsGetElementPtr(arguments_array, arguments_array_storage, zeros),
         /* target */ create_string_constant(target.to_string()),
-        /* name */ create_string_constant(function_name)};
+        /* name */ create_string_constant(map_string(function_name))};
 
     GlobalVariable *metadata_storage = new GlobalVariable(
         *module,

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1149,7 +1149,11 @@ gengen
                 gen->set_generator_param_values(sub_generator_args);
                 return build_gradient_module ? gen->build_gradient_module(fn_name) : gen->build_module(fn_name);
             };
-            compile_multitarget(function_name, output_files, targets, /*suffixes*/ {}, module_factory, compiler_logger_factory);
+            // Pass target_strings for suffixes; if we omit this, we'll use *canonical* target strings
+            // for suffixes, but our caller might have passed non-canonical-but-still-legal target strings,
+            // and if we don't use those, the output filenames might not match what the caller expects.
+            const auto &suffixes = target_strings;
+            compile_multitarget(function_name, output_files, targets, suffixes, module_factory, compiler_logger_factory);
         }
     }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1129,7 +1129,7 @@ gengen
                 gen->set_generator_param_values(sub_generator_args);
                 return build_gradient_module ? gen->build_gradient_module(name) : gen->build_module(name);
             };
-            compile_multitarget(function_name, output_files, targets, target_strings, module_factory, compiler_logger_factory);
+            compile_multitarget(function_name, output_files, targets, /*suffixes*/ {}, module_factory, compiler_logger_factory);
         }
     }
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -954,7 +954,7 @@ void compile_multitarget(const std::string &fn_name,
 
     if (needs_wrapper) {
         const auto make_wrapper = [](const std::vector<Expr> &wrapper_args, const std::string &fn_name) -> Stmt {
-            internal_assert(fn_name.find("-") == std::string::npos);
+            internal_assert(fn_name.find('-') == std::string::npos);
             Expr indirect_result = Call::make(Int(32), Call::call_cached_indirect_function, wrapper_args, Call::Intrinsic);
             std::string private_result_name = unique_name(fn_name + "_result");
             Expr private_result_var = Variable::make(Int(32), private_result_name);

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -954,7 +954,7 @@ void compile_multitarget(const std::string &fn_name,
 
     if (needs_wrapper) {
         const auto make_wrapper = [](const std::vector<Expr> &wrapper_args, const std::string &fn_name) -> Stmt {
-            internal_assert(fn_name.find('-') == std::string::npos);
+            internal_assert(fn_name.find('-') == std::string::npos) << fn_name;
             Expr indirect_result = Call::make(Int(32), Call::call_cached_indirect_function, wrapper_args, Call::Intrinsic);
             std::string private_result_name = unique_name(fn_name + "_result");
             Expr private_result_var = Variable::make(Int(32), private_result_name);

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -760,6 +760,11 @@ void compile_multitarget(const std::string &fn_name,
     user_assert(suffixes.empty() || suffixes.size() == targets.size())
         << "The suffixes list must be empty or the same length as the targets list.\n";
 
+    // Some tests were mistakenly passing filenames/pathnames here, which is not kosher
+    for (char c : "/\\-") {
+        user_assert(fn_name.find(c) == std::string::npos) << "compile_multitarget: fn_name must not contain '" << c << "', but saw '" << fn_name << "'\n";
+    }
+
     // The final target in the list is considered "baseline", and is used
     // for (e.g.) the runtime and shared code. It is often just arch-bits-os
     // with no other features (though this is *not* a requirement).

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -761,7 +761,7 @@ void compile_multitarget(const std::string &fn_name,
         << "The suffixes list must be empty or the same length as the targets list.\n";
 
     // Some tests were mistakenly passing filenames/pathnames here, which is not kosher
-    for (char c : "/\\-") {
+    for (char c : "/\\") {
         user_assert(fn_name.find(c) == std::string::npos) << "compile_multitarget: fn_name must not contain '" << c << "', but saw '" << fn_name << "'\n";
     }
 
@@ -864,10 +864,8 @@ void compile_multitarget(const std::string &fn_name,
 
         // Each sub-target has a function name that is the 'real' name plus a suffix
         std::string suffix = suffix_for_entry(i);
-        // Leave the filenames with hyphens in them, but normalize the - to _ in function/symbol names.
-        std::string suffix_for_fn_names = replace_all(suffix, "-", "_");
-        std::string sub_fn_name = needs_wrapper ? (fn_name + suffix_for_fn_names) : fn_name;
-        std::string md_sub_fn_name = needs_wrapper ? (fn_name + suffix_for_fn_names + "_metadata") : md_fn_name;
+        std::string sub_fn_name = needs_wrapper ? (fn_name + suffix) : fn_name;
+        std::string md_sub_fn_name = needs_wrapper ? (fn_name + suffix + "_metadata") : md_fn_name;
 
         // We always produce the runtime separately, so add NoRuntime explicitly.
         Target sub_fn_target = target.with_feature(Target::NoRuntime);
@@ -959,7 +957,6 @@ void compile_multitarget(const std::string &fn_name,
 
     if (needs_wrapper) {
         const auto make_wrapper = [](const std::vector<Expr> &wrapper_args, const std::string &fn_name) -> Stmt {
-            internal_assert(fn_name.find('-') == std::string::npos) << fn_name;
             Expr indirect_result = Call::make(Int(32), Call::call_cached_indirect_function, wrapper_args, Call::Intrinsic);
             std::string private_result_name = unique_name(fn_name + "_result");
             Expr private_result_var = Variable::make(Int(32), private_result_name);

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -5,6 +5,13 @@
 
 using namespace Halide;
 
+// Given a path like /path/to/some/file.ext, return file.ext
+// If the path contains no separators (/ or \), just return it as-is
+std::string leaf_name(const std::string &path) {
+    size_t sep = std::min(path.rfind('/'), path.rfind('\\'));
+    return path.substr(sep == std::string::npos ? 0 : sep + 1);
+}
+
 std::string get_fname(const std::string &base) {
     return Internal::get_test_tmp_dir() + "halide_test_correctness_compile_to_multitarget_" + base;
 }
@@ -205,7 +212,8 @@ void test_compile_to_everything(Func j, bool do_object) {
         // it exists or not --  so just fill in with arbitrary strings.
         return std::unique_ptr<Internal::CompilerLogger>(new Internal::JSONCompilerLogger("generator_name", "function_name", "autoscheduler_name", Target(), "generator_args", false));
     };
-    compile_multitarget(fname, outputs, targets, target_strings, module_producer, compiler_logger_factory);
+    // The first argument to compile_multitarget is *function* name, not filename
+    compile_multitarget(leaf_name(fname), outputs, targets, target_strings, module_producer, compiler_logger_factory);
 
     for (auto f : files) {
         Internal::assert_file_exists(f);

--- a/test/generator/multitarget_generator.cpp
+++ b/test/generator/multitarget_generator.cpp
@@ -1,3 +1,4 @@
+
 #include "Halide.h"
 
 namespace {


### PR DESCRIPTION
Multitarget codegen has worked correctly for years, but calling the generated `_metadata()` function (returning `halide_filter_metadata_t*`) has been subtly wrong: the `target` field always contains the baseline target. This PR proposes to smarten the codegen by using the same `can_use_target` logic for the generated metadata getters, so that the `target` field you inspect always matches the one that was used for the actual filter that will be executed.

(This is, admittedly, a rather niche use case, but if nothing else, it is helpful for some debug and test scenarios, as it gives us a simpler way to verify at runtime that the version we are executing is the one we expect.)