### PR TITLE
slow tests should support sharding

### DIFF
--- a/test/common/test_sharding.h
+++ b/test/common/test_sharding.h
@@ -50,7 +50,8 @@ public:
         }
     }
 
-    explicit Sharder(size_t num_tasks) : sharded_first(0), sharded_last(num_tasks - 1), sharded(false) {
+    explicit Sharder(size_t num_tasks)
+        : sharded_first(0), sharded_last(num_tasks - 1), sharded(false) {
         accept_sharded_status();
 
         int total_shards = std::atoi(get_env("TEST_TOTAL_SHARDS").c_str());  // 0 if not present
@@ -71,9 +72,15 @@ public:
         }
     }
 
-    size_t first() const { return sharded_first; }
-    size_t last() const { return sharded_last; }
-    bool is_sharded() const { return sharded; }
+    size_t first() const {
+        return sharded_first;
+    }
+    size_t last() const {
+        return sharded_last;
+    }
+    bool is_sharded() const {
+        return sharded;
+    }
 };
 
 }  // namespace Test

--- a/test/common/test_sharding.h
+++ b/test/common/test_sharding.h
@@ -1,0 +1,83 @@
+#ifndef TEST_SHARDING_H
+#define TEST_SHARDING_H
+
+// This file may be used by AOT tests, so it deliberately does not
+// include Halide.h
+
+#include <cassert>
+#include <fstream>
+#include <string>
+#include <utility>
+
+namespace Halide {
+namespace Internal {
+namespace Test {
+
+// Support the environment variables are used by the GoogleTest framework
+// to allow a large test to be 'sharded' into smaller pieces:
+//
+// - If TEST_SHARD_STATUS_FILE is not empty, we should create a file at that path
+//   to indicate to the test framework that we support sharding. (Note that this
+//   must be done even if the test does a [SKIP] and executes no tests.)
+// - If TEST_TOTAL_SHARDS and TEST_SHARD_INDEX are defined, we should
+//   split our work into TEST_TOTAL_SHARDS chunks, and only do the TEST_SHARD_INDEX-th
+//   chunk on this run.
+//
+// The Halide buildbots don't (yet) make use of these, but some downstream consumers do.
+
+class Sharder {
+    static std::string get_env(const char *v) {
+        const char *r = getenv(v);
+        if (!r) r = "";
+        return r;
+    }
+
+    size_t sharded_first, sharded_last;
+    bool sharded;
+
+public:
+    // Available publicly in case the test is skipped via [SKIP] --
+    // even if the test runs nothing, we still need to write to this file
+    // (if requested) to avoid making the external test framework unhappy.
+    // (We don't need to call it when actually instantiating a Sharder.)
+    static void accept_sharded_status() {
+        std::string shard_status_file = get_env("TEST_SHARD_STATUS_FILE");
+        if (!shard_status_file.empty()) {
+            std::ofstream f(shard_status_file, std::ios::out | std::ios::binary);
+            f << "sharder\n";
+            f.flush();
+            f.close();
+        }
+    }
+
+    explicit Sharder(size_t num_tasks) : sharded_first(0), sharded_last(num_tasks - 1), sharded(false) {
+        accept_sharded_status();
+
+        int total_shards = std::atoi(get_env("TEST_TOTAL_SHARDS").c_str());  // 0 if not present
+        int current_shard = std::atoi(get_env("TEST_SHARD_INDEX").c_str());  // 0 if not present
+
+        if (total_shards != 0) {
+            if (total_shards < 0 || current_shard < 0 || current_shard >= total_shards) {
+                std::cerr << "Illegal values for sharding: total " << total_shards << " current " << current_shard << "\n";
+                exit(-1);
+            }
+
+            size_t shard_size = (num_tasks + total_shards - 1) / total_shards;
+            sharded_first = current_shard * shard_size;
+            sharded_last = std::min(sharded_first + shard_size - 1, num_tasks - 1);
+            sharded = true;
+            // Useful for debugging
+            // std::cout << "Tasks " << tasks.size() << " shard_size " << shard_size << " sharded_first " << sharded_first << " sharded_last " << sharded_last << "\n";
+        }
+    }
+
+    size_t first() const { return sharded_first; }
+    size_t last() const { return sharded_last; }
+    bool is_sharded() const { return sharded; }
+};
+
+}  // namespace Test
+}  // namespace Internal
+}  // namespace Halide
+
+#endif  // TEST_SHARDING_H

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
-#include <algorithm>
-#include <future>
+#include "test_sharding.h"
 
+#include <algorithm>
 #include <cstdio>
 
 using namespace Halide;
@@ -180,9 +180,11 @@ bool check_mirror_interior(const Buffer<T> &input, Func f,
     return success;
 }
 
