### PR TITLE
Rewrite strided loads of 4 in AlignLoads

### DIFF
--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -78,8 +78,8 @@ private:
             // non-constant strides.
             return IRMutator::visit(op);
         }
-        if (!(*const_stride == 1 || *const_stride == 2 || *const_stride == 3)) {
-            // Handle ramps with stride 1, 2 or 3 only.
+        if (!(*const_stride == 1 || *const_stride == 2 || *const_stride == 3 || *const_stride == 4)) {
+            // Handle ramps with stride 1, 2, 3 or 4 only.
             return IRMutator::visit(op);
         }
 

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -290,6 +290,8 @@ public:
         check("vdelta(v*,v*)", hvx_width / 2, in_u32(3 * x / 2));
         check("vdelta(v*,v*)", hvx_width * 3, in_u16(x * 3));
         check("vdelta(v*,v*)", hvx_width * 3, in_u8(x * 3));
+        check("vdelta(v*,v*)", hvx_width * 4, in_u16(x * 4));
+        check("vdelta(v*,v*)", hvx_width * 4, in_u8(x * 4));
 
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(u8_1));
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(clamp(u16_1, 0, 63)));


### PR DESCRIPTION
This is in addition to the current 1-, 2-, 3- strides. 

This change is motivated by the 4x downsample use-case where I see a significant performance improvement after enabling these.

