### PR TITLE
Fix two minor bugs triggered by an or reduction with early-out

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -2640,7 +2640,7 @@ private:
     void visit(const IfThenElse *op) override {
         TRACK_BOXES_TOUCHED;
         op->condition.accept(this);
-        if (expr_uses_vars(op->condition, scope)) {
+        if (expr_uses_vars(op->condition, scope) || !is_pure(op->condition)) {
             // We need to simplify the condition to get it into a
             // canonical form (e.g. (a < b) instead of !(a >= b))
             vector<pair<Expr, Stmt>> cases;

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -182,6 +182,11 @@ private:
                 }
             }
         }
+
+        // It also misses wrappers
+        for (auto p : func.wrappers()) {
+            Function(p.second).accept(this);
+        }
     }
 
     void include_parameter(const Parameter &p) {

--- a/src/InferArguments.cpp
+++ b/src/InferArguments.cpp
@@ -184,7 +184,7 @@ private:
         }
 
         // It also misses wrappers
-        for (auto p : func.wrappers()) {
+        for (const auto &p : func.wrappers()) {
             Function(p.second).accept(this);
         }
     }

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -86,6 +86,7 @@ tests(GROUPS correctness
       dynamic_allocation_in_gpu_kernel.cpp
       dynamic_reduction_bounds.cpp
       embed_bitcode.cpp
+      early_out.cpp
       erf.cpp
       exception.cpp
       explicit_inline_reductions.cpp

--- a/test/correctness/early_out.cpp
+++ b/test/correctness/early_out.cpp
@@ -43,5 +43,7 @@ int main(int argc, char **argv) {
 
     output.compile_jit();
 
+    printf("Success!\n");
+
     return 0;
 }

--- a/test/correctness/early_out.cpp
+++ b/test/correctness/early_out.cpp
@@ -1,0 +1,47 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // This is a test case that performs an or reduction using a where clause to
+    // get early-out behavior on the reduction loop. It triggered two bugs.
+    //
+    // First, there's a param that's only used in a specialization of a wrapper
+    // func, and this wasn't picked up by InferArguments.
+    //
+    // Second, there's a variable-free condition
+    // that feeds into bounds inference (test()), and bounds inference assumed
+    // that being variable-free meant it only depended on params and could be
+    // lifted out into a bounds expression.
+    //
+    // Both of these bugs caused compilation failures, so this test just
+    // verifies that things compile.
+
+    Param<int> height;
+
+    Var y;
+
+    Func test_rows("test_rows");
+    test_rows(y) = y < 100;
+
+    Func test("test");
+    test() = cast<bool>(false);
+    RDom ry(0, 1024);
+    ry.where(!test());
+    test() = test_rows(ry);
+
+    Func output;
+    output() = select(test(), cast<uint8_t>(0), cast<uint8_t>(1));
+
+    Expr num_slices = (height + 255) / 256;
+    Expr slice_size = (height + num_slices - 1) / num_slices;
+
+    test_rows.in()
+        .compute_root()
+        .specialize(height > slice_size)
+        .parallel(y, slice_size, TailStrategy::ShiftInwards);
+
+    output.compile_jit();
+
+    return 0;
+}


### PR DESCRIPTION
I was trying out using a where clause in a big or reduction to get early-out behavior and found two bugs that this PR fixes.

First, if there's a param that's only used in a specialization of a wrapper func, it isn't picked up by InferArguments.

Second, a variable-free condition that feeds into bounds inference is assumed to depend only on parameters, which is a bad assumption because it could also be a scalar Func. 

Both of these manifested as compilation failures.
