### PR TITLE
LLVM codegen: register AA pipeline if LLVM is older than 14

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1119,6 +1119,13 @@ void CodeGen_LLVM::optimize_module() {
     llvm::CGSCCAnalysisManager cgam;
     llvm::ModuleAnalysisManager mam;
 
+#if LLVM_VERSION < 140
+    // If building against LLVM older than 14, explicitly specify AA pipeline.
+    // Not needed with LLVM14 or later, already the default.
+    llvm::AAManager aa = pb.buildDefaultAAPipeline();
+    fam.registerPass([&] { return std::move(aa); });
+#endif
+
     // Register all the basic analyses with the managers.
     pb.registerModuleAnalyses(mam);
     pb.registerCGSCCAnalyses(cgam);


### PR DESCRIPTION
It's the default after https://reviews.llvm.org/D113210 / https://github.com/llvm/llvm-project/commit/13317286f8298eb3bafa9ddebd1c03bef4918948,
but still needs to be done for earlier LLVM's.

Refs. https://github.com/halide/Halide/issues/6783
Refs. https://github.com/halide/Halide/pull/6718

Partially reverts https://github.com/halide/Halide/pull/6718