### PR TITLE
Track down atomics failure on Windows

### DIFF
--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -5,7 +5,7 @@ namespace Halide {
 namespace Internal {
 
 int debug::debug_level() {
-    static int cached_debug_level = ([]() -> int {
+    /*static*/ int cached_debug_level = ([]() -> int {
         std::string lvl = get_env_variable("HL_DEBUG_CODEGEN");
         return !lvl.empty() ? atoi(lvl.c_str()) : 0;
     })();

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -978,10 +978,11 @@ void test_hist_tuple_rfactor(const Backend &backend) {
     }
 }
 
-#ifdef _WIN32
-#define LOG_TEST(T, B)                                                                                                \
-    do {                                                                                                              \
-        std::cout << "Test type=" << Halide::type_of<T>() << " backend=" << (int)(B) << " line=" << __LINE__ << "\n"; \
+#if 1  // def _WIN32
+#define LOG_TEST(T, B)                                                                                               \
+    do {                                                                                                             \
+        std::cout << "Test type=" << Halide::type_of<T>() << " backend=" << (int)(B) << " line=" << __LINE__ << "\n" \
+                  << std::flush;                                                                                     \
     } while (0)
 #else
 #define LOG_TEST(T, B) \
@@ -1214,75 +1215,85 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    Target target = get_jit_target_from_environment();
+    // Target target = get_jit_target_from_environment();
 // Most of the schedules used in this test are terrible for large
 // thread count machines, due to massive amounts of
 // contention. We'll just set the thread count to 4. Unfortunately
 // there's no JIT api for this yet.
 #ifdef _WIN32
     _putenv_s("HL_NUM_THREADS", "4");
+    _putenv_s("HL_DEBUG_CODEGEN", "2");
 #else
     setenv("HL_NUM_THREADS", "4", 1);
+    setenv("HL_DEBUG_CODEGEN", "2", 1);
 #endif
-    test_all<uint8_t>(Backend::CPU);
-    test_all<uint8_t>(Backend::CPUVectorize);
-    test_all<int8_t>(Backend::CPU);
-    test_all<int8_t>(Backend::CPUVectorize);
-    test_all<uint16_t>(Backend::CPU);
-    test_all<uint16_t>(Backend::CPUVectorize);
-    test_all<int16_t>(Backend::CPU);
-    test_all<int16_t>(Backend::CPUVectorize);
-    if (target.has_feature(Target::F16C)) {
-        test_all<float16_t>(Backend::CPU);
-        test_all<float16_t>(Backend::CPUVectorize);
+    // test_all<uint8_t>(Backend::CPU);
+    // test_all<uint8_t>(Backend::CPUVectorize);
+    // test_all<int8_t>(Backend::CPU);
+    // test_all<int8_t>(Backend::CPUVectorize);
+    // test_all<uint16_t>(Backend::CPU);
+    // test_all<uint16_t>(Backend::CPUVectorize);
+    // test_all<int16_t>(Backend::CPU);
+    // test_all<int16_t>(Backend::CPUVectorize);
+    // if (target.has_feature(Target::F16C)) {
+    //     test_all<float16_t>(Backend::CPU);
+    //     test_all<float16_t>(Backend::CPUVectorize);
+    // }
+    // test_all<bfloat16_t>(Backend::CPU);
+    // test_all<bfloat16_t>(Backend::CPUVectorize);
+    // test_all<uint32_t>(Backend::CPU);
+    // test_all<uint32_t>(Backend::CPUVectorize);
+    // test_all<int32_t>(Backend::CPU);
+    // test_all<int32_t>(Backend::CPUVectorize);
+    // test_all<float>(Backend::CPU);
+    // test_all<float>(Backend::CPUVectorize);
+    // test_all<uint64_t>(Backend::CPU);
+    // test_all<uint64_t>(Backend::CPUVectorize);
+    // test_all<int64_t>(Backend::CPU);
+    // test_all<int64_t>(Backend::CPUVectorize);
+    try {
+        test_all<double>(Backend::CPU);
+        test_all<double>(Backend::CPUVectorize);
+    } catch (const std::runtime_error &e) {
+        std::cerr << "runtime_error " << e.what() << "\n"
+                  << std::flush;
+    } catch (...) {
+        std::cerr << "UNHANDLED exception!\n"
+                  << std::flush;
     }
-    test_all<bfloat16_t>(Backend::CPU);
-    test_all<bfloat16_t>(Backend::CPUVectorize);
-    test_all<uint32_t>(Backend::CPU);
-    test_all<uint32_t>(Backend::CPUVectorize);
-    test_all<int32_t>(Backend::CPU);
-    test_all<int32_t>(Backend::CPUVectorize);
-    test_all<float>(Backend::CPU);
-    test_all<float>(Backend::CPUVectorize);
-    test_all<uint64_t>(Backend::CPU);
-    test_all<uint64_t>(Backend::CPUVectorize);
-    test_all<int64_t>(Backend::CPU);
-    test_all<int64_t>(Backend::CPUVectorize);
-    test_all<double>(Backend::CPU);
-    test_all<double>(Backend::CPUVectorize);
-    if (target.has_feature(Target::OpenCL)) {
-        // No support for 8-bit & 16-bit atomics in OpenCL
-        test_all<uint32_t>(Backend::OpenCL);
-        test_all<int32_t>(Backend::OpenCL);
-        test_all<float>(Backend::OpenCL);
-        if (target.has_feature(Target::CLAtomics64)) {
-            test_all<uint64_t>(Backend::OpenCL);
-            test_all<int64_t>(Backend::OpenCL);
-            test_all<double>(Backend::OpenCL);
-        }
-    }
-    if (target.has_feature(Target::CUDA)) {
-        // No support for 8-bit & 16-bit atomics in CUDA
-        // float16 is possible but not implemented yet.
-        test_all<uint32_t>(Backend::CUDA);
-        test_all<int32_t>(Backend::CUDA);
-        test_all<float>(Backend::CUDA);
-        test_all<uint64_t>(Backend::CUDA);
-        test_all<int64_t>(Backend::CUDA);
-        test_all<double>(Backend::CUDA);
+    // if (target.has_feature(Target::OpenCL)) {
+    //     // No support for 8-bit & 16-bit atomics in OpenCL
+    //     test_all<uint32_t>(Backend::OpenCL);
+    //     test_all<int32_t>(Backend::OpenCL);
+    //     test_all<float>(Backend::OpenCL);
+    //     if (target.has_feature(Target::CLAtomics64)) {
+    //         test_all<uint64_t>(Backend::OpenCL);
+    //         test_all<int64_t>(Backend::OpenCL);
+    //         test_all<double>(Backend::OpenCL);
+    //     }
+    // }
+    // if (target.has_feature(Target::CUDA)) {
+    //     // No support for 8-bit & 16-bit atomics in CUDA
+    //     // float16 is possible but not implemented yet.
+    //     test_all<uint32_t>(Backend::CUDA);
+    //     test_all<int32_t>(Backend::CUDA);
+    //     test_all<float>(Backend::CUDA);
+    //     test_all<uint64_t>(Backend::CUDA);
+    //     test_all<int64_t>(Backend::CUDA);
+    //     test_all<double>(Backend::CUDA);
 
-        test_all<uint32_t>(Backend::CUDAVectorize);
-        test_all<int32_t>(Backend::CUDAVectorize);
-        test_all<float>(Backend::CUDAVectorize);
-        test_all<uint64_t>(Backend::CUDAVectorize);
-        test_all<int64_t>(Backend::CUDAVectorize);
-        test_all<double>(Backend::CUDAVectorize);
-    }
-    test_extern_func(Backend::CPU);
-    test_extern_func(Backend::CPUVectorize);
-    test_async(Backend::CPU);
-    test_async(Backend::CPUVectorize);
-    test_async_tuple(Backend::CPU);
+    //     test_all<uint32_t>(Backend::CUDAVectorize);
+    //     test_all<int32_t>(Backend::CUDAVectorize);
+    //     test_all<float>(Backend::CUDAVectorize);
+    //     test_all<uint64_t>(Backend::CUDAVectorize);
+    //     test_all<int64_t>(Backend::CUDAVectorize);
+    //     test_all<double>(Backend::CUDAVectorize);
+    // }
+    // test_extern_func(Backend::CPU);
+    // test_extern_func(Backend::CPUVectorize);
+    // test_async(Backend::CPU);
+    // test_async(Backend::CPUVectorize);
+    // test_async_tuple(Backend::CPU);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -979,8 +979,8 @@ void test_hist_tuple_rfactor(const Backend &backend) {
 }
 
 #ifdef _WIN32
-#define LOG_TEST(T, B)                                                                                                                                                   \
-    do {                                                                                                                                                                 \
+#define LOG_TEST(T, B)                                                                                                \
+    do {                                                                                                              \
         std::cout << "Test type=" << Halide::type_of<T>() << " backend=" << (int)(B) << " line=" << __LINE__ << "\n"; \
     } while (0)
 #else

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -1215,43 +1215,44 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    // Target target = get_jit_target_from_environment();
+    Target target = get_jit_target_from_environment();
 // Most of the schedules used in this test are terrible for large
 // thread count machines, due to massive amounts of
 // contention. We'll just set the thread count to 4. Unfortunately
 // there's no JIT api for this yet.
 #ifdef _WIN32
     _putenv_s("HL_NUM_THREADS", "4");
-    _putenv_s("HL_DEBUG_CODEGEN", "2");
+    //_putenv_s("HL_DEBUG_CODEGEN", "2");
 #else
     setenv("HL_NUM_THREADS", "4", 1);
-    setenv("HL_DEBUG_CODEGEN", "2", 1);
+    //setenv("HL_DEBUG_CODEGEN", "2", 1);
 #endif
-    // test_all<uint8_t>(Backend::CPU);
-    // test_all<uint8_t>(Backend::CPUVectorize);
-    // test_all<int8_t>(Backend::CPU);
-    // test_all<int8_t>(Backend::CPUVectorize);
-    // test_all<uint16_t>(Backend::CPU);
-    // test_all<uint16_t>(Backend::CPUVectorize);
-    // test_all<int16_t>(Backend::CPU);
-    // test_all<int16_t>(Backend::CPUVectorize);
-    // if (target.has_feature(Target::F16C)) {
-    //     test_all<float16_t>(Backend::CPU);
-    //     test_all<float16_t>(Backend::CPUVectorize);
-    // }
-    // test_all<bfloat16_t>(Backend::CPU);
-    // test_all<bfloat16_t>(Backend::CPUVectorize);
-    // test_all<uint32_t>(Backend::CPU);
-    // test_all<uint32_t>(Backend::CPUVectorize);
-    // test_all<int32_t>(Backend::CPU);
-    // test_all<int32_t>(Backend::CPUVectorize);
-    // test_all<float>(Backend::CPU);
-    // test_all<float>(Backend::CPUVectorize);
-    // test_all<uint64_t>(Backend::CPU);
-    // test_all<uint64_t>(Backend::CPUVectorize);
-    // test_all<int64_t>(Backend::CPU);
-    // test_all<int64_t>(Backend::CPUVectorize);
+
     try {
+        test_all<uint8_t>(Backend::CPU);
+        test_all<uint8_t>(Backend::CPUVectorize);
+        test_all<int8_t>(Backend::CPU);
+        test_all<int8_t>(Backend::CPUVectorize);
+        test_all<uint16_t>(Backend::CPU);
+        test_all<uint16_t>(Backend::CPUVectorize);
+        test_all<int16_t>(Backend::CPU);
+        test_all<int16_t>(Backend::CPUVectorize);
+        if (target.has_feature(Target::F16C)) {
+            test_all<float16_t>(Backend::CPU);
+            test_all<float16_t>(Backend::CPUVectorize);
+        }
+        test_all<bfloat16_t>(Backend::CPU);
+        test_all<bfloat16_t>(Backend::CPUVectorize);
+        test_all<uint32_t>(Backend::CPU);
+        test_all<uint32_t>(Backend::CPUVectorize);
+        test_all<int32_t>(Backend::CPU);
+        test_all<int32_t>(Backend::CPUVectorize);
+        test_all<float>(Backend::CPU);
+        test_all<float>(Backend::CPUVectorize);
+        test_all<uint64_t>(Backend::CPU);
+        test_all<uint64_t>(Backend::CPUVectorize);
+        test_all<int64_t>(Backend::CPU);
+        test_all<int64_t>(Backend::CPUVectorize);
         test_all<double>(Backend::CPU);
         test_all<double>(Backend::CPUVectorize);
     } catch (const std::runtime_error &e) {
@@ -1289,12 +1290,18 @@ int main(int argc, char **argv) {
     //     test_all<int64_t>(Backend::CUDAVectorize);
     //     test_all<double>(Backend::CUDAVectorize);
     // }
-    // test_extern_func(Backend::CPU);
-    // test_extern_func(Backend::CPUVectorize);
-    // test_async(Backend::CPU);
-    // test_async(Backend::CPUVectorize);
-    // test_async_tuple(Backend::CPU);
+    std::cout<<"TEST:"<<__LINE__<<"\n"<<std::flush;
+    test_extern_func(Backend::CPU);
+    std::cout<<"TEST:"<<__LINE__<<"\n"<<std::flush;
+    test_extern_func(Backend::CPUVectorize);
+    std::cout<<"TEST:"<<__LINE__<<"\n"<<std::flush;
+    test_async(Backend::CPU);
+    std::cout<<"TEST:"<<__LINE__<<"\n"<<std::flush;
+    test_async(Backend::CPUVectorize);
+    std::cout<<"TEST:"<<__LINE__<<"\n"<<std::flush;
+    test_async_tuple(Backend::CPU);
 
-    printf("Success!\n");
+    // printf("Success!\n");
+    std::cout<<"Success!\n"<<std::flush;
     return 0;
 }

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -978,27 +978,52 @@ void test_hist_tuple_rfactor(const Backend &backend) {
     }
 }
 
+#ifdef _WIN32
+#define LOG_TEST(T, B)                                                                                                                                                   \
+    do {                                                                                                                                                                 \
+        std::cout << "Test type=" << Halide::type_of<T>() << " backend=" << (int)(B) << " line=" << __LINE__ << "\n"; \
+    } while (0)
+#else
+#define LOG_TEST(T, B) \
+    do {               \
+    } while (0)
+#endif
+
 template<typename T>
 void test_all(const Backend &backend) {
+    LOG_TEST(T, backend);
     test_parallel_hist<T>(backend);
+    LOG_TEST(T, backend);
     test_parallel_cas_update<T>(backend);
+    LOG_TEST(T, backend);
     if (backend != Backend::CPUVectorize) {
         // Doesn't support vectorized predicated store yet.
+        LOG_TEST(T, backend);
         test_predicated_hist<T>(backend);
     }
+    LOG_TEST(T, backend);
     test_hist_compute_at<T>(backend);
     if (backend == Backend::CPU || backend == Backend::CPUVectorize) {
+        LOG_TEST(T, backend);
         test_hist_store_at<T>(backend);
     }
+    LOG_TEST(T, backend);
     test_hist_rfactor<T>(backend);
     if (backend == Backend::CPU) {
         // These require mutex locking which does not support vectorization and GPU
+        LOG_TEST(T, backend);
         test_parallel_hist_tuple<T>(backend);
+        LOG_TEST(T, backend);
         test_parallel_hist_tuple2<T>(backend);
+        LOG_TEST(T, backend);
         test_tuple_reduction<T>(backend);
+        LOG_TEST(T, backend);
         test_nested_atomics<T>(backend);
+        LOG_TEST(T, backend);
         test_hist_tuple_compute_at<T>(backend);
+        LOG_TEST(T, backend);
         test_hist_tuple_rfactor<T>(backend);
+        LOG_TEST(T, backend);
     }
 }
 


### PR DESCRIPTION
correctness_atomics has intermittent failures on Windows, with no useful diagnostic outputs. This is a draft PR that adds logging in hopes of getting more actionable info about this failure.