### PR TITLE
Make all tests default to `-fvisibility=hidden`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,9 @@ TEST_LD_FLAGS = -L$(BIN_DIR) -lHalide $(COMMON_LD_FLAGS)
 # In the tests, some of our expectations change depending on the llvm version
 TEST_CXX_FLAGS += -DLLVM_VERSION=$(LLVM_VERSION_TIMES_10)
 
+# In the tests, default to exporting no symbols that aren't explicitly exported
+TEST_CXX_FLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
+
 # gcc 4.8 fires a bogus warning on old versions of png.h
 ifneq (,$(findstring g++,$(CXX_VERSION)))
 ifneq (,$(findstring 4.8,$(CXX_VERSION)))

--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -56,6 +56,10 @@ function(add_halide_test TARGET)
                          SKIP_REGULAR_EXPRESSION "\\[SKIP\\]"
                          WILL_FAIL ${args_EXPECT_FAILURE})
 
+    set_target_properties(${TARGET} PROPERTIES
+                          CXX_VISIBILITY_PRESET hidden
+                          VISIBILITY_INLINES_HIDDEN TRUE)
+
     # Add a meta-target for each group, to allow us to build by group easily
     foreach (GROUP IN LISTS args_GROUPS)
         set(META_TARGET build_${GROUP})

