### PR TITLE
Rework .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ tools/objc/BUILD
 
 *.txt.user*
 
+*.png
+!apps/**/*.png
+!images/**/*.png
+
+*.weights
+!src/autoschedulers/**/*.weights
+
 ## Halide-specific build intermediates
 # apps
 apps/*/*.def
@@ -39,6 +46,12 @@ tutorial/lesson_10_halide.h
 err.txt
 log.txt
 test/*.lowered
+
+# linker scripts
+py_*.ldscript*
+
+# generated CMake configuration
+Halide-*-deps.cmake
 
 ## Build outputs
 # Directories
@@ -97,6 +110,21 @@ CMakeUserPresets.json
 # Common build directory names
 build*/
 cmake[-_]build*/
+
+# Generated files
+*ConfigVersion.cmake
+*-config-version.cmake
+
+# Build directory contents
+CMakeCache.txt
+*.ninja
+cmake_install.cmake
+compile_commands.json
+CPack*.cmake
+CTest*.cmake
+.cmake/
+_deps/
+CMakeFiles/
 
 ## IDE folders and metadata
 # Visual Studio

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+# NOTE: one can debug these rules with the following commands:
+#
+# $ git clean -ffdx
+# $ find . -not -path './.git/*' | git check-ignore --stdin --no-index
+#
+# The first command will delete all files that are ignored by Git (be warned!).
+# The second command will print all files that are checked in, but _would be_
+# ignored under the rules in this file. Such files should either be explicitly
+# added to the exclusions at the bottom of this file, or the rule excluding them
+# should be refined.
+
 ################################################################################
 ## Exclude files without extensions
 

--- a/.gitignore
+++ b/.gitignore
@@ -80,29 +80,30 @@ py_*.ldscript*
 _initmod*.cpp
 
 # Tests
-err.txt
-log.txt
+**/python_bindings/correctness/generators/*.h
 **/test/generator/*.h
 **/test/generator/external_code_extern_bitcode_32.cpp
 **/test/generator/external_code_extern_bitcode_64.cpp
 **/test/generator/external_code_extern_cpp_source.cpp
-**/python_bindings/correctness/generators/*.h
+compile_log.txt
+stderr.txt
+stdout.txt
 
 # Tutorials
-**/tutorial/lesson_10_halide.h
 **/tutorial/auto_schedule_false.h
 **/tutorial/auto_schedule_true.h
 **/tutorial/brighten_either.h
 **/tutorial/brighten_interleaved.h
 **/tutorial/brighten_planar.h
 **/tutorial/brighten_specialized.h
-**/tutorial/my_first_generator.h
+**/tutorial/lesson_10_halide.h
 **/tutorial/my_first_generator_win32.h
+**/tutorial/my_first_generator.h
 **/tutorial/my_second_generator_1.h
 **/tutorial/my_second_generator_2.h
 **/tutorial/my_second_generator_3.h
 
-# Tutorial images, except the expected ones
+# Tutorial images that were copied to the install tree
 **/tutorial/images/
 !tutorial/images/
 
@@ -138,13 +139,14 @@ a.out
 ################################################################################
 ## Temporary and swap files
 
-tmp/
 temp/
+tmp/
 
 .*.swp
 .\#*
 .DS_Store
 *.log
+*.tmp
 *.txt.user*
 *~
 \#*\#
@@ -153,8 +155,8 @@ temp/
 ## Python
 
 # Common virtual environment directory names
-venv/
 .venv/
+venv/
 
 # Python binary caches
 __pycache__
@@ -171,10 +173,10 @@ build*/
 cmake[-_]build*/
 
 # Generated config files
-*Config.cmake
-*-config.cmake
-*ConfigVersion.cmake
 *-config-version.cmake
+*-config.cmake
+*Config.cmake
+*ConfigVersion.cmake
 
 # Build directory contents
 _deps/
@@ -201,9 +203,9 @@ CMakeSettings.json
 
 # XCode
 *.xcworkspacedata
-xcuserdata
 tools/objc/*.mobileprovision
 tools/objc/BUILD
+xcuserdata
 
 # CLion
 .idea/
@@ -230,11 +232,11 @@ TAGS
 ## Halide-specific rule overrides
 
 # Allow particular extension-less files
-!Makefile
 !gradlew
-!packaging/ubuntu/triggers
-!packaging/ubuntu/copyright
+!Makefile
 !packaging/ubuntu/changelog
+!packaging/ubuntu/copyright
+!packaging/ubuntu/triggers
 
 # Allow XCode PCHs in the HelloiOS app
 !apps/HelloiOS/**/*-Prefix.pch
@@ -252,5 +254,5 @@ TAGS
 !src/autoschedulers/adams2019/included_schedule_file.schedule.h
 
 # TODO: these should become .cmake.in
