### PR TITLE
Silence Adams2019 Autoscheduler

### DIFF
--- a/src/autoschedulers/adams2019/ASLog.cpp
+++ b/src/autoschedulers/adams2019/ASLog.cpp
@@ -41,7 +41,7 @@ std::array<aslog_stream, kMaxLevel + 1> aslog_streams = {
     aslog_stream(0),
     aslog_stream(1),
     aslog_stream(2),
-    aslog_stream(3)
+    aslog_stream(3),
 };
 
 }  // namespace

--- a/src/autoschedulers/adams2019/ASLog.cpp
+++ b/src/autoschedulers/adams2019/ASLog.cpp
@@ -1,8 +1,5 @@
 #include "ASLog.h"
 
-#include <array>
-#include <cassert>
-
 namespace Halide {
 namespace Internal {
 
@@ -37,22 +34,9 @@ std::string get_env_variable(char const *env_var_name) {
     return "";
 }
 
-constexpr int kMaxLevel = 3;
-std::array<aslog_stream, kMaxLevel + 1> aslog_streams = {
-    aslog_stream(0),
-    aslog_stream(1),
-    aslog_stream(2),
-    aslog_stream(3),
-};
-
 }  // namespace
 
-aslog_stream &aslog(int verbosity) {
-    assert(verbosity <= kMaxLevel);
-    return aslog_streams[verbosity];
-}
-
-int aslog_level() {
+int aslog::aslog_level() {
     static int cached_aslog_level = ([]() -> int {
         // If HL_DEBUG_AUTOSCHEDULE is defined, use that value.
         std::string lvl = get_env_variable("HL_DEBUG_AUTOSCHEDULE");

--- a/src/autoschedulers/adams2019/ASLog.cpp
+++ b/src/autoschedulers/adams2019/ASLog.cpp
@@ -36,19 +36,19 @@ std::string get_env_variable(char const *env_var_name) {
     return "";
 }
 
-constexpr unsigned int kMaxLevel = 4;
+constexpr int kMaxLevel = 3;
 std::array<aslog_stream, kMaxLevel + 1> aslog_streams = {
     aslog_stream(0),
     aslog_stream(1),
     aslog_stream(2),
-    aslog_stream(3),
-    aslog_stream(4),
+    aslog_stream(3)
 };
 
 }  // namespace
 
-aslog_stream &aslog(unsigned int verbosity) {
-    return aslog_streams[std::min(verbosity, kMaxLevel)];
+aslog_stream &aslog(int verbosity) {
+    assert(verbosity <= kMaxLevel);
+    return aslog_streams[verbosity];
 }
 
 int aslog_level() {

--- a/src/autoschedulers/adams2019/ASLog.cpp
+++ b/src/autoschedulers/adams2019/ASLog.cpp
@@ -1,6 +1,7 @@
 #include "ASLog.h"
 
 #include <array>
+#include <cassert>
 
 namespace Halide {
 namespace Internal {

--- a/src/autoschedulers/adams2019/ASLog.cpp
+++ b/src/autoschedulers/adams2019/ASLog.cpp
@@ -1,5 +1,7 @@
 #include "ASLog.h"
 
+#include <array>
+
 namespace Halide {
 namespace Internal {
 
@@ -34,9 +36,22 @@ std::string get_env_variable(char const *env_var_name) {
     return "";
 }
 
+constexpr unsigned int kMaxLevel = 4;
+std::array<aslog_stream, kMaxLevel + 1> aslog_streams = {
+    aslog_stream(0),
+    aslog_stream(1),
+    aslog_stream(2),
+    aslog_stream(3),
+    aslog_stream(4),
+};
+
 }  // namespace
 
-int aslog::aslog_level() {
+aslog_stream &aslog(unsigned int verbosity) {
+    return aslog_streams[std::min(verbosity, kMaxLevel)];
+}
+
+int aslog_level() {
     static int cached_aslog_level = ([]() -> int {
         // If HL_DEBUG_AUTOSCHEDULE is defined, use that value.
         std::string lvl = get_env_variable("HL_DEBUG_AUTOSCHEDULE");

--- a/src/autoschedulers/adams2019/ASLog.h
+++ b/src/autoschedulers/adams2019/ASLog.h
@@ -53,7 +53,7 @@ public:
     aslog_stream &operator=(aslog_stream &&) = delete;
 };
 
-aslog_stream &aslog(unsigned int verbosity);
+aslog_stream &aslog(int verbosity);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/autoschedulers/adams2019/ASLog.h
+++ b/src/autoschedulers/adams2019/ASLog.h
@@ -5,6 +5,7 @@
 // libHalide, so (despite the namespace) we are better off not
 // including Halide.h, lest we reference something we won't have available
 
+#include <cassert>
 #include <cstdlib>
 #include <iostream>
 #include <utility>
@@ -29,8 +30,8 @@ public:
     }
 
     std::ostream &get_ostream() {
+        // It is an error to call this for an aslog() instance that cannot log.
         assert(logging);
-        if (!logging) abort();
         return std::cerr;
     }
 

--- a/src/autoschedulers/adams2019/ASLog.h
+++ b/src/autoschedulers/adams2019/ASLog.h
@@ -12,48 +12,30 @@
 namespace Halide {
 namespace Internal {
 
-class aslog_streambuf : public std::streambuf {
+class aslog {
+    const bool logging;
+
 public:
-    explicit aslog_streambuf(bool do_log)
-        : do_log_(do_log) {
+    aslog(int verbosity)
+        : logging(verbosity <= aslog_level()) {
     }
 
-protected:
-    std::streamsize xsputn(const char_type *s, std::streamsize n) override {
-        if (do_log_) {
-            std::cerr.write(s, n);
+    template<typename T>
+    aslog &operator<<(T &&x) {
+        if (logging) {
+            std::cerr << std::forward<T>(x);
         }
-        return n;  // returns the number of characters successfully written.
-    };
-
-    int_type overflow(int_type ch) override {
-        if (do_log_) {
-            std::cerr.put(ch);
-        }
-        return 1;  // returns the number of characters successfully written.
+        return *this;
     }
 
-private:
-    const bool do_log_;
-};
-
-int aslog_level();
-
-class aslog_stream : private aslog_streambuf, public std::ostream {
-public:
-    explicit aslog_stream(int verbosity)
-        : aslog_streambuf(verbosity <= aslog_level()), std::ostream(this) {
+    std::ostream &get_ostream() {
+        assert(logging);
+        if (!logging) abort();
+        return std::cerr;
     }
 
-    // Not movable, not copyable.
-    aslog_stream() = delete;
-    aslog_stream(const aslog_stream &) = delete;
-    aslog_stream &operator=(const aslog_stream &) = delete;
-    aslog_stream(aslog_stream &&) = delete;
-    aslog_stream &operator=(aslog_stream &&) = delete;
+    static int aslog_level();
 };
-
-aslog_stream &aslog(int verbosity);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/autoschedulers/adams2019/ASLog.h
+++ b/src/autoschedulers/adams2019/ASLog.h
@@ -14,21 +14,23 @@ namespace Internal {
 
 class aslog_streambuf : public std::streambuf {
 public:
-    explicit aslog_streambuf(bool do_log): do_log_(do_log) {}
+    explicit aslog_streambuf(bool do_log)
+        : do_log_(do_log) {
+    }
 
 protected:
-    std::streamsize xsputn(const char_type* s, std::streamsize n) override {
+    std::streamsize xsputn(const char_type *s, std::streamsize n) override {
         if (do_log_) {
             std::cerr.write(s, n);
         }
-        return n; // returns the number of characters successfully written.
+        return n;  // returns the number of characters successfully written.
     };
 
     int_type overflow(int_type ch) override {
         if (do_log_) {
             std::cerr.put(ch);
         }
-        return 1; // returns the number of characters successfully written.
+        return 1;  // returns the number of characters successfully written.
     }
 
 private:
@@ -39,7 +41,9 @@ int aslog_level();
 
 class aslog_stream : private aslog_streambuf, public std::ostream {
 public:
-    explicit aslog_stream(int verbosity) : aslog_streambuf(verbosity <= aslog_level()), std::ostream(this) {}
+    explicit aslog_stream(int verbosity)
+        : aslog_streambuf(verbosity <= aslog_level()), std::ostream(this) {
+    }
 
     // Not movable, not copyable.
     aslog_stream() = delete;

--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -508,7 +508,7 @@ IntrusivePtr<State> optimal_schedule(FunctionDAG &dag,
 
         tick.clear();
 
-        if (aslog::aslog_level() == 0) {
+        if (aslog_level() == 0) {
             aslog(0) << "Pass " << i << " of " << num_passes << ", cost: " << pass->cost << ", time (ms): " << milli << "\n";
         } else {
             aslog(0) << "Pass " << i << " result: ";
@@ -576,7 +576,7 @@ void generate_schedule(const std::vector<Function> &outputs,
 
     // Analyse the Halide algorithm and construct our abstract representation of it
     FunctionDAG dag(outputs, params, target);
-    if (aslog::aslog_level() > 0) {
+    if (aslog_level() > 0) {
         dag.dump();
     }
 
@@ -602,13 +602,13 @@ void generate_schedule(const std::vector<Function> &outputs,
     aslog(1) << "** Optimal schedule:\n";
 
     // Just to get the debugging prints to fire
-    optimal->calculate_cost(dag, params, cost_model.get(), cache_options, memory_limit, aslog::aslog_level() > 0);
+    optimal->calculate_cost(dag, params, cost_model.get(), cache_options, memory_limit, aslog_level() > 0);
 
     // Apply the schedules to the pipeline
     optimal->apply_schedule(dag, params);
 
     // Print out the schedule
-    if (aslog::aslog_level() > 0) {
+    if (aslog_level() > 0) {
         optimal->dump();
     }
 

--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -439,7 +439,7 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
             for (int choice_label = (int)q.size() - 1; choice_label >= 0; choice_label--) {
                 auto state = q[choice_label];
                 std::cout << "\n[" << choice_label << "]:\n";
-                state->dumpz(std::cout);
+                state->dump(std::cout);
                 constexpr int verbosity_level = 0;  // always
                 state->calculate_cost(dag, params, cost_model, cache->options, memory_limit, verbosity_level);
             }
@@ -453,7 +453,7 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
             }
 
             auto selected = q[selection];
-            selected->dumpz(std::cout);
+            selected->dump(std::cout);
             q.clear();
             q.emplace(std::move(selected));
         }
@@ -516,7 +516,7 @@ IntrusivePtr<State> optimal_schedule(FunctionDAG &dag,
             break;
         default:
             aslog(2) << "Pass " << i << " result: ";
-            pass->dumpz(aslog(2));
+            pass->dump(aslog(2));
         }
 
         if (i == 0 || pass->cost < best->cost) {
@@ -581,7 +581,7 @@ void generate_schedule(const std::vector<Function> &outputs,
     // Analyse the Halide algorithm and construct our abstract representation of it
     FunctionDAG dag(outputs, params, target);
     if (aslog_level() >= 2) {
-        dag.dumpz(aslog(2));
+        dag.dump(aslog(2));
     }
 
     // Construct a cost model to use to evaluate states. Currently we
@@ -613,7 +613,7 @@ void generate_schedule(const std::vector<Function> &outputs,
 
     // Print out the schedule
     if (aslog_level() >= 2) {
-        optimal->dumpz(aslog(2));
+        optimal->dump(aslog(2));
     }
 
     string schedule_file = get_env_variable("HL_SCHEDULE_FILE");

--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -123,36 +123,38 @@ struct ProgressBar {
             return;
         }
         const int pos = (int)(progress * 78);
-        aslog(0) << "[";
+        os << "[";
         for (int j = 0; j < 78; j++) {
             if (j < pos) {
-                aslog(0) << ".";
+                os << ".";
             } else if (j - 1 < pos) {
-                aslog(0) << "/-\\|"[(counter >> bits) % 4];
+                os << "/-\\|"[(counter >> bits) % 4];
             } else {
-                aslog(0) << " ";
+                os << " ";
             }
         }
-        aslog(0) << "]";
+        os << "]";
         for (int j = 0; j < 80; j++) {
-            aslog(0) << "\b";
+            os << "\b";
         }
     }
 
     void clear() {
         if (counter) {
             for (int j = 0; j < 80; j++) {
-                aslog(0) << " ";
+                os << " ";
             }
             for (int j = 0; j < 80; j++) {
-                aslog(0) << "\b";
+                os << "\b";
             }
         }
     }
 
 private:
     uint32_t counter = 0;
-    const bool draw_progress_bar = isatty(2);
+    static constexpr int ProgressBarLogLevel = 1;
+    const bool draw_progress_bar = isatty(2) && aslog_level() >= ProgressBarLogLevel;
+    std::ostream &os = aslog(ProgressBarLogLevel);
 };
 
 // Get the HL_RANDOM_DROPOUT environment variable. Purpose of this is described above.

--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -291,7 +291,7 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
     std::function<void(IntrusivePtr<State> &&)> enqueue_new_children =
         [&](IntrusivePtr<State> &&s) {
             // aslog(0) << "\n** Generated child: ";
-            // s->dump();
+            // s->dump(aslog(0));
             // s->calculate_cost(dag, params, nullptr, true);
 
             // Each child should have one more decision made than its parent state.
@@ -441,7 +441,7 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
             for (int choice_label = (int)q.size() - 1; choice_label >= 0; choice_label--) {
                 auto state = q[choice_label];
                 aslog(0) << "\n[" << choice_label << "]:\n";
-                state->dump();
+                state->dump(aslog(0));
                 state->calculate_cost(dag, params, cost_model, cache->options, memory_limit, true);
             }
             cost_model->evaluate_costs();
@@ -454,7 +454,7 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
             }
 
             auto selected = q[selection];
-            selected->dump();
+            selected->dump(aslog(0));
             q.clear();
             q.emplace(std::move(selected));
         }
@@ -512,7 +512,7 @@ IntrusivePtr<State> optimal_schedule(FunctionDAG &dag,
             aslog(0) << "Pass " << i << " of " << num_passes << ", cost: " << pass->cost << ", time (ms): " << milli << "\n";
         } else {
             aslog(0) << "Pass " << i << " result: ";
-            pass->dump();
+            pass->dump(aslog(0));
         }
 
         if (i == 0 || pass->cost < best->cost) {
@@ -576,8 +576,8 @@ void generate_schedule(const std::vector<Function> &outputs,
 
     // Analyse the Halide algorithm and construct our abstract representation of it
     FunctionDAG dag(outputs, params, target);
-    if (aslog_level() > 0) {
-        dag.dump();
+    if (aslog_level() >= 1) {
+        dag.dump(aslog(1));
     }
 
     // Construct a cost model to use to evaluate states. Currently we
@@ -608,8 +608,8 @@ void generate_schedule(const std::vector<Function> &outputs,
     optimal->apply_schedule(dag, params);
 
     // Print out the schedule
-    if (aslog_level() > 0) {
-        optimal->dump();
+    if (aslog_level() >= 1) {
+        optimal->dump(aslog(1));
     }
 
     string schedule_file = get_env_variable("HL_SCHEDULE_FILE");

--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -117,6 +117,7 @@ struct ProgressBar {
         if (!draw_progress_bar) {
             return;
         }
+        auto &os = aslog(ProgressBarLogLevel).get_ostream();
         counter++;
         const int bits = 11;
         if (counter & ((1 << bits) - 1)) {
@@ -141,6 +142,7 @@ struct ProgressBar {
 
     void clear() {
         if (counter) {
+            auto &os = aslog(ProgressBarLogLevel).get_ostream();
             for (int j = 0; j < 80; j++) {
                 os << " ";
             }
@@ -153,8 +155,7 @@ struct ProgressBar {
 private:
     uint32_t counter = 0;
     static constexpr int ProgressBarLogLevel = 1;
-    const bool draw_progress_bar = isatty(2) && aslog_level() >= ProgressBarLogLevel;
-    std::ostream &os = aslog(ProgressBarLogLevel);
+    const bool draw_progress_bar = isatty(2) && aslog::aslog_level() >= ProgressBarLogLevel;
 };
 
 // Get the HL_RANDOM_DROPOUT environment variable. Purpose of this is described above.
@@ -507,7 +508,7 @@ IntrusivePtr<State> optimal_schedule(FunctionDAG &dag,
 
         tick.clear();
 
-        switch (aslog_level()) {
+        switch (aslog::aslog_level()) {
         case 0:
             // Silence
             break;
@@ -516,7 +517,7 @@ IntrusivePtr<State> optimal_schedule(FunctionDAG &dag,
             break;
         default:
             aslog(2) << "Pass " << i << " result: ";
-            pass->dump(aslog(2));
+            pass->dump(aslog(2).get_ostream());
         }
 
         if (i == 0 || pass->cost < best->cost) {
@@ -580,8 +581,8 @@ void generate_schedule(const std::vector<Function> &outputs,
 
     // Analyse the Halide algorithm and construct our abstract representation of it
     FunctionDAG dag(outputs, params, target);
-    if (aslog_level() >= 2) {
-        dag.dump(aslog(2));
+    if (aslog::aslog_level() >= 2) {
+        dag.dump(aslog(2).get_ostream());
     }
 
     // Construct a cost model to use to evaluate states. Currently we
@@ -612,8 +613,8 @@ void generate_schedule(const std::vector<Function> &outputs,
     optimal->apply_schedule(dag, params);
 
     // Print out the schedule
-    if (aslog_level() >= 2) {
-        optimal->dump(aslog(2));
+    if (aslog::aslog_level() >= 2) {
+        optimal->dump(aslog(2).get_ostream());
     }
 
     string schedule_file = get_env_variable("HL_SCHEDULE_FILE");

--- a/src/autoschedulers/adams2019/DefaultCostModel.cpp
+++ b/src/autoschedulers/adams2019/DefaultCostModel.cpp
@@ -232,18 +232,18 @@ float DefaultCostModel::backprop(const Runtime::Buffer<const float> &true_runtim
         *(cost_ptrs(i)) = dst(i);
         if (std::isnan(dst(i))) {
             any_nans = true;
-            aslog(0) << "Prediction " << i << " is NaN. True runtime is " << true_runtimes(i) << "\n";
-            aslog(0) << "Checking pipeline features for NaNs...\n";
+            aslog(1) << "Prediction " << i << " is NaN. True runtime is " << true_runtimes(i) << "\n";
+            aslog(1) << "Checking pipeline features for NaNs...\n";
             pipeline_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
-            aslog(0) << "None found\n";
-            aslog(0) << "Checking schedule features for NaNs...\n";
+            aslog(1) << "None found\n";
+            aslog(1) << "Checking schedule features for NaNs...\n";
             schedule_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
-            aslog(0) << "None found\n";
-            aslog(0) << "Checking network weights for NaNs...\n";
+            aslog(1) << "None found\n";
+            aslog(1) << "Checking network weights for NaNs...\n";
             weights.for_each_buffer([&](const Runtime::Buffer<float> &buf) {
                 buf.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
             });
-            aslog(0) << "None found\n";
+            aslog(1) << "None found\n";
         }
         internal_assert(true_runtimes(i) > 0);
     }

--- a/src/autoschedulers/adams2019/Featurization.h
+++ b/src/autoschedulers/adams2019/Featurization.h
@@ -99,8 +99,7 @@ struct PipelineFeatures {
     // Each row sums to 1 or 0. Each column sums to 1. f(z, y, x, 4)
     int slice_accesses[(int)AccessType::NumAccessTypes][(int)ScalarType::NumScalarTypes] = {};
 
-    template<typename OS>
-    void dump(OS &os) const {
+    void dump(std::ostream &os) const {
         for (int i = 0; i < (int)ScalarType::NumScalarTypes; i++) {
             const char *type_names[] = {"Bool", "UInt8", "UInt16", "UInt32", "UInt64", "Float", "Double"};
             // Skip printing for types not used
@@ -156,10 +155,6 @@ struct PipelineFeatures {
                << slice_accesses[2][i] << " "
                << slice_accesses[3][i] << "\n";
         }
-    }
-    void dump() const {
-        auto &os = aslog(0);
-        dump(os);
     }
 };
 
@@ -314,8 +309,7 @@ struct ScheduleFeatures {
     double working_set_at_realization = 0;
     double working_set_at_root = 0;
 
-    template<typename OS>
-    void dump(OS &os) const {
+    void dump(std::ostream &os) const {
         os << "    num_realizations:                      " << num_realizations << "\n"
            << "    num_productions:                       " << num_productions << "\n"
            << "    points_computed_per_realization:       " << points_computed_per_realization << "\n"
@@ -355,10 +349,6 @@ struct ScheduleFeatures {
            << "    working_set_at_production:             " << working_set_at_production << "\n"
            << "    working_set_at_realization:            " << working_set_at_realization << "\n"
            << "    working_set_at_root:                   " << working_set_at_root << "\n";
-    }
-    void dump() const {
-        auto &os = aslog(0);
-        dump(os);
     }
 
     bool equal(const ScheduleFeatures &other) const {

--- a/src/autoschedulers/adams2019/Featurization.h
+++ b/src/autoschedulers/adams2019/Featurization.h
@@ -158,7 +158,7 @@ struct PipelineFeatures {
         }
     }
     void dump() const {
-        auto os = aslog(0);
+        auto &os = aslog(0);
         dump(os);
     }
 };
@@ -357,7 +357,7 @@ struct ScheduleFeatures {
            << "    working_set_at_root:                   " << working_set_at_root << "\n";
     }
     void dump() const {
-        auto os = aslog(0);
+        auto &os = aslog(0);
         dump(os);
     }
 

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -333,16 +333,18 @@ void BoundContents::validate() const {
     for (int i = 0; i < layout->total_size; i++) {
         auto p = data()[i];
         if (p.max() < p.min()) {
-            aslog(0) << "Bad bounds object:\n";
+            std::ostringstream err;
+            err << "Bad bounds object:\n";
             for (int j = 0; j < layout->total_size; j++) {
                 if (i == j) {
-                    aslog(0) << "=> ";
+                    err << "=> ";
                 } else {
-                    aslog(0) << "   ";
+                    err << "   ";
                 }
-                aslog(0) << j << ": " << data()[j].min() << ", " << data()[j].max() << "\n";
+                err << j << ": " << data()[j].min() << ", " << data()[j].max() << "\n";
             }
-            internal_error << "Aborting";
+            err << "Aborting";
+            internal_error << err.str();
         }
     }
 }
@@ -1039,7 +1041,7 @@ void FunctionDAG::featurize() {
     }
 }
 
-void FunctionDAG::dump(std::ostream &os) const {
+void FunctionDAG::dumpz(std::ostream &os) const {
     for (const Node &n : nodes) {
         os << "Node: " << n.func.name() << "\n"
            << "  Symbolic region required: \n";

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -1041,7 +1041,7 @@ void FunctionDAG::featurize() {
     }
 }
 
-void FunctionDAG::dumpz(std::ostream &os) const {
+void FunctionDAG::dump(std::ostream &os) const {
     for (const Node &n : nodes) {
         os << "Node: " << n.func.name() << "\n"
            << "  Symbolic region required: \n";

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -307,26 +307,26 @@ public:
 
 }  // namespace
 
-void LoadJacobian::dump(const char *prefix) const {
+void LoadJacobian::dump(std::ostream &os, const char *prefix) const {
     if (count() > 1) {
-        aslog(0) << prefix << count() << " x\n";
+        os << prefix << count() << " x\n";
     }
     for (size_t i = 0; i < producer_storage_dims(); i++) {
-        aslog(0) << prefix << "  [";
+        os << prefix << "  [";
 
         for (size_t j = 0; j < consumer_loop_dims(); j++) {
             const auto &c = (*this)(i, j);
             if (!c.exists) {
-                aslog(0) << " _  ";
+                os << " _  ";
             } else if (c.denominator == 1) {
-                aslog(0) << " " << c.numerator << "  ";
+                os << " " << c.numerator << "  ";
             } else {
-                aslog(0) << c.numerator << "/" << c.denominator << " ";
+                os << c.numerator << "/" << c.denominator << " ";
             }
         }
-        aslog(0) << "]\n";
+        os << "]\n";
     }
-    aslog(0) << "\n";
+    os << "\n";
 }
 
 void BoundContents::validate() const {
@@ -1039,8 +1039,7 @@ void FunctionDAG::featurize() {
     }
 }
 
-template<typename OS>
-void FunctionDAG::dump_internal(OS &os) const {
+void FunctionDAG::dump(std::ostream &os) const {
     for (const Node &n : nodes) {
         os << "Node: " << n.func.name() << "\n"
            << "  Symbolic region required: \n";
@@ -1076,19 +1075,9 @@ void FunctionDAG::dump_internal(OS &os) const {
 
         os << "  Load Jacobians:\n";
         for (const auto &jac : e.load_jacobians) {
-            jac.dump("  ");
+            jac.dump(os, "  ");
         }
     }
-}
-
-void FunctionDAG::dump() const {
-    auto &os = aslog(0);
-    dump_internal(os);
-}
-
-std::ostream &FunctionDAG::dump(std::ostream &os) const {
-    dump_internal(os);
-    return os;
 }
 
 }  // namespace Autoscheduler

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -1082,7 +1082,7 @@ void FunctionDAG::dump_internal(OS &os) const {
 }
 
 void FunctionDAG::dump() const {
-    auto os = aslog(0);
+    auto &os = aslog(0);
     dump_internal(os);
 }
 

--- a/src/autoschedulers/adams2019/FunctionDAG.h
+++ b/src/autoschedulers/adams2019/FunctionDAG.h
@@ -565,7 +565,7 @@ struct FunctionDAG {
     // analysis. This is done once up-front before the tree search.
     FunctionDAG(const vector<Function> &outputs, const MachineParams &params, const Target &target);
 
-    void dumpz(std::ostream &os) const;
+    void dump(std::ostream &os) const;
 
 private:
     // Compute the featurization for the entire DAG

--- a/src/autoschedulers/adams2019/FunctionDAG.h
+++ b/src/autoschedulers/adams2019/FunctionDAG.h
@@ -565,7 +565,7 @@ struct FunctionDAG {
     // analysis. This is done once up-front before the tree search.
     FunctionDAG(const vector<Function> &outputs, const MachineParams &params, const Target &target);
 
-   void dump(std::ostream &os) const;
+    void dump(std::ostream &os) const;
 
 private:
     // Compute the featurization for the entire DAG

--- a/src/autoschedulers/adams2019/FunctionDAG.h
+++ b/src/autoschedulers/adams2019/FunctionDAG.h
@@ -565,7 +565,7 @@ struct FunctionDAG {
     // analysis. This is done once up-front before the tree search.
     FunctionDAG(const vector<Function> &outputs, const MachineParams &params, const Target &target);
 
-    void dump(std::ostream &os) const;
+    void dumpz(std::ostream &os) const;
 
 private:
     // Compute the featurization for the entire DAG

--- a/src/autoschedulers/adams2019/FunctionDAG.h
+++ b/src/autoschedulers/adams2019/FunctionDAG.h
@@ -205,7 +205,7 @@ public:
         return result;
     }
 
-    void dump(const char *prefix) const;
+    void dump(std::ostream &os, const char *prefix) const;
 };
 
 // Classes to represent a concrete set of bounds for a Func. A Span is
@@ -565,15 +565,11 @@ struct FunctionDAG {
     // analysis. This is done once up-front before the tree search.
     FunctionDAG(const vector<Function> &outputs, const MachineParams &params, const Target &target);
 
-    void dump() const;
-    std::ostream &dump(std::ostream &os) const;
+   void dump(std::ostream &os) const;
 
 private:
     // Compute the featurization for the entire DAG
     void featurize();
-
-    template<typename OS>
-    void dump_internal(OS &os) const;
 
 public:
     // This class uses a lot of internal pointers, so we'll make it uncopyable/unmovable.

--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -1091,7 +1091,7 @@ const Bound &LoopNest::get_bounds(const FunctionDAG::Node *f) const {
 }
 
 // Recursively print a loop nest representation to stderr
-void LoopNest::dump(std::ostream &os, string prefix, const LoopNest *parent) const {
+void LoopNest::dumpz(std::ostream &os, string prefix, const LoopNest *parent) const {
     if (!is_root()) {
         // Non-root nodes always have parents.
         internal_assert(parent != nullptr);
@@ -1138,7 +1138,7 @@ void LoopNest::dump(std::ostream &os, string prefix, const LoopNest *parent) con
         os << prefix << "realize: " << p->func.name() << "\n";
     }
     for (size_t i = children.size(); i > 0; i--) {
-        children[i - 1]->dump(os, prefix, this);
+        children[i - 1]->dumpz(os, prefix, this);
     }
     for (auto it = inlined.begin(); it != inlined.end(); it++) {
         os << prefix << "inlined: " << it.key()->func.name() << " " << it.value() << "\n";
@@ -1504,7 +1504,7 @@ vector<IntrusivePtr<const LoopNest>> LoopNest::compute_in_tiles(const FunctionDA
         auto tilings = generate_tilings(size, (int)(size.size() - 1), 2, !in_realization);
 
         if (tilings.size() > 10000) {
-            aslog(0) << "Warning: lots of tilings: " << tilings.size() << "\n";
+            aslog(1) << "Warning: lots of tilings: " << tilings.size() << "\n";
         }
 
         for (auto t : tilings) {

--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -1091,24 +1091,24 @@ const Bound &LoopNest::get_bounds(const FunctionDAG::Node *f) const {
 }
 
 // Recursively print a loop nest representation to stderr
-void LoopNest::dump(string prefix, const LoopNest *parent) const {
+void LoopNest::dump(std::ostream &os, string prefix, const LoopNest *parent) const {
     if (!is_root()) {
         // Non-root nodes always have parents.
         internal_assert(parent != nullptr);
 
-        aslog(0) << prefix << node->func.name();
+        os << prefix << node->func.name();
         prefix += " ";
 
         for (size_t i = 0; i < size.size(); i++) {
-            aslog(0) << " " << size[i];
+            os << " " << size[i];
             // The vectorized loop gets a 'v' suffix
             if (innermost && i == (size_t)vectorized_loop_index) {
-                aslog(0) << "v";
+                os << "v";
             }
             // Loops that have a known constant size get a
             // 'c'. Useful for knowing what we can unroll.
             if (parent->get_bounds(node)->loops(stage->index, i).constant_extent()) {
-                aslog(0) << "c";
+                os << "c";
             }
         }
 
@@ -1117,31 +1117,31 @@ void LoopNest::dump(string prefix, const LoopNest *parent) const {
             const auto &bounds = get_bounds(node);
             for (size_t i = 0; i < size.size(); i++) {
                 const auto &p = bounds->loops(stage->index, i);
-                aslog(0) << " [" << p.first << ", " << p.second << "]";
+                os << " [" << p.first << ", " << p.second << "]";
             }
         */
 
-        aslog(0) << " (" << vectorized_loop_index << ", " << vector_dim << ")";
+        os << " (" << vectorized_loop_index << ", " << vector_dim << ")";
     }
 
     if (tileable) {
-        aslog(0) << " t";
+        os << " t";
     }
     if (innermost) {
-        aslog(0) << " *\n";
+        os << " *\n";
     } else if (parallel) {
-        aslog(0) << " p\n";
+        os << " p\n";
     } else {
-        aslog(0) << "\n";
+        os << "\n";
     }
     for (const auto *p : store_at) {
-        aslog(0) << prefix << "realize: " << p->func.name() << "\n";
+        os << prefix << "realize: " << p->func.name() << "\n";
     }
     for (size_t i = children.size(); i > 0; i--) {
-        children[i - 1]->dump(prefix, this);
+        children[i - 1]->dump(os, prefix, this);
     }
     for (auto it = inlined.begin(); it != inlined.end(); it++) {
-        aslog(0) << prefix << "inlined: " << it.key()->func.name() << " " << it.value() << "\n";
+        os << prefix << "inlined: " << it.key()->func.name() << " " << it.value() << "\n";
     }
 }
 

--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -1091,7 +1091,7 @@ const Bound &LoopNest::get_bounds(const FunctionDAG::Node *f) const {
 }
 
 // Recursively print a loop nest representation to stderr
-void LoopNest::dumpz(std::ostream &os, string prefix, const LoopNest *parent) const {
+void LoopNest::dump(std::ostream &os, string prefix, const LoopNest *parent) const {
     if (!is_root()) {
         // Non-root nodes always have parents.
         internal_assert(parent != nullptr);
@@ -1138,7 +1138,7 @@ void LoopNest::dumpz(std::ostream &os, string prefix, const LoopNest *parent) co
         os << prefix << "realize: " << p->func.name() << "\n";
     }
     for (size_t i = children.size(); i > 0; i--) {
-        children[i - 1]->dumpz(os, prefix, this);
+        children[i - 1]->dump(os, prefix, this);
     }
     for (auto it = inlined.begin(); it != inlined.end(); it++) {
         os << prefix << "inlined: " << it.key()->func.name() << " " << it.value() << "\n";

--- a/src/autoschedulers/adams2019/LoopNest.h
+++ b/src/autoschedulers/adams2019/LoopNest.h
@@ -157,7 +157,7 @@ struct LoopNest {
     const Bound &get_bounds(const FunctionDAG::Node *f) const;
 
     // Recursively print a loop nest representation to stderr
-    void dump(string prefix, const LoopNest *parent) const;
+    void dump(std::ostream &os, string prefix, const LoopNest *parent) const;
 
     // Does this loop nest access the given Func
     bool calls(const FunctionDAG::Node *f) const;

--- a/src/autoschedulers/adams2019/LoopNest.h
+++ b/src/autoschedulers/adams2019/LoopNest.h
@@ -157,7 +157,7 @@ struct LoopNest {
     const Bound &get_bounds(const FunctionDAG::Node *f) const;
 
     // Recursively print a loop nest representation to stderr
-    void dump(std::ostream &os, string prefix, const LoopNest *parent) const;
+    void dumpz(std::ostream &os, string prefix, const LoopNest *parent) const;
 
     // Does this loop nest access the given Func
     bool calls(const FunctionDAG::Node *f) const;

--- a/src/autoschedulers/adams2019/LoopNest.h
+++ b/src/autoschedulers/adams2019/LoopNest.h
@@ -157,7 +157,7 @@ struct LoopNest {
     const Bound &get_bounds(const FunctionDAG::Node *f) const;
 
     // Recursively print a loop nest representation to stderr
-    void dumpz(std::ostream &os, string prefix, const LoopNest *parent) const;
+    void dump(std::ostream &os, string prefix, const LoopNest *parent) const;
 
     // Does this loop nest access the given Func
     bool calls(const FunctionDAG::Node *f) const;

--- a/src/autoschedulers/adams2019/State.cpp
+++ b/src/autoschedulers/adams2019/State.cpp
@@ -131,12 +131,12 @@ bool State::calculate_cost(const FunctionDAG &dag, const MachineParams &params,
 
     cost = 0.0f;
 
-    if (verbosity <= aslog_level()) {
+    if (verbosity <= aslog::aslog_level()) {
         for (auto it = features.begin(); it != features.end(); it++) {
             const auto &stage = *(it.key());
             const auto &feat = it.value();
             aslog(verbosity) << "Schedule features for " << stage.stage.name() << "\n";
-            feat.dump(aslog(verbosity));
+            feat.dump(aslog(verbosity).get_ostream());
         }
     }
 
@@ -524,7 +524,7 @@ void State::generate_children(const FunctionDAG &dag,
     if (num_children == 0) {
         aslog(1) << "Warning: Found no legal way to schedule "
                  << node->func.name() << " in the following State:\n";
-        dump(aslog(1));
+        dump(aslog(1).get_ostream());
         // All our children died. Maybe other states have had
         // children. Carry on.
     }

--- a/src/autoschedulers/adams2019/State.cpp
+++ b/src/autoschedulers/adams2019/State.cpp
@@ -54,7 +54,7 @@ void State::compute_featurization(const FunctionDAG &dag, const MachineParams &p
                 l = consumer_site.compute;
             }
             if (!l) {
-                if (aslog::aslog_level() > 0) {
+                if (aslog_level() > 0) {
                     dump();
                 }
                 internal_error << e->producer->func.name() << " -> " << e->consumer->name << "\n";

--- a/src/autoschedulers/adams2019/State.cpp
+++ b/src/autoschedulers/adams2019/State.cpp
@@ -54,8 +54,8 @@ void State::compute_featurization(const FunctionDAG &dag, const MachineParams &p
                 l = consumer_site.compute;
             }
             if (!l) {
-                if (aslog_level() > 0) {
-                    dump();
+                if (aslog_level() >= 1) {
+                    dump(aslog(1));
                 }
                 internal_error << e->producer->func.name() << " -> " << e->consumer->name << "\n";
             }
@@ -136,7 +136,7 @@ bool State::calculate_cost(const FunctionDAG &dag, const MachineParams &params,
             const auto &stage = *(it.key());
             const auto &feat = it.value();
             aslog(0) << "Schedule features for " << stage.stage.name() << "\n";
-            feat.dump();
+            feat.dump(aslog(0));
         }
     }
 
@@ -244,7 +244,7 @@ void State::generate_children(const FunctionDAG &dag,
 
     if (!node->outgoing_edges.empty() && !root->calls(node)) {
         aslog(0) << "In state:\n";
-        dump();
+        dump(aslog(0));
         aslog(0) << node->func.name() << " is consumed by:\n";
         for (const auto *e : node->outgoing_edges) {
             aslog(0) << e->consumer->name << "\n";
@@ -522,16 +522,16 @@ void State::generate_children(const FunctionDAG &dag,
     if (num_children == 0) {
         aslog(0) << "Warning: Found no legal way to schedule "
                  << node->func.name() << " in the following State:\n";
-        dump();
+        dump(aslog(0));
         // All our children died. Maybe other states have had
         // children. Carry on.
     }
 }
 
-void State::dump() const {
-    aslog(0) << "State with cost " << cost << ":\n";
-    root->dump("", nullptr);
-    aslog(0) << schedule_source;
+void State::dump(std::ostream &os) const {
+    os << "State with cost " << cost << ":\n";
+    root->dump(os, "", nullptr);
+    os << schedule_source;
 }
 
 // Apply the schedule represented by this state to a Halide

--- a/src/autoschedulers/adams2019/State.cpp
+++ b/src/autoschedulers/adams2019/State.cpp
@@ -55,7 +55,7 @@ void State::compute_featurization(const FunctionDAG &dag, const MachineParams &p
             }
             if (!l) {
                 std::ostringstream err;
-                dumpz(err);
+                dump(err);
                 err << e->producer->func.name() << " -> " << e->consumer->name << "\n";
                 internal_error << err.str();
             }
@@ -245,7 +245,7 @@ void State::generate_children(const FunctionDAG &dag,
     if (!node->outgoing_edges.empty() && !root->calls(node)) {
         std::ostringstream err;
         err << "In state:\n";
-        dumpz(err);
+        dump(err);
         err << node->func.name() << " is consumed by:\n";
         for (const auto *e : node->outgoing_edges) {
             err << e->consumer->name << "\n";
@@ -524,15 +524,15 @@ void State::generate_children(const FunctionDAG &dag,
     if (num_children == 0) {
         aslog(1) << "Warning: Found no legal way to schedule "
                  << node->func.name() << " in the following State:\n";
-        dumpz(aslog(1));
+        dump(aslog(1));
         // All our children died. Maybe other states have had
         // children. Carry on.
     }
 }
 
-void State::dumpz(std::ostream &os) const {
+void State::dump(std::ostream &os) const {
     os << "State with cost " << cost << ":\n";
-    root->dumpz(os, "", nullptr);
+    root->dump(os, "", nullptr);
     os << schedule_source;
 }
 

--- a/src/autoschedulers/adams2019/State.cpp
+++ b/src/autoschedulers/adams2019/State.cpp
@@ -54,10 +54,10 @@ void State::compute_featurization(const FunctionDAG &dag, const MachineParams &p
                 l = consumer_site.compute;
             }
             if (!l) {
-                if (aslog_level() >= 1) {
-                    dump(aslog(1));
-                }
-                internal_error << e->producer->func.name() << " -> " << e->consumer->name << "\n";
+                std::ostringstream err;
+                dumpz(err);
+                err << e->producer->func.name() << " -> " << e->consumer->name << "\n";
+                internal_error << err.str();
             }
             if (loop) {
                 loop = deepest_common_ancestor(parent, l, loop);
@@ -125,18 +125,18 @@ void State::save_featurization(const FunctionDAG &dag, const MachineParams &para
 
 bool State::calculate_cost(const FunctionDAG &dag, const MachineParams &params,
                            CostModel *cost_model, const CachingOptions &cache_options,
-                           int64_t memory_limit, bool verbose) {
+                           int64_t memory_limit, int verbosity) {
     StageMap<ScheduleFeatures> features;
     compute_featurization(dag, params, &features, cache_options);
 
     cost = 0.0f;
 
-    if (verbose) {
+    if (verbosity <= aslog_level()) {
         for (auto it = features.begin(); it != features.end(); it++) {
             const auto &stage = *(it.key());
             const auto &feat = it.value();
-            aslog(0) << "Schedule features for " << stage.stage.name() << "\n";
-            feat.dump(aslog(0));
+            aslog(verbosity) << "Schedule features for " << stage.stage.name() << "\n";
+            feat.dump(aslog(verbosity));
         }
     }
 
@@ -235,7 +235,7 @@ void State::generate_children(const FunctionDAG &dag,
         // We don't need to schedule nodes that represent inputs,
         // and there are no other decisions to be made about them
         // at this time.
-        // aslog(0) << "Skipping over scheduling input node: " << node->func.name() << "\n";
+        // aslog(1) << "Skipping over scheduling input node: " << node->func.name() << "\n";
         auto child = make_child();
         child->num_decisions_made++;
         accept_child(std::move(child));
@@ -243,17 +243,19 @@ void State::generate_children(const FunctionDAG &dag,
     }
 
     if (!node->outgoing_edges.empty() && !root->calls(node)) {
-        aslog(0) << "In state:\n";
-        dump(aslog(0));
-        aslog(0) << node->func.name() << " is consumed by:\n";
+        std::ostringstream err;
+        err << "In state:\n";
+        dumpz(err);
+        err << node->func.name() << " is consumed by:\n";
         for (const auto *e : node->outgoing_edges) {
-            aslog(0) << e->consumer->name << "\n";
-            aslog(0) << "Which in turn consumes:\n";
+            err << e->consumer->name << "\n";
+            err << "Which in turn consumes:\n";
             for (const auto *e2 : e->consumer->incoming_edges) {
-                aslog(0) << "  " << e2->producer->func.name() << "\n";
+                err << "  " << e2->producer->func.name() << "\n";
             }
         }
-        internal_error << "Pipeline so far doesn't use next Func: " << node->func.name() << "\n";
+        err << "Pipeline so far doesn't use next Func: " << node->func.name() << "\n";
+        internal_error << err.str();
     }
 
     int num_children = 0;
@@ -520,17 +522,17 @@ void State::generate_children(const FunctionDAG &dag,
     }
 
     if (num_children == 0) {
-        aslog(0) << "Warning: Found no legal way to schedule "
+        aslog(1) << "Warning: Found no legal way to schedule "
                  << node->func.name() << " in the following State:\n";
-        dump(aslog(0));
+        dumpz(aslog(1));
         // All our children died. Maybe other states have had
         // children. Carry on.
     }
 }
 
-void State::dump(std::ostream &os) const {
+void State::dumpz(std::ostream &os) const {
     os << "State with cost " << cost << ":\n";
-    root->dump(os, "", nullptr);
+    root->dumpz(os, "", nullptr);
     os << schedule_source;
 }
 

--- a/src/autoschedulers/adams2019/State.h
+++ b/src/autoschedulers/adams2019/State.h
@@ -85,8 +85,8 @@ struct State {
                            std::function<void(IntrusivePtr<State> &&)> &accept_child,
                            Cache *cache) const;
 
-    // Dumps cost, the `root` LoopNest, and then `schedule_source` to `aslog(0)`.
-    void dump() const;
+    // Dumps cost, the `root` LoopNest, and then `schedule_source` to `os`.
+    void dump(std::ostream &os) const;
 
     // Apply the schedule represented by this state to a Halide
     // Pipeline. Also generate source code for the schedule for the

--- a/src/autoschedulers/adams2019/State.h
+++ b/src/autoschedulers/adams2019/State.h
@@ -86,7 +86,7 @@ struct State {
                            Cache *cache) const;
 
     // Dumps cost, the `root` LoopNest, and then `schedule_source` to `os`.
-    void dumpz(std::ostream &os) const;
+    void dump(std::ostream &os) const;
 
     // Apply the schedule represented by this state to a Halide
     // Pipeline. Also generate source code for the schedule for the

--- a/src/autoschedulers/adams2019/State.h
+++ b/src/autoschedulers/adams2019/State.h
@@ -67,7 +67,7 @@ struct State {
     // otherwise sets `cost` equal to a large value and returns false.
     bool calculate_cost(const FunctionDAG &dag, const MachineParams &params,
                         CostModel *cost_model, const CachingOptions &cache_options,
-                        int64_t memory_limit, bool verbose = false);
+                        int64_t memory_limit, int verbosity = 99);
 
     // Make a child copy of this state. The loop nest is const (we
     // make mutated copies of it, rather than mutating it), so we can
@@ -86,7 +86,7 @@ struct State {
                            Cache *cache) const;
 
     // Dumps cost, the `root` LoopNest, and then `schedule_source` to `os`.
-    void dump(std::ostream &os) const;
+    void dumpz(std::ostream &os) const;
 
     // Apply the schedule represented by this state to a Halide
     // Pipeline. Also generate source code for the schedule for the

--- a/src/autoschedulers/adams2019/autotune_loop.sh
+++ b/src/autoschedulers/adams2019/autotune_loop.sh
@@ -79,6 +79,12 @@ if [ $(uname -s) = "Darwin" ] && ! which $TIMEOUT_CMD 2>&1 >/dev/null; then
     fi
 fi
 
+if [ $(uname -s) = "Darwin" ]; then
+    SHARED_EXT=dylib
+else
+    SHARED_EXT=so
+fi
+
 # Build a single featurization of the pipeline with a random schedule
 make_featurization() {
     D=${1}
@@ -111,7 +117,7 @@ make_featurization() {
         target=${HL_TARGET} \
         auto_schedule=true \
         ${EXTRA_GENERATOR_ARGS} \
-        -p ${AUTOSCHED_BIN}/libautoschedule_adams2019.so \
+        -p ${AUTOSCHED_BIN}/libautoschedule_adams2019.${SHARED_EXT} \
         -s Adams2019 \
           2> ${D}/compile_log.txt || echo "Compilation failed or timed out for ${D}"
 


### PR DESCRIPTION
The overall goal of this PR is that when *using* the Adams2019 autoscheduler, the default behavior should be no output to stdout or stderr, period, unless a fatal error occurs: no progress, no warnings, nothing. (This can be overridden by setting `HL_DEBUG_AUTOSCHEDULE` or `HL_DEBUG_CODEGEN` as you see fit, for progressively more logging.)

This change happened in multiple steps, though:
- ~~reworked the `aslog()` class to be a proper subclass of `std::ostream` rather than a one-off templated thing~~
- reworked all the `dump()` method to output solely to an `ostream` argument rather than assuming an output level
- tweaked `aslog()` levels in various places; in particular, the *only* place right now that uses `aslog(0)` is the ScopedTimer class (which isn't in use right now and generally shouldn't be).

Note that the "no output at all" rule doesn't apply to training scripts, tests, etc... just the "normal" usage of the autoscheduler itself.

I'm sure that some of the new aslog levels I've assigned will need tweaking, but I think this change is fairly reasonable as-is.

~~(Feedback on the change to make `aslog()` a proper ostream is welcome; I'm tempted to do something similar to the `debug()` class in Halide proper but want more feedback first...)~~