--- a/python_bindings/stub/PyStub.cpp
+++ b/python_bindings/stub/PyStub.cpp
@@ -28,17 +28,9 @@ extern "C" PyObject *_halide_pystub_impl(const char *module_name, const Halide::
 #define _HALIDE_CONCAT(first, second) first##second
 #define HALIDE_CONCAT(first, second) _HALIDE_CONCAT(first, second)
 
-// Don't use HALIDE_EXPORT: Halide.h will already have defined it,
-// but it might be defined the wrong way (import rather than export).
-#if defined(WIN32) || defined(_WIN32)
-#define HALIDE_PLUGIN_EXPORT __declspec(dllexport)
-#else
-#define HALIDE_PLUGIN_EXPORT __attribute__((visibility("default")))
-#endif
-
 static_assert(PY_MAJOR_VERSION >= 3, "Python bindings for Halide require Python 3+");
 
-#define _HALIDE_PLUGIN_IMPL(name) extern "C" HALIDE_PLUGIN_EXPORT PyObject *PyInit_##name() /* NOLINT(bugprone-macro-parentheses) */
+#define _HALIDE_PLUGIN_IMPL(name) extern "C" HALIDE_EXPORT_SYMBOL PyObject *PyInit_##name() /* NOLINT(bugprone-macro-parentheses) */
 #define HALIDE_PLUGIN_IMPL(name) _HALIDE_PLUGIN_IMPL(name)
 
 // clang-format off

--- a/src/Error.h
+++ b/src/Error.h
@@ -13,27 +13,27 @@ namespace Halide {
 bool exceptions_enabled();
 
 /** A base class for Halide errors. */
-struct Error : public std::runtime_error {
+struct HALIDE_EXPORT_SYMBOL Error : public std::runtime_error {
     // Give each class a non-inlined constructor so that the type
     // doesn't get separately instantiated in each compilation unit.
     Error(const std::string &msg);
 };
 
 /** An error that occurs while running a JIT-compiled Halide pipeline. */
-struct RuntimeError : public Error {
+struct HALIDE_EXPORT_SYMBOL RuntimeError : public Error {
     RuntimeError(const std::string &msg);
 };
 
 /** An error that occurs while compiling a Halide pipeline that Halide
  * attributes to a user error. */
-struct CompileError : public Error {
+struct HALIDE_EXPORT_SYMBOL CompileError : public Error {
     CompileError(const std::string &msg);
 };
 
 /** An error that occurs while compiling a Halide pipeline that Halide
  * attributes to an internal compiler bug, or to an invalid use of
  * Halide's internals. */
-struct InternalError : public Error {
+struct HALIDE_EXPORT_SYMBOL InternalError : public Error {
     InternalError(const std::string &msg);
 };
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -55,6 +55,14 @@ extern "C" {
 #endif
 #endif
 
+#ifndef HALIDE_EXPORT_SYMBOL
+#ifdef _MSC_VER
+#define HALIDE_EXPORT_SYMBOL __declspec(dllexport)
+#else
+#define HALIDE_EXPORT_SYMBOL __attribute__((visibility("default")))
+#endif
+#endif
+
 /** \file
  *
  * This file declares the routines used by Halide internally in its

--- a/test/auto_schedule/extern.cpp
+++ b/test/auto_schedule/extern.cpp
@@ -4,7 +4,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // An extern stage that translates.

--- a/test/auto_schedule/extern.cpp
+++ b/test/auto_schedule/extern.cpp
@@ -1,14 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // An extern stage that translates.
-extern "C" DLLEXPORT int translate(halide_buffer_t *in, int dx, int dy, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int translate(halide_buffer_t *in, int dx, int dy, halide_buffer_t *out) {
 
     if (in->is_bounds_query()) {
         in->dim[0].min = out->dim[0].min + dx;

--- a/test/correctness/async.cpp
+++ b/test/correctness/async.cpp
@@ -2,13 +2,7 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int expensive(int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int expensive(int x) {
     float f = 3.0f;
     for (int i = 0; i < (1 << 10); i++) {
         f = sqrtf(sinf(cosf(f)));

--- a/test/correctness/async.cpp
+++ b/test/correctness/async.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int expensive(int x) {

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -7,7 +7,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 enum class Backend {

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -4,12 +4,6 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 enum class Backend {
     CPU,
     CPUVectorize,
@@ -1008,7 +1002,7 @@ void test_all(const Backend &backend) {
     }
 }
 
-extern "C" DLLEXPORT int extern_func(int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int extern_func(int x) {
     return x + 1;
 }
 HalideExtern_1(int, extern_func, int);
@@ -1060,7 +1054,7 @@ void test_extern_func(const Backend &backend) {
     }
 }
 
-extern "C" DLLEXPORT int expensive(int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int expensive(int x) {
     float f = 3.0f;
     for (int i = 0; i < (1 << 10); i++) {
         f = sqrtf(sinf(cosf(f)));

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -7,27 +7,21 @@ using namespace Halide;
 // This is not supported by the C backend.
 
 // On windows, you need to use declspec to do the same.
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_counter = 0;
-extern "C" DLLEXPORT float my_func(int x, float y) {
+extern "C" HALIDE_EXPORT_SYMBOL float my_func(int x, float y) {
     call_counter++;
     return x * y;
 }
 HalideExtern_2(float, my_func, int, float);
 
 int call_counter2 = 0;
-extern "C" DLLEXPORT float my_func2(int x, float y) {
+extern "C" HALIDE_EXPORT_SYMBOL float my_func2(int x, float y) {
     call_counter2++;
     return x * y;
 }
 
 int call_counter3 = 0;
-extern "C" DLLEXPORT float my_func3(int x, float y) {
+extern "C" HALIDE_EXPORT_SYMBOL float my_func3(int x, float y) {
     call_counter3++;
     return x * y;
 }

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -10,7 +10,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_counter = 0;

--- a/test/correctness/compute_at_split_rvar.cpp
+++ b/test/correctness/compute_at_split_rvar.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_counter = 0;

--- a/test/correctness/compute_at_split_rvar.cpp
+++ b/test/correctness/compute_at_split_rvar.cpp
@@ -3,14 +3,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_counter = 0;
-extern "C" DLLEXPORT int count(int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int count(int x) {
     return call_counter++;
 }
 HalideExtern_1(int, count, int);

--- a/test/correctness/concat.cpp
+++ b/test/correctness/concat.cpp
@@ -2,14 +2,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int count[2];
-extern "C" DLLEXPORT int call_counter(int slot, int val) {
+extern "C" HALIDE_EXPORT_SYMBOL int call_counter(int slot, int val) {
     count[slot]++;
     return val;
 }

--- a/test/correctness/concat.cpp
+++ b/test/correctness/concat.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int count[2];

--- a/test/correctness/custom_lowering_pass.cpp
+++ b/test/correctness/custom_lowering_pass.cpp
@@ -24,14 +24,8 @@ class CheckForFloatDivision : public IRMutator {
 
 // A mutator that injects code that counts floating point multiplies,
 // and an extern function that it calls out to for the accounting.
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int multiply_count = 0;
-extern "C" DLLEXPORT float record_float_mul(float arg) {
+extern "C" HALIDE_EXPORT_SYMBOL float record_float_mul(float arg) {
     multiply_count++;
     return arg;
 }

--- a/test/correctness/custom_lowering_pass.cpp
+++ b/test/correctness/custom_lowering_pass.cpp
@@ -27,7 +27,7 @@ class CheckForFloatDivision : public IRMutator {
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int multiply_count = 0;

--- a/test/correctness/exception.cpp
+++ b/test/correctness/exception.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
         error = true;
         std::cout << "Expected compile error:\n"
                   << e.what() << "\n";
-    };
+    }
     // We should have entered the catch block
     check_error(error);
 

--- a/test/correctness/extern_bounds_inference.cpp
+++ b/test/correctness/extern_bounds_inference.cpp
@@ -4,7 +4,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // An extern stage that translates.

--- a/test/correctness/extern_bounds_inference.cpp
+++ b/test/correctness/extern_bounds_inference.cpp
@@ -1,14 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // An extern stage that translates.
-extern "C" DLLEXPORT int translate(halide_buffer_t *in, int dx, int dy, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int translate(halide_buffer_t *in, int dx, int dy, halide_buffer_t *out) {
 
     if (in->is_bounds_query()) {
         in->dim[0].min = out->dim[0].min + dx;

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -8,7 +8,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int dump_to_file(halide_buffer_t *input, const char *filename,

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -5,15 +5,9 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int dump_to_file(halide_buffer_t *input, const char *filename,
-                                      int desired_min, int desired_extent,
-                                      halide_buffer_t *) {
+extern "C" HALIDE_EXPORT_SYMBOL int dump_to_file(halide_buffer_t *input, const char *filename,
+                                                 int desired_min, int desired_extent,
+                                                 halide_buffer_t *) {
     // Note the final output buffer argument is unused.
     if (input->is_bounds_query()) {
         // Request some range of the input buffer

--- a/test/correctness/extern_consumer_tiled.cpp
+++ b/test/correctness/extern_consumer_tiled.cpp
@@ -8,7 +8,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int copy_plus_xcoord(halide_buffer_t *input, int tile_extent_x, int tile_extent_y, halide_buffer_t *output) {

--- a/test/correctness/extern_consumer_tiled.cpp
+++ b/test/correctness/extern_consumer_tiled.cpp
@@ -5,13 +5,7 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int copy_plus_xcoord(halide_buffer_t *input, int tile_extent_x, int tile_extent_y, halide_buffer_t *output) {
+extern "C" HALIDE_EXPORT_SYMBOL int copy_plus_xcoord(halide_buffer_t *input, int tile_extent_x, int tile_extent_y, halide_buffer_t *output) {
     // Note the final output buffer argument is unused.
     if (input->is_bounds_query()) {
         for (int d = 0; d < 2; d++) {

--- a/test/correctness/extern_error.cpp
+++ b/test/correctness/extern_error.cpp
@@ -3,20 +3,14 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 bool extern_error_called = false;
-extern "C" DLLEXPORT int extern_error(JITUserContext *user_context, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int extern_error(JITUserContext *user_context, halide_buffer_t *out) {
     extern_error_called = true;
     return -1;
 }
 
 bool error_occurred = false;
-extern "C" DLLEXPORT void my_halide_error(JITUserContext *user_context, const char *msg) {
+extern "C" HALIDE_EXPORT_SYMBOL void my_halide_error(JITUserContext *user_context, const char *msg) {
     printf("Expected: %s\n", msg);
     error_occurred = true;
 }

--- a/test/correctness/extern_error.cpp
+++ b/test/correctness/extern_error.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 bool extern_error_called = false;

--- a/test/correctness/extern_output_expansion.cpp
+++ b/test/correctness/extern_output_expansion.cpp
@@ -4,7 +4,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // out(x) = in(x) * x;

--- a/test/correctness/extern_output_expansion.cpp
+++ b/test/correctness/extern_output_expansion.cpp
@@ -1,14 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // out(x) = in(x) * x;
-extern "C" DLLEXPORT int extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
     assert(in->type == halide_type_of<int>());
     assert(out->type == halide_type_of<int>());
     if (in->host == nullptr || out->host == nullptr) {

--- a/test/correctness/extern_partial.cpp
+++ b/test/correctness/extern_partial.cpp
@@ -5,13 +5,7 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int copy_row_plus_xcoord(halide_buffer_t *input, halide_buffer_t *output) {
+extern "C" HALIDE_EXPORT_SYMBOL int copy_row_plus_xcoord(halide_buffer_t *input, halide_buffer_t *output) {
     // Note the final output buffer argument is unused.
     if (input->is_bounds_query()) {
         for (int d = 0; d < 2; d++) {

--- a/test/correctness/extern_partial.cpp
+++ b/test/correctness/extern_partial.cpp
@@ -8,7 +8,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int copy_row_plus_xcoord(halide_buffer_t *input, halide_buffer_t *output) {

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -3,12 +3,6 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // Some helper functions for rounding
 int round_down(int, int);
 int round_up(int x, int m) {
@@ -29,7 +23,7 @@ int round_down(int x, int m) {
 
 // Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using a
 // periodic integer function.
-extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int make_data(halide_buffer_t *out) {
     static int desired_row_extent = 0;
     if (out->is_bounds_query()) {
         // Bounds query mode. To make life interesting, let's add some
@@ -72,7 +66,7 @@ extern "C" DLLEXPORT int make_data(halide_buffer_t *out) {
 
 // Imagine that this loads from a file, or tiled storage. Here we'll just fill in the data using a
 // periodic integer function.
-extern "C" DLLEXPORT int make_data_multi(halide_buffer_t *out1, halide_buffer_t *out2) {
+extern "C" HALIDE_EXPORT_SYMBOL int make_data_multi(halide_buffer_t *out1, halide_buffer_t *out2) {
     if (!out1->host || !out2->host) {
         // Bounds query mode. We're ok with any requested output size (Halide guarantees they match).
         return 0;

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // Some helper functions for rounding

--- a/test/correctness/extern_reorder_storage.cpp
+++ b/test/correctness/extern_reorder_storage.cpp
@@ -1,14 +1,8 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // An extern stage that translates.
-extern "C" DLLEXPORT int copy_and_check_strides(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int copy_and_check_strides(halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         for (int i = 0; i < 2; i++) {
             in->dim[i].min = out->dim[i].min;

--- a/test/correctness/extern_reorder_storage.cpp
+++ b/test/correctness/extern_reorder_storage.cpp
@@ -4,7 +4,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // An extern stage that translates.

--- a/test/correctness/extern_sort.cpp
+++ b/test/correctness/extern_sort.cpp
@@ -7,7 +7,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // Use an extern stage to do a sort

--- a/test/correctness/extern_sort.cpp
+++ b/test/correctness/extern_sort.cpp
@@ -4,14 +4,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // Use an extern stage to do a sort
-extern "C" DLLEXPORT int sort_buffer(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int sort_buffer(halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         in->dim[0].min = out->dim[0].min;
         in->dim[0].extent = out->dim[0].extent;

--- a/test/correctness/extern_stage.cpp
+++ b/test/correctness/extern_stage.cpp
@@ -1,13 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int flip_x(halide_buffer_t *in1, halide_buffer_t *in2, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int flip_x(halide_buffer_t *in1, halide_buffer_t *in2, halide_buffer_t *out) {
     int min = out->dim[0].min;
     int max = out->dim[0].min + out->dim[0].extent - 1;
 

--- a/test/correctness/extern_stage.cpp
+++ b/test/correctness/extern_stage.cpp
@@ -4,7 +4,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int flip_x(halide_buffer_t *in1, halide_buffer_t *in2, halide_buffer_t *out) {

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -4,19 +4,13 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // An extern stage implemented by a Halide pipeline running
 // either on host or device. The outer Halide filter must
 // override the "device_api" parameter of Func::define_extern
 // when using the extern_stage on device.
-extern "C" DLLEXPORT int extern_stage(int extern_on_device,
-                                      int outer_filter_on_device,
-                                      halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int extern_stage(int extern_on_device,
+                                                 int outer_filter_on_device,
+                                                 halide_buffer_t *out) {
     if (!out->is_bounds_query()) {
         if (extern_on_device > 0 && outer_filter_on_device > 0) {
             // If both the extern and the outer filter are on running on

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -7,7 +7,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // An extern stage implemented by a Halide pipeline running

--- a/test/correctness/handle.cpp
+++ b/test/correctness/handle.cpp
@@ -3,15 +3,9 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // Make a custom strlen so that it always returns a 32-bit int,
 // instead of switching based on bit-width.
-extern "C" DLLEXPORT int my_strlen(const char *c) {
+extern "C" HALIDE_EXPORT_SYMBOL int my_strlen(const char *c) {
     int l = 0;
     while (*c) {
         c++;

--- a/test/correctness/handle.cpp
+++ b/test/correctness/handle.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // Make a custom strlen so that it always returns a 32-bit int,

--- a/test/correctness/image_of_lists.cpp
+++ b/test/correctness/image_of_lists.cpp
@@ -8,7 +8,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT std::list<int> *list_create(int) {

--- a/test/correctness/image_of_lists.cpp
+++ b/test/correctness/image_of_lists.cpp
@@ -5,18 +5,12 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT std::list<int> *list_create(int) {
+extern "C" HALIDE_EXPORT_SYMBOL std::list<int> *list_create(int) {
     return new std::list<int>();
 }
 HalideExtern_1(std::list<int> *, list_create, int);
 
-extern "C" DLLEXPORT std::list<int> *list_maybe_insert(std::list<int> *list, bool insert, int value) {
+extern "C" HALIDE_EXPORT_SYMBOL std::list<int> *list_maybe_insert(std::list<int> *list, bool insert, int value) {
     if (insert) {
         list->push_back(value);
     }

--- a/test/correctness/lazy_convolution.cpp
+++ b/test/correctness/lazy_convolution.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_count;

--- a/test/correctness/lazy_convolution.cpp
+++ b/test/correctness/lazy_convolution.cpp
@@ -3,14 +3,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_count;
-extern "C" DLLEXPORT float call_counter(float x) {
+extern "C" HALIDE_EXPORT_SYMBOL float call_counter(float x) {
     call_count++;
     return x;
 }

--- a/test/correctness/loop_invariant_extern_calls.cpp
+++ b/test/correctness/loop_invariant_extern_calls.cpp
@@ -5,20 +5,14 @@ using namespace Halide;
 
 // NB: You must compile with -rdynamic for llvm to be able to find the appropriate symbols
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_counter[] = {0, 0, 0, 0, 0, 0};
-extern "C" DLLEXPORT int my_func(int counter, int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int my_func(int counter, int x) {
     call_counter[counter]++;
     return x;
 }
 HalidePureExtern_2(int, my_func, int, int);
 
-extern "C" DLLEXPORT int my_impure_func(int counter, int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int my_impure_func(int counter, int x) {
     call_counter[counter]++;
     return x;
 }

--- a/test/correctness/loop_invariant_extern_calls.cpp
+++ b/test/correctness/loop_invariant_extern_calls.cpp
@@ -8,7 +8,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_counter[] = {0, 0, 0, 0, 0, 0};

--- a/test/correctness/make_struct.cpp
+++ b/test/correctness/make_struct.cpp
@@ -11,13 +11,7 @@ struct struct_t {
     const char *d;
 };
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int check_struct(struct_t *s) {
+extern "C" HALIDE_EXPORT_SYMBOL int check_struct(struct_t *s) {
     if (s->a != 3.0 ||
         s->b != 1234567 ||
         s->c != 1234 ||

--- a/test/correctness/make_struct.cpp
+++ b/test/correctness/make_struct.cpp
@@ -14,7 +14,7 @@ struct struct_t {
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int check_struct(struct_t *s) {

--- a/test/correctness/many_small_extern_stages.cpp
+++ b/test/correctness/many_small_extern_stages.cpp
@@ -4,7 +4,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 void dump_buffer_shape(halide_buffer_t *b) {

--- a/test/correctness/many_small_extern_stages.cpp
+++ b/test/correctness/many_small_extern_stages.cpp
@@ -1,19 +1,13 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 void dump_buffer_shape(halide_buffer_t *b) {
     for (int i = 0; i < b->dimensions; i++) {
         printf(" %d %d %d\n", b->dim[i].min, b->dim[i].extent, b->dim[i].stride);
     }
 }
 
-extern "C" DLLEXPORT int copy(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int copy(halide_buffer_t *in, halide_buffer_t *out) {
 
     /*
     printf("out:\n");

--- a/test/correctness/memoize.cpp
+++ b/test/correctness/memoize.cpp
@@ -6,17 +6,11 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // External functions to track whether the cache is working.
 
 int call_count = 0;
 
-extern "C" DLLEXPORT int count_calls(halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int count_calls(halide_buffer_t *out) {
     if (!out->is_bounds_query()) {
         call_count++;
         Halide::Runtime::Buffer<uint8_t>(*out).fill(42);
@@ -26,7 +20,7 @@ extern "C" DLLEXPORT int count_calls(halide_buffer_t *out) {
 
 int call_count_with_arg = 0;
 
-extern "C" DLLEXPORT int count_calls_with_arg(uint8_t val, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int count_calls_with_arg(uint8_t val, halide_buffer_t *out) {
     if (!out->is_bounds_query()) {
         call_count_with_arg++;
         Halide::Runtime::Buffer<uint8_t>(*out).fill(val);
@@ -36,7 +30,7 @@ extern "C" DLLEXPORT int count_calls_with_arg(uint8_t val, halide_buffer_t *out)
 
 int call_count_with_arg_parallel[8];
 
-extern "C" DLLEXPORT int count_calls_with_arg_parallel(uint8_t val, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int count_calls_with_arg_parallel(uint8_t val, halide_buffer_t *out) {
     if (!out->is_bounds_query()) {
         call_count_with_arg_parallel[out->dim[2].min]++;
         Halide::Runtime::Buffer<uint8_t>(*out).fill(val);
@@ -46,7 +40,7 @@ extern "C" DLLEXPORT int count_calls_with_arg_parallel(uint8_t val, halide_buffe
 
 int call_count_staged[4];
 
-extern "C" DLLEXPORT int count_calls_staged(int32_t stage, uint8_t val, halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int count_calls_staged(int32_t stage, uint8_t val, halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         for (int i = 0; i < out->dimensions; i++) {
             in->dim[i] = out->dim[i];
@@ -60,7 +54,7 @@ extern "C" DLLEXPORT int count_calls_staged(int32_t stage, uint8_t val, halide_b
     return 0;
 }
 
-extern "C" DLLEXPORT int computed_eviction_key(int a) {
+extern "C" HALIDE_EXPORT_SYMBOL int computed_eviction_key(int a) {
     return 2020 + a;
 }
 HalideExtern_1(int, computed_eviction_key, int);

--- a/test/correctness/memoize.cpp
+++ b/test/correctness/memoize.cpp
@@ -9,7 +9,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // External functions to track whether the cache is working.

--- a/test/correctness/memoize_cloned.cpp
+++ b/test/correctness/memoize_cloned.cpp
@@ -2,14 +2,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_count;
-extern "C" DLLEXPORT int call_counter(int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int call_counter(int x) {
     call_count++;
     return x;
 }

--- a/test/correctness/memoize_cloned.cpp
+++ b/test/correctness/memoize_cloned.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_count;

--- a/test/correctness/multiple_outputs_extern.cpp
+++ b/test/correctness/multiple_outputs_extern.cpp
@@ -1,13 +1,7 @@
 #include "Halide.h"
 #include <stdio.h>
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int flip_x_and_sum(halide_buffer_t *in1, halide_buffer_t *in2, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int flip_x_and_sum(halide_buffer_t *in1, halide_buffer_t *in2, halide_buffer_t *out) {
     int min = out->dim[0].min;
     int max = out->dim[0].min + out->dim[0].extent - 1;
 

--- a/test/correctness/multiple_outputs_extern.cpp
+++ b/test/correctness/multiple_outputs_extern.cpp
@@ -4,7 +4,7 @@
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int flip_x_and_sum(halide_buffer_t *in1, halide_buffer_t *in2, halide_buffer_t *out) {

--- a/test/correctness/non_nesting_extern_bounds_query.cpp
+++ b/test/correctness/non_nesting_extern_bounds_query.cpp
@@ -2,12 +2,6 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // Extern stages are supposed to obey the following nesting property
 // on bounds queries: If some region of the output O requires some
 // region of the input I, then requesting any subset of O should only
@@ -22,7 +16,7 @@ using namespace Halide;
 // received in non-bounds-query-mode is the intersection of what it
 // asked for for a single scanline and what it asked for for the whole
 // image.
-extern "C" DLLEXPORT int misbehaving_extern_stage(halide_buffer_t *in, int variant, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int misbehaving_extern_stage(halide_buffer_t *in, int variant, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         // As a baseline, require the same amount of input as output, like a copy
         memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));

--- a/test/correctness/non_nesting_extern_bounds_query.cpp
+++ b/test/correctness/non_nesting_extern_bounds_query.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // Extern stages are supposed to obey the following nesting property

--- a/test/correctness/parallel_fork.cpp
+++ b/test/correctness/parallel_fork.cpp
@@ -11,13 +11,7 @@ using namespace Halide::Tools;
 
 std::atomic<int32_t> call_count{0};
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int five_ms(int arg) {
+extern "C" HALIDE_EXPORT_SYMBOL int five_ms(int arg) {
     call_count++;
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     return arg;

--- a/test/correctness/parallel_fork.cpp
+++ b/test/correctness/parallel_fork.cpp
@@ -14,7 +14,7 @@ std::atomic<int32_t> call_count{0};
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int five_ms(int arg) {

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_counter = 0;

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -3,14 +3,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_counter = 0;
-extern "C" DLLEXPORT float my_func(int x, float y) {
+extern "C" HALIDE_EXPORT_SYMBOL float my_func(int x, float y) {
     call_counter++;
     return x * y;
 }

--- a/test/correctness/process_some_tiles.cpp
+++ b/test/correctness/process_some_tiles.cpp
@@ -8,7 +8,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_count = 0;

--- a/test/correctness/process_some_tiles.cpp
+++ b/test/correctness/process_some_tiles.cpp
@@ -5,14 +5,8 @@
 using namespace Halide;
 
 // A version of pow that tracks usage so we can check how many times it was called.
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_count = 0;
-extern "C" DLLEXPORT float my_powf(float x, float y) {
+extern "C" HALIDE_EXPORT_SYMBOL float my_powf(float x, float y) {
     call_count++;
     // We have to read from call_count, or for some reason apple clang removes it entirely.
     assert(call_count != -1);

--- a/test/correctness/side_effects.cpp
+++ b/test/correctness/side_effects.cpp
@@ -15,14 +15,8 @@ using namespace Halide;
 // thread-safe.
 
 // Here we use an extern call to print an ascii-art Mandelbrot set.
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_count = 0;
-extern "C" DLLEXPORT int draw_pixel(int x, int y, int val) {
+extern "C" HALIDE_EXPORT_SYMBOL int draw_pixel(int x, int y, int val) {
     call_count++;
     static int last_y = 0;
     if (y != last_y) {

--- a/test/correctness/side_effects.cpp
+++ b/test/correctness/side_effects.cpp
@@ -18,7 +18,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_count = 0;

--- a/test/correctness/skip_stages.cpp
+++ b/test/correctness/skip_stages.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_count[4];

--- a/test/correctness/skip_stages.cpp
+++ b/test/correctness/skip_stages.cpp
@@ -3,14 +3,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_count[4];
-extern "C" DLLEXPORT int call_counter(int x, int idx) {
+extern "C" HALIDE_EXPORT_SYMBOL int call_counter(int x, int idx) {
     call_count[idx]++;
     return x;
 }

--- a/test/correctness/skip_stages_external_array_functions.cpp
+++ b/test/correctness/skip_stages_external_array_functions.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int bounds_query_count[4];

--- a/test/correctness/skip_stages_external_array_functions.cpp
+++ b/test/correctness/skip_stages_external_array_functions.cpp
@@ -3,15 +3,9 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int bounds_query_count[4];
 int call_count[4];
-extern "C" DLLEXPORT int call_counter(halide_buffer_t *input, int x, int idx, halide_buffer_t *output) {
+extern "C" HALIDE_EXPORT_SYMBOL int call_counter(halide_buffer_t *input, int x, int idx, halide_buffer_t *output) {
     if (input->is_bounds_query()) {
         bounds_query_count[idx]++;
         input->dim[0] = output->dim[0];

--- a/test/correctness/sliding_backwards.cpp
+++ b/test/correctness/sliding_backwards.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_counter = 0;

--- a/test/correctness/sliding_backwards.cpp
+++ b/test/correctness/sliding_backwards.cpp
@@ -3,14 +3,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_counter = 0;
-extern "C" DLLEXPORT int count(int arg) {
+extern "C" HALIDE_EXPORT_SYMBOL int count(int arg) {
     call_counter++;
     return arg;
 }

--- a/test/correctness/sliding_over_guard_with_if.cpp
+++ b/test/correctness/sliding_over_guard_with_if.cpp
@@ -6,14 +6,8 @@
 using namespace Halide;
 using namespace Halide::Tools;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int call_count = 0;
-extern "C" DLLEXPORT int call_counter(int x, int y) {
+extern "C" HALIDE_EXPORT_SYMBOL int call_counter(int x, int y) {
     call_count++;
     return x;
 }

--- a/test/correctness/sliding_over_guard_with_if.cpp
+++ b/test/correctness/sliding_over_guard_with_if.cpp
@@ -9,7 +9,7 @@ using namespace Halide::Tools;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int call_count = 0;

--- a/test/correctness/sliding_reduction.cpp
+++ b/test/correctness/sliding_reduction.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int counter = 0;

--- a/test/correctness/sliding_reduction.cpp
+++ b/test/correctness/sliding_reduction.cpp
@@ -3,14 +3,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int counter = 0;
-extern "C" DLLEXPORT int call_count(int x) {
+extern "C" HALIDE_EXPORT_SYMBOL int call_count(int x) {
     counter++;
     assert(counter > 0);
     return 99;

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -3,14 +3,8 @@
 
 using namespace Halide;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 int count = 0;
-extern "C" DLLEXPORT int call_counter(int x, int y) {
+extern "C" HALIDE_EXPORT_SYMBOL int call_counter(int x, int y) {
     count++;
     return 0;
 }

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 int count = 0;

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -43,14 +43,8 @@ bool check_expected_mallocs(const std::vector<size_t> &expected) {
     return true;
 }
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // An extern stage that copies input -> output
-extern "C" DLLEXPORT int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
     } else {
@@ -60,7 +54,7 @@ extern "C" DLLEXPORT int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t
 }
 
 // An extern stage accesses the input in a non-monotonic way in the y dimension.
-extern "C" DLLEXPORT int zigzag_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int zigzag_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
 

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -46,7 +46,7 @@ bool check_expected_mallocs(const std::vector<size_t> &expected) {
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // An extern stage that copies input -> output

--- a/test/failing_with_issue/3292_async_specialize.cpp
+++ b/test/failing_with_issue/3292_async_specialize.cpp
@@ -22,7 +22,7 @@ void my_free(void *user_context, void *ptr) {
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // An extern stage that copies input -> output

--- a/test/failing_with_issue/3292_async_specialize.cpp
+++ b/test/failing_with_issue/3292_async_specialize.cpp
@@ -19,14 +19,8 @@ void my_free(void *user_context, void *ptr) {
     free(((void **)ptr)[-1]);
 }
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // An extern stage that copies input -> output
-extern "C" DLLEXPORT int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
     } else {

--- a/test/failing_with_issue/3293_storage_folding_async.cpp
+++ b/test/failing_with_issue/3293_storage_folding_async.cpp
@@ -22,7 +22,7 @@ void my_free(void *user_context, void *ptr) {
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // An extern stage that copies input -> output

--- a/test/failing_with_issue/3293_storage_folding_async.cpp
+++ b/test/failing_with_issue/3293_storage_folding_async.cpp
@@ -19,14 +19,8 @@ void my_free(void *user_context, void *ptr) {
     free(((void **)ptr)[-1]);
 }
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // An extern stage that copies input -> output
-extern "C" DLLEXPORT int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
+extern "C" HALIDE_EXPORT_SYMBOL int simple_buffer_copy(halide_buffer_t *in, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         memcpy(in->dim, out->dim, out->dimensions * sizeof(halide_dimension_t));
     } else {

--- a/test/generator/extern_output_aottest.cpp
+++ b/test/generator/extern_output_aottest.cpp
@@ -9,7 +9,7 @@ using namespace Halide::Runtime;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 extern "C" DLLEXPORT int extern_stage(halide_buffer_t *input, int addend, halide_buffer_t *output) {

--- a/test/generator/extern_output_aottest.cpp
+++ b/test/generator/extern_output_aottest.cpp
@@ -6,13 +6,7 @@
 
 using namespace Halide::Runtime;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
-extern "C" DLLEXPORT int extern_stage(halide_buffer_t *input, int addend, halide_buffer_t *output) {
+extern "C" HALIDE_EXPORT_SYMBOL int extern_stage(halide_buffer_t *input, int addend, halide_buffer_t *output) {
     // Note the final output buffer argument is unused.
     if (input->is_bounds_query()) {
         for (int d = 0; d < 2; d++) {

--- a/test/performance/fast_pow.cpp
+++ b/test/performance/fast_pow.cpp
@@ -9,7 +9,7 @@ using namespace Halide::Tools;
 #ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
-#define DLLEXPORT
+#define DLLEXPORT __attribute__((visibility("default")))
 #endif
 
 // powf() is a macro in some environments, so always wrap it

--- a/test/performance/fast_pow.cpp
+++ b/test/performance/fast_pow.cpp
@@ -6,14 +6,8 @@
 using namespace Halide;
 using namespace Halide::Tools;
 
-#ifdef _WIN32
-#define DLLEXPORT __declspec(dllexport)
-#else
-#define DLLEXPORT __attribute__((visibility("default")))
-#endif
-
 // powf() is a macro in some environments, so always wrap it
-extern "C" DLLEXPORT float pow_ref(float x, float y) {
+extern "C" HALIDE_EXPORT_SYMBOL float pow_ref(float x, float y) {
     return powf(x, y);
 }
 HalideExtern_2(float, pow_ref, float, float);


### PR DESCRIPTION
Right now, when compiling on Unixy systems, we default to compiling tests with all symbols visible and exported. We should really default to using the qquivalent of `-fvisibility=hidden -fvisibility-inlines-hidden` and only exporting the symbols we actually need to be visible. This:
- fixes the build files so that all our tests build this way
- adds a `HALIDE_EXPORT_SYMBOL` macro in HalideRuntime.h that does the right thing
- replaces the several dozen replicated DLLEXPORT macros in tests with HALIDE_EXPORT_SYMBOL

This doesn't move the needle much on test code size (typically a few kb per test executable smaller), but it does bring the default behavior of Unixy builds closer to that of Windows (ie, forgetting to explicitly export a symbol when needed will fail ~everywhere rather than just on Windows).