### PR TITLE
Apply CMAKE_C_COMPILER_LAUNCHER to initmod clang calls

### DIFF
--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -267,7 +267,7 @@ foreach (i IN LISTS RUNTIME_CPP)
                 target_compile_definitions(${basename} PRIVATE ${RUNTIME_DEFINES})
             else()
                 add_custom_command(OUTPUT "${LL}"
-                                   COMMAND clang ${clang_flags} -o "${ll_path}" "$<SHELL_PATH:${SOURCE}>"
+                                   COMMAND ${CMAKE_C_COMPILER_LAUNCHER} $<TARGET_FILE:clang> ${clang_flags} -o "${ll_path}" "$<SHELL_PATH:${SOURCE}>"
                                    DEPENDS "${SOURCE}"
                                    ${dep_args}
                                    VERBATIM)


### PR DESCRIPTION
This makes recompiling the initmod stuff ~3x faster for me.

Need `$<TARGET_FILE:...>` here because when `CMAKE_C_COMPILER_LAUNCHER` is non-empty, then `clang` could be the clang found in the `PATH` rather than via `find_package`.