### PR TITLE
Minor typedef cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin/*
 build/*
 share/*
 python_bindings/bin/*
+build-32/*
 build-64/*
 build-ios/*
 build-osx/*

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1523,7 +1523,7 @@ void CodeGen_C::emit_argv_wrapper(const std::string &function_name,
 
 void CodeGen_C::emit_metadata_getter(const std::string &function_name,
                                      const std::vector<LoweredArgument> &args,
-                                     const std::map<std::string, std::string> &metadata_name_map) {
+                                     const MetadataNameMap &metadata_name_map) {
     if (is_header_or_extern_decl()) {
         stream << "\nHALIDE_FUNCTION_ATTRS\nconst struct halide_filter_metadata_t *" << function_name << "_metadata();\n";
         return;
@@ -1798,7 +1798,7 @@ void CodeGen_C::compile(const Module &input) {
     }
 }
 
-void CodeGen_C::compile(const LoweredFunc &f, const std::map<std::string, std::string> &metadata_name_map) {
+void CodeGen_C::compile(const LoweredFunc &f, const MetadataNameMap &metadata_name_map) {
     // Don't put non-external function declarations in headers.
     if (is_header_or_extern_decl() && f.linkage == LinkageType::Internal) {
         return;

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -65,7 +65,7 @@ protected:
 
     /** Emit a declaration. */
     // @{
-    virtual void compile(const LoweredFunc &func, const std::map<std::string, std::string> &metadata_name_map);
+    virtual void compile(const LoweredFunc &func, const MetadataNameMap &metadata_name_map);
     virtual void compile(const Buffer<> &buffer);
     // @}
 
@@ -270,7 +270,7 @@ protected:
                            const std::vector<LoweredArgument> &args);
     void emit_metadata_getter(const std::string &function_name,
                               const std::vector<LoweredArgument> &args,
-                              const std::map<std::string, std::string> &metadata_name_map);
+                              const MetadataNameMap &metadata_name_map);
 };
 
 }  // namespace Internal

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -965,7 +965,7 @@ llvm::Function *CodeGen_LLVM::add_argv_wrapper(llvm::Function *fn,
 
 llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_name,
                                                     const std::string &function_name, const std::vector<LoweredArgument> &args,
-                                                    const std::map<std::string, std::string> &metadata_name_map) {
+                                                    const MetadataNameMap &metadata_name_map) {
     Constant *zero = ConstantInt::get(i32_t, 0);
 
     const int num_args = (int)args.size();

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -532,7 +532,7 @@ private:
      */
     llvm::Function *embed_metadata_getter(const std::string &metadata_getter_name,
                                           const std::string &function_name, const std::vector<LoweredArgument> &args,
-                                          const std::map<std::string, std::string> &metadata_name_map);
+                                          const MetadataNameMap &metadata_name_map);
 
     /** Embed a constant expression as a global variable. */
     llvm::Constant *embed_constant_expr(Expr e, llvm::Type *t);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -849,7 +849,7 @@ gengen
         return g;
     };
 