-!packaging/common/HalideHelpersConfig.cmake
 !packaging/common/HalideConfig.cmake
+!packaging/common/HalideHelpersConfig.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ Halide-*-deps.cmake
 
 # Distribution headers
 **/include/Halide*.h
+**/include/wasm-rt*.h
 
 # Generator executables
 *.generator
@@ -184,6 +185,7 @@ CMakeFiles/
 compile_commands.json
 CPack*.cmake
 CTest*.cmake
+install_manifest.txt
 
 # Ninja files
 *.ninja*

--- a/.gitignore
+++ b/.gitignore
@@ -1,97 +1,132 @@
-CMakeUserPresets.json
+## Halide-specific exclusions
+apps/patchmatch/
+cpp/
+llvm/
+msvc/*/Win32/
+msvc/*/x64/
+testing/
 
-/tutorial/figures/tmp/trace.bin
-/apps/*/bin
-/apps/*/cmake_build
-bin/*
-build/*
-share/*
-python_bindings/bin/*
-build-32/*
-build-64/*
-build-ios/*
-build-osx/*
-build_wasm*/*
-cmake_build*/*
-*/build/*
-tmp/*
-include/*
-distrib/*
-testing/*
-msvc/*/Win32/*
-msvc/*/x64/*
-\#*\#
-.\#*
-*~
-*.o
-*.a
-*.so
-*.dot
-.DS_Store
-*.log
-generated.obj
-hello-fimage
-test.s
-testX64
-xcuserdata
-in.png
 _build
-a.out
-*.bc
-*.cubin
-tags
-src/*.top
-llvm_svn
-llvm/*
-cpp/*
-*.h.gch
-src/test_*.ll
-src/test_*.s
-.clang_complete
+*.dot
 *.guru
-*.dSYM
-.*.swp
-tools/objc/BUILD
-tools/objc/*.mobileprovision
-*.xcworkspacedata
-__pycache__
+hello-fimage
+in.png
+llvm_svn
+src/*.top
+test*.s
+testX64
 
+tools/objc/*.mobileprovision
+tools/objc/BUILD
 
 *.txt.user*
+
+## Halide-specific build intermediates
+# apps
+apps/*/*.def
+apps/*/*.lowered
+apps/*/*.ptx
+apps/*/*.sass
+apps/*/*out*.png
+apps/*/filter
+apps/*/passes.txt
+apps/HelloAndroidGL/jni/halide_gl_filter.h
+
+# tutorials
+tutorial/lesson_10_halide.h
+
+# tests
+err.txt
+log.txt
+test/*.lowered
+
+## Build outputs
+# Directories
+bin/
+distrib/
+include/
+lib/
+lib64/
+share/
+
+# Binaries
+*.a
+*.cubin
+*.dll
+*.dylib
+*.exe
+*.lib
+*.o
+*.obj
+*.so
+a.out
+
+# Compiler intermediates / debugging info
+*.[ip]db
+*.[pg]ch
+*.d
+*.dSYM
+
+# LLVM generated files
+*.bc
+*.ll
+!src/runtime/*.ll
+
+## Temporary and swap files
+tmp/
+
+.*.swp
+.DS_Store
+*.log
+*~
+
+.\#*
+\#*\#
+
+## Python cruft
+venv/
+.venv/
+
+__pycache__
+*.py[cod]
+
+## CMake files
+# User-specific configuration files
+CMakeUserPresets.json
+
+# Common build directory names
+build*/
+cmake[-_]build*/
+
+## IDE folders and metadata
+# Visual Studio
+.vs/
+out/
+
+CMakeSettings.json
+
+# XCode
+*.xcworkspacedata
+xcuserdata
+
+# CLion
 .idea/
 
-# jrk editor settings
+# VSCode
+.vscode/
+
+# TextMate
 .tm_properties
+
+# Sublime Text
+.tags
+.tags_sorted_by_file
 *.sublime-project
 *.sublime-workspace
 
-apps/patchmatch
+# Vim
+.clang_complete
 
-# app intermediates
-apps/*/*out*.png
-apps/*/*.lowered
-apps/*/*.def
-apps/*/*.ptx
-apps/*/passes.txt
-apps/*/*.ll
-apps/*/*.sass
-apps/*/filter
-apps/HelloAndroidGL/jni/halide_gl_filter.h
-
-# tutorial intermediates
-tutorial/lesson_10_halide.h
-
-# test intermediates
-log.txt
-err.txt
-test/*.lowered
-*.pyc
-
-src/.tags
-src/.tags_sorted_by_file
-
-/.vs
-/out
-/CMakeSettings.json
-/venv/
-/cmake-build-*/
+# Emacs
+tags
+TAGS

