### PR TITLE
Fix use of ASanGlobalsMetadataAnalysis in LLVM 15

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1168,9 +1168,12 @@ void CodeGen_LLVM::optimize_module() {
     }
 
     if (get_target().has_feature(Target::ASAN)) {
+#if LLVM_VERSION < 150
+        // LLVM 15's ModuleAddressSanitizerPass absorbs this pass.
         pb.registerPipelineStartEPCallback([&](ModulePassManager &mpm, OptimizationLevel) {
             mpm.addPass(RequireAnalysisPass<ASanGlobalsMetadataAnalysis, llvm::Module>());
         });
+#endif
         pb.registerPipelineStartEPCallback([](ModulePassManager &mpm, OptimizationLevel) {
 #if LLVM_VERSION >= 140
             AddressSanitizerOptions asan_options;  // default values are good...


### PR DESCRIPTION
Fixes error found in #6821 