### PR TITLE
Fix Param<T>::set_estimate for T=void

### DIFF
--- a/src/Param.h
+++ b/src/Param.h
@@ -170,47 +170,49 @@ public:
 
     /** Set the current value of this parameter. Only meaningful when jitting.
         Asserts if type is not losslessly-convertible to Parameter's type. */
-    // @{
-    template<typename SOME_TYPE, typename T2 = T, typename std::enable_if<!std::is_void<T2>::value>::type * = nullptr>
+    template<typename SOME_TYPE>
     HALIDE_NO_USER_CODE_INLINE void set(const SOME_TYPE &val) {
-        user_assert(Internal::IsRoundtrippable<T>::value(val))
-            << "The value " << val << " cannot be losslessly converted to type " << type();
-        param.set_scalar<T>(val);
-    }
+        if constexpr (!std::is_void<T>::value) {
+            user_assert(Internal::IsRoundtrippable<T>::value(val))
+                << "The value " << val << " cannot be losslessly converted to type " << type();
+            param.set_scalar<T>(val);
+        } else {
+            // clang-format off
 
-    // Specialized version for when T = void (thus the type is only known at runtime,
-    // not compiletime). Note that this actually works fine for all Params; we specialize
-    // it just to reduce code size for the common case of T != void.
-    template<typename SOME_TYPE, typename T2 = T, typename std::enable_if<std::is_void<T2>::value>::type * = nullptr>
-    HALIDE_NO_USER_CODE_INLINE void set(const SOME_TYPE &val) {
-#define HALIDE_HANDLE_TYPE_DISPATCH(CODE, BITS, TYPE)                                     \
-    case halide_type_t(CODE, BITS).as_u32():                                              \
-        user_assert(Internal::IsRoundtrippable<TYPE>::value(val))                         \
-            << "The value " << val << " cannot be losslessly converted to type " << type; \
-        param.set_scalar<TYPE>(Internal::StaticCast<TYPE>::value(val));                   \
-        break;
+            // Specialized version for when T = void (thus the type is only known at runtime,
+            // not compiletime). Note that this actually works fine for all Params; we specialize
+            // it just to reduce code size for the common case of T != void.
 
-        const Type type = param.type();
-        switch (((halide_type_t)type).element_of().as_u32()) {
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 32, float)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 64, double)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 8, int8_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 16, int16_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 32, int32_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 64, int64_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 1, bool)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 8, uint8_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 16, uint16_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 32, uint32_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 64, uint64_t)
-            HALIDE_HANDLE_TYPE_DISPATCH(halide_type_handle, 64, uint64_t)  // Handle types are always set via set_scalar<uint64_t>, not set_scalar<void*>
-        default:
-            internal_error << "Unsupported type in Param::set<" << type << ">\n";
+            #define HALIDE_HANDLE_TYPE_DISPATCH(CODE, BITS, TYPE)                                     \
+                case halide_type_t(CODE, BITS).as_u32():                                              \
+                    user_assert(Internal::IsRoundtrippable<TYPE>::value(val))                         \
+                        << "The value " << val << " cannot be losslessly converted to type " << type; \
+                    param.set_scalar<TYPE>(Internal::StaticCast<TYPE>::value(val));                   \
+                    break;
+
+            const Type type = param.type();
+            switch (((halide_type_t)type).element_of().as_u32()) {
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 32, float)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 64, double)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 8, int8_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 16, int16_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 32, int32_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 64, int64_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 1, bool)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 8, uint8_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 16, uint16_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 32, uint32_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 64, uint64_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_handle, 64, uint64_t)  // Handle types are always set via set_scalar<uint64_t>, not set_scalar<void*>
+            default:
+                internal_error << "Unsupported type in Param::set<" << type << ">\n";
+            }
+
+            #undef HALIDE_HANDLE_TYPE_DISPATCH
+
+            // clang-format on
         }
-
-#undef HALIDE_HANDLE_TYPE_DISPATCH
     }