--- a/.gitignore
+++ b/.gitignore
@@ -20,14 +20,28 @@
 ################################################################################
 ## Halide-specific build artifacts
 
-# Runtime modules
-_initmod*.cpp
+# Apps
+apps/*/*.def
+apps/*/*.ptx
+apps/*/*.sass
+apps/*/*out*.png
+apps/*/filter
+apps/*/passes.txt
+apps/HelloAndroidGL/jni/halide_gl_filter.h
 
-# Generated linker scripts
-py_*.ldscript*
+# Autoschedulers
+**/src/autoschedulers/adams2019/baseline.cpp
+**/src/autoschedulers/adams2019/cost_model.h
+**/src/autoschedulers/adams2019/demo.h
+**/src/autoschedulers/adams2019/included_schedule_file.h
+**/src/autoschedulers/adams2019/train_cost_model.h
+**/src/autoschedulers/li2018/demo_gradient.h
 
 # CMake configuration
 Halide-*-deps.cmake
+
+# Distribution headers
+**/include/Halide*.h
 
 # Generator executables
 *.generator
@@ -47,21 +61,38 @@ Halide-*-deps.cmake
 *.stmt.html
 *.stub.h
 
-# Apps
-apps/*/*.def
-apps/*/*.ptx
-apps/*/*.sass
-apps/*/*out*.png
-apps/*/filter
-apps/*/passes.txt
-apps/HelloAndroidGL/jni/halide_gl_filter.h
+# Linker scripts
+py_*.ldscript*
 
-# Tutorials
-tutorial/lesson_10_halide.h
+# Runtime modules
+_initmod*.cpp
 
 # Tests
 err.txt
 log.txt
+**/test/generator/*.h
+**/test/generator/external_code_extern_bitcode_32.cpp
+**/test/generator/external_code_extern_bitcode_64.cpp
+**/test/generator/external_code_extern_cpp_source.cpp
+**/python_bindings/correctness/generators/*.h
+
+# Tutorials
+**/tutorial/lesson_10_halide.h
+**/tutorial/auto_schedule_false.h
+**/tutorial/auto_schedule_true.h
+**/tutorial/brighten_either.h
+**/tutorial/brighten_interleaved.h
+**/tutorial/brighten_planar.h
+**/tutorial/brighten_specialized.h
+**/tutorial/my_first_generator.h
+**/tutorial/my_first_generator_win32.h
+**/tutorial/my_second_generator_1.h
+**/tutorial/my_second_generator_2.h
+**/tutorial/my_second_generator_3.h
+
+# Tutorial images, except the expected ones
+**/tutorial/images/
+!tutorial/images/
 
 ################################################################################
 ## Common build artifacts
@@ -69,7 +100,6 @@ log.txt
 # Directories
 bin/
 distrib/
-# include/
 lib/
 lib64/
 share/
@@ -128,7 +158,9 @@ CMakeUserPresets.json
 build*/
 cmake[-_]build*/
 
-# Generated files
+# Generated config files
+*Config.cmake
+*-config.cmake
 *ConfigVersion.cmake
 *-config-version.cmake
 
@@ -184,7 +216,6 @@ TAGS
 ################################################################################
 ## Halide-specific rule overrides
 
-
 # Allow particular extension-less files
 !Makefile
 !gradlew
@@ -206,3 +237,7 @@ TAGS
 
 # TODO: should this be checked in?
 !src/autoschedulers/adams2019/included_schedule_file.schedule.h
+
+# TODO: these should become .cmake.in
+!packaging/common/HalideHelpersConfig.cmake
+!packaging/common/HalideConfig.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,54 @@
+################################################################################
+## Exclude files without extensions
+
+*
+!*.*
+!*/
+
+################################################################################
 ## Halide-specific exclusions
-apps/patchmatch/
-cpp/
-llvm/
-msvc/*/Win32/
-msvc/*/x64/
-testing/
 
-_build
-*.dot
-*.guru
-hello-fimage
-in.png
-llvm_svn
-src/*.top
-test*.s
-testX64
-
-tools/objc/*.mobileprovision
-tools/objc/BUILD
-
-*.txt.user*
-
+# Images only allowed in apps and directories named "images"
 *.png
 !apps/**/*.png
-!images/**/*.png
+!**/images/**/*.png
 
+# Pre-trained weights only allowed in autoscheduler directories
 *.weights
 !src/autoschedulers/**/*.weights
 
