### PR TITLE
Revise the calling convention of the generated code for _metadata

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1529,7 +1529,7 @@ void CodeGen_C::emit_metadata_getter(const std::string &function_name,
 
         // Add an inline wrapper that uses the older name and calling convention,
         // so that existing code (probably) doesn't need to change.
-        stream << "HALIDE_FUNCTION_ATTRS\ninline const struct halide_filter_metadata_t *" << function_name << "_metadata() {\n";
+        stream << "\nHALIDE_FUNCTION_ATTRS\ninline const struct halide_filter_metadata_t *" << function_name << "_metadata() {\n";
         stream << "    const halide_filter_metadata_t *md = nullptr;\n";
         stream << "    int r = " << function_name << "_get_metadata(&md);\n";
         stream << "    return r == 0 ? md : nullptr;\n";

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1072,8 +1072,7 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
     llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", metadata_getter);
     builder->SetInsertPoint(block);
     llvm::Value *arg_array = iterator_to_pointer(metadata_getter->arg_begin());
-    llvm::Value *md_out = builder->CreateConstInBoundsGEP1_32(arg_types[0], arg_array, 0);
-    builder->CreateStore(metadata_storage, md_out);
+    builder->CreateStore(metadata_storage, arg_array);
     builder->CreateRet(ConstantInt::getSigned(i32_t, 0));
     internal_assert(!verifyFunction(*metadata_getter, &llvm::errs()));
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -187,7 +187,7 @@ void halide_register_argv_and_metadata(
 
 $NAMESPACEOPEN$
 extern int $SHORTNAME$_argv(void **args);
-extern const struct halide_filter_metadata_t *$SHORTNAME$_metadata();
+extern int $SHORTNAME$_get_metadata(const struct halide_filter_metadata_t **md_out);
 $NAMESPACECLOSE$
 
 #ifdef HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
@@ -198,10 +198,15 @@ namespace $NREGS$ {
 namespace {
 struct Registerer {
     Registerer() {
+        const halide_filter_metadata_t *md = nullptr;
+        int result = ::$FULLNAME$_get_metadata(&md);
+        if (result != 0) {
+            md = nullptr;
+        }
 #ifdef HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
-        halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC());
+        halide_register_argv_and_metadata(::$FULLNAME$_argv, md, HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC());
 #else
-        halide_register_argv_and_metadata(::$FULLNAME$_argv, ::$FULLNAME$_metadata(), nullptr);
+        halide_register_argv_and_metadata(::$FULLNAME$_argv, md, nullptr);
 #endif  // HALIDE_REGISTER_EXTRA_KEY_VALUE_PAIRS_FUNC
     }
 };

--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -124,7 +124,14 @@ HALIDE_FUNCTION_ATTRS
 int test1_argv(void **args);
 
 HALIDE_FUNCTION_ATTRS
-const struct halide_filter_metadata_t *test1_metadata();
+int test1_get_metadata(const struct halide_filter_metadata_t **md_out);
+
+HALIDE_FUNCTION_ATTRS
+inline const struct halide_filter_metadata_t *test1_metadata() {
+    const halide_filter_metadata_t *md = nullptr;
+    int r = test1_get_metadata(&md);
+    return r == 0 ? md : nullptr;
+}
 
 #ifdef __cplusplus
 }  // extern "C"
@@ -206,7 +213,14 @@ HALIDE_FUNCTION_ATTRS
 int test2_argv(void **args);
 
 HALIDE_FUNCTION_ATTRS
-const struct halide_filter_metadata_t *test2_metadata();
+int test2_get_metadata(const struct halide_filter_metadata_t **md_out);
+
+HALIDE_FUNCTION_ATTRS
+inline const struct halide_filter_metadata_t *test2_metadata() {
+    const halide_filter_metadata_t *md = nullptr;
+    int r = test2_get_metadata(&md);
+    return r == 0 ? md : nullptr;
+}
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
This PR does some groundwork necessary to implement #6757 cleanly:
- #6757 uses `call_cached_indirect_function` to support multitarget cleanliness for metadata getters
- but, name-mangling in MSVC includes the return type, which is currently `halide_filter_metadata_t*` for the getter
- the existing code in Codegen_LLVM assumes that all the functions passed to `compile()` return int32; while this *could* probably be generalized, there is potentially a long tail of special-cases to deal with, as I discovered from some experimentation
- therefore, this changes the *generated* code of the metadata getetr to match the form of the signature that this expects, ie `int foo(args)`.

Before this, we'd generate an extern func like:

    const struct halide_filter_metadata_t * metadata_tester_metadata();

now, we generate an extern func like:

    int metadata_tester_get_metadata(const struct halide_filter_metadata_t **md_out);

...along with an inline wrapper using the old name and calling convention so that call sites don't need to change.