### PR TITLE
Fix error in Makefile for Adams2019 on OSX

### DIFF
--- a/src/autoschedulers/adams2019/Makefile
+++ b/src/autoschedulers/adams2019/Makefile
@@ -152,7 +152,7 @@ $(BIN)/test_function_dag: $(SRC)/test_function_dag.cpp $(SRC)/FunctionDAG.h $(SR
 # Simple jit-based test
 $(BIN)/%/test: $(SRC)/test.cpp $(BIN)/libautoschedule_adams2019.$(SHARED_EXT)
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) $^ -o $@ $(LIBHALIDE_LDFLAGS) $(HALIDE_SYSTEM_LIBS)
+	$(CXX) $(CXXFLAGS) $(USE_EXPORT_DYNAMIC) $< -o $@ $(LIBHALIDE_LDFLAGS) $(HALIDE_SYSTEM_LIBS)
 
 test_perfect_hash_map: $(BIN)/test_perfect_hash_map
 	$^


### PR DESCRIPTION
We erroneously link in the dylib and also dynamically load it, causing an error. We should skip the linkage and always load dynamically..