-bool test_all(int vector_width, Target t) {
-    bool success = true;
+struct Task {
+    std::function<bool()> fn;
+};
 
+void add_all(int vector_width, Target t, std::vector<Task> &tasks) {
     const int W = 32;
     const int H = 32;
     Buffer<uint8_t> input(W, H);
@@ -201,34 +203,34 @@ bool test_all(int vector_width, Target t) {
         const int32_t test_extent = 100;
 
         // Func input.
-        success &= check_repeat_edge(
-            input,
-            repeat_edge(input_f, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_edge(
+                                     input,
+                                     repeat_edge(input_f, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Image input.
-        success &= check_repeat_edge(
-            input,
-            repeat_edge(input, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_edge(
+                                     input,
+                                     repeat_edge(input, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Undefined bounds.
-        success &= check_repeat_edge(
-            input,
-            repeat_edge(input, {{Expr(), Expr()}, {0, H}}),
-            0, W, test_min, test_extent,
-            vector_width, t);
-        success &= check_repeat_edge(
-            input,
-            repeat_edge(input, {{0, W}, {Expr(), Expr()}}),
-            test_min, test_extent, 0, H,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_edge(
+                                     input,
+                                     repeat_edge(input, {{Expr(), Expr()}, {0, H}}),
+                                     0, W, test_min, test_extent,
+                                     vector_width, t); }});
+        tasks.push_back({[=]() { return check_repeat_edge(
+                                     input,
+                                     repeat_edge(input, {{0, W}, {Expr(), Expr()}}),
+                                     test_min, test_extent, 0, H,
+                                     vector_width, t); }});
         // Implicitly determined bounds.
-        success &= check_repeat_edge(
-            input,
-            repeat_edge(input),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_edge(
+                                     input,
+                                     repeat_edge(input),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
     }
 
     // constant_exterior:
@@ -239,34 +241,34 @@ bool test_all(int vector_width, Target t) {
         const uint8_t exterior = 42;
 
         // Func input.
-        success &= check_constant_exterior(
-            input, exterior,
-            constant_exterior(input_f, exterior, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_constant_exterior(
+                                     input, exterior,
+                                     constant_exterior(input_f, exterior, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Image input.
-        success &= check_constant_exterior(
-            input, exterior,
-            constant_exterior(input, exterior, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_constant_exterior(
+                                     input, exterior,
+                                     constant_exterior(input, exterior, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Undefined bounds.
-        success &= check_constant_exterior(
-            input, exterior,
-            constant_exterior(input, exterior, {{Expr(), Expr()}, {0, H}}),
-            0, W, test_min, test_extent,
-            vector_width, t);
-        success &= check_constant_exterior(
-            input, exterior,
-            constant_exterior(input, exterior, {{0, W}, {Expr(), Expr()}}),
-            test_min, test_extent, 0, H,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_constant_exterior(
+                                     input, exterior,
+                                     constant_exterior(input, exterior, {{Expr(), Expr()}, {0, H}}),
+                                     0, W, test_min, test_extent,
+                                     vector_width, t); }});
+        tasks.push_back({[=]() { return check_constant_exterior(
+                                     input, exterior,
+                                     constant_exterior(input, exterior, {{0, W}, {Expr(), Expr()}}),
+                                     test_min, test_extent, 0, H,
+                                     vector_width, t); }});
         // Implicitly determined bounds.
-        success &= check_constant_exterior(
-            input, exterior,
-            constant_exterior(input, exterior),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_constant_exterior(
+                                     input, exterior,
+                                     constant_exterior(input, exterior),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
     }
 
     // repeat_image:
@@ -275,34 +277,34 @@ bool test_all(int vector_width, Target t) {
         const int32_t test_extent = 100;
 
         // Func input.
-        success &= check_repeat_image(
-            input,
-            repeat_image(input_f, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_image(
+                                     input,
+                                     repeat_image(input_f, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Image input.
-        success &= check_repeat_image(
-            input,
-            repeat_image(input, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_image(
+                                     input,
+                                     repeat_image(input, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Undefined bounds.
-        success &= check_repeat_image(
-            input,
-            repeat_image(input, {{Expr(), Expr()}, {0, H}}),
-            0, W, test_min, test_extent,
-            vector_width, t);
-        success &= check_repeat_image(
-            input,
-            repeat_image(input, {{0, W}, {Expr(), Expr()}}),
-            test_min, test_extent, 0, H,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_image(
+                                     input,
+                                     repeat_image(input, {{Expr(), Expr()}, {0, H}}),
+                                     0, W, test_min, test_extent,
+                                     vector_width, t); }});
+        tasks.push_back({[=]() { return check_repeat_image(
+                                     input,
+                                     repeat_image(input, {{0, W}, {Expr(), Expr()}}),
+                                     test_min, test_extent, 0, H,
+                                     vector_width, t); }});
         // Implicitly determined bounds.
-        success &= check_repeat_image(
-            input,
-            repeat_image(input),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_repeat_image(
+                                     input,
+                                     repeat_image(input),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
     }
 
     // mirror_image:
@@ -311,34 +313,34 @@ bool test_all(int vector_width, Target t) {
         const int32_t test_extent = 100;
 
         // Func input.
-        success &= check_mirror_image(
-            input,
-            mirror_image(input_f, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_image(
+                                     input,
+                                     mirror_image(input_f, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Image input.
-        success &= check_mirror_image(
-            input,
-            mirror_image(input, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_image(
+                                     input,
+                                     mirror_image(input, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Undefined bounds.
-        success &= check_mirror_image(
-            input,
-            mirror_image(input, {{Expr(), Expr()}, {0, H}}),
-            0, W, test_min, test_extent,
-            vector_width, t);
-        success &= check_mirror_image(
-            input,
-            mirror_image(input, {{0, W}, {Expr(), Expr()}}),
-            test_min, test_extent, 0, H,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_image(
+                                     input,
+                                     mirror_image(input, {{Expr(), Expr()}, {0, H}}),
+                                     0, W, test_min, test_extent,
+                                     vector_width, t); }});
+        tasks.push_back({[=]() { return check_mirror_image(
+                                     input,
+                                     mirror_image(input, {{0, W}, {Expr(), Expr()}}),
+                                     test_min, test_extent, 0, H,
+                                     vector_width, t); }});
         // Implicitly determined bounds.
-        success &= check_mirror_image(
-            input,
-            mirror_image(input),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_image(
+                                     input,
+                                     mirror_image(input),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
     }
 
     // mirror_interior:
@@ -347,44 +349,40 @@ bool test_all(int vector_width, Target t) {
         const int32_t test_extent = 100;
 
         // Func input.
-        success &= check_mirror_interior(
-            input,
-            mirror_interior(input_f, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_interior(
+                                     input,
+                                     mirror_interior(input_f, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Image input.
-        success &= check_mirror_interior(
-            input,
-            mirror_interior(input, {{0, W}, {0, H}}),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_interior(
+                                     input,
+                                     mirror_interior(input, {{0, W}, {0, H}}),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
         // Undefined bounds.
-        success &= check_mirror_interior(
-            input,
-            mirror_interior(input, {{Expr(), Expr()}, {0, H}}),
-            0, W, test_min, test_extent,
-            vector_width, t);
-        success &= check_mirror_interior(
-            input,
-            mirror_interior(input, {{0, W}, {Expr(), Expr()}}),
-            test_min, test_extent, 0, H,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_interior(
+                                     input,
+                                     mirror_interior(input, {{Expr(), Expr()}, {0, H}}),
+                                     0, W, test_min, test_extent,
+                                     vector_width, t); }});
+        tasks.push_back({[=]() { return check_mirror_interior(
+                                     input,
+                                     mirror_interior(input, {{0, W}, {Expr(), Expr()}}),
+                                     test_min, test_extent, 0, H,
+                                     vector_width, t); }});
         // Implicitly determined bounds.
-        success &= check_mirror_interior(
-            input,
-            mirror_interior(input),
-            test_min, test_extent, test_min, test_extent,
-            vector_width, t);
+        tasks.push_back({[=]() { return check_mirror_interior(
+                                     input,
+                                     mirror_interior(input),
+                                     test_min, test_extent, test_min, test_extent,
+                                     vector_width, t); }});
     }
-
-    return success;
 }
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
-    Halide::Internal::ThreadPool<bool> pool;
-    std::vector<std::future<bool>> futures;
     int vector_width_max = 32;
     if (target.has_feature(Target::Metal) ||
         target.has_feature(Target::OpenGLCompute) ||
@@ -396,24 +394,20 @@ int main(int argc, char **argv) {
         // The wasm jit is very slow, so shorten this test here.
         vector_width_max = 8;
     }
+
+    std::vector<Task> tasks;
     for (int vector_width = 1; vector_width <= vector_width_max; vector_width *= 2) {
-        std::cout << "Testing vector_width: " << vector_width << "\n";
-        if (target.has_feature(Target::OpenGLCompute)) {
-            // GL can't be used from multiple threads at once
-            test_all(vector_width, target);
-        } else {
-            futures.push_back(pool.async(test_all, vector_width, target));
+        add_all(vector_width, target, tasks);
+    }
+
+    using Sharder = Halide::Internal::Test::Sharder;
+    Sharder sharder(tasks.size());
+    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
+    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+        const auto &task = tasks.at(t);
+        if (!task.fn()) {
+            exit(-1);
         }
-    }
-
-    bool success = true;
-    for (auto &f : futures) {
-        success &= f.get();
-    }
-
-    if (!success) {
-        fprintf(stderr, "Failed!\n");
-        return -1;
     }
 
     printf("Success!\n");

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -401,9 +401,9 @@ int main(int argc, char **argv) {
     }
 
     using Sharder = Halide::Internal::Test::Sharder;
-    Sharder sharder(tasks.size());
-    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
-    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+    Sharder sharder;
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn()) {
             exit(-1);

--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -1,5 +1,6 @@
 #include "Halide.h"
 #include "check_call_graphs.h"
+#include "test_sharding.h"
 
 #include <cstdio>
 #include <map>
@@ -2206,152 +2207,58 @@ int two_compute_at_test() {
 }  // namespace
 
 int main(int argc, char **argv) {
-    printf("Running split reorder test\n");
-    if (split_test() != 0) {
-        return -1;
-    }
+    struct Task {
+        std::string desc;
+        std::function<int()> fn;
+    };
 
-    printf("Running fuse test\n");
-    if (fuse_test() != 0) {
-        return -1;
-    }
+    std::vector<Task> tasks = {
+        {"split reorder test", split_test},
+        {"fuse test", fuse_test},
+        {"multiple fuse group test", multiple_fuse_group_test},
+        {"multiple outputs test", multiple_outputs_test},
+        {"double split fuse test", double_split_fuse_test},
+        {"vectorize test", vectorize_test},
+        //
+        // Note: we are deprecating skipping parts of a fused group in favor of
+        //       cloning funcs in particular stages via a new (clone_)in overload.
+        // TODO: remove this code when the new clone_in is implemented.
+        //
+        // {"some are skipped test", some_are_skipped_test},
+        {"rgb to yuv420 test", rgb_yuv420_test},
+        {"with specialization test", with_specialization_test},
+        {"fuse compute at test", fuse_compute_at_test},
+        {"nested compute with test", nested_compute_with_test},
+        {"mixed tile factor test", mixed_tile_factor_test},
+        // NOTE: disabled because it generates OOB (see #4751 for discussion).
+        // {"only some are tiled test", only_some_are_tiled_test},
+        {"multiple outputs on gpu test", multiple_outputs_on_gpu_test},
+        {"multi tile mixed tile factor test", multi_tile_mixed_tile_factor_test},
+        {"update stage test", update_stage_test},
+        {"update stage2 test", update_stage2_test},
+        {"update stage3 test", update_stage3_test},
+        {"update stage pairwise test", update_stage_pairwise_test},
+        // I think this should work, but there is an overzealous check somewhere.
+        // {"update stage pairwise zigzag test", update_stage_pairwise_zigzag_test},
+        {"update stage diagonal test", update_stage_diagonal_test},
+        {"update stage rfactor test", update_stage_rfactor_test},
+        {"vectorize inlined test", vectorize_inlined_test},
+        {"mismatching splits test", mismatching_splits_test},
+        {"different arg number compute_at test", different_arg_num_compute_at_test},
+        {"store_at different levels test", store_at_different_levels_test},
+        {"rvar bounds test", rvar_bounds_test},
+        {"two_compute_at test", two_compute_at_test},
+    };
 
-    printf("Running multiple fuse group test\n");
-    if (multiple_fuse_group_test() != 0) {
-        return -1;
-    }
-
-    printf("Running multiple outputs test\n");
-    if (multiple_outputs_test() != 0) {
-        return -1;
-    }
-
-    printf("Running double split fuse test\n");
-    if (double_split_fuse_test() != 0) {
-        return -1;
-    }
-
-    printf("Running vectorize test\n");
-    if (vectorize_test() != 0) {
-        return -1;
-    }
-
-    /*
-     * Note: we are deprecating skipping parts of a fused group in favor of
-     *       cloning funcs in particular stages via a new (clone_)in overload.
-     * TODO: remove this code when the new clone_in is implemented.
-     */
-    //    printf("Running some are skipped test\n");
-    //    if (some_are_skipped_test() != 0) {
-    //        return -1;
-    //    }
-
-    printf("Running rgb to yuv420 test\n");
-    if (rgb_yuv420_test() != 0) {
-        return -1;
-    }
-
-    printf("Running with specialization test\n");
-    if (with_specialization_test() != 0) {
-        return -1;
-    }
-
-    printf("Running fuse compute at test\n");
-    if (fuse_compute_at_test() != 0) {
-        return -1;
-    }
-
-    printf("Running nested compute with test\n");
-    if (nested_compute_with_test() != 0) {
-        return -1;
-    }
-
-    printf("Running mixed tile factor test\n");
-    if (mixed_tile_factor_test() != 0) {
-        return -1;
-    }
-
-    // NOTE: disabled because it generates OOB (see #4751 for discussion).
-    /*
-    printf("Running only some are tiled test\n");
-    if (only_some_are_tiled_test() != 0) {
-        return -1;
-    }
-    */
-    printf("Running multiple outputs on gpu test\n");
-    if (multiple_outputs_on_gpu_test() != 0) {
-        return -1;
-    }
-
-    printf("Running multi tile mixed tile factor test\n");
-    if (multi_tile_mixed_tile_factor_test() != 0) {
-        return -1;
-    }
-
-    printf("Running update stage test\n");
-    if (update_stage_test() != 0) {
-        return -1;
-    }
-
-    printf("Running update stage2 test\n");
-    if (update_stage2_test() != 0) {
-        return -1;
-    }
-
-    printf("Running update stage3 test\n");
-    if (update_stage3_test() != 0) {
-        return -1;
-    }
-
-    printf("Running update stage pairwise test\n");
-    if (update_stage_pairwise_test() != 0) {
-        return -1;
-    }
-
-    // I think this should work, but there is an overzealous check somewhere.
-    // printf("Running update stage pairwise zigzag test\n");
-    // if (update_stage_pairwise_zigzag_test() != 0) {
-    //     return -1;
-    // }
-
-    printf("Running update stage diagonal test\n");
-    if (update_stage_diagonal_test() != 0) {
-        return -1;
-    }
-
-    printf("Running update stage rfactor test\n");
-    if (update_stage_rfactor_test() != 0) {
-        return -1;
-    }
-
-    printf("Running vectorize inlined test\n");
-    if (vectorize_inlined_test() != 0) {
-        return -1;
-    }
-
-    printf("Running mismatching splits test\n");
-    if (mismatching_splits_test() != 0) {
-        return -1;
-    }
-
-    printf("Running different arg number compute_at test\n");
-    if (different_arg_num_compute_at_test() != 0) {
-        return -1;
-    }
-
-    printf("Running store_at different levels test\n");
-    if (store_at_different_levels_test() != 0) {
-        return -1;
-    }
-
-    printf("Running rvar bounds test\n");
-    if (rvar_bounds_test() != 0) {
-        return -1;
-    }
-
-    printf("Running two_compute_at test\n");
-    if (two_compute_at_test() != 0) {
-        return -1;
+    using Sharder = Halide::Internal::Test::Sharder;
+    Sharder sharder(tasks.size());
+    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
+    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+        const auto &task = tasks.at(t);
+        std::cout << task.desc << "\n";
+        if (task.fn() != 0) {
+            return -1;
+        }
     }
 
     printf("Success!\n");

--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -2251,9 +2251,9 @@ int main(int argc, char **argv) {
     };
 
     using Sharder = Halide::Internal::Test::Sharder;
-    Sharder sharder(tasks.size());
-    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
-    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+    Sharder sharder;
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         std::cout << task.desc << "\n";
         if (task.fn() != 0) {

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -322,14 +322,17 @@ int main(int argc, char **argv) {
     printf("HL_TARGET is: %s\n", hl_target.to_string().c_str());
     printf("HL_JIT_TARGET is: %s\n", jit_target.to_string().c_str());
 
+    // Create Test Object
+    // Use smaller dimension than default(768, 128) to avoid fp16 overflow in reduction test case
+    // Instantiate the SimdOpCheck before we skip-return,
+    // so that the sharding setup (if any) will be happy.
+    SimdOpCheck test(hl_target, 384, 32);
+
     // Only for 64bit target with fp16 feature
     if (!(hl_target.arch == Target::ARM && hl_target.bits == 64 && hl_target.has_feature(Target::ARMFp16))) {
         printf("[SKIP] To run this test, set HL_TARGET=arm-64-<os>-arm_fp16. \n");
         return 0;
     }
-    // Create Test Object
-    // Use smaller dimension than default(768, 128) to avoid fp16 overflow in reduction test case
-    SimdOpCheck test(hl_target, 384, 32);
 
     if (!test.can_run_code()) {
         printf("[WARN] To run verification of realization, set HL_JIT_TARGET=arm-64-<os>-arm_fp16. \n");

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -322,17 +322,16 @@ int main(int argc, char **argv) {
     printf("HL_TARGET is: %s\n", hl_target.to_string().c_str());
     printf("HL_JIT_TARGET is: %s\n", jit_target.to_string().c_str());
 
-    // Create Test Object
-    // Use smaller dimension than default(768, 128) to avoid fp16 overflow in reduction test case
-    // Instantiate the SimdOpCheck before we skip-return,
-    // so that the sharding setup (if any) will be happy.
-    SimdOpCheck test(hl_target, 384, 32);
-
     // Only for 64bit target with fp16 feature
     if (!(hl_target.arch == Target::ARM && hl_target.bits == 64 && hl_target.has_feature(Target::ARMFp16))) {
+        Halide::Internal::Test::Sharder::accept_sharded_status();
         printf("[SKIP] To run this test, set HL_TARGET=arm-64-<os>-arm_fp16. \n");
         return 0;
     }
+
+    // Create Test Object
+    // Use smaller dimension than default(768, 128) to avoid fp16 overflow in reduction test case
+    SimdOpCheck test(hl_target, 384, 32);
 
     if (!test.can_run_code()) {
         printf("[WARN] To run verification of realization, set HL_JIT_TARGET=arm-64-<os>-arm_fp16. \n");

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -337,26 +337,11 @@ int main(int argc, char **argv) {
 
     if (argc > 1) {
         test.filter = argv[1];
-        test.set_num_threads(1);
     }
 
     if (getenv("HL_SIMD_OP_CHECK_FILTER")) {
         test.filter = getenv("HL_SIMD_OP_CHECK_FILTER");
     }
-
-    // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;
-    // the fundamental issue is that we make one set of ImageParams to construct many
-    // Exprs, then realize those Exprs on arbitrary threads; it is known that sharing
-    // one Func across multiple threads is not guaranteed to be safe, and indeed, TSAN
-    // reports data races, of which some are likely 'benign' (e.g. Function.freeze) but others
-    // are highly suspect (e.g. Function.lock_loop_levels). Since multithreading here
-    // was added just to avoid having this test be the last to finish, the expedient 'fix'
-    // for now is to remove the multithreading. A proper fix could be made by restructuring this
-    // test so that every Expr constructed for testing was guaranteed to share no Funcs
-    // (Function.deep_copy() perhaps). Of course, it would also be desirable to allow Funcs, Exprs, etc
-    // to be usable across multiple threads, but that is a major undertaking that is
-    // definitely not worthwhile for present Halide usage patterns.
-    test.set_num_threads(1);
 
     if (argc > 2) {
         // Don't forget: if you want to run the standard tests to a specific output

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -573,9 +573,9 @@ int main(int argc, char **argv) {
     }
 
     using Sharder = Halide::Internal::Test::Sharder;
-    Sharder sharder(tasks.size());
-    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
-    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+    Sharder sharder;
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn()) {
             exit(-1);

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -1,7 +1,7 @@
 #include "Halide.h"
+#include "test_sharding.h"
 
 #include <algorithm>
-#include <future>
 #include <math.h>
 #include <stdio.h>
 
@@ -501,53 +501,44 @@ bool f_mod() {
     return success;
 }
 
-bool test_mul(int vector_width, ScheduleVariant scheduling, Target target) {
-    std::cout << "Testing mul vector_width: " + std::to_string(vector_width) + "\n";
+struct Task {
+    std::function<bool()> fn;
+};
 
-    bool success = true;
-
+void add_test_mul(int vector_width, ScheduleVariant scheduling, Target target, std::vector<Task> &tasks) {
     // Non-widening multiplication.
-    success &= mul<uint8_t, uint8_t, uint8_t, uint64_t>(vector_width, scheduling, target);
-    success &= mul<uint16_t, uint16_t, uint16_t, uint64_t>(vector_width, scheduling, target);
-    success &= mul<uint32_t, uint32_t, uint32_t, uint64_t>(vector_width, scheduling, target);
-    success &= mul<int8_t, int8_t, int8_t, int64_t>(vector_width, scheduling, target);
-    success &= mul<int16_t, int16_t, int16_t, int64_t>(vector_width, scheduling, target);
-    success &= mul<int32_t, int32_t, int32_t, int64_t>(vector_width, scheduling, target);
+    tasks.push_back({[=]() { return mul<uint8_t, uint8_t, uint8_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<uint16_t, uint16_t, uint16_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<uint32_t, uint32_t, uint32_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<int8_t, int8_t, int8_t, int64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<int16_t, int16_t, int16_t, int64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<int32_t, int32_t, int32_t, int64_t>(vector_width, scheduling, target); }});
 
     // Widening multiplication.
-    success &= mul<uint8_t, uint8_t, uint16_t, uint64_t>(vector_width, scheduling, target);
-    success &= mul<uint16_t, uint16_t, uint32_t, uint64_t>(vector_width, scheduling, target);
-    success &= mul<int8_t, int8_t, int16_t, int64_t>(vector_width, scheduling, target);
-    success &= mul<int16_t, int16_t, int32_t, int64_t>(vector_width, scheduling, target);
+    tasks.push_back({[=]() { return mul<uint8_t, uint8_t, uint16_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<uint16_t, uint16_t, uint32_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<int8_t, int8_t, int16_t, int64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<int16_t, int16_t, int32_t, int64_t>(vector_width, scheduling, target); }});
 
     // Mixed multiplication. This isn't all of the possible mixed
     // multiplications, but it covers all of the special cases we
     // have in Halide.
-    success &= mul<uint16_t, uint32_t, uint32_t, uint64_t>(vector_width, scheduling, target);
-    success &= mul<int16_t, int32_t, int32_t, int64_t>(vector_width, scheduling, target);
-    success &= mul<uint16_t, int32_t, int32_t, uint64_t>(vector_width, scheduling, target);
-
-    return success;
+    tasks.push_back({[=]() { return mul<uint16_t, uint32_t, uint32_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<int16_t, int32_t, int32_t, int64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return mul<uint16_t, int32_t, int32_t, uint64_t>(vector_width, scheduling, target); }});
 }
 
-bool test_div_mod(int vector_width, ScheduleVariant scheduling, Target target) {
-    std::cout << "Testing div_mod vector_width: " + std::to_string(vector_width) + "\n";
-
-    bool success = true;
-
-    success &= div_mod<uint8_t, uint64_t>(vector_width, scheduling, target);
-    success &= div_mod<uint16_t, uint64_t>(vector_width, scheduling, target);
-    success &= div_mod<uint32_t, uint64_t>(vector_width, scheduling, target);
-    success &= div_mod<int8_t, int64_t>(vector_width, scheduling, target);
-    success &= div_mod<int16_t, int64_t>(vector_width, scheduling, target);
-    success &= div_mod<int32_t, int64_t>(vector_width, scheduling, target);
-    return success;
+void add_test_div_mod(int vector_width, ScheduleVariant scheduling, Target target, std::vector<Task> &tasks) {
+    tasks.push_back({[=]() { return div_mod<uint8_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return div_mod<uint16_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return div_mod<uint32_t, uint64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return div_mod<int8_t, int64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return div_mod<int16_t, int64_t>(vector_width, scheduling, target); }});
+    tasks.push_back({[=]() { return div_mod<int32_t, int64_t>(vector_width, scheduling, target); }});
 }
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-
-    bool can_parallelize = !target.has_feature(Target::OpenGLCompute);
 
     ScheduleVariant scheduling = CPU;
     if (target.has_gpu_feature()) {
@@ -573,52 +564,24 @@ int main(int argc, char **argv) {
         }
     }
 
-    size_t num_threads = Halide::Internal::ThreadPool<bool>::num_processors_online();
-    if (target.has_feature(Target::OpenCL)) {
-        // TODO(https://github.com/halide/Halide/issues/5634):
-        // Try to track down sporadic failures of this function for OpenCL
-        // -- avoid running simultaneous tests
-        // -- set HL_DEBUG_CODEGEN so we can see what the IR looks like
-        num_threads = 1;
-#ifdef _WIN32
-        _putenv_s("HL_DEBUG_CODEGEN", "1");
-#else
-        setenv("HL_DEBUG_CODEGEN", "1", 1);
-#endif
+    std::vector<Task> tasks;
+    for (int vector_width : vector_widths) {
+        add_test_mul(vector_width, scheduling, target, tasks);
+    }
+    for (int vector_width : vector_widths) {
+        add_test_div_mod(vector_width, scheduling, target, tasks);
     }
 
-    Halide::Internal::ThreadPool<bool> pool(num_threads);
-    std::vector<std::future<bool>> futures;
-
-    for (int vector_width : vector_widths) {
-        if (can_parallelize) {
-            auto f = pool.async(test_mul, vector_width, scheduling, target);
-            futures.push_back(std::move(f));
-        } else if (!test_mul(vector_width, scheduling, target)) {
-            return -1;
+    using Sharder = Halide::Internal::Test::Sharder;
+    Sharder sharder(tasks.size());
+    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
+    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+        const auto &task = tasks.at(t);
+        if (!task.fn()) {
+            exit(-1);
         }
     }
 
-    for (int vector_width : vector_widths) {
-        if (can_parallelize) {
-            auto f = pool.async(test_div_mod, vector_width, scheduling, target);
-            futures.push_back(std::move(f));
-        } else if (!test_div_mod(vector_width, scheduling, target)) {
-            return -1;
-        }
-    }
-
-    futures.push_back(pool.async(f_mod<float, double>));
-
-    bool success = true;
-    for (auto &f : futures) {
-        success &= f.get();
-    }
-
-    if (!success) {
-        printf("Failure!\n");
-        return -1;
-    }
     printf("Success!\n");
     return 0;
 }

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -1035,9 +1035,9 @@ int main(int argc, char **argv) {
     };
 
     using Sharder = Halide::Internal::Test::Sharder;
-    Sharder sharder(tasks.size());
-    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
-    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+    Sharder sharder;
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         std::cout << task.desc << "\n";
         if (task.fn() != 0) {

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -1,5 +1,6 @@
 #include "Halide.h"
 #include "check_call_graphs.h"
+#include "test_sharding.h"
 
 #include <cstdio>
 #include <map>
@@ -12,7 +13,8 @@ using std::string;
 using namespace Halide;
 using namespace Halide::Internal;
 
-int simple_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int simple_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y");
 
@@ -52,7 +54,8 @@ int simple_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int reorder_split_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int reorder_split_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y");
 
@@ -97,7 +100,8 @@ int reorder_split_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int multi_split_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int multi_split_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y");
 
@@ -145,7 +149,8 @@ int multi_split_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int reorder_fuse_wrapper_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int reorder_fuse_wrapper_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y"), z("z");
 
@@ -195,7 +200,8 @@ int reorder_fuse_wrapper_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int non_trivial_lhs_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int non_trivial_lhs_rfactor_test() {
     Func a("a"), b("b"), c("c");
     Var x("x"), y("y"), z("z");
 
@@ -265,7 +271,8 @@ int non_trivial_lhs_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int simple_rfactor_with_specialize_test(bool compile_module) {
+template<bool compile_module>
+int simple_rfactor_with_specialize_test() {
     Func f("f"), g("g");
     Var x("x"), y("y");
 
@@ -319,7 +326,8 @@ int simple_rfactor_with_specialize_test(bool compile_module) {
     return 0;
 }
 
-int rdom_with_predicate_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int rdom_with_predicate_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y"), z("z");
 
@@ -364,7 +372,8 @@ int rdom_with_predicate_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int histogram_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int histogram_rfactor_test() {
     int W = 128, H = 128;
 
     // Compute a random image and its true histogram
@@ -420,7 +429,8 @@ int histogram_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int parallel_dot_product_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int parallel_dot_product_rfactor_test() {
     int size = 1024;
 
     Func f("f"), g("g"), a("a"), b("b");
@@ -482,7 +492,8 @@ int parallel_dot_product_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int tuple_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int tuple_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y");
 
@@ -552,7 +563,8 @@ int tuple_rfactor_test(bool compile_module) {
     return 0;
 }
 
-int tuple_specialize_rdom_predicate_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int tuple_specialize_rdom_predicate_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y"), z("z");
 
@@ -887,7 +899,8 @@ int rfactor_tile_reorder_test() {
     return 0;
 }
 
-int tuple_partial_reduction_rfactor_test(bool compile_module) {
+template<bool compile_module>
+int tuple_partial_reduction_rfactor_test() {
     Func f("f"), g("g");
     Var x("x"), y("y");
 
@@ -982,160 +995,53 @@ int self_assignment_rfactor_test() {
 }  // namespace
 
 int main(int argc, char **argv) {
-    printf("Running self assignment rfactor test\n");
-    if (self_assignment_rfactor_test() != 0) {
-        return -1;
-    }
+    struct Task {
+        std::string desc;
+        std::function<int()> fn;
+    };
 
-    printf("Running simple rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (simple_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (simple_rfactor_test(false) != 0) {
-        return -1;
-    }
+    std::vector<Task> tasks = {
+        {"self assignment rfactor test", self_assignment_rfactor_test},
+        {"simple rfactor test: checking call graphs...", simple_rfactor_test<true>},
+        {"simple rfactor test: checking output img correctness...", simple_rfactor_test<false>},
+        {"reorder split rfactor test: checking call graphs...", reorder_split_rfactor_test<true>},
+        {"reorder split rfactor test: checking output img correctness...", reorder_split_rfactor_test<false>},
+        {"multiple split rfactor test: checking call graphs...", multi_split_rfactor_test<true>},
+        {"multiple split rfactor test: checking output img correctness...", multi_split_rfactor_test<false>},
+        {"reorder fuse wrapper rfactor test: checking call graphs...", reorder_fuse_wrapper_rfactor_test<true>},
+        {"reorder fuse wrapper rfactor test: checking output img correctness...", reorder_fuse_wrapper_rfactor_test<false>},
+        {"non trivial lhs rfactor test: checking call graphs...", non_trivial_lhs_rfactor_test<true>},
+        {"non trivial lhs rfactor test: checking output img correctness...", non_trivial_lhs_rfactor_test<false>},
+        {"simple rfactor with specialization test: checking call graphs...", simple_rfactor_with_specialize_test<true>},
+        {"simple rfactor with specialization test: checking output img correctness...", simple_rfactor_with_specialize_test<false>},
+        {"rdom with predicate rfactor test: checking call graphs...", rdom_with_predicate_rfactor_test<true>},
+        {"rdom with predicate rfactor test: checking output img correctness...", rdom_with_predicate_rfactor_test<false>},
+        {"histogram rfactor test: checking call graphs...", histogram_rfactor_test<true>},
+        {"histogram rfactor test: checking output img correctness...", histogram_rfactor_test<false>},
+        {"parallel dot product rfactor test: checking call graphs...", parallel_dot_product_rfactor_test<true>},
+        {"parallel dot product rfactor test: checking output img correctness...", parallel_dot_product_rfactor_test<false>},
+        {"tuple rfactor test: checking call graphs...", tuple_rfactor_test<true>},
+        {"tuple rfactor test: checking output img correctness...", tuple_rfactor_test<false>},
+        {"tuple specialize rdom predicate rfactor test: checking call graphs...", tuple_specialize_rdom_predicate_rfactor_test<true>},
+        {"tuple specialize rdom predicate rfactor test: checking output img correctness...", tuple_specialize_rdom_predicate_rfactor_test<false>},
+        {"parallel dot product rfactor test: checking call graphs...", parallel_dot_product_rfactor_test<true>},
+        {"parallel dot product rfactor test: checking output img correctness...", parallel_dot_product_rfactor_test<false>},
+        {"tuple partial reduction rfactor test: checking call graphs...", tuple_partial_reduction_rfactor_test<true>},
+        {"tuple partial reduction rfactor test: checking output img correctness...", tuple_partial_reduction_rfactor_test<false>},
+        {"check allocation bound test", check_allocation_bound_test},
+        {"rfactor tile reorder test: checking output img correctness...", rfactor_tile_reorder_test},
+        {"complex multiply rfactor test", complex_multiply_rfactor_test},
+        {"argmin rfactor test", argmin_rfactor_test},
+    };
 
-    printf("Running reorder split rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (reorder_split_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (reorder_split_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running multiple split rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (multi_split_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (multi_split_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running reorder fuse wrapper rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (reorder_fuse_wrapper_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (reorder_fuse_wrapper_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running non trivial lhs rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (non_trivial_lhs_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (non_trivial_lhs_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running simple rfactor with specialization test\n");
-    printf("    checking call graphs...\n");
-    if (simple_rfactor_with_specialize_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (simple_rfactor_with_specialize_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running rdom with predicate rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (rdom_with_predicate_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (rdom_with_predicate_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running histogram rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (histogram_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (histogram_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running parallel dot product rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (parallel_dot_product_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (parallel_dot_product_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running tuple rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (tuple_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (tuple_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running tuple specialize rdom predicate rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (tuple_specialize_rdom_predicate_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (tuple_specialize_rdom_predicate_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running parallel dot product rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (parallel_dot_product_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (parallel_dot_product_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running tuple partial reduction rfactor test\n");
-    printf("    checking call graphs...\n");
-    if (tuple_partial_reduction_rfactor_test(true) != 0) {
-        return -1;
-    }
-    printf("    checking output img correctness...\n");
-    if (tuple_partial_reduction_rfactor_test(false) != 0) {
-        return -1;
-    }
-
-    printf("Running check allocation bound test\n");
-    if (check_allocation_bound_test() != 0) {
-        return -1;
-    }
-
-    printf("Running rfactor tile reorder test\n");
-    printf("    checking output img correctness...\n");
-    if (rfactor_tile_reorder_test() != 0) {
-        return -1;
-    }
-
-    printf("Running complex multiply rfactor test\n");
-    if (complex_multiply_rfactor_test() != 0) {
-        return -1;
-    }
-
-    printf("Running argmin rfactor test\n");
-    if (argmin_rfactor_test() != 0) {
-        return -1;
+    using Sharder = Halide::Internal::Test::Sharder;
+    Sharder sharder(tasks.size());
+    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+        const auto &task = tasks.at(t);
+        std::cout << task.desc << "\n";
+        if (task.fn() != 0) {
+            return -1;
+        }
     }
 
     printf("Success!\n");

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -1036,6 +1036,7 @@ int main(int argc, char **argv) {
 
     using Sharder = Halide::Internal::Test::Sharder;
     Sharder sharder(tasks.size());
+    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
     for (size_t t = sharder.first(); t <= sharder.last(); t++) {
         const auto &task = tasks.at(t);
         std::cout << task.desc << "\n";

--- a/test/correctness/simd_op_check.cpp
+++ b/test/correctness/simd_op_check.cpp
@@ -2247,7 +2247,6 @@ int main(int argc, char **argv) {
 
     if (argc > 1) {
         test.filter = argv[1];
-        test.set_num_threads(1);
     }
 
     if (getenv("HL_SIMD_OP_CHECK_FILTER")) {
@@ -2257,20 +2256,6 @@ int main(int argc, char **argv) {
     const int seed = argc > 2 ? atoi(argv[2]) : time(nullptr);
     std::cout << "simd_op_check test seed: " << seed << "\n";
     test.set_seed(seed);
-
-    // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;
-    // the fundamental issue is that we make one set of ImageParams to construct many
-    // Exprs, then realize those Exprs on arbitrary threads; it is known that sharing
-    // one Func across multiple threads is not guaranteed to be safe, and indeed, TSAN
-    // reports data races, of which some are likely 'benign' (e.g. Function.freeze) but others
-    // are highly suspect (e.g. Function.lock_loop_levels). Since multithreading here
-    // was added just to avoid having this test be the last to finish, the expedient 'fix'
-    // for now is to remove the multithreading. A proper fix could be made by restructuring this
-    // test so that every Expr constructed for testing was guaranteed to share no Funcs
-    // (Function.deep_copy() perhaps). Of course, it would also be desirable to allow Funcs, Exprs, etc
-    // to be usable across multiple threads, but that is a major undertaking that is
-    // definitely not worthwhile for present Halide usage patterns.
-    test.set_num_threads(1);
 
     if (argc > 2) {
         // Don't forget: if you want to run the standard tests to a specific output

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -315,9 +315,10 @@ public:
         /* First add some tests based on the target */
         add_tests();
 
-        Sharder sharder(tasks.size());
+        Sharder sharder;
         bool success = true;
-        for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+        for (size_t t = 0; t < tasks.size(); t++) {
+            if (!sharder.should_run(t)) continue;
             const auto &task = tasks.at(t);
             auto result = check_one(task.op, task.name, task.vector_width, task.expr);
             std::cout << result.op << "\n";

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -46,26 +46,23 @@ public:
     int W;
     int H;
 
+    static std::string get_env(const char *v) {
+        const char *r = getenv(v);
+        if (!r) r = "";
+        return r;
+    }
+
     SimdOpCheckTest(const Target t, int w, int h)
         : target(t), W(w), H(h) {
         target = target
                      .with_feature(Target::NoBoundsQuery)
                      .with_feature(Target::NoAsserts)
                      .with_feature(Target::NoRuntime);
-        num_threads = Internal::ThreadPool<void>::num_processors_online();
     }
     virtual ~SimdOpCheckTest() = default;
 
     void set_seed(int seed) {
         rng.seed(seed);
-    }
-
-    size_t get_num_threads() const {
-        return num_threads;
-    }
-
-    void set_num_threads(size_t n) {
-        num_threads = n;
     }
 
     virtual bool can_run_code() const {
@@ -320,17 +317,48 @@ public:
     virtual bool test_all() {
         /* First add some tests based on the target */
         add_tests();
-        Internal::ThreadPool<TestResult> pool(num_threads);
-        std::vector<std::future<TestResult>> futures;
-        for (const Task &task : tasks) {
-            futures.push_back(pool.async([this, task]() {
-                return check_one(task.op, task.name, task.vector_width, task.expr);
-            }));
+
+        size_t first_task = 0;
+        size_t last_task = tasks.size() - 1;
+
+        // These environment variables are used by the GoogleTest framework
+        // to allow a large test to be 'sharded' into smaller pieces:
+        //
+        // - If TEST_SHARD_STATUS_FILE is not empty, we should create a file at that path
+        //   to indicate to the test framework that we support sharding.
+        // - If TEST_TOTAL_SHARDS and TEST_SHARD_INDEX are defined, we should
+        //   split our work into TEST_TOTAL_SHARDS chunks, and only do the TEST_SHARD_INDEX-th
+        //   chunk on this run.
+        //
+        // The Halide buildbots don't (yet) make use of these, but some downstream consumers do.
+        int total_shards = std::atoi(get_env("TEST_TOTAL_SHARDS").c_str());  // 0 if not present
+        int current_shard = std::atoi(get_env("TEST_SHARD_INDEX").c_str());  // 0 if not present
+        std::string shard_status_file = get_env("TEST_SHARD_STATUS_FILE");
+
+        if (total_shards != 0) {
+            if (total_shards < 0 || current_shard < 0 || current_shard >= total_shards) {
+                std::cerr << "Illegal values for sharding: total " << total_shards << " current " << current_shard << "\n";
+                exit(-1);
+            }
+
+            // If shard_status_file is nonempty, we must create that file (the contents don't matter)
+            if (!shard_status_file.empty()) {
+                std::ofstream f(shard_status_file, std::ios::out | std::ios::binary);
+                f << "simd_op_check\n";
+                f.flush();
+                f.close();
+            }
+
+            size_t shard_size = (tasks.size() + total_shards - 1) / total_shards;
+            first_task = current_shard * shard_size;
+            last_task = std::min(first_task + shard_size - 1, tasks.size() - 1);
+            std::cout << "Tasks " << tasks.size() << " shard_size " << shard_size << " first_task " << first_task << " last_task " << last_task << " shard_status_file (" << shard_status_file << ")\n";
         }
 
         bool success = true;
-        for (auto &f : futures) {
-            const TestResult &result = f.get();
+        for (size_t t = first_task; t <= last_task; t++) {
+            const auto &task = tasks.at(t);
+            auto result = check_one(task.op, task.name, task.vector_width, task.expr);
             std::cout << result.op << "\n";
             if (!result.error_msg.empty()) {
                 std::cerr << result.error_msg;
@@ -342,8 +370,9 @@ public:
     }
 
 private:
-    size_t num_threads;
     const Halide::Var x{"x"}, y{"y"};
 };
+
 }  // namespace Halide
+
 #endif  // SIMD_OP_CHECK_H

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -66,7 +66,6 @@ public:
             f.flush();
             f.close();
         }
-
     }
     virtual ~SimdOpCheckTest() = default;
 

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -315,7 +315,6 @@ public:
         /* First add some tests based on the target */
         add_tests();
 
-        Sharder::accept_sharded_status();
         Sharder sharder(tasks.size());
         bool success = true;
         for (size_t t = sharder.first(); t <= sharder.last(); t++) {

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -58,6 +58,15 @@ public:
                      .with_feature(Target::NoBoundsQuery)
                      .with_feature(Target::NoAsserts)
                      .with_feature(Target::NoRuntime);
+        // See comments in test_all()
+        std::string shard_status_file = get_env("TEST_SHARD_STATUS_FILE");
+        if (!shard_status_file.empty()) {
+            std::ofstream f(shard_status_file, std::ios::out | std::ios::binary);
+            f << "simd_op_check\n";
+            f.flush();
+            f.close();
+        }
+
     }
     virtual ~SimdOpCheckTest() = default;
 
@@ -339,14 +348,6 @@ public:
             if (total_shards < 0 || current_shard < 0 || current_shard >= total_shards) {
                 std::cerr << "Illegal values for sharding: total " << total_shards << " current " << current_shard << "\n";
                 exit(-1);
-            }
-
-            // If shard_status_file is nonempty, we must create that file (the contents don't matter)
-            if (!shard_status_file.empty()) {
-                std::ofstream f(shard_status_file, std::ios::out | std::ios::binary);
-                f << "simd_op_check\n";
-                f.flush();
-                f.close();
             }
 
             size_t shard_size = (tasks.size() + total_shards - 1) / total_shards;

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -717,12 +717,15 @@ int main(int argc, char **argv) {
             t.set_feature(f);
         }
     }
+
+    // Instantiate the SimdOpCheck before we skip-return,
+    // so that the sharding setup (if any) will be happy.
+    SimdOpCheckHVX test_hvx(t);
+
     if (t == Target("hexagon-32-noos")) {
         printf("[SKIP] No HVX target enabled.\n");
         return 0;
     }
-
-    SimdOpCheckHVX test_hvx(t);
 
     if (argc > 1) {
         test_hvx.filter = argv[1];

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -723,9 +723,12 @@ int main(int argc, char **argv) {
     SimdOpCheckHVX test_hvx(t);
 
     if (t == Target("hexagon-32-noos")) {
+        Halide::Internal::Test::Sharder::accept_sharded_status();
         printf("[SKIP] No HVX target enabled.\n");
         return 0;
     }
+
+    SimdOpCheckHVX test_hvx(t);
 
     if (argc > 1) {
         test_hvx.filter = argv[1];

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -726,7 +726,6 @@ int main(int argc, char **argv) {
 
     if (argc > 1) {
         test_hvx.filter = argv[1];
-        test_hvx.set_num_threads(1);
     }
 
     if (getenv("HL_SIMD_OP_CHECK_FILTER")) {
@@ -738,20 +737,6 @@ int main(int argc, char **argv) {
     test_hvx.set_seed(seed);
 
     // Remove some features like simd_op_check.cpp used to do.
-
-    // TODO: multithreading here is the cause of https://github.com/halide/Halide/issues/3669;
-    // the fundamental issue is that we make one set of ImageParams to construct many
-    // Exprs, then realize those Exprs on arbitrary threads; it is known that sharing
-    // one Func across multiple threads is not guaranteed to be safe, and indeed, TSAN
-    // reports data races, of which some are likely 'benign' (e.g. Function.freeze) but others
-    // are highly suspect (e.g. Function.lock_loop_levels). Since multithreading here
-    // was added just to avoid having this test be the last to finish, the expedient 'fix'
-    // for now is to remove the multithreading. A proper fix could be made by restructuring this
-    // test so that every Expr constructed for testing was guaranteed to share no Funcs
-    // (Function.deep_copy() perhaps). Of course, it would also be desirable to allow Funcs, Exprs, etc
-    // to be usable across multiple threads, but that is a major undertaking that is
-    // definitely not worthwhile for present Halide usage patterns.
-    test_hvx.set_num_threads(1);
 
     if (argc > 2) {
         // Don't forget: if you want to run the standard tests to a specific output

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -718,10 +718,6 @@ int main(int argc, char **argv) {
         }
     }
 
-    // Instantiate the SimdOpCheck before we skip-return,
-    // so that the sharding setup (if any) will be happy.
-    SimdOpCheckHVX test_hvx(t);
-
     if (t == Target("hexagon-32-noos")) {
         Halide::Internal::Test::Sharder::accept_sharded_status();
         printf("[SKIP] No HVX target enabled.\n");

--- a/test/correctness/vector_cast.cpp
+++ b/test/correctness/vector_cast.cpp
@@ -156,9 +156,9 @@ int main(int argc, char **argv) {
     }
 
     using Sharder = Halide::Internal::Test::Sharder;
-    Sharder sharder(tasks.size());
-    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
-    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+    Sharder sharder;
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn()) {
             exit(-1);

--- a/test/correctness/vector_cast.cpp
+++ b/test/correctness/vector_cast.cpp
@@ -1,5 +1,6 @@
 #include "Halide.h"
-#include <future>
+#include "test_sharding.h"
+
 #include <stdio.h>
 
 using namespace Halide;
@@ -34,6 +35,11 @@ bool is_type_supported(int vec_width, const Target &target) {
 
 template<typename A, typename B>
 bool test(int vec_width, const Target &target) {
+    // Useful for debugging; leave in (commented out)
+    // printf("Test %s x %d -> %s x %d\n",
+    //         string_of_type<A>(), vec_width,
+    //         string_of_type<B>(), vec_width);
+
     if (!is_type_supported<A>(vec_width, target) || !is_type_supported<B>(vec_width, target)) {
         // Type not supported, return pass.
         return true;
@@ -101,18 +107,21 @@ bool test(int vec_width, const Target &target) {
     return true;
 }
 
+struct Task {
+    std::function<bool()> fn;
+};
+
 template<typename A>
-bool test_all(int vec_width, const Target &target) {
-    bool success = true;
-    success = success && test<A, float>(vec_width, target);
-    success = success && test<A, double>(vec_width, target);
-    success = success && test<A, uint8_t>(vec_width, target);
-    success = success && test<A, uint16_t>(vec_width, target);
-    success = success && test<A, uint32_t>(vec_width, target);
-    success = success && test<A, int8_t>(vec_width, target);
-    success = success && test<A, int16_t>(vec_width, target);
-    success = success && test<A, int32_t>(vec_width, target);
-    return success;
+void add_all(int vec_width, const Target &target, std::vector<Task> &tasks) {
+    tasks.push_back({[=]() { return test<A, float>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, float>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, double>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, uint8_t>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, uint16_t>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, uint32_t>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, int8_t>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, int16_t>(vec_width, target); }});
+    tasks.push_back({[=]() { return test<A, int32_t>(vec_width, target); }});
 }
 
 int main(int argc, char **argv) {
@@ -129,34 +138,33 @@ int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
     // We only test power-of-two vector widths for now
-    Halide::Internal::ThreadPool<bool> pool;
-    std::vector<std::future<bool>> futures;
     int vec_width_max = 64;
     if (target.arch == Target::WebAssembly) {
         // The wasm jit is very slow, so shorten this test here.
         vec_width_max = 16;
     }
+    std::vector<Task> tasks;
     for (int vec_width = 1; vec_width <= vec_width_max; vec_width *= 2) {
-        futures.push_back(pool.async([=]() {
-            bool success = true;
-            success = success && test_all<float>(vec_width, target);
-            success = success && test_all<double>(vec_width, target);
-            success = success && test_all<uint8_t>(vec_width, target);
-            success = success && test_all<uint16_t>(vec_width, target);
-            success = success && test_all<uint32_t>(vec_width, target);
-            success = success && test_all<int8_t>(vec_width, target);
-            success = success && test_all<int16_t>(vec_width, target);
-            success = success && test_all<int32_t>(vec_width, target);
-            return success;
-        }));
+        add_all<float>(vec_width, target, tasks);
+        add_all<double>(vec_width, target, tasks);
+        add_all<uint8_t>(vec_width, target, tasks);
+        add_all<uint16_t>(vec_width, target, tasks);
+        add_all<uint32_t>(vec_width, target, tasks);
+        add_all<int8_t>(vec_width, target, tasks);
+        add_all<int16_t>(vec_width, target, tasks);
+        add_all<int32_t>(vec_width, target, tasks);
     }
 
-    bool ok = true;
-    for (auto &f : futures) {
-        ok &= f.get();
+    using Sharder = Halide::Internal::Test::Sharder;
+    Sharder sharder(tasks.size());
+    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
+    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+        const auto &task = tasks.at(t);
+        if (!task.fn()) {
+            exit(-1);
+        }
     }
 
-    if (!ok) return -1;
     printf("Success!\n");
     return 0;
 }

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <future>
 #include <math.h>
 #include <random>
 #include <stdio.h>
@@ -743,6 +742,7 @@ int main(int argc, char **argv) {
 
     using Sharder = Halide::Internal::Test::Sharder;
     Sharder sharder(tasks.size());
+    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
     for (size_t t = sharder.first(); t <= sharder.last(); t++) {
         const auto &task = tasks.at(t);
         if (!task.fn(task.lanes, task.seed)) {

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -1,4 +1,6 @@
 #include "Halide.h"
+#include "test_sharding.h"
+
 #include <algorithm>
 #include <cmath>
 #include <future>
@@ -713,32 +715,41 @@ bool test(int lanes, int seed) {
 }
 
 int main(int argc, char **argv) {
-
     int seed = argc > 1 ? atoi(argv[1]) : time(nullptr);
     std::cout << "vector_math test seed: " << seed << std::endl;
 
+    struct Task {
+        std::function<bool(int, int)> fn;
+        int lanes;
+        int seed;
+    };
+
     // Only native vector widths - llvm doesn't handle others well
-    Halide::Internal::ThreadPool<bool> pool;
-    std::vector<std::future<bool>> futures;
-    futures.push_back(pool.async(test<float>, 4, seed));
-    futures.push_back(pool.async(test<float>, 8, seed));
-    futures.push_back(pool.async(test<double>, 2, seed));
-    futures.push_back(pool.async(test<uint8_t>, 16, seed));
-    futures.push_back(pool.async(test<int8_t>, 16, seed));
-    futures.push_back(pool.async(test<uint16_t>, 8, seed));
-    futures.push_back(pool.async(test<int16_t>, 8, seed));
-    futures.push_back(pool.async(test<uint32_t>, 4, seed));
-    futures.push_back(pool.async(test<int32_t>, 4, seed));
-    futures.push_back(pool.async(test<bfloat16_t>, 8, seed));
-    futures.push_back(pool.async(test<bfloat16_t>, 16, seed));
-    futures.push_back(pool.async(test<float16_t>, 8, seed));
-    futures.push_back(pool.async(test<float16_t>, 16, seed));
-    bool ok = true;
-    for (auto &f : futures) {
-        ok &= f.get();
+    std::vector<Task> tasks = {
+        {test<float>, 4, seed},
+        {test<float>, 8, seed},
+        {test<double>, 2, seed},
+        {test<uint8_t>, 16, seed},
+        {test<int8_t>, 16, seed},
+        {test<uint16_t>, 8, seed},
+        {test<int16_t>, 8, seed},
+        {test<uint32_t>, 4, seed},
+        {test<int32_t>, 4, seed},
+        {test<bfloat16_t>, 8, seed},
+        {test<bfloat16_t>, 16, seed},
+        {test<float16_t>, 8, seed},
+        {test<float16_t>, 16, seed},
+    };
+
+    using Sharder = Halide::Internal::Test::Sharder;
+    Sharder sharder(tasks.size());
+    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+        const auto &task = tasks.at(t);
+        if (!task.fn(task.lanes, task.seed)) {
+            exit(-1);
+        }
     }
 
-    if (!ok) return -1;
     printf("Success!\n");
     return 0;
 }

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -741,9 +741,9 @@ int main(int argc, char **argv) {
     };
 
     using Sharder = Halide::Internal::Test::Sharder;
-    Sharder sharder(tasks.size());
-    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
-    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+    Sharder sharder;
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn(task.lanes, task.seed)) {
             exit(-1);

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -190,6 +190,7 @@ int main(int argc, char **argv) {
 
     using Sharder = Halide::Internal::Test::Sharder;
     Sharder sharder(tasks.size());
+    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
     Target prev_target;
     for (size_t t = sharder.first(); t <= sharder.last(); t++) {
         const auto &task = tasks.at(t);

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -189,10 +189,10 @@ int main(int argc, char **argv) {
     }
 
     using Sharder = Halide::Internal::Test::Sharder;
-    Sharder sharder(tasks.size());
-    std::cout << "Tasks " << tasks.size() << " first " << sharder.first() << " last " << sharder.last() << "\n";
+    Sharder sharder;
     Target prev_target;
-    for (size_t t = sharder.first(); t <= sharder.last(); t++) {
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (task.target != prev_target) {
             std::cout << "vector_reductions: Testing with " << task.target << "\n";

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -111,33 +111,37 @@ void add_tasks(const Target &target, std::vector<Task> &tasks) {
                             .vectorize(rx);
                         ref.compute_root();
 
-                        // Useful for debugging; leave in (commented out)
-                        // std::cout << "Testing: dst_lanes: " << dst_lanes
-                        //           << " reduce_factor " << reduce_factor
-                        //           << " src_type " << src_type
-                        //           << " widen_factor " << widen_factor
-                        //           << " dst_type " << dst_type
-                        //           << " op " << op
-                        //           << "\n";
+                        tasks.push_back({target, [=]() {
+                                             // Useful for debugging; leave in (commented out)
+                                             // std::cout << "Testing: "
+                                             //           << " target: " << target
+                                             //           << " dst_lanes: " << dst_lanes
+                                             //           << " reduce_factor " << reduce_factor
+                                             //           << " src_type " << src_type
+                                             //           << " widen_factor " << widen_factor
+                                             //           << " dst_type " << dst_type
+                                             //           << " op " << op
+                                             //           << "\n";
 
-                        RDom c(0, 128);
+                                             RDom c(0, 128);
 
-                        // Func.evaluate() doesn't let you specify a Target (!),
-                        // so let's use Func.realize() instead.
-                        Func err("err");
-                        err() = cast<double>(maximum(absd(f(c), ref(c))));
-                        Buffer<double, 0> err_im = err.realize({}, target);
-                        double e = err_im();
+                                             // Func.evaluate() doesn't let you specify a Target (!),
+                                             // so let's use Func.realize() instead.
+                                             Func err("err");
+                                             err() = cast<double>(maximum(absd(f(c), ref(c))));
+                                             Buffer<double, 0> err_im = err.realize({}, target);
+                                             double e = err_im();
 
-                        if (e > 1e-3) {
-                            std::cerr
-                                << "Horizontal reduction produced different output when vectorized!\n"
-                                << "Maximum error = " << e << "\n"
-                                << "Reducing from " << src_type.with_lanes(src_lanes)
-                                << " to " << dst_type.with_lanes(dst_lanes) << "\n"
-                                << "RHS: " << f.update_value() << "\n";
-                            exit(-1);
-                        }
+                                             if (e > 1e-3) {
+                                                 std::cerr
+                                                     << "Horizontal reduction produced different output when vectorized!\n"
+                                                     << "Maximum error = " << e << "\n"
+                                                     << "Reducing from " << src_type.with_lanes(src_lanes)
+                                                     << " to " << dst_type.with_lanes(dst_lanes) << "\n"
+                                                     << "RHS: " << f.update_value() << "\n";
+                                                 exit(-1);
+                                             }
+                                         }});
                     }
                 }
             }

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -111,37 +111,39 @@ void add_tasks(const Target &target, std::vector<Task> &tasks) {
                             .vectorize(rx);
                         ref.compute_root();
 
-                        tasks.push_back({target, [=]() {
-                                             // Useful for debugging; leave in (commented out)
-                                             // std::cout << "Testing: "
-                                             //           << " target: " << target
-                                             //           << " dst_lanes: " << dst_lanes
-                                             //           << " reduce_factor " << reduce_factor
-                                             //           << " src_type " << src_type
-                                             //           << " widen_factor " << widen_factor
-                                             //           << " dst_type " << dst_type
-                                             //           << " op " << op
-                                             //           << "\n";
-
-                                             RDom c(0, 128);
-
-                                             // Func.evaluate() doesn't let you specify a Target (!),
-                                             // so let's use Func.realize() instead.
                                              Func err("err");
-                                             err() = cast<double>(maximum(absd(f(c), ref(c))));
-                                             Buffer<double, 0> err_im = err.realize({}, target);
-                                             double e = err_im();
+                        const auto fn - [=]() {
+                            // Useful for debugging; leave in (commented out)
+                            // std::cout << "Testing: "
+                            //           << " target: " << target
+                            //           << " dst_lanes: " << dst_lanes
+                            //           << " reduce_factor " << reduce_factor
+                            //           << " src_type " << src_type
+                            //           << " widen_factor " << widen_factor
+                            //           << " dst_type " << dst_type
+                            //           << " op " << op
+                            //           << "\n";
 
-                                             if (e > 1e-3) {
-                                                 std::cerr
-                                                     << "Horizontal reduction produced different output when vectorized!\n"
-                                                     << "Maximum error = " << e << "\n"
-                                                     << "Reducing from " << src_type.with_lanes(src_lanes)
-                                                     << " to " << dst_type.with_lanes(dst_lanes) << "\n"
-                                                     << "RHS: " << f.update_value() << "\n";
-                                                 exit(-1);
-                                             }
-                                         }});
+                            RDom c(0, 128);
+
+                            // Func.evaluate() doesn't let you specify a Target (!),
+                            // so let's use Func.realize() instead.
+                            Func err("err");
+                            err() = cast<double>(maximum(absd(f(c), ref(c))));
+                            Buffer<double, 0> err_im = err.realize({}, target);
+                            double e = err_im();
+
+                            if (e > 1e-3) {
+                                std::cerr
+                                    << "Horizontal reduction produced different output when vectorized!\n"
+                                    << "Maximum error = " << e << "\n"
+                                    << "Reducing from " << src_type.with_lanes(src_lanes)
+                                    << " to " << dst_type.with_lanes(dst_lanes) << "\n"
+                                    << "RHS: " << f.update_value() << "\n";
+                                exit(-1);
+                            }
+                        };
+                        tasks.emplace_back(target, fn);
                     }
                 }
             }

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -142,7 +142,7 @@ void add_tasks(const Target &target, std::vector<Task> &tasks) {
                                 exit(-1);
                             }
                         };
-                        tasks.emplace_back(target, fn);
+                        tasks.push_back({target, fn});
                     }
                 }
             }

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -111,8 +111,7 @@ void add_tasks(const Target &target, std::vector<Task> &tasks) {
                             .vectorize(rx);
                         ref.compute_root();
 
-                                             Func err("err");
-                        const auto fn - [=]() {
+                        const auto fn = [=]() {
                             // Useful for debugging; leave in (commented out)
                             // std::cout << "Testing: "
                             //           << " target: " << target


### PR DESCRIPTION
The simd_op_check test suite is pretty slow (especially for wasm, where it is interpreted); at one point we tried to use ThreadPool to speed it up, but too many pieces of Halide IR aren't threadsafe and we disabled it long ago.

This removes the ThreadPool usage entirely, and instead adds support for the GoogleTest 'sharded test' protocol, which uses certain env vars to allow a test to opt in for splitting its test into smaller pieces.

At present our buildbot isn't attempting to make use of this feature, but it will be a big win for downstream usage in Google, where tests that run "too long" are problematic and splitting them into multiple shards makes various day to day activiites much more pleasant.