-    const auto build_target_strings = [](std::map<std::string, std::string> *gp) {
+    const auto build_target_strings = [](GeneratorParamsMap *gp) {
         std::vector<std::string> target_strings;
         if (gp->find("target") != gp->end()) {
             target_strings = split_string((*gp)["target"], ",");

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -4110,7 +4110,7 @@ struct halide_global_ns;
     namespace GEN_REGISTRY_NAME##_ns {                                                                                              \
         std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext &context) {                     \
             auto g = ORIGINAL_REGISTRY_NAME##_ns::factory(context);                                                                 \
-            const Halide::Internal::GeneratorParamsMap m = __VA_ARGS__;                                                                               \
+            const Halide::Internal::GeneratorParamsMap m = __VA_ARGS__;                                                             \
             for (const auto &c : m) {                                                                                               \
                 g->set_generatorparam_value(c.first, c.second);                                                                     \
             }                                                                                                                       \

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3164,22 +3164,6 @@ struct NoRealizations<T, Args...> {
 // if they cannot return a valid Generator, they must assert-fail.
 using GeneratorFactory = std::function<AbstractGeneratorPtr(const GeneratorContext &context)>;
 
-struct StringOrLoopLevel {
-    std::string string_value;
-    LoopLevel loop_level;
-
-    StringOrLoopLevel() = default;
-    /*not-explicit*/ StringOrLoopLevel(const char *s)
-        : string_value(s) {
-    }
-    /*not-explicit*/ StringOrLoopLevel(const std::string &s)
-        : string_value(s) {
-    }
-    /*not-explicit*/ StringOrLoopLevel(const LoopLevel &loop_level)
-        : loop_level(loop_level) {
-    }
-};
-
 class GeneratorParamInfo {
     // names used across all params, inputs, and outputs.
     std::set<std::string> names;
@@ -3967,6 +3951,8 @@ public:
 
 // -----------------------------
 
+using GeneratorParamsMap = std::map<std::string, std::string>;
+
 /** ExecuteGeneratorArgs is the set of arguments to execute_generator().
  */
 struct ExecuteGeneratorArgs {
@@ -4027,7 +4013,7 @@ struct ExecuteGeneratorArgs {
     //
     // If any of the generator param names specified in this map are unknown
     // to the Generator created, an error will occur.
-    std::map<std::string, std::string> generator_params;
+    GeneratorParamsMap generator_params;
 
     // Compiler Logger to use, for diagnostic work. If null, don't do any logging.
     CompilerLoggerFactory compiler_logger_factory = nullptr;
@@ -4124,7 +4110,7 @@ struct halide_global_ns;
     namespace GEN_REGISTRY_NAME##_ns {                                                                                              \
         std::unique_ptr<Halide::Internal::AbstractGenerator> factory(const Halide::GeneratorContext &context) {                     \
             auto g = ORIGINAL_REGISTRY_NAME##_ns::factory(context);                                                                 \
-            const std::map<std::string, std::string> m = __VA_ARGS__;                                                               \
+            const Halide::Internal::GeneratorParamsMap m = __VA_ARGS__;                                                                               \
             for (const auto &c : m) {                                                                                               \
                 g->set_generatorparam_value(c.first, c.second);                                                                     \
             }                                                                                                                       \

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -330,7 +330,7 @@ struct ModuleContents {
     std::vector<Internal::LoweredFunc> functions;
     std::vector<Module> submodules;
     std::vector<ExternalCode> external_code;
-    std::map<std::string, std::string> metadata_name_map;
+    MetadataNameMap metadata_name_map;
     bool any_strict_float{false};
     std::unique_ptr<AutoSchedulerResults> auto_scheduler_results;
 };
@@ -548,7 +548,7 @@ void Module::remap_metadata_name(const std::string &from, const std::string &to)
     contents->metadata_name_map[from] = to;
 }
 
-std::map<std::string, std::string> Module::get_metadata_name_map() const {
+MetadataNameMap Module::get_metadata_name_map() const {
     return contents->metadata_name_map;
 }
 

--- a/src/Module.h
+++ b/src/Module.h
@@ -131,6 +131,8 @@ class CompilerLogger;
 
 struct AutoSchedulerResults;
 
+using MetadataNameMap = std::map<std::string, std::string>;
+
 /** A halide module. This represents IR containing lowered function
  * definitions and buffers. */
 class Module {
@@ -192,7 +194,7 @@ public:
     void remap_metadata_name(const std::string &from, const std::string &to) const;
 
     /** Retrieve the metadata name map. */
-    std::map<std::string, std::string> get_metadata_name_map() const;
+    MetadataNameMap get_metadata_name_map() const;
 
     /** Set the AutoSchedulerResults for the Module. It is an error to call this
      * multiple times for a given Module. */

--- a/test/generator/abstractgeneratortest_generator.cpp
+++ b/test/generator/abstractgeneratortest_generator.cpp
@@ -34,7 +34,7 @@ class AbstractGeneratorTest : public AbstractGenerator {
     const GeneratorContext context_;
 
     // Constants (aka GeneratorParams)
-    std::map<std::string, std::string> constants_ = {
+    GeneratorParamsMap constants_ = {
         {"scaling", "2"},
     };
 


### PR DESCRIPTION
Add typedefs for `GeneratorParamMap` and `MetadataNameMap` to distinguish their usage from other string maps.

Also, drive-by addition to .gitignore.