-## Halide-specific build intermediates
-# apps
+################################################################################
+## Halide-specific build artifacts
+
+# Runtime modules
+_initmod*.cpp
+
+# Generated linker scripts
+py_*.ldscript*
+
+# CMake configuration
+Halide-*-deps.cmake
+
+# Generator executables
+*.generator
+
+# Generator outputs
+*.bc
+*.featurization
+*.halide_compiler_log
+*.halide_generated.cpp
+*.ll
+*.py.cpp
+*.pytorch.h
+*.registration.cpp
+*.s
+*.schedule.h
+*.stmt
+*.stmt.html
+*.stub.h
+
+# Apps
 apps/*/*.def
-apps/*/*.lowered
 apps/*/*.ptx
 apps/*/*.sass
 apps/*/*out*.png
@@ -39,25 +56,20 @@ apps/*/filter
 apps/*/passes.txt
 apps/HelloAndroidGL/jni/halide_gl_filter.h
 
-# tutorials
+# Tutorials
 tutorial/lesson_10_halide.h
 
-# tests
+# Tests
 err.txt
 log.txt
-test/*.lowered
 
-# linker scripts
-py_*.ldscript*
+################################################################################
+## Common build artifacts
 
-# generated CMake configuration
-Halide-*-deps.cmake
-
-## Build outputs
 # Directories
 bin/
 distrib/
-include/
+# include/
 lib/
 lib64/
 share/
@@ -72,6 +84,7 @@ share/
 *.o
 *.obj
 *.so
+*.so.*
 a.out
 
 # Compiler intermediates / debugging info
@@ -80,30 +93,34 @@ a.out
 *.d
 *.dSYM
 
-# LLVM generated files
-*.bc
-*.ll
-!src/runtime/*.ll
-
+################################################################################
 ## Temporary and swap files
+
 tmp/
+temp/
 
 .*.swp
+.\#*
 .DS_Store
 *.log
+*.txt.user*
 *~
-
-.\#*
 \#*\#
 
-## Python cruft
+################################################################################
+## Python
+
+# Common virtual environment directory names
 venv/
 .venv/
 
+# Python binary caches
 __pycache__
 *.py[cod]
 
-## CMake files
+################################################################################
+## CMake
+
 # User-specific configuration files
 CMakeUserPresets.json
 
@@ -116,17 +133,21 @@ cmake[-_]build*/
 *-config-version.cmake
 
 # Build directory contents
-CMakeCache.txt
-*.ninja
+_deps/
+.cmake/
 cmake_install.cmake
+CMakeCache.txt
+CMakeFiles/
 compile_commands.json
 CPack*.cmake
 CTest*.cmake
-.cmake/
-_deps/
-CMakeFiles/
 
-## IDE folders and metadata
+# Ninja files
+*.ninja*
+
+################################################################################
+## IDE directories and metadata
+
 # Visual Studio
 .vs/
 out/
@@ -136,6 +157,8 @@ CMakeSettings.json
 # XCode
 *.xcworkspacedata
 xcuserdata
+tools/objc/*.mobileprovision
+tools/objc/BUILD
 
 # CLion
 .idea/
@@ -149,8 +172,7 @@ xcuserdata
 # Sublime Text
 .tags
 .tags_sorted_by_file
-*.sublime-project
-*.sublime-workspace
+*.sublime-*
 
 # Vim
 .clang_complete
@@ -158,3 +180,29 @@ xcuserdata
 # Emacs
 tags
 TAGS
+
+################################################################################
+## Halide-specific rule overrides
+
+
+# Allow particular extension-less files
+!Makefile
+!gradlew
+!packaging/ubuntu/triggers
+!packaging/ubuntu/copyright
+!packaging/ubuntu/changelog
+
+# Allow XCode PCHs in the HelloiOS app
+!apps/HelloiOS/**/*-Prefix.pch
+
+# Allow the runtime to have handwritten LLVM modules
+!src/runtime/*.ll
+
+# Allow precompiled Nvidia bitcode
+!src/runtime/nvidia_libdevice_bitcode/*.bc
+
+# Anything goes in the hexagon_remote binaries
+!src/runtime/hexagon_remote/**/*
+
+# TODO: should this be checked in?
+!src/autoschedulers/adams2019/included_schedule_file.schedule.h


### PR DESCRIPTION
While setting up a new development environment with VS Code, I accidentally did an in-tree build. This pumped out a bunch of files that shouldn't be checked in. Between these and the VS Code specific ignores, I went down a rabbit hole of auditing our .gitignore. Lotta stuff for OCaml builds from a decade ago in there.

The new .gitignore should be relatively robust to in-tree builds and to out-of-source builds with unexpected directory names. It's a bit hard to distinguish Halide-generated header file names in some circumstances. I wonder if we can adjust our build to improve on this (e.g. putting them all in a `_gen/` subfolder so we can match on `**/_gen/*`)

It is also grouped by reason for inclusion/exclusion and ignores files without extensions (which are presumed to be executables). The main exception to the latter rule is Makefiles, but there are a few others that might be removable.