### PR TITLE
Pacify clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: >
     -bugprone-narrowing-conversions,
     -bugprone-reserved-identifier,
     -bugprone-signed-char-misuse,
+    clang-diagnostic-shadow-field,
     misc-*,
     -misc-no-recursion,
     -misc-non-private-member-variables-in-classes,

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1370,18 +1370,18 @@ template<typename T = void>
 class StubOutputBuffer : public StubOutputBufferBase {
     template<typename T2>
     friend class GeneratorOutput_Buffer;
-    explicit StubOutputBuffer(const Func &f, const std::shared_ptr<AbstractGenerator> &generator)
-        : StubOutputBufferBase(f, generator) {
+    explicit StubOutputBuffer(const Func &fn, const std::shared_ptr<AbstractGenerator> &gen)
+        : StubOutputBufferBase(fn, gen) {
     }
 
 public:
     StubOutputBuffer() = default;
 
     static std::vector<StubOutputBuffer<T>> to_output_buffers(const std::vector<Func> &v,
-                                                              const std::shared_ptr<AbstractGenerator> &generator) {
+                                                              const std::shared_ptr<AbstractGenerator> &gen) {
         std::vector<StubOutputBuffer<T>> result;
         for (const Func &f : v) {
-            result.push_back(StubOutputBuffer<T>(f, generator));
+            result.push_back(StubOutputBuffer<T>(f, gen));
         }
         return result;
     }


### PR DESCRIPTION
Enable `clang-diagnostic-shadow-field` and fix relevant issues.