### PR TITLE
Ensure $CMAKE_{lang}_OUTPUT_EXTENSION is set before using it

### DIFF
--- a/cmake/BundleStatic.cmake
+++ b/cmake/BundleStatic.cmake
@@ -184,7 +184,9 @@ function(transfer_locations)
 
             set(globs "")
             foreach (lang IN LISTS languages)
-                list(APPEND globs "${stage}/*${CMAKE_${lang}_OUTPUT_EXTENSION}")
+                if (DEFINED "CMAKE_${lang}_OUTPUT_EXTENSION")
+                    list(APPEND globs "${stage}/*${CMAKE_${lang}_OUTPUT_EXTENSION}")
+                endif ()
             endforeach ()
 
             file(GLOB_RECURSE objects ${globs})


### PR DESCRIPTION
Fixes #6876.

This adds a check to `BundleStatic.cmake` to ensure the extension is non-empty, so we don't pick up files we shouldn't when bundling objects into libHalide.