### PR TITLE
Fix the PLUGINS argument to properly join multiple arguments

### DIFF
--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -321,7 +321,9 @@ function(add_halide_library TARGET)
         foreach (p IN LISTS ARG_PLUGINS)
             list(APPEND generator_plugins "$<TARGET_FILE:${p}>")
         endforeach ()
-        set(generator_plugins -p "$<JOIN:${generator_plugins},$<COMMA>>")
+        # $<JOIN:> gets confused about quoting. Just use list(JOIN) here instead.
+        list(JOIN generator_plugins $<COMMA> generator_plugins_list)
+        set(generator_plugins -p ${generator_plugins_list})
     endif ()
 
     add_custom_command(OUTPUT ${generator_output_files}


### PR DESCRIPTION
The existing code for joining multiple plugin paths in `add_halide_library` produces wonky results if multiple plugins are listed (eg `PLUGINS Halide::Adams2019 Halide::Li2018 Halide::Mullapudi2016`) ... we end up with something like `-p "\$<JOIN:/Users/srj/GitHub/Halide/build/src/autoschedulers/adams2019/libautoschedule_adams2019.so" /Users/srj/GitHub/Halide/build/src/autoschedulers/li2018/libautoschedule_li2018.so "/Users/srj/GitHub/Halide/build/src/autoschedulers/mullapudi2016/libautoschedule_mullapudi2016.so,,>"`.

I couldn't easily find a way to make $<JOIN> happy, so I changed it to use `list(JOIN)` instead, which seems to work.

