### PR TITLE
Add placeholder code for bfloat16 in Python (#6849)

### DIFF
--- a/python_bindings/src/PyBinaryOperators.h
+++ b/python_bindings/src/PyBinaryOperators.h
@@ -61,6 +61,7 @@ HANDLE_SCALAR_TYPE(int8_t)
 HANDLE_SCALAR_TYPE(int16_t)
 HANDLE_SCALAR_TYPE(int32_t)
 HANDLE_SCALAR_TYPE(int64_t)
+// HANDLE_SCALAR_TYPE(bfloat16_t)  -- see https://github.com/halide/Halide/issues/6849
 HANDLE_SCALAR_TYPE(float16_t)
 HANDLE_SCALAR_TYPE(float)
 HANDLE_SCALAR_TYPE(double)

--- a/python_bindings/src/PyBinaryOperators.h
+++ b/python_bindings/src/PyBinaryOperators.h
@@ -61,7 +61,7 @@ HANDLE_SCALAR_TYPE(int8_t)
 HANDLE_SCALAR_TYPE(int16_t)
 HANDLE_SCALAR_TYPE(int32_t)
 HANDLE_SCALAR_TYPE(int64_t)
-// HANDLE_SCALAR_TYPE(bfloat16_t)  -- see https://github.com/halide/Halide/issues/6849
+// HANDLE_SCALAR_TYPE(bfloat16_t)  TODO: https://github.com/halide/Halide/issues/6849
 HANDLE_SCALAR_TYPE(float16_t)
 HANDLE_SCALAR_TYPE(float)
 HANDLE_SCALAR_TYPE(double)

--- a/python_bindings/src/PyBuffer.cpp
+++ b/python_bindings/src/PyBuffer.cpp
@@ -57,6 +57,12 @@ inline float16_t value_cast<float16_t>(const py::object &value) {
     return float16_t(value.cast<double>());
 }
 
+// TODO: https://github.com/halide/Halide/issues/6849
+// template<>
+// inline bfloat16_t value_cast<bfloat16_t>(const py::object &value) {
+//     return bfloat16_t(value.cast<double>());
+// }
+
 template<typename T>
 inline std::string format_descriptor() {
     return py::format_descriptor<T>::format();
@@ -66,6 +72,12 @@ template<>
 inline std::string format_descriptor<float16_t>() {
     return "e";
 }
+
+// TODO: https://github.com/halide/Halide/issues/6849
+// template<>
+// inline std::string format_descriptor<bfloat16_t>() {
+//     return there-is-no-python-buffer-format-descriptor-for-bfloat16;
+// }
 
 void call_fill(Buffer<> &b, const py::object &value) {
 
@@ -84,6 +96,8 @@ void call_fill(Buffer<> &b, const py::object &value) {
     HANDLE_BUFFER_TYPE(int16_t)
     HANDLE_BUFFER_TYPE(int32_t)
     HANDLE_BUFFER_TYPE(int64_t)
+    // TODO: https://github.com/halide/Halide/issues/6849
+    // HANDLE_BUFFER_TYPE(bfloat16_t)
     HANDLE_BUFFER_TYPE(float16_t)
     HANDLE_BUFFER_TYPE(float)
     HANDLE_BUFFER_TYPE(double)
@@ -109,6 +123,8 @@ bool call_all_equal(Buffer<> &b, const py::object &value) {
     HANDLE_BUFFER_TYPE(int16_t)
     HANDLE_BUFFER_TYPE(int32_t)
     HANDLE_BUFFER_TYPE(int64_t)
+    // TODO: https://github.com/halide/Halide/issues/6849
+    // HANDLE_BUFFER_TYPE(bfloat16_t)
     HANDLE_BUFFER_TYPE(float16_t)
     HANDLE_BUFFER_TYPE(float)
     HANDLE_BUFFER_TYPE(double)
@@ -133,6 +149,8 @@ std::string type_to_format_descriptor(const Type &type) {
     HANDLE_BUFFER_TYPE(int16_t)
     HANDLE_BUFFER_TYPE(int32_t)
     HANDLE_BUFFER_TYPE(int64_t)
+    // TODO: https://github.com/halide/Halide/issues/6849
+    // HANDLE_BUFFER_TYPE(bfloat16_t)
     HANDLE_BUFFER_TYPE(float16_t)
     HANDLE_BUFFER_TYPE(float)
     HANDLE_BUFFER_TYPE(double)
@@ -159,6 +177,8 @@ Type format_descriptor_to_type(const std::string &fd) {
     HANDLE_BUFFER_TYPE(int16_t)
     HANDLE_BUFFER_TYPE(int32_t)
     HANDLE_BUFFER_TYPE(int64_t)
+    // TODO: https://github.com/halide/Halide/issues/6849
+    // HANDLE_BUFFER_TYPE(bfloat16_t)
     HANDLE_BUFFER_TYPE(float16_t)
     HANDLE_BUFFER_TYPE(float)
     HANDLE_BUFFER_TYPE(double)
@@ -196,6 +216,8 @@ py::object buffer_getitem_operator(Buffer<> &buf, const std::vector<int> &pos) {
     HANDLE_BUFFER_TYPE(int16_t)
     HANDLE_BUFFER_TYPE(int32_t)
     HANDLE_BUFFER_TYPE(int64_t)
+    // TODO: https://github.com/halide/Halide/issues/6849
+    // HANDLE_BUFFER_TYPE(bfloat16_t)
     HANDLE_BUFFER_TYPE(float16_t)
     HANDLE_BUFFER_TYPE(float)
     HANDLE_BUFFER_TYPE(double)
@@ -224,6 +246,8 @@ py::object buffer_setitem_operator(Buffer<> &buf, const std::vector<int> &pos, c
     HANDLE_BUFFER_TYPE(int16_t)
     HANDLE_BUFFER_TYPE(int32_t)
     HANDLE_BUFFER_TYPE(int64_t)
+    // TODO: https://github.com/halide/Halide/issues/6849
+    // HANDLE_BUFFER_TYPE(bfloat16_t)
     HANDLE_BUFFER_TYPE(float16_t)
     HANDLE_BUFFER_TYPE(float)
     HANDLE_BUFFER_TYPE(double)

--- a/python_bindings/test/correctness/buffer.py
+++ b/python_bindings/test/correctness/buffer.py
@@ -130,6 +130,20 @@ def test_float16():
     hl_img = hl.Buffer(array_in)
     array_out = np.array(hl_img, copy = False)
 
+# TODO: https://github.com/halide/Halide/issues/6849
+# def test_bfloat16():
+#     try:
+#         from tensorflow.python.lib.core import _pywrap_bfloat16
+#         bfloat16 = _pywrap_bfloat16.TF_bfloat16_type()
+#         array_in = np.zeros((256, 256, 3), dtype=bfloat16, order='F')
+#         hl_img = hl.Buffer(array_in)
+#         array_out = np.array(hl_img, copy = False)
+#     except ModuleNotFoundError as e:
+#         print("skipping test_bfloat16() because tensorflow was not found: %s" % str(e))
+#         return
+#     else:
+#         assert False, "This should not happen"
+
 def test_int64():
     array_in = np.zeros((256, 256, 3), dtype=np.int64, order='F')
     hl_img = hl.Buffer(array_in)
@@ -279,6 +293,8 @@ if __name__ == "__main__":
     test_for_each_element()
     test_fill_all_equal()
     test_bufferinfo_sharing()
+    # TODO: https://github.com/halide/Halide/issues/6849
+    # test_bfloat16()
     test_float16()
     test_int64()
     test_reorder()


### PR DESCRIPTION
This is a no-op change; I just want to mark the place(s) in the Python bindings that need attention if/when it becomes possible to support bfloat16 in Python buffers.