-    // @}
 
     /** Get the halide type of the Param */
     Type type() const {
@@ -249,10 +251,47 @@ public:
     // @}
 
     template<typename SOME_TYPE>
-    void set_estimate(const SOME_TYPE &value) {
-        user_assert(Internal::IsRoundtrippable<T>::value(value))
-            << "The value " << value << " cannot be losslessly converted to type " << type();
-        param.set_estimate(Expr(value));
+    HALIDE_NO_USER_CODE_INLINE void set_estimate(const SOME_TYPE &val) {
+        if constexpr (!std::is_void<T>::value) {
+            user_assert(Internal::IsRoundtrippable<T>::value(val))
+                << "The value " << val << " cannot be losslessly converted to type " << type();
+            param.set_estimate(Expr(val));
+        } else {
+            // clang-format off
+
+            // Specialized version for when T = void (thus the type is only known at runtime,
+            // not compiletime). Note that this actually works fine for all Params; we specialize
+            // it just to reduce code size for the common case of T != void.
+
+            #define HALIDE_HANDLE_TYPE_DISPATCH(CODE, BITS, TYPE)                                     \
+                case halide_type_t(CODE, BITS).as_u32():                                              \
+                    user_assert(Internal::IsRoundtrippable<TYPE>::value(val))                         \
+                        << "The value " << val << " cannot be losslessly converted to type " << type; \
+                    param.set_estimate(Expr(Internal::StaticCast<TYPE>::value(val)));                   \
+                    break;
+
+            const Type type = param.type();
+            switch (((halide_type_t)type).element_of().as_u32()) {
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 32, float)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 64, double)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 8, int8_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 16, int16_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 32, int32_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 64, int64_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 1, bool)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 8, uint8_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 16, uint16_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 32, uint32_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_uint, 64, uint64_t)
+                HALIDE_HANDLE_TYPE_DISPATCH(halide_type_handle, 64, uint64_t)  // Handle types are always set via set_scalar<uint64_t>, not set_scalar<void*>
+            default:
+                internal_error << "Unsupported type in Param::set<" << type << ">\n";
+            }
+
+            #undef HALIDE_HANDLE_TYPE_DISPATCH
+
+            // clang-format on
+        }
     }
 
     /** You can use this parameter as an expression in a halide

--- a/src/Util.h
+++ b/src/Util.h
@@ -370,14 +370,13 @@ void halide_toc_impl(const char *file, int line);
 // regarding 'bool' in some compliation configurations.
 template<typename TO>
 struct StaticCast {
-    template<typename FROM, typename TO2 = TO, typename std::enable_if<!std::is_same<TO2, bool>::value>::type * = nullptr>
-    inline constexpr static TO2 value(const FROM &from) {
-        return static_cast<TO2>(from);
-    }
-
-    template<typename FROM, typename TO2 = TO, typename std::enable_if<std::is_same<TO2, bool>::value>::type * = nullptr>
-    inline constexpr static TO2 value(const FROM &from) {
-        return from != 0;
+    template<typename FROM>
+    inline constexpr static TO value(const FROM &from) {
+        if constexpr (std::is_same<TO, bool>::value) {
+            return from != 0;
+        } else {
+            return static_cast<TO>(from);
+        }
     }
 };
 
@@ -386,19 +385,21 @@ struct StaticCast {
 // or dropping of fractional parts).
 template<typename TO>
 struct IsRoundtrippable {
-    template<typename FROM, typename TO2 = TO, typename std::enable_if<!std::is_convertible<FROM, TO>::value>::type * = nullptr>
+    template<typename FROM>
     inline constexpr static bool value(const FROM &from) {
-        return false;
-    }
-
-    template<typename FROM, typename TO2 = TO, typename std::enable_if<std::is_convertible<FROM, TO>::value && std::is_arithmetic<TO>::value && std::is_arithmetic<FROM>::value && !std::is_same<TO, FROM>::value>::type * = nullptr>
-    inline constexpr static bool value(const FROM &from) {
-        return StaticCast<FROM>::value(StaticCast<TO>::value(from)) == from;
-    }
-
-    template<typename FROM, typename TO2 = TO, typename std::enable_if<std::is_convertible<FROM, TO>::value && !(std::is_arithmetic<TO>::value && std::is_arithmetic<FROM>::value && !std::is_same<TO, FROM>::value)>::type * = nullptr>
-    inline constexpr static bool value(const FROM &from) {
-        return true;
+        if constexpr (std::is_convertible<FROM, TO>::value) {
+            if constexpr (std::is_arithmetic<TO>::value &&
+                          std::is_arithmetic<FROM>::value &&
+                          !std::is_same<TO, FROM>::value) {
+                const TO to = static_cast<TO>(from);
+                const FROM roundtripped = static_cast<FROM>(to);
+                return roundtripped == from;
+            } else {
+                return true;
+            }
+        } else {
+            return false;
+        }
     }
 };
 

--- a/test/correctness/param.cpp
+++ b/test/correctness/param.cpp
@@ -24,6 +24,7 @@ int main(int argc, char **argv) {
         }
 
         u.set(17);
+        u.set_estimate(17);
         Buffer<int> out_17 = f.realize({1024}, target);
 
         // verify the get method.
@@ -33,6 +34,7 @@ int main(int argc, char **argv) {
         // so setting the copy should be equivalent to setting the original.
         Param<int> u_alias = u;
         u_alias.set(123);
+        u_alias.set_estimate(123);
         Buffer<int> out_123 = f.realize({1024}, target);
 
         // verify the get method, again.
@@ -69,6 +71,7 @@ int main(int argc, char **argv) {
         // For Param<void>, you must provide an explicit template argument to set(),
         // and it must match the dynamic type of the Param.
         u.set<int32_t>(17);
+        u.set_estimate<int32_t>(17);
         Buffer<int32_t> out_17 = f.realize({1024}, target);
 
         // For Param<void>, you must provide an explicit template argument to get(),
@@ -82,6 +85,7 @@ int main(int argc, char **argv) {
         // so setting the copy should be equivalent to setting the original.
         Param<> u_alias = u;
         u_alias.set(123);
+        u_alias.set_estimate(123);
         Buffer<int32_t> out_123 = f.realize({1024}, target);
 
         assert(u.get<int32_t>() == 123);
@@ -105,12 +109,14 @@ int main(int argc, char **argv) {
         f(x) = u;
 
         u.set(17);
+        u.set_estimate(17);
         Buffer<int32_t> out_17 = f.realize({1});
         assert(out_17(0) == 17);
 
         // You can always construct a Param<void> from a Param<nonvoid>
         Param<> u_alias = u;
         u_alias.set(123);
+        u_alias.set_estimate(123);
         Buffer<int32_t> out_123 = f.realize({1});
         assert(out_123(0) == 123);
 
@@ -119,6 +125,7 @@ int main(int argc, char **argv) {
         // of the LHS (otherwise, assert-fails)
         Param<int32_t> u_alias2 = u_alias;
         u_alias2.set(124);
+        u_alias2.set_estimate(124);
         Buffer<int32_t> out_124 = f.realize({1});
         assert(out_124(0) == 124);
     }
@@ -131,6 +138,7 @@ int main(int argc, char **argv) {
         f(x) = u;
 
         u.set(17);
+        u.set_estimate(17);
         Buffer<int32_t> out_17 = f.realize({1});
         assert(out_17(0) == 17);
 
@@ -139,6 +147,7 @@ int main(int argc, char **argv) {
         u_alias = u;
         assert(u_alias.type() == Int(32));
         u_alias.set(123);
+        u_alias.set_estimate(123);
         Buffer<int32_t> out_123 = f.realize({1});
         assert(out_123(0) == 123);
 
@@ -148,6 +157,7 @@ int main(int argc, char **argv) {
         Param<int32_t> u_alias2;
         u_alias2 = u_alias;
         u_alias2.set(124);
+        u_alias2.set_estimate(124);
         Buffer<int32_t> out_124 = f.realize({1});
         assert(out_124(0) == 124);
     }


### PR DESCRIPTION
The `set_estimate` method needed to specialize for T=void to do runtime checking of the correct type to test. (Previously, we'd get the confusing error that "the value can't be converted losslessly", because, technically, float <-> void is indeed not a roundtrippable conversion.)

While I was there, did drive-by updating of `Param::set`, `IsRoundtrippable`, and `StaticCast` to use the C++17 `if constexpr` mechanism instead of `enable_if`, which IMHO is vastly more readable.