### PR TITLE
Remove Generator::value_tracker and friends

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -292,7 +292,6 @@ namespace Internal {
 void generator_test();
 
 class GeneratorBase;
-class ValueTracker;
 
 std::vector<Expr> parameter_constraints(const Parameter &p);
 
@@ -3085,13 +3084,11 @@ private:
     bool auto_schedule_ = false;
     MachineParams machine_params_ = MachineParams::generic();
     std::shared_ptr<ExternsMap> externs_map_;
-    std::shared_ptr<Internal::ValueTracker> value_tracker_;
 
     GeneratorContext(const Target &target,
                      bool auto_schedule,
                      const MachineParams &machine_params,
-                     std::shared_ptr<ExternsMap> externs_map,
-                     std::shared_ptr<Internal::ValueTracker> value_tracker);
+                     std::shared_ptr<ExternsMap> externs_map);
 };
 
 class NamesInterface {
@@ -3464,8 +3461,6 @@ protected:
     virtual void call_generate() = 0;
     virtual void call_schedule() = 0;
 
-    void track_parameter_values(bool include_outputs);
-
     void pre_build();
     void post_build();
     void pre_configure();
@@ -3554,7 +3549,6 @@ private:
 
     const size_t size;
     std::shared_ptr<GeneratorContext::ExternsMap> externs_map;
-    std::shared_ptr<Internal::ValueTracker> value_tracker;
 
     // Lazily-allocated-and-inited struct with info about our various Params.
     // Do not access directly: use the param_info() getter.


### PR DESCRIPTION
This is an internal-to-Generator helper that is used to try to detect certain classes of errors when using GeneratorStubs. To the best of my knowledge, it has ~never found a useful error in all of its existence; combined with the very limited usage of GeneratorStubs, I think this code no longer pays for itself, and should be removed.

(Note that this was never externally visible, thus no deprecation warnings should be necessary.)