### PR TITLE
[x86] Separate vector instruction selection and CodeGen passes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -573,7 +573,8 @@ SOURCE_FILES = \
   Var.cpp \
   VectorizeLoops.cpp \
   WasmExecutor.cpp \
-  WrapCalls.cpp
+  WrapCalls.cpp \
+  X86Optimize.cpp
 
 # The externally-visible header files that go into making Halide.h.
 # Don't include anything here that includes llvm headers.
@@ -738,7 +739,8 @@ HEADER_FILES = \
   Util.h \
   Var.h \
   VectorizeLoops.h \
-  WrapCalls.h
+  WrapCalls.h \
+  X86Optimize.h
 
 OBJECTS = $(SOURCE_FILES:%.cpp=$(BUILD_DIR)/%.o)
 HEADERS = $(HEADER_FILES:%.h=$(SRC_DIR)/%.h)

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1110,6 +1110,11 @@ private:
         op->value.accept(this);
     }
 
+    void visit(const VectorIntrinsic *op) override {
+        // TODO(rootjalex): we may need to implement bounds queries.
+        internal_error << "Unexpected VectorIntrinsic in bounds query: " << Expr(op) << "\n";
+    }
+
     void visit(const Call *op) override {
         TRACK_BOUNDS_INTERVAL;
         TRACK_BOUNDS_INFO("name:", op->name);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,6 +165,7 @@ set(HEADER_FILES
     VectorizeLoops.h
     WasmExecutor.h
     WrapCalls.h
+    X86Optimize.h
     )
 
 set(SOURCE_FILES
@@ -342,6 +343,7 @@ set(SOURCE_FILES
     VectorizeLoops.cpp
     WasmExecutor.cpp
     WrapCalls.cpp
+    X86Optimize.cpp
     )
 
 ##

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4001,7 +4001,8 @@ void CodeGen_LLVM::visit(const Shuffle *op) {
 }
 
 void CodeGen_LLVM::visit(const VectorIntrinsic *op) {
-    internal_error << "CodeGen_LLVM received VectorIntrinsic node, should be handled by architecture-specific CodeGen class:\n" << Expr(op) << "\n";
+    internal_error << "CodeGen_LLVM received VectorIntrinsic node, should be handled by architecture-specific CodeGen class:\n"
+                   << Expr(op) << "\n";
 }
 
 void CodeGen_LLVM::visit(const VectorReduce *op) {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4000,6 +4000,10 @@ void CodeGen_LLVM::visit(const Shuffle *op) {
     }
 }
 
+void CodeGen_LLVM::visit(const VectorIntrinsic *op) {
+    internal_error << "CodeGen_LLVM received VectorIntrinsic node, should be handled by architecture-specific CodeGen class:\n" << Expr(op) << "\n";
+}
+
 void CodeGen_LLVM::visit(const VectorReduce *op) {
     codegen_vector_reduce(op, Expr());
 }

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -362,6 +362,7 @@ protected:
     void visit(const IfThenElse *) override;
     void visit(const Evaluate *) override;
     void visit(const Shuffle *) override;
+    void visit(const VectorIntrinsic *) override;
     void visit(const VectorReduce *) override;
     void visit(const Prefetch *) override;
     void visit(const Atomic *) override;

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -57,6 +57,7 @@ enum class IRNodeType {
     Call,
     Let,
     Shuffle,
+    VectorIntrinsic,
     VectorReduce,
     // Stmts
     LetStmt,

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -901,6 +901,17 @@ Stmt Atomic::make(const std::string &producer_name,
     return node;
 }
 
+Expr VectorIntrinsic::make(Type type, const std::string &name, const std::vector<Expr> &args) {
+    user_assert(!name.empty()) << "VectorIntrinsic without a name\n";
+    user_assert(!args.empty()) << "VectorInrinsic without arguments\n";
+
+    VectorIntrinsic *node = new VectorIntrinsic;
+    node->type = type;
+    node->name = name;
+    node->args = args;
+    return node;
+}
+
 Expr VectorReduce::make(VectorReduce::Operator op,
                         Expr vec,
                         int lanes) {
@@ -1079,6 +1090,10 @@ void ExprNode<Call>::accept(IRVisitor *v) const {
 template<>
 void ExprNode<Shuffle>::accept(IRVisitor *v) const {
     v->visit((const Shuffle *)this);
+}
+template<>
+void ExprNode<VectorIntrinsic>::accept(IRVisitor *v) const {
+    v->visit((const VectorIntrinsic *)this);
 }
 template<>
 void ExprNode<VectorReduce>::accept(IRVisitor *v) const {
@@ -1268,6 +1283,10 @@ Expr ExprNode<Call>::mutate_expr(IRMutator *v) const {
 template<>
 Expr ExprNode<Shuffle>::mutate_expr(IRMutator *v) const {
     return v->visit((const Shuffle *)this);
+}
+template<>
+Expr ExprNode<VectorIntrinsic>::mutate_expr(IRMutator *v) const {
+    return v->visit((const VectorIntrinsic *)this);
 }
 template<>
 Expr ExprNode<VectorReduce>::mutate_expr(IRMutator *v) const {

--- a/src/IR.h
+++ b/src/IR.h
@@ -886,6 +886,15 @@ struct Atomic : public StmtNode<Atomic> {
     static const IRNodeType _node_type = IRNodeType::Atomic;
 };
 
+struct VectorIntrinsic : public ExprNode<VectorIntrinsic> {
+    std::string name;
+    std::vector<Expr> args;
+
+    static Expr make(Type type, const std::string &name, const std::vector<Expr> &args);
+
+    static const IRNodeType _node_type = IRNodeType::VectorIntrinsic;
+};
+
 /** Horizontally reduce a vector to a scalar or narrower vector using
  * the given commutative and associative binary operator. The reduction
  * factor is dictated by the number of lanes in the input and output

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -98,6 +98,7 @@ private:
     void visit(const Shuffle *) override;
     void visit(const Prefetch *) override;
     void visit(const Atomic *) override;
+    void visit(const VectorIntrinsic *) override;
     void visit(const VectorReduce *) override;
 };
 
@@ -627,6 +628,13 @@ void IRComparer::visit(const Atomic *op) {
     compare_names(s->producer_name, op->producer_name);
     compare_names(s->mutex_name, op->mutex_name);
     compare_stmt(s->body, op->body);
+}
+
+void IRComparer::visit(const VectorIntrinsic *op) {
+    const VectorIntrinsic *e = expr.as<VectorIntrinsic>();
+
+    compare_names(e->name, op->name);
+    compare_expr_vector(e->args, op->args);
 }
 
 void IRComparer::visit(const VectorReduce *op) {

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1586,7 +1586,7 @@ auto bitwise_xor(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decl
     return {Call::bitwise_xor, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator^(A &&a, B &&b) noexcept -> auto {
+HALIDE_ALWAYS_INLINE auto operator^(A &&a, B &&b) noexcept -> auto{
     assert_is_lvalue_if_expr<A>();
     assert_is_lvalue_if_expr<B>();
     return bitwise_xor(a, b);
@@ -1596,7 +1596,7 @@ auto bitwise_and(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), decl
     return {Call::bitwise_and, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator&(A &&a, B &&b) noexcept -> auto {
+HALIDE_ALWAYS_INLINE auto operator&(A &&a, B &&b) noexcept -> auto{
     assert_is_lvalue_if_expr<A>();
     assert_is_lvalue_if_expr<B>();
     return bitwise_and(a, b);
@@ -1606,7 +1606,7 @@ auto bitwise_or(A &&a, B &&b) noexcept -> Intrin<decltype(pattern_arg(a)), declt
     return {Call::bitwise_or, pattern_arg(a), pattern_arg(b)};
 }
 template<typename A, typename B>
-HALIDE_ALWAYS_INLINE auto operator|(A &&a, B &&b) noexcept -> auto {
+HALIDE_ALWAYS_INLINE auto operator|(A &&a, B &&b) noexcept -> auto{
     assert_is_lvalue_if_expr<A>();
     assert_is_lvalue_if_expr<B>();
     return bitwise_or(a, b);

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -327,6 +327,14 @@ Expr IRMutator::visit(const Shuffle *op) {
     return Shuffle::make(new_vectors, op->indices);
 }
 
+Expr IRMutator::visit(const VectorIntrinsic *op) {
+    auto [new_args, changed] = mutate_with_changes(op->args);
+    if (!changed) {
+        return op;
+    }
+    return VectorIntrinsic::make(op->type, op->name, new_args);
+}
+
 Expr IRMutator::visit(const VectorReduce *op) {
     Expr value = mutate(op->value);
     if (value.same_as(op->value)) {

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -81,6 +81,7 @@ protected:
     virtual Expr visit(const Call *);
     virtual Expr visit(const Let *);
     virtual Expr visit(const Shuffle *);
+    virtual Expr visit(const VectorIntrinsic *);
     virtual Expr visit(const VectorReduce *);
 
     virtual Stmt visit(const LetStmt *);

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -1073,6 +1073,16 @@ void IRPrinter::visit(const Shuffle *op) {
     }
 }
 
+void IRPrinter::visit(const VectorIntrinsic *op) {
+    stream << "("
+           << op->type
+           << ")vector_intrinsic(\""
+           << op->name
+           << "\", ";
+    print_list(op->args);
+    stream << ")";
+}
+
 void IRPrinter::visit(const VectorReduce *op) {
     stream << "("
            << op->type

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -194,6 +194,7 @@ protected:
     void visit(const IfThenElse *) override;
     void visit(const Evaluate *) override;
     void visit(const Shuffle *) override;
+    void visit(const VectorIntrinsic *) override;
     void visit(const VectorReduce *) override;
     void visit(const Prefetch *) override;
     void visit(const Atomic *) override;

--- a/src/IRVisitor.cpp
+++ b/src/IRVisitor.cpp
@@ -257,6 +257,12 @@ void IRVisitor::visit(const Shuffle *op) {
     }
 }
 
+void IRVisitor::visit(const VectorIntrinsic *op) {
+    for (const auto &arg : op->args) {
+        arg.accept(this);
+    }
+}
+
 void IRVisitor::visit(const VectorReduce *op) {
     op->value.accept(this);
 }
@@ -512,6 +518,12 @@ void IRGraphVisitor::visit(const Evaluate *op) {
 void IRGraphVisitor::visit(const Shuffle *op) {
     for (const Expr &i : op->vectors) {
         include(i);
+    }
+}
+
+void IRGraphVisitor::visit(const VectorIntrinsic *op) {
+    for (const auto &arg : op->args) {
+        include(arg);
     }
 }
 

--- a/src/IRVisitor.h
+++ b/src/IRVisitor.h
@@ -71,6 +71,7 @@ protected:
     virtual void visit(const IfThenElse *);
     virtual void visit(const Evaluate *);
     virtual void visit(const Shuffle *);
+    virtual void visit(const VectorIntrinsic *);
     virtual void visit(const VectorReduce *);
     virtual void visit(const Prefetch *);
     virtual void visit(const Fork *);
@@ -142,6 +143,7 @@ protected:
     void visit(const IfThenElse *) override;
     void visit(const Evaluate *) override;
     void visit(const Shuffle *) override;
+    void visit(const VectorIntrinsic *) override;
     void visit(const VectorReduce *) override;
     void visit(const Prefetch *) override;
     void visit(const Acquire *) override;
@@ -224,6 +226,8 @@ private:
             return ((T *)this)->visit((const Let *)node, std::forward<Args>(args)...);
         case IRNodeType::Shuffle:
             return ((T *)this)->visit((const Shuffle *)node, std::forward<Args>(args)...);
+        case IRNodeType::VectorIntrinsic:
+            return ((T *)this)->visit((const VectorIntrinsic *)node, std::forward<Args>(args)...);
         case IRNodeType::VectorReduce:
             return ((T *)this)->visit((const VectorReduce *)node, std::forward<Args>(args)...);
             // Explicitly list the Stmt types rather than using a
@@ -286,6 +290,7 @@ private:
         case IRNodeType::Call:
         case IRNodeType::Let:
         case IRNodeType::Shuffle:
+        case IRNodeType::VectorIntrinsic:
         case IRNodeType::VectorReduce:
             internal_error << "Unreachable";
             break;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -75,6 +75,7 @@
 #include "UnsafePromises.h"
 #include "VectorizeLoops.h"
 #include "WrapCalls.h"
+#include "X86Optimize.h"
 
 namespace Halide {
 namespace Internal {
@@ -441,6 +442,13 @@ void lower_impl(const vector<Function> &output_funcs,
                  << s << "\n\n";
     } else {
         debug(1) << "Skipping GPU offload...\n";
+    }
+
+    if (t.arch == Target::X86) {
+        debug(1) << "Performing x86-specific vector instruction selection...\n";
+        s = optimize_x86_instructions(s, t);
+        debug(2) << "Lowering after performing x86-specific vector instruction selection:\n"
+                 << s << "\n\n";
     }
 
     // TODO: This needs to happen before lowering parallel tasks, because global

--- a/src/Simplify_Exprs.cpp
+++ b/src/Simplify_Exprs.cpp
@@ -59,6 +59,11 @@ Expr Simplify::visit(const Broadcast *op, ExprInfo *bounds) {
     }
 }
 
+Expr Simplify::visit(const VectorIntrinsic *op, ExprInfo *bounds) {
+    clear_bounds_info(bounds);
+    return op;
+}
+
 Expr Simplify::visit(const VectorReduce *op, ExprInfo *bounds) {
     Expr value = mutate(op->value, bounds);
 

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -333,6 +333,7 @@ public:
     Expr visit(const Load *op, ExprInfo *bounds);
     Expr visit(const Call *op, ExprInfo *bounds);
     Expr visit(const Shuffle *op, ExprInfo *bounds);
+    Expr visit(const VectorIntrinsic *op, ExprInfo *bounds);
     Expr visit(const VectorReduce *op, ExprInfo *bounds);
     Expr visit(const Let *op, ExprInfo *bounds);
     Stmt visit(const LetStmt *op);

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -712,6 +712,13 @@ private:
         stream << close_span();
     }
 
+    void visit(const VectorIntrinsic *op) override {
+        stream << open_span("VectoIntrinsic");
+        stream << open_span("Type") << op->type << close_span();
+        print_list(symbol("vector_intrinsic") + "(\"" + op->name + "\"", op->args, ")");
+        stream << close_span();
+    }
+
     void visit(const VectorReduce *op) override {
         stream << open_span("VectorReduce");
         stream << open_span("Type") << op->type << close_span();

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -713,7 +713,7 @@ private:
     }
 
     void visit(const VectorIntrinsic *op) override {
-        stream << open_span("VectoIntrinsic");
+        stream << open_span("VectorIntrinsic");
         stream << open_span("Type") << op->type << close_span();
         print_list(symbol("vector_intrinsic") + "(\"" + op->name + "\"", op->args, ")");
         stream << close_span();

--- a/src/X86Optimize.cpp
+++ b/src/X86Optimize.cpp
@@ -1,0 +1,588 @@
+#include "X86Optimize.h"
+
+#include "CSE.h"
+// FIXME: move lower_int_uint_div out of CodeGen_Internal to remove this dependency.
+#include "CodeGen_Internal.h"
+#include "FindIntrinsics.h"
+#include "IR.h"
+#include "IRMatch.h"
+#include "IRMutator.h"
+#include "IROperator.h"
+#include "Simplify.h"
+
+namespace Halide {
+namespace Internal {
+
+// Populate feature flags in a target according to those implied by
+// existing flags, so that instruction patterns can just check for the
+// oldest feature flag that supports an instruction.
+Target complete_x86_target(Target t) {
+    if (t.has_feature(Target::AVX512_SapphireRapids)) {
+        t.set_feature(Target::AVX512_Cannonlake);
+    }
+    if (t.has_feature(Target::AVX512_Cannonlake)) {
+        t.set_feature(Target::AVX512_Skylake);
+    }
+    if (t.has_feature(Target::AVX512_Cannonlake) ||
+        t.has_feature(Target::AVX512_Skylake) ||
+        t.has_feature(Target::AVX512_KNL)) {
+        t.set_feature(Target::AVX2);
+    }
+    if (t.has_feature(Target::AVX2)) {
+        t.set_feature(Target::AVX);
+    }
+    if (t.has_feature(Target::AVX)) {
+        t.set_feature(Target::SSE41);
+    }
+    return t;
+}
+
+#if defined(WITH_X86)
+
+namespace {
+
+// i32(i16_a)*i32(i16_b) +/- i32(i16_c)*i32(i16_d) can be done by
+// interleaving a, c, and b, d, and then using dot_product.
+bool should_use_dot_product(const Expr &a, const Expr &b, std::vector<Expr> &result) {
+    Type t = a.type();
+    internal_assert(b.type() == t) << a << " and " << b << " don't match types\n";
+
+    if (!(t.is_int() && t.bits() == 32 && t.lanes() >= 4)) {
+        return false;
+    }
+
+    const Call *ma = Call::as_intrinsic(a, {Call::widening_mul});
+    const Call *mb = Call::as_intrinsic(b, {Call::widening_mul});
+    // dot_product can't handle mixed type widening muls.
+    if (ma && ma->args[0].type() != ma->args[1].type()) {
+        return false;
+    }
+    if (mb && mb->args[0].type() != mb->args[1].type()) {
+        return false;
+    }
+    // If the operands are widening shifts, we might be able to treat these as
+    // multiplies.
+    const Call *sa = Call::as_intrinsic(a, {Call::widening_shift_left});
+    const Call *sb = Call::as_intrinsic(b, {Call::widening_shift_left});
+    if (sa && !is_const(sa->args[1])) {
+        sa = nullptr;
+    }
+    if (sb && !is_const(sb->args[1])) {
+        sb = nullptr;
+    }
+    if ((ma || sa) && (mb || sb)) {
+        Expr a0 = ma ? ma->args[0] : sa->args[0];
+        Expr a1 = ma ? ma->args[1] : lossless_cast(sa->args[0].type(), simplify(make_const(sa->type, 1) << sa->args[1]));
+        Expr b0 = mb ? mb->args[0] : sb->args[0];
+        Expr b1 = mb ? mb->args[1] : lossless_cast(sb->args[0].type(), simplify(make_const(sb->type, 1) << sb->args[1]));
+        if (a1.defined() && b1.defined()) {
+            std::vector<Expr> args = {a0, a1, b0, b1};
+            result.swap(args);
+            return true;
+        }
+    }
+    return false;
+}
+
+// // Templated saturating casts for use in rewrite rules.
+// template<typename T>
+// auto saturating_cast()
+
+/** A code generator that replaces Halide IR with VectorIntrinsics specific to x86. */
+class Optimize_X86 : public IRMutator {
+public:
+    /** Create an x86 code generator. Processor features can be
+     * enabled using the appropriate flags in the target struct. */
+    Optimize_X86(const Target &t) : target(t) {
+    }
+
+protected:
+
+    bool should_peephole_optimize(const Type &type) {
+        // We only have peephole optimizations for vectors here.
+        // FIXME: should we only optimize vectors that are multiples of the native vector width?
+        //        when we do, we fail simd_op_check tests on weird vector sizes.
+        return type.is_vector();
+    }
+
+    Expr visit(const Div *op) override {
+        if (!should_peephole_optimize(op->type) || !op->type.is_int_or_uint()) {
+            return IRMutator::visit(op);
+        }
+        // Lower division here in order to do pattern-matching on intrinsics.
+        return mutate(lower_int_uint_div(op->a, op->b));
+    }
+
+    /** Nodes for which we want to emit specific sse/avx intrinsics */
+    Expr visit(const Add *op) override {
+        if (!should_peephole_optimize(op->type)) {
+            return IRMutator::visit(op);
+        }
+
+        std::vector<Expr> matches;
+        // TODO(rootjalex): is it possible to rewrite should_use_dot_product
+        // as a series of rewrite-rules? lossless_cast is the hardest part.
+        const int lanes = op->type.lanes();
+
+        // FIXME: should we check for accumulating dot_products first?
+        //        can there even be overlap between these?
+        auto rewrite = IRMatcher::rewriter(IRMatcher::add(op->a, op->b), op->type);
+        if (
+            // Only AVX512_SapphireRapids has accumulating dot products.
+            target.has_feature(Target::AVX512_SapphireRapids) &&
+            // FIXME: add the float16 -> float32 versions as well.
+            (op->type.element_of() == Int(32)) &&
+
+            // Accumulating pmaddubsw
+            (rewrite(
+                x + h_add(cast(Int(32, lanes * 4), widening_mul(y, z)), lanes),
+                v_intrin("dot_product", x, y, z),
+                is_uint(y, 8) && is_int(z, 8)) ||
+
+             rewrite(
+                x + h_add(cast(Int(32, lanes * 4), widening_mul(y, z)), lanes),
+                v_intrin("dot_product", x, z, y),
+                is_int(y, 8) && is_uint(z, 8)) ||
+
+             rewrite(
+                h_add(cast(Int(32, lanes * 4), widening_mul(x, y)), lanes) + z,
+                v_intrin("dot_product", z, x, y),
+                is_uint(x, 8) && is_int(y, 8)) ||
+
+             rewrite(
+                h_add(cast(Int(32, lanes * 4), widening_mul(x, y)), lanes) + z,
+                v_intrin("dot_product", z, y, x),
+                is_int(x, 8) && is_uint(y, 8)) ||
+
+             // Accumulating pmaddwd.
+             rewrite(
+                x + h_add(widening_mul(y, z), lanes),
+                v_intrin("dot_product", x, y, z),
+                is_int(y, 16, lanes * 2) && is_int(z, 16, lanes * 2)) ||
+            
+             rewrite(
+                h_add(widening_mul(x, y), lanes) + z,
+                v_intrin("dot_product", z, x, y),
+                is_int(x, 16, lanes * 2) && is_int(y, 16, lanes * 2)) ||
+
+             false)) {
+            return mutate(rewrite.result);
+        }
+
+        if ((op->type.lanes() % 4 == 0) && should_use_dot_product(op->a, op->b, matches)) {
+            Expr ac = Shuffle::make_interleave({matches[0], matches[2]});
+            Expr bd = Shuffle::make_interleave({matches[1], matches[3]});
+            // We have dot_products for every x86 arch (because SSE2 has it),
+            // so this is `always` safe (as long as the output type lanes has
+            // a factor of 4).
+            return mutate(VectorIntrinsic::make(op->type, "dot_product", {ac, bd}));
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const Sub *op) override {
+        if (!should_peephole_optimize(op->type)) {
+            return IRMutator::visit(op);
+        }
+
+        std::vector<Expr> matches;
+        // TODO(rootjalex): same issue as the Add case, lossless_cast and
+        // lossless_negate are hard to use in rewrite rules.
+
+        if ((op->type.lanes() % 4 == 0) && should_use_dot_product(op->a, op->b, matches)) {
+            // Negate one of the factors in the second expression
+            Expr negative_2 = lossless_negate(matches[2]);
+            Expr negative_3 = lossless_negate(matches[3]);
+            if (negative_2.defined() || negative_3.defined()) {
+                if (negative_2.defined()) {
+                    matches[2] = negative_2;
+                } else {
+                    matches[3] = negative_3;
+                }
+                Expr ac = Shuffle::make_interleave({matches[0], matches[2]});
+                Expr bd = Shuffle::make_interleave({matches[1], matches[3]});
+                // Always safe, see comment in Add case above.
+                return mutate(VectorIntrinsic::make(op->type, "dot_product", {ac, bd}));
+            }
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const Cast *op) override {
+        if (!should_peephole_optimize(op->type)) {
+            return IRMutator::visit(op);
+        }
+
+        const int lanes = op->type.lanes();
+
+        auto rewrite = IRMatcher::rewriter(IRMatcher::cast(op->type, op->value), op->type);
+
+        // TODO: saturating casts should be intrinsics, and supported in IRMatch.h.
+        const Expr i32_i16max = cast(Int(32, lanes), Int(16).max());
+        const Expr i32_i16min = cast(Int(32, lanes), Int(16).min());
+        const Expr i16_i8max = cast(Int(16, lanes), Int(8).max());
+        const Expr i16_i8min = cast(Int(16, lanes), Int(8).min());
+        const Expr i16_u8max = cast(Int(16, lanes), UInt(8).max());
+        const Expr i16_u8min = cast(Int(16, lanes), UInt(8).min());
+        const Expr i32_u16max = cast(Int(32, lanes), UInt(16).max());
+        const Expr i32_u16min = cast(Int(32, lanes), UInt(16).min());
+
+        if (
+            // pmulhrs is supported via AVX2 and SSE41, so SSE41 is the LCD.
+            (target.has_feature(Target::SSE41) &&
+             rewrite(
+                cast(Int(16, lanes), rounding_shift_right(widening_mul(x, y), 15)),
+                v_intrin("pmulhrs", x, y),
+                is_int(x, 16) && is_int(y, 16))) ||
+
+            // saturating_narrow is always supported (via SSE2) for:
+            //   int32 -> int16, int16 -> int8, int16 -> uint8
+            rewrite(
+                cast(Int(16, lanes), max(min(x, i32_i16min), i32_i16min)),
+                v_intrin("saturating_narrow", x),
+                is_int(x, 32)) ||
+
+            rewrite(
+                cast(Int(8, lanes), max(min(x, i16_i8min), i16_i8min)),
+                v_intrin("saturating_narrow", x),
+                is_int(x, 16)) ||
+
+            rewrite(
+                cast(UInt(8, lanes), max(min(x, i16_u8min), i16_u8min)),
+                v_intrin("saturating_narrow", x),
+                is_int(x, 16)) ||
+
+            //   int32 -> uint16 is supported via SSE41
+            (target.has_feature(Target::SSE41) &&
+             rewrite(
+                cast(UInt(16, lanes), max(min(x, i32_u16min), i32_u16min)),
+                v_intrin("saturating_narrow", x),
+                is_int(x, 32))) ||
+
+            // f32_to_bf16 is supported only via Target::AVX512_SapphireRapids
+            (target.has_feature(Target::AVX512_SapphireRapids) &&
+             rewrite(
+                cast(BFloat(16, lanes), x),
+                v_intrin("f32_to_bf16", x),
+                is_float(x, 32))) ||
+
+            false) {
+            return mutate(rewrite.result);
+        }
+
+        // TODO: should we handle CodeGen_X86's weird 8 -> 16 bit issue here?
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const Call *op) override {
+        if (!should_peephole_optimize(op->type)) {
+            return IRMutator::visit(op);
+        }
+
+        // TODO: This optimization is hard to do via a rewrite-rule because of lossless_cast.
+
+        // A 16-bit mul-shift-right of less than 16 can sometimes be rounded up to a
+        // full 16 to use pmulh(u)w by left-shifting one of the operands. This is
+        // handled here instead of in the lowering of mul_shift_right because it's
+        // unlikely to be a good idea on platforms other than x86, as it adds an
+        // extra shift in the fully-lowered case.
+        if ((op->type.element_of() == UInt(16) ||
+            op->type.element_of() == Int(16)) &&
+            op->is_intrinsic(Call::mul_shift_right)) {
+            internal_assert(op->args.size() == 3);
+            const uint64_t *shift = as_const_uint(op->args[2]);
+            if (shift && *shift < 16 && *shift >= 8) {
+                Type narrow = op->type.with_bits(8);
+                Expr narrow_a = lossless_cast(narrow, op->args[0]);
+                Expr narrow_b = narrow_a.defined() ? Expr() : lossless_cast(narrow, op->args[1]);
+                int shift_left = 16 - (int)(*shift);
+                if (narrow_a.defined()) {
+                    return mutate(mul_shift_right(op->args[0] << shift_left, op->args[1], 16));
+                } else if (narrow_b.defined()) {
+                    return mutate(mul_shift_right(op->args[0], op->args[1] << shift_left, 16));
+                }
+            }
+        }
+
+        const int lanes = op->type.lanes();
+        const int bits = op->type.bits();
+
+        auto rewrite = IRMatcher::rewriter(op, op->type);
+
+        Type unsigned_type = op->type.with_code(halide_type_uint);
+        auto x_uint = cast(unsigned_type, x);
+        auto y_uint = cast(unsigned_type, y);
+
+        if (
+            // We can redirect signed rounding halving add to unsigned rounding
+            // halving add by adding 128 / 32768 to the result if the sign of the
+            // args differs.
+            ((op->type.is_int() && bits <= 16) &&
+             rewrite(
+                rounding_halving_add(x, y),
+                cast(op->type, rounding_halving_add(x_uint, y_uint) + ((x_uint ^ y_uint) & (1 << (bits - 1)))))) ||
+
+            // On x86, there are many 3-instruction sequences to compute absd of
+            // unsigned integers. This one consists solely of instructions with
+            // throughput of 3 ops per cycle on Cannon Lake.
+            //
+            // Solution due to Wojciech Mula:
+            // http://0x80.pl/notesen/2018-03-11-sse-abs-unsigned.html
+            (op->type.is_uint() &&
+             rewrite(
+                absd(x, y),
+                saturating_sub(x, y) | saturating_sub(y, x))) ||
+
+            // Current best way to lower absd on x86.
+            (op->type.is_int() &&
+             rewrite(
+                absd(x, y),
+                max(x, y) - min(x, y))) ||
+
+            // pmulh is always supported (via SSE2).
+            ((op->type.is_int_or_uint() && bits == 16) &&
+             rewrite(
+                mul_shift_right(x, y, 16),
+                v_intrin("pmulh", x, y))) ||
+
+            // saturating_pmulhrs is supported via SSE41
+            ((target.has_feature(Target::SSE41) &&
+              op->type.is_int() && bits == 16) &&
+             rewrite(
+                rounding_mul_shift_right(x, y, 15),
+                v_intrin("saturating_pmulhrs", x, y))) ||
+
+            // TODO(rootjalex): The following intrinsics are
+            // simply one-to-one mappings, should they even
+            // be handled here?
+
+            // int(8 | 16 | 32) -> uint is supported via SSE41
+            // float is always supported (via SSE2).
+            (((target.has_feature(Target::SSE41) && bits <= 32) ||
+              op->type.is_float()) &&
+             rewrite(
+                abs(x),
+                v_intrin("abs", x))) ||
+
+            // saturating ops for 8 and 16 bits are always supported (via SSE2).
+            ((bits == 8 || bits == 16) &&
+             (rewrite(
+                saturating_add(x, y),
+                v_intrin("saturating_add", x, y)) ||
+             rewrite(
+                saturating_sub(x, y),
+                v_intrin("saturating_sub", x, y)))) ||
+
+            // pavg ops for 8 and 16 bits are always supported (via SSE2).
+            ((op->type.is_uint() && (bits == 8  || bits == 16)) &&
+             rewrite(
+                rounding_halving_add(x, y),
+                v_intrin("rounding_halving_add", x, y))) ||
+
+            // int16 -> int32 widening_mul has a (v)pmaddwd implementation.
+            // always supported (via SSE2).
+            ((op->type.is_int() && (bits == 32)) &&
+             rewrite(
+                widening_mul(x, y),
+                v_intrin("widening_mul", x, y),
+                is_int(x, 16) && is_int(y, 16))) ||
+
+            (target.has_feature(Target::AVX512_SapphireRapids) &&
+             (op->type.is_int() && (bits == 32)) &&
+             // SapphireRapids accumulating dot products.
+             (rewrite(
+                saturating_add(x, h_satadd(cast(Int(32, lanes * 4), widening_mul(y, z)) , lanes)),
+                v_intrin("saturating_dot_product", x, y, z),
+                is_uint(y, 8) && is_int(z, 8)) ||
+
+              rewrite(
+                saturating_add(x, h_satadd(cast(Int(32, lanes * 4), widening_mul(y, z)) , lanes)),
+                v_intrin("saturating_dot_product", x, z, y),
+                is_int(y, 8) && is_uint(z, 8)) ||
+            
+              rewrite(
+                saturating_add(x, h_satadd(cast(Int(32, lanes * 2), widening_mul(y, z)) , lanes)),
+                v_intrin("saturating_dot_product", x, y, z),
+                is_uint(y, 8) && is_int(z, 8)) ||
+
+              rewrite(
+                saturating_add(x, h_satadd(cast(Int(32, lanes * 2), widening_mul(y, z)) , lanes)),
+                v_intrin("saturating_dot_product", x, z, y),
+                is_int(y, 8) && is_uint(z, 8)) ||
+            
+              rewrite(
+                saturating_add(x, h_satadd(widening_mul(y, z) , lanes)),
+                v_intrin("saturating_dot_product", x, z, y),
+                is_int(y, 16, lanes * 2) && is_int(z, 16, lanes * 2)) ||
+            
+             false)) ||
+
+            false) {
+            return mutate(rewrite.result);
+        }
+
+        // Fixed-point intrinsics should be lowered here.
+        // This is safe because this mutator is top-down.
+        if (op->is_intrinsic({
+              Call::halving_add,
+              Call::halving_sub,
+              Call::mul_shift_right,
+              Call::rounding_halving_add,
+              Call::rounding_mul_shift_right,
+              Call::rounding_shift_left,
+              Call::rounding_shift_right,
+              Call::saturating_add,
+              Call::saturating_sub,
+              Call::sorted_avg,
+              Call::widening_add,
+              Call::widening_mul,
+              Call::widening_shift_left,
+              Call::widening_shift_right,
+              Call::widening_sub,
+            })) {
+            // TODO: Should we have a base-class that does this + the VectorReduce lowering needed below?
+            return mutate(lower_intrinsic(op));
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const VectorReduce *op) override {
+        // FIXME: We need to split up VectorReduce nodes in the same way that
+        //        CodeGen_LLVM::codegen_vector_reduce does, in order to do all
+        //        matching here.
+        if ((op->op != VectorReduce::Add && op->op != VectorReduce::SaturatingAdd) ||
+            !should_peephole_optimize(op->type)) {
+            return IRMutator::visit(op);
+        }
+
+        const int lanes = op->type.lanes();
+        const int value_lanes = op->value.type().lanes();
+        const int factor = value_lanes / lanes;
+        Expr value = op->value;
+
+        switch (op->op) {
+        case VectorReduce::Add: {
+            auto rewrite = IRMatcher::rewriter(IRMatcher::h_add(value, lanes), op->type);
+            auto x_is_int_or_uint = is_int(x) || is_uint(x);
+            auto y_is_int_or_uint = is_int(y) || is_uint(y);
+            if (
+                // 2-way dot-products, int16 -> int32 is always supported (via SSE2).
+                ((factor == 2) &&
+                 (rewrite(
+                    h_add(cast(Int(32, value_lanes), widening_mul(x, y)), lanes),
+                    v_intrin("dot_product", cast(Int(16, value_lanes), x), cast(Int(16, value_lanes), y)),
+                    x_is_int_or_uint && y_is_int_or_uint) ||
+                
+                 // Horizontal widening add via pmaddwd
+                 rewrite(
+                    h_add(cast(Int(32, value_lanes), x), lanes),
+                    v_intrin("dot_product", x, make_const(Int(16, value_lanes), 1)),
+                    is_int(x, 16)) ||
+
+                 (rewrite(
+                    h_add(widening_mul(x, y), lanes),
+                    v_intrin("dot_product", x, y),
+                    is_int(x, 16) && is_int(y, 16))) ||
+                
+                 // pmaddub supported via SSE41
+                 (target.has_feature(Target::SSE41) &&
+                  // Horizontal widening adds using 2-way saturating dot products.
+                  (rewrite(
+                    h_add(cast(UInt(16, value_lanes), x), lanes),
+                    cast(UInt(16, lanes), typed(Int(16, lanes), v_intrin("saturating_dot_product", x, make_const(Int(8, value_lanes), 1)))),
+                    is_uint(x, 8)) ||
+
+                   rewrite(
+                    h_add(cast(Int(16, value_lanes), x), lanes),
+                    v_intrin("saturating_dot_product", x, make_const(Int(8, value_lanes), 1)),
+                    is_uint(x, 8)) ||
+
+                   rewrite(
+                    h_add(cast(Int(16, value_lanes), x), lanes),
+                    v_intrin("saturating_dot_product", make_const(UInt(8, value_lanes), 1), x),
+                    is_int(x, 8)) ||
+
+                   // SSE41 and AVX2 support horizontal_add via phadd intrinsics.
+                   rewrite(
+                    h_add(x, lanes),
+                    v_intrin("horizontal_add", x),
+                    is_int(x, 16, lanes * 2) || is_uint(x, 16, lanes * 2) ||
+                     is_int(x, 32, lanes * 2) || is_uint(x, 32, lanes * 2)) ||
+
+                    // TODO: add in Andrew's psadbw pattern.
+
+                 false)) ||
+
+                false))) {
+                return mutate(rewrite.result);
+            }
+            break;
+        }
+        case VectorReduce::SaturatingAdd: {
+            auto rewrite = IRMatcher::rewriter(IRMatcher::h_satadd(value, lanes), op->type);
+            if (
+                // Saturating dot products are supported via SSE41 and AVX2.
+                ((factor == 2) && target.has_feature(Target::SSE41) &&
+                 (rewrite(
+                    h_satadd(widening_mul(x, y), lanes),
+                    v_intrin("saturating_dot_product", x, y),
+                    is_uint(x, 8) && is_int(y, 8)) ||
+
+                  rewrite(
+                    h_satadd(widening_mul(x, y), lanes),
+                    v_intrin("saturating_dot_product", y, x),
+                    is_int(x, 8) && is_uint(y, 8)) ||
+
+                 false))) {
+                return mutate(rewrite.result);
+            }
+            break;
+        }
+        default:
+            break;
+        }
+
+        // FIXME: We need to split up VectorReduce nodes in the same way that
+        //        CodeGen_LLVM::codegen_vector_reduce does, in order to do all
+        //        matching here.
+
+        return IRMutator::visit(op);
+    }
+
+private:
+    const Target &target;
+
+    IRMatcher::Wild<0> x;
+    IRMatcher::Wild<1> y;
+    IRMatcher::Wild<2> z;
+};
+
+}
+
+
+
+Stmt optimize_x86_instructions(Stmt s, const Target &t) {
+    s = Optimize_X86(complete_x86_target(t)).mutate(s);
+    // Some of the rules above can introduce repeated sub-terms, so run CSE again.
+    s = common_subexpression_elimination(s);
+    return s;
+}
+
+#else  // WITH_X86
+
+Stmt optimize_x86_instructions(Stmt s, const Target &t) {
+    user_error << "x86 not enabled for this build of Halide.\n";
+    return Stmt();
+}
+
+
+#endif  // WITH_X86
+
+}  // namespace Internal
+}  // namespace Halide
+
+

--- a/src/X86Optimize.h
+++ b/src/X86Optimize.h
@@ -1,0 +1,22 @@
+#ifndef HALIDE_IR_X86_OPTIMIZE_H
+#define HALIDE_IR_X86_OPTIMIZE_H
+
+/** \file
+ * Tools for optimizing IR for x86.
+ */
+
+#include "Expr.h"
+#include "Target.h"
+
+namespace Halide {
+namespace Internal {
+
+/** Perform vector instruction selection, inserting VectorIntrinsic nodes. */
+Stmt optimize_x86_instructions(Stmt s, const Target &t);
+
+Target complete_x86_target(Target t);
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif


### PR DESCRIPTION
Left as a draft for now because this work is unfinished, but I was hoping to get feedback.

This PR is intended to create a separate vector-instruction-selection pass for x86, akin to HexagonOptimize. That pass is defined in X86Optimize.(h | cpp), and as many rules as possible are written via the IRMatch.h templating. In order to successfully create this TRS, this PR also adds:
- a VectorIntrinsic IR Node, which is not restricted to element-wise operations (i.e. it supports `dot_product`s)
- updates to IRMatch.h, i.e. supporting bitwise operations and type hints via a new `typed()` method

Work that still needs to be done (possibly):
- [] Implement VectorReduce logic similar to `CodeGen_LLVM::codegen_vector_reduce` to split up VectorReduce nodes
- [] Implement a base class for ^ and possibly for division + fixed-point intrinsics lowering (?)
- [] Add the SapphireRapids float32 + bfloat16 accumulating `dot_product` pattern, and the `psadbw` from #6872 

This TRS addresses the issue that @abadams raised on #6878, namely that rewriting `horizontal_widening_add` directly into Halide IR that corresponds to the `dot_product` instructions is cleaner and more extensible than the implementation in that PR.

I am tagging people that might be interested, but would love feedback from anyone (especially on the points above, and anywhere in the code that says TODO / FIXME).