### PR TITLE
#6863 - Fixes to make address sanitizer happy for internal runtime classes

### DIFF
--- a/src/runtime/internal/block_allocator.h
+++ b/src/runtime/internal/block_allocator.h
@@ -231,6 +231,7 @@ void BlockAllocator::destroy(void *user_context) {
         destroy_block_entry(user_context, block_entry);
         block_entry = prev_entry;
     }
+    block_list.destroy(user_context);
 }
 
 MemoryRegion *BlockAllocator::reserve_memory_region(void *user_context, RegionAllocator *allocator, const MemoryRequest &request) {
@@ -331,7 +332,6 @@ void BlockAllocator::destroy_region_allocator(void *user_context, RegionAllocato
                         << "region_allocator=" << (void *)(region_allocator) << ")...\n";
 #endif
     if (region_allocator == nullptr) { return; }
-    region_allocator->destroy(user_context);
     RegionAllocator::destroy(user_context, region_allocator);
 }
 

--- a/src/runtime/internal/memory_arena.h
+++ b/src/runtime/internal/memory_arena.h
@@ -128,7 +128,7 @@ void MemoryArena::initialize(void *user_context,
 }
 
 void MemoryArena::destroy(void *user_context) {
-    if(!blocks.empty()) {
+    if (!blocks.empty()) {
         for (size_t i = blocks.size(); i--;) {
             Block *block = lookup_block(user_context, i);
             halide_abort_if_false(user_context, block != nullptr);

--- a/src/runtime/internal/memory_arena.h
+++ b/src/runtime/internal/memory_arena.h
@@ -128,10 +128,12 @@ void MemoryArena::initialize(void *user_context,
 }
 
 void MemoryArena::destroy(void *user_context) {
-    for (size_t i = blocks.size(); i--;) {
-        Block *block = lookup_block(user_context, i);
-        halide_abort_if_false(user_context, block != nullptr);
-        destroy_block(user_context, block);
+    if(!blocks.empty()) {
+        for (size_t i = blocks.size(); i--;) {
+            Block *block = lookup_block(user_context, i);
+            halide_abort_if_false(user_context, block != nullptr);
+            destroy_block(user_context, block);
+        }
     }
     blocks.destroy(user_context);
 }

--- a/src/runtime/internal/memory_resources.h
+++ b/src/runtime/internal/memory_resources.h
@@ -13,6 +13,7 @@ enum class AllocationStatus {
     InvalidStatus,
     InUse,
     Available,
+    Purgeable,
     Dedicated
 };
 

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -31,9 +31,26 @@ struct StringUtils {
         return count;
     }
 
-    static size_t count_length(const char *str) {
+    // retuns true if s1 contains s2 (within n characters)
+    static bool contains(const char *s1, const char *s2, size_t n) {
+        if(is_empty(s2)) { return true; } // s2 is empty ... return true to match strstr 
+        char starts_with = *s2;
+        for (size_t length = strlen(s2); length <= n; n--, s1++) {
+            if (*s1 == starts_with) {
+                for (size_t i = 1; i <= length; i++) {
+                    if (i == length)
+                        return true;
+                    if (s1[i] != s2[i])
+                        break;
+                }
+            }
+        }
+        return false;
+    }
+
+    static size_t count_length(const char *str, size_t max_chars) {
         const char *ptr = str;
-        while (!StringUtils::is_empty(ptr)) {
+        while (!StringUtils::is_empty(ptr) && ((size_t(ptr - str)) < max_chars)) {
             ++ptr;
         }
         return size_t(ptr - str);
@@ -49,6 +66,10 @@ public:
     StringStorage(void *user_context = nullptr, uint32_t capacity = 0, const SystemMemoryAllocatorFns &sma = default_allocator());
     StringStorage(const StringStorage &other) = default;
     ~StringStorage();
+
+    // Factory methods for creation / destruction
+    static StringStorage *create(void *user_context, const SystemMemoryAllocatorFns &ma);
+    static void destroy(void *user_context, StringStorage *string_storage);
 
     void initialize(void *user_context, uint32_t capacity = 0, const SystemMemoryAllocatorFns &sma = default_allocator());
     void destroy(void *user_context);
@@ -89,6 +110,28 @@ StringStorage::~StringStorage() {
     destroy(nullptr);
 }
 
+StringStorage *StringStorage::create(void *user_context, const SystemMemoryAllocatorFns &system_allocator) {
+    halide_abort_if_false(user_context, system_allocator.allocate != nullptr);
+    StringStorage *result = reinterpret_cast<StringStorage *>(
+        system_allocator.allocate(user_context, sizeof(StringStorage)));
+
+    if (result == nullptr) {
+        halide_error(user_context, "StringStorage: Failed to create instance! Out of memory!\n");
+        return nullptr;
+    }
+
+    result->initialize(user_context, 32, system_allocator);
+    return result;
+}
+
+void StringStorage::destroy(void *user_context, StringStorage *instance) {
+    halide_abort_if_false(user_context, instance != nullptr);
+    const SystemMemoryAllocatorFns &system_allocator = instance->current_allocator();
+    instance->destroy(user_context);
+    halide_abort_if_false(user_context, system_allocator.deallocate != nullptr);
+    system_allocator.deallocate(user_context, instance);
+}
+
 StringStorage &StringStorage::operator=(const StringStorage &other) {
     if (&other != this) {
         assign(nullptr, other.data(), other.length());
@@ -97,14 +140,17 @@ StringStorage &StringStorage::operator=(const StringStorage &other) {
 }
 
 bool StringStorage::contains(const char *str) const {
+    if(contents.empty()) { return false; }
     const char *this_str = static_cast<const char *>(contents.data());
-    return strstr(this_str, str) != nullptr;
+    return StringUtils::contains(this_str, str, contents.size());
 }
 
 bool StringStorage::contains(const StringStorage &other) const {
+    if(contents.empty()) { return false; }
+    if(other.contents.empty()) { return false; }
     const char *this_str = static_cast<const char *>(contents.data());
     const char *other_str = static_cast<const char *>(other.contents.data());
-    return strstr(this_str, other_str) != nullptr;
+    return StringUtils::contains(this_str, other_str, contents.size());
 }
 
 bool StringStorage::operator==(const StringStorage &other) const {
@@ -125,64 +171,72 @@ void StringStorage::reserve(void *user_context, size_t length) {
 }
 
 void StringStorage::assign(void *user_context, char ch) {
-    contents.resize(user_context, 1);
+    reserve(user_context, 1);
     char *ptr = static_cast<char *>(contents[0]);
     (*ptr) = ch;
+    terminate(user_context, 1);
 }
 
 void StringStorage::assign(void *user_context, const char *str, size_t length) {
     if (StringUtils::is_empty(str)) { return; }
     if (length == 0) { length = strlen(str); }
-    char *this_str = static_cast<char *>(contents.data());
     reserve(user_context, length);
-    memcpy(this_str, str, length);
+    contents.replace(user_context, 0, str, length);
     terminate(user_context, length);
 }
 
 void StringStorage::append(void *user_context, const char *str, size_t length) {
     if (StringUtils::is_empty(str)) { return; }
     if (length == 0) { length = strlen(str); }
-    const size_t old_size = contents.size();
-    size_t new_length = old_size + length;
-    char *this_str = static_cast<char *>(contents[old_size]);
-    reserve(user_context, length);
-    memcpy(this_str, str, length);
+    const size_t old_length = StringUtils::count_length(data(), contents.size());
+    size_t new_length = old_length + length;
+    reserve(user_context, new_length);
+    contents.insert(user_context, old_length, str, length);
     terminate(user_context, new_length);
 }
 
 void StringStorage::append(void *user_context, char ch) {
-    contents.append(user_context, &ch);
+    const size_t old_length = StringUtils::count_length(data(), contents.size());
+    size_t new_length = old_length + 1;
+    reserve(user_context, new_length);
+    contents.insert(user_context, old_length, &ch, 1);
+    terminate(user_context, new_length);
 }
 
 void StringStorage::prepend(void *user_context, const char *str, size_t length) {
     if (StringUtils::is_empty(str)) { return; }
     if (length == 0) { length = strlen(str); }
-    const size_t old_size = contents.size();
-    size_t new_length = old_size + length;
-    char *this_str = static_cast<char *>(contents.data());
+    const size_t old_length = StringUtils::count_length(data(), contents.size());
+    size_t new_length = old_length + length;
     reserve(user_context, new_length);
-    memcpy(this_str + length, this_str, old_size);
-    memcpy(this_str, str, length);
+    contents.insert(user_context, 0, str, length);
     terminate(user_context, new_length);
 }
 
 void StringStorage::prepend(void *user_context, char ch) {
+    const size_t old_length = StringUtils::count_length(data(), contents.size());
+    size_t new_length = old_length + 1;
+    reserve(user_context, new_length);
     contents.prepend(user_context, &ch);
+    terminate(user_context, new_length);
 }
 
 void StringStorage::terminate(void *user_context, size_t length) {
-    char *end_ptr = static_cast<char *>(contents[length]);
-    (*end_ptr) = '\0';
+    if(contents.data() && (length < contents.size())) {
+        char *end_ptr = static_cast<char *>(contents[length]);
+        (*end_ptr) = '\0';
+    }
 }
 
 void StringStorage::clear(void *user_context) {
     contents.clear(user_context);
-    if (contents.data()) { terminate(user_context, 0); }
+    terminate(user_context, 0);
 }
 
 void StringStorage::initialize(void *user_context, uint32_t capacity, const SystemMemoryAllocatorFns &sma) {
     contents.initialize(user_context, {sizeof(char), 32, 32}, sma);
-    if (capacity) { contents.reserve(user_context, capacity); }
+    reserve(user_context, capacity);
+    terminate(user_context, 0);
 }
 
 void StringStorage::destroy(void *user_context) {
@@ -190,7 +244,7 @@ void StringStorage::destroy(void *user_context) {
 }
 
 size_t StringStorage::length() const {
-    return StringUtils::count_length(data());
+    return StringUtils::count_length(data(), contents.size());
 }
 
 const char *StringStorage::data() const {

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -33,7 +33,7 @@ struct StringUtils {
 
     // retuns true if s1 contains s2 (within n characters)
     static bool contains(const char *s1, const char *s2, size_t n) {
-        if(is_empty(s2)) { return true; } // s2 is empty ... return true to match strstr 
+        if (is_empty(s2)) { return true; }  // s2 is empty ... return true to match strstr
         char starts_with = *s2;
         for (size_t length = strlen(s2); length <= n; n--, s1++) {
             if (*s1 == starts_with) {
@@ -140,14 +140,14 @@ StringStorage &StringStorage::operator=(const StringStorage &other) {
 }
 
 bool StringStorage::contains(const char *str) const {
-    if(contents.empty()) { return false; }
+    if (contents.empty()) { return false; }
     const char *this_str = static_cast<const char *>(contents.data());
     return StringUtils::contains(this_str, str, contents.size());
 }
 
 bool StringStorage::contains(const StringStorage &other) const {
-    if(contents.empty()) { return false; }
-    if(other.contents.empty()) { return false; }
+    if (contents.empty()) { return false; }
+    if (other.contents.empty()) { return false; }
     const char *this_str = static_cast<const char *>(contents.data());
     const char *other_str = static_cast<const char *>(other.contents.data());
     return StringUtils::contains(this_str, other_str, contents.size());
@@ -222,7 +222,7 @@ void StringStorage::prepend(void *user_context, char ch) {
 }
 
 void StringStorage::terminate(void *user_context, size_t length) {
-    if(contents.data() && (length < contents.size())) {
+    if (contents.data() && (length < contents.size())) {
         char *end_ptr = static_cast<char *>(contents[length]);
         (*end_ptr) = '\0';
     }

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -38,10 +38,12 @@ struct StringUtils {
         for (size_t length = strlen(s2); length <= n; n--, s1++) {
             if (*s1 == starts_with) {
                 for (size_t i = 1; i <= length; i++) {
-                    if (i == length)
+                    if (i == length) {
                         return true;
-                    if (s1[i] != s2[i])
+                    }
+                    if (s1[i] != s2[i]) {
                         break;
+                    }
                 }
             }
         }

--- a/src/runtime/internal/string_table.h
+++ b/src/runtime/internal/string_table.h
@@ -62,7 +62,7 @@ private:
 // --
 
 StringTable::StringTable(const SystemMemoryAllocatorFns &sma)
-    : contents(nullptr, 0, sma), 
+    : contents(nullptr, 0, sma),
       pointers(nullptr, 0, sma) {
     // EMPTY!
 }
@@ -85,7 +85,7 @@ StringTable::~StringTable() {
 
 void StringTable::resize(void *user_context, size_t capacity) {
     pointers.resize(user_context, capacity);
-    while(contents.size() < capacity) {
+    while (contents.size() < capacity) {
         StringStorage *storage_ptr = StringStorage::create(user_context, contents.current_allocator());
         contents.append(user_context, storage_ptr);
     }
@@ -112,7 +112,7 @@ void StringTable::destroy(void *user_context) {
 }
 
 const char *StringTable::operator[](size_t index) const {
-    if(index < pointers.size()) {
+    if (index < pointers.size()) {
         return static_cast<const char *>(pointers[index]);
     }
     return nullptr;

--- a/src/runtime/internal/string_table.h
+++ b/src/runtime/internal/string_table.h
@@ -1,7 +1,7 @@
 #ifndef HALIDE_RUNTIME_STRING_TABLE_H
 #define HALIDE_RUNTIME_STRING_TABLE_H
 
-#include "linked_list.h"
+#include "block_storage.h"
 #include "pointer_table.h"
 #include "string_storage.h"
 
@@ -55,26 +55,26 @@ public:
     }
 
 private:
-    LinkedList contents;    //< owns string data
-    PointerTable pointers;  //< stores pointers
+    PointerTable contents;  //< owns string data
+    PointerTable pointers;  //< pointers to raw string data
 };
 
 // --
 
 StringTable::StringTable(const SystemMemoryAllocatorFns &sma)
-    : contents(nullptr, sizeof(StringStorage), 0, sma),
+    : contents(nullptr, 0, sma), 
       pointers(nullptr, 0, sma) {
     // EMPTY!
 }
 
 StringTable::StringTable(void *user_context, size_t capacity, const SystemMemoryAllocatorFns &sma)
-    : contents(user_context, sizeof(StringStorage), capacity, sma),
+    : contents(user_context, capacity, sma),
       pointers(user_context, capacity, sma) {
     if (capacity) { resize(user_context, capacity); }
 }
 
 StringTable::StringTable(void *user_context, const char **array, size_t count, const SystemMemoryAllocatorFns &sma)
-    : contents(user_context, sizeof(StringStorage), count, sma),
+    : contents(user_context, count, sma),
       pointers(user_context, count, sma) {
     fill(user_context, array, count);
 }
@@ -84,20 +84,18 @@ StringTable::~StringTable() {
 }
 
 void StringTable::resize(void *user_context, size_t capacity) {
-    for (size_t n = contents.size(); n < capacity; ++n) {
-        LinkedList::EntryType *entry_ptr = contents.append(user_context);
-        StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
-        storage_ptr->initialize(user_context, 0, contents.current_allocator());
-    }
     pointers.resize(user_context, capacity);
+    while(contents.size() < capacity) {
+        StringStorage *storage_ptr = StringStorage::create(user_context, contents.current_allocator());
+        contents.append(user_context, storage_ptr);
+    }
 }
 
 void StringTable::clear(void *user_context) {
     for (size_t n = 0; n < contents.size(); ++n) {
-        LinkedList::EntryType *entry_ptr = contents.front();
-        StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
-        storage_ptr->clear(user_context);
-        contents.pop_front(user_context);
+        StringStorage *storage_ptr = static_cast<StringStorage *>(contents[n]);
+        StringStorage::destroy(user_context, storage_ptr);
+        contents.assign(user_context, n, nullptr);
     }
     contents.clear(user_context);
     pointers.clear(user_context);
@@ -105,57 +103,50 @@ void StringTable::clear(void *user_context) {
 
 void StringTable::destroy(void *user_context) {
     for (size_t n = 0; n < contents.size(); ++n) {
-        LinkedList::EntryType *entry_ptr = contents.front();
-        StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
-        storage_ptr->destroy(user_context);
-        contents.pop_front(user_context);
+        StringStorage *storage_ptr = static_cast<StringStorage *>(contents[n]);
+        StringStorage::destroy(user_context, storage_ptr);
+        contents.assign(user_context, n, nullptr);
     }
     contents.destroy(user_context);
     pointers.destroy(user_context);
 }
 
 const char *StringTable::operator[](size_t index) const {
-    return static_cast<const char *>(pointers[index]);
+    if(index < pointers.size()) {
+        return static_cast<const char *>(pointers[index]);
+    }
+    return nullptr;
 }
 
 void StringTable::fill(void *user_context, const char **array, size_t count) {
     resize(user_context, count);
-    LinkedList::EntryType *entry_ptr = contents.front();
-    for (size_t n = 0; n < count && n < contents.size() && entry_ptr != nullptr; ++n) {
-        StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
+    for (size_t n = 0; n < count && n < contents.size(); ++n) {
+        StringStorage *storage_ptr = static_cast<StringStorage *>(contents[n]);
         storage_ptr->assign(user_context, array[n]);
         pointers.assign(user_context, n, storage_ptr->data());
-        entry_ptr = entry_ptr->next_ptr;
     }
 }
 
 void StringTable::assign(void *user_context, size_t index, const char *str, size_t length) {
     if (length == 0) { length = strlen(str); }
-    LinkedList::EntryType *entry_ptr = contents.front();
-    for (size_t n = 0; n < contents.size() && entry_ptr != nullptr; ++n) {
-        if (n == index) {
-            StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
-            storage_ptr->assign(user_context, str, length);
-            pointers.assign(user_context, n, storage_ptr->data());
-            break;
-        }
-        entry_ptr = entry_ptr->next_ptr;
+    if (index < contents.size()) {
+        StringStorage *storage_ptr = static_cast<StringStorage *>(contents[index]);
+        storage_ptr->assign(user_context, str, length);
+        pointers.assign(user_context, index, storage_ptr->data());
     }
 }
 
 void StringTable::append(void *user_context, const char *str, size_t length) {
-    LinkedList::EntryType *entry_ptr = contents.append(user_context);
-    StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
-    storage_ptr->initialize(user_context, 0, contents.current_allocator());
+    StringStorage *storage_ptr = StringStorage::create(user_context, contents.current_allocator());
     storage_ptr->assign(user_context, str, length);
+    contents.append(user_context, storage_ptr);
     pointers.append(user_context, storage_ptr->data());
 }
 
 void StringTable::prepend(void *user_context, const char *str, size_t length) {
-    LinkedList::EntryType *entry_ptr = contents.prepend(user_context);
-    StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
-    storage_ptr->initialize(user_context, 0, contents.current_allocator());
+    StringStorage *storage_ptr = StringStorage::create(user_context, contents.current_allocator());
     storage_ptr->assign(user_context, str, length);
+    contents.prepend(user_context, storage_ptr);
     pointers.prepend(user_context, storage_ptr->data());
 }
 
@@ -172,16 +163,14 @@ size_t StringTable::parse(void *user_context, const char *str, const char *delim
     // save each entry into the table
     size_t index = 0;
     const char *ptr = str;
-    LinkedList::EntryType *entry_ptr = contents.front();
     while (!StringUtils::is_empty(ptr) && (index < entry_count)) {
         size_t ptr_offset = ptr - str;
         const char *next_delim = strstr(ptr, delim);
         size_t token_length = (next_delim == nullptr) ? (total_length - ptr_offset) : (next_delim - ptr);
-        if (token_length > 0 && entry_ptr != nullptr) {
-            StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
+        if (token_length > 0 && index < contents.size()) {
+            StringStorage *storage_ptr = static_cast<StringStorage *>(contents[index]);
             storage_ptr->assign(user_context, ptr, token_length);
             pointers.assign(user_context, index, storage_ptr->data());
-            entry_ptr = entry_ptr->next_ptr;
             ++index;
         }
         ptr = (next_delim != nullptr) ? (next_delim + delim_length) : nullptr;
@@ -191,14 +180,11 @@ size_t StringTable::parse(void *user_context, const char *str, const char *delim
 
 bool StringTable::contains(const char *str) const {
     if (StringUtils::is_empty(str)) { return false; }
-
-    const LinkedList::EntryType *entry_ptr = contents.front();
-    for (size_t n = 0; n < contents.size() && entry_ptr != nullptr; ++n) {
-        StringStorage *storage_ptr = static_cast<StringStorage *>(entry_ptr->value);
+    for (size_t n = 0; n < contents.size(); ++n) {
+        StringStorage *storage_ptr = static_cast<StringStorage *>(contents[n]);
         if (storage_ptr->contains(str)) {
             return true;
         }
-        entry_ptr = entry_ptr->next_ptr;
     }
 
     return false;

--- a/test/runtime/common.h
+++ b/test/runtime/common.h
@@ -27,3 +27,53 @@ void halide_profiler_reset() {
 }  // extern "C"
 
 #include "printer.h"
+
+namespace {
+
+size_t allocated_system_memory = 0;
+
+void * align_up(void* ptr, size_t offset, size_t alignment) {
+    return (void*)(((((size_t)ptr + offset)) + (alignment - 1)) & ~(alignment - 1));
+}
+
+void * allocate_system(void *user_context, size_t bytes) {
+    constexpr size_t alignment = 128;
+    constexpr size_t header_size = 2 * sizeof(size_t); 
+    size_t alloc_size = bytes + header_size + (alignment - 1);
+    void* raw_ptr = malloc(alloc_size);
+    if(raw_ptr == nullptr) { return nullptr; }
+    void* aligned_ptr = align_up(raw_ptr, header_size, alignment);
+    size_t aligned_offset = (size_t)((size_t)aligned_ptr - (size_t)raw_ptr);
+    *((size_t *) aligned_ptr - 1) = aligned_offset;
+    *((size_t *) aligned_ptr - 2) = alloc_size;
+    allocated_system_memory += alloc_size;
+
+    debug(user_context) << "Test : allocate_system ("
+                        << "ptr=" << (void *)(raw_ptr) << " "
+                        << "aligned_ptr=" << (void *)(aligned_ptr) << " "
+                        << "aligned_offset=" << int32_t(aligned_offset) << " "
+                        << "alloc_size=" << int32_t(alloc_size) << " "
+                        << "allocated_system_memory=" << int32_t(allocated_system_memory) << " "
+                        << ") !\n";
+
+    return aligned_ptr;
+}
+
+void deallocate_system(void *user_context, void *aligned_ptr) {
+    size_t aligned_offset = *((size_t *) aligned_ptr - 1);
+    size_t alloc_size = *((size_t *) aligned_ptr - 2);
+    void* raw_ptr = (void*)((uint8_t *)aligned_ptr - aligned_offset);
+    free(raw_ptr);
+    allocated_system_memory -= alloc_size;
+
+    debug(user_context) << "Test : deallocate_system ("
+                        << "ptr=" << (void *)(raw_ptr) << " "
+                        << "aligned_ptr=" << (void *)(aligned_ptr) << " "
+                        << "aligned_offset=" << int32_t(aligned_offset) << " "
+                        << "alloc_size=" << int32_t(alloc_size) << " "
+                        << "allocated_system_memory=" << int32_t(allocated_system_memory) << " "
+                        << ") !\n";
+
+}    
+
+} // anonymous namespace

--- a/test/runtime/common.h
+++ b/test/runtime/common.h
@@ -32,20 +32,20 @@ namespace {
 
 size_t allocated_system_memory = 0;
 
-void * align_up(void* ptr, size_t offset, size_t alignment) {
-    return (void*)(((((size_t)ptr + offset)) + (alignment - 1)) & ~(alignment - 1));
+void *align_up(void *ptr, size_t offset, size_t alignment) {
+    return (void *)(((((size_t)ptr + offset)) + (alignment - 1)) & ~(alignment - 1));
 }
 
-void * allocate_system(void *user_context, size_t bytes) {
+void *allocate_system(void *user_context, size_t bytes) {
     constexpr size_t alignment = 128;
-    constexpr size_t header_size = 2 * sizeof(size_t); 
+    constexpr size_t header_size = 2 * sizeof(size_t);
     size_t alloc_size = bytes + header_size + (alignment - 1);
-    void* raw_ptr = malloc(alloc_size);
-    if(raw_ptr == nullptr) { return nullptr; }
-    void* aligned_ptr = align_up(raw_ptr, header_size, alignment);
+    void *raw_ptr = malloc(alloc_size);
+    if (raw_ptr == nullptr) { return nullptr; }
+    void *aligned_ptr = align_up(raw_ptr, header_size, alignment);
     size_t aligned_offset = (size_t)((size_t)aligned_ptr - (size_t)raw_ptr);
-    *((size_t *) aligned_ptr - 1) = aligned_offset;
-    *((size_t *) aligned_ptr - 2) = alloc_size;
+    *((size_t *)aligned_ptr - 1) = aligned_offset;
+    *((size_t *)aligned_ptr - 2) = alloc_size;
     allocated_system_memory += alloc_size;
 
     debug(user_context) << "Test : allocate_system ("
@@ -60,9 +60,9 @@ void * allocate_system(void *user_context, size_t bytes) {
 }
 
 void deallocate_system(void *user_context, void *aligned_ptr) {
-    size_t aligned_offset = *((size_t *) aligned_ptr - 1);
-    size_t alloc_size = *((size_t *) aligned_ptr - 2);
-    void* raw_ptr = (void*)((uint8_t *)aligned_ptr - aligned_offset);
+    size_t aligned_offset = *((size_t *)aligned_ptr - 1);
+    size_t alloc_size = *((size_t *)aligned_ptr - 2);
+    void *raw_ptr = (void *)((uint8_t *)aligned_ptr - aligned_offset);
     free(raw_ptr);
     allocated_system_memory -= alloc_size;
 
@@ -73,7 +73,6 @@ void deallocate_system(void *user_context, void *aligned_ptr) {
                         << "alloc_size=" << int32_t(alloc_size) << " "
                         << "allocated_system_memory=" << int32_t(allocated_system_memory) << " "
                         << ") !\n";
+}
 
-}    
-
-} // anonymous namespace
+}  // anonymous namespace

--- a/test/runtime/linked_list.cpp
+++ b/test/runtime/linked_list.cpp
@@ -18,10 +18,11 @@ T read_as(const LinkedList::EntryType *entry_ptr) {
 
 int main(int argc, char **argv) {
     void *user_context = (void *)1;
+    SystemMemoryAllocatorFns test_allocator = {allocate_system, deallocate_system};
 
     // test class interface
     {
-        LinkedList list(user_context, sizeof(int), 64);
+        LinkedList list(user_context, sizeof(int), 64, test_allocator);
         halide_abort_if_false(user_context, list.size() == 0);
 
         const int i0 = 12;
@@ -60,11 +61,20 @@ int main(int argc, char **argv) {
 
         list.clear(user_context);
         halide_abort_if_false(user_context, list.size() == 0);
+
+        size_t count = 4 * 1024;
+        for (size_t n = 0; n < count; ++n) {
+            list.append(user_context, &n);
+        }        
+        halide_abort_if_false(user_context, list.size() == count);
+
+        list.destroy(user_context);
+        halide_abort_if_false(user_context, allocated_system_memory == 0);
     }
 
     // test struct storage
     {
-        LinkedList list(user_context, sizeof(TestStruct));
+        LinkedList list(user_context, sizeof(TestStruct), 32, test_allocator);
         halide_abort_if_false(user_context, list.size() == 0);
 
         TestStruct s1 = {8, 16, 32.0f};
@@ -84,6 +94,9 @@ int main(int argc, char **argv) {
         halide_abort_if_false(user_context, e2.i8 == s2.i8);
         halide_abort_if_false(user_context, e2.ui16 == s2.ui16);
         halide_abort_if_false(user_context, e2.f32 == s2.f32);
+
+        list.destroy(user_context);
+        halide_abort_if_false(user_context, allocated_system_memory == 0);       
     }
 
     print(user_context) << "Success!\n";

--- a/test/runtime/linked_list.cpp
+++ b/test/runtime/linked_list.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
         size_t count = 4 * 1024;
         for (size_t n = 0; n < count; ++n) {
             list.append(user_context, &n);
-        }        
+        }
         halide_abort_if_false(user_context, list.size() == count);
 
         list.destroy(user_context);
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
         halide_abort_if_false(user_context, e2.f32 == s2.f32);
 
         list.destroy(user_context);
-        halide_abort_if_false(user_context, allocated_system_memory == 0);       
+        halide_abort_if_false(user_context, allocated_system_memory == 0);
     }
 
     print(user_context) << "Success!\n";

--- a/test/runtime/memory_arena.cpp
+++ b/test/runtime/memory_arena.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
         SystemMemoryAllocatorFns test_allocator = {allocate_system, deallocate_system};
 
         MemoryArena::Config config = {sizeof(double), 32, 0};
-        MemoryArena* arena = MemoryArena::create(user_context, config, test_allocator);
+        MemoryArena *arena = MemoryArena::create(user_context, config, test_allocator);
 
         size_t count = 4 * 1024;
         void *pointers[count];

--- a/test/runtime/memory_arena.cpp
+++ b/test/runtime/memory_arena.cpp
@@ -4,22 +4,6 @@
 
 using namespace Halide::Runtime::Internal;
 
-namespace {
-
-size_t counter = 0;
-
-void *allocate_system(void *user_context, size_t bytes) {
-    ++counter;
-    return native_system_malloc(user_context, bytes);
-}
-
-void deallocate_system(void *user_context, void *ptr) {
-    native_system_free(user_context, ptr);
-    --counter;
-}
-
-}  // namespace
-
 struct TestStruct {
     int8_t i8;
     uint16_t ui16;
@@ -36,18 +20,42 @@ int main(int argc, char **argv) {
         MemoryArena::Config config = {sizeof(int), 32, 0};
         MemoryArena arena(user_context, config, test_allocator);
         void *p1 = arena.reserve(user_context);
-        halide_abort_if_false(user_context, counter > 1);
+        halide_abort_if_false(user_context, allocated_system_memory >= (1 * sizeof(int)));
         halide_abort_if_false(user_context, p1 != nullptr);
 
         void *p2 = arena.reserve(user_context, true);
-        halide_abort_if_false(user_context, counter > 2);
+        halide_abort_if_false(user_context, allocated_system_memory >= (2 * sizeof(int)));
         halide_abort_if_false(user_context, p2 != nullptr);
         halide_abort_if_false(user_context, (*static_cast<int *>(p2)) == 0);
 
         arena.reclaim(user_context, p1);
         arena.destroy(user_context);
 
-        halide_abort_if_false(user_context, counter == 0);
+        halide_abort_if_false(user_context, allocated_system_memory == 0);
+    }
+
+    // test dyanmic construction
+    {
+        SystemMemoryAllocatorFns test_allocator = {allocate_system, deallocate_system};
+
+        MemoryArena::Config config = {sizeof(double), 32, 0};
+        MemoryArena* arena = MemoryArena::create(user_context, config, test_allocator);
+
+        size_t count = 4 * 1024;
+        void *pointers[count];
+        for (size_t n = 0; n < count; ++n) {
+            pointers[n] = arena->reserve(user_context, true);
+        }
+        halide_abort_if_false(user_context, allocated_system_memory >= (count * sizeof(int)));
+        for (size_t n = 0; n < count; ++n) {
+            void *ptr = pointers[n];
+            halide_abort_if_false(user_context, ptr != nullptr);
+            halide_abort_if_false(user_context, (*static_cast<double *>(ptr)) == 0.0);
+        }
+        arena->destroy(user_context);
+
+        MemoryArena::destroy(user_context, arena);
+        halide_abort_if_false(user_context, allocated_system_memory == 0);
     }
 
     // test struct allocations
@@ -57,7 +65,7 @@ int main(int argc, char **argv) {
         MemoryArena arena(user_context, config, test_allocator);
         void *s1 = arena.reserve(user_context, true);
         halide_abort_if_false(user_context, s1 != nullptr);
-        halide_abort_if_false(user_context, counter > 1);
+        halide_abort_if_false(user_context, allocated_system_memory >= (1 * sizeof(int)));
         halide_abort_if_false(user_context, ((TestStruct *)s1)->i8 == int8_t(0));
         halide_abort_if_false(user_context, ((TestStruct *)s1)->ui16 == uint16_t(0));
         halide_abort_if_false(user_context, ((TestStruct *)s1)->f32 == float(0));
@@ -80,7 +88,7 @@ int main(int argc, char **argv) {
 
         arena.destroy(user_context);
 
-        halide_abort_if_false(user_context, counter == 0);
+        halide_abort_if_false(user_context, allocated_system_memory == 0);
     }
 
     print(user_context) << "Success!\n";

--- a/test/runtime/string_storage.cpp
+++ b/test/runtime/string_storage.cpp
@@ -6,10 +6,11 @@ using namespace Halide::Runtime::Internal;
 
 int main(int argc, char **argv) {
     void *user_context = (void *)1;
+    SystemMemoryAllocatorFns test_allocator = {allocate_system, deallocate_system};
 
     // test class interface
     {
-        StringStorage ss;
+        StringStorage ss(user_context, 0, test_allocator);
         halide_abort_if_false(user_context, ss.length() == 0);
 
         const char *ts1 = "Testing!";
@@ -30,6 +31,10 @@ int main(int argc, char **argv) {
 
         ss.clear(user_context);
         halide_abort_if_false(user_context, ss.length() == 0);
+
+        ss.destroy(user_context);
+        halide_abort_if_false(user_context, allocated_system_memory == 0);
+
     }
 
     // test copy and equality
@@ -40,10 +45,10 @@ int main(int argc, char **argv) {
         const char *ts2 = "Test Two!";
         const size_t ts2_length = strlen(ts2);
 
-        StringStorage ss1;
+        StringStorage ss1(user_context, 0, test_allocator);
         ss1.assign(user_context, ts1, ts1_length);
 
-        StringStorage ss2;
+        StringStorage ss2(user_context, 0, test_allocator);
         ss2.assign(user_context, ts2, ts2_length);
 
         StringStorage ss3(ss1);
@@ -57,6 +62,11 @@ int main(int argc, char **argv) {
 
         ss2 = ss1;
         halide_abort_if_false(user_context, ss1 == ss2);
+
+        ss1.destroy(user_context);
+        ss2.destroy(user_context);
+        ss3.destroy(user_context);
+        halide_abort_if_false(user_context, allocated_system_memory == 0);
     }
     print(user_context) << "Success!\n";
     return 0;

--- a/test/runtime/string_storage.cpp
+++ b/test/runtime/string_storage.cpp
@@ -34,7 +34,6 @@ int main(int argc, char **argv) {
 
         ss.destroy(user_context);
         halide_abort_if_false(user_context, allocated_system_memory == 0);
-
     }
 
     // test copy and equality

--- a/test/runtime/string_table.cpp
+++ b/test/runtime/string_table.cpp
@@ -6,6 +6,7 @@ using namespace Halide::Runtime::Internal;
 
 int main(int argc, char **argv) {
     void *user_context = (void *)1;
+    SystemMemoryAllocatorFns test_allocator = {allocate_system, deallocate_system};
 
     // test class interface
     {
@@ -13,7 +14,7 @@ int main(int argc, char **argv) {
         const char *data[] = {
             "one", "two", "three", "four"};
 
-        StringTable st1;
+        StringTable st1(user_context, 0, test_allocator);
         halide_abort_if_false(user_context, st1.size() == 0);
 
         st1.fill(user_context, data, data_size);


### PR DESCRIPTION
This PR addresses some obvious defects detected when built under ASAN as reported by @LebedevRI in Issue #6863 :

Fixed initialization defects in StringStorage that could cause buffer overruns.
Fixed memory leaks within RegionAllocator and BlockAllocator.
Added system memory allocation tracking to all internal runtime tests.