### PR TITLE
Upgrade clang-format and clang-tidy to v14

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.13
+      - uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: '.'
           extensions: 'h,c,cpp'
-          clangFormatVersion: 13
+          clangFormatVersion: 14
   check_clang_tidy:
     name: Check clang-tidy
     runs-on: ubuntu-20.04
@@ -30,14 +30,14 @@ jobs:
           # from apt.llvm.org
           # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
-          sudo apt-add-repository "deb https://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-13 main"
+          sudo apt-add-repository "deb https://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-14 main"
           sudo apt-get update
-          sudo apt-get install llvm-13 clang-13 liblld-13-dev libclang-13-dev clang-tidy-13 ninja-build
+          sudo apt-get install llvm-14 clang-14 liblld-14-dev libclang-14-dev clang-tidy-14 ninja-build
       - name: Run clang-tidy
         run: |
-          export CC=clang-13
-          export CXX=clang++-13
-          export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-13
+          export CC=clang-14
+          export CXX=clang++-14
+          export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-14
           ./run-clang-tidy.sh
   check_cmake_file_lists:
     name: Check CMake file lists

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -4,23 +4,23 @@ set -e
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# We are currently standardized on using LLVM/Clang13 for this script.
+# We are currently standardized on using LLVM/Clang14 for this script.
 # Note that this is totally independent of the version of LLVM that you
-# are using to build Halide itself. If you don't have LLVM13 installed,
+# are using to build Halide itself. If you don't have LLVM14 installed,
 # you can usually install what you need easily via:
 #
-# sudo apt-get install llvm-13 clang-13 libclang-13-dev clang-tidy-13
-# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-13
+# sudo apt-get install llvm-14 clang-14 libclang-14-dev clang-tidy-14
+# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-14
 
 [ -z "$CLANG_FORMAT_LLVM_INSTALL_DIR" ] && echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_FORMAT_LLVM_INSTALL_DIR = ${CLANG_FORMAT_LLVM_INSTALL_DIR}
 
 VERSION=$(${CLANG_FORMAT_LLVM_INSTALL_DIR}/bin/clang-format --version)
-if [[ ${VERSION} =~ .*version\ 13.* ]]
+if [[ ${VERSION} =~ .*version\ 14.* ]]
 then
-    echo "clang-format version 13 found."
+    echo "clang-format version 14 found."
 else
-    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 13 install!"
+    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 14 install!"
     exit 1
 fi
 

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -8,23 +8,23 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 FIX=$1
 
-# We are currently standardized on using LLVM/Clang12 for this script.
+# We are currently standardized on using LLVM/Clang14 for this script.
 # Note that this is totally independent of the version of LLVM that you
-# are using to build Halide itself. If you don't have LLVM12 installed,
+# are using to build Halide itself. If you don't have LLVM14 installed,
 # you can usually install what you need easily via:
 #
-# sudo apt-get install llvm-13 clang-13 libclang-13-dev clang-tidy-13
-# export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-13
+# sudo apt-get install llvm-14 clang-14 libclang-14-dev clang-tidy-14
+# export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-14
 
 [ -z "$CLANG_TIDY_LLVM_INSTALL_DIR" ] && echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_TIDY_LLVM_INSTALL_DIR = ${CLANG_TIDY_LLVM_INSTALL_DIR}
 
 VERSION=$(${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-tidy --version)
-if [[ ${VERSION} =~ .*version\ 13.* ]]
+if [[ ${VERSION} =~ .*version\ 14.* ]]
 then
-    echo "clang-tidy version 13 found."
+    echo "clang-tidy version 14 found."
 else
-    echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM 13 install!"
+    echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM 14 install!"
     exit 1
 fi
 

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -860,7 +860,7 @@ public:
 
         // Do any pure inlining (TODO: This is currently slow)
         for (size_t i = f.size(); i > 0; i--) {
-            Function func = f[i - 1];
+            const Function &func = f[i - 1];
             if (inlined[i - 1]) {
                 for (auto &s : stages) {
                     for (auto &cond_val : s.exprs) {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -318,8 +318,7 @@ public:
 }  // namespace
 
 CodeGen_C::CodeGen_C(ostream &s, const Target &t, OutputKind output_kind, const std::string &guard)
-    : IRPrinter(s), id("$$ BAD ID $$"), target(t), output_kind(output_kind),
-      extern_c_open(false), inside_atomic_mutex_node(false), emit_atomic_stores(false), using_vector_typedefs(false) {
+    : IRPrinter(s), id("$$ BAD ID $$"), target(t), output_kind(output_kind) {
 
     if (is_header()) {
         // If it's a header, emit an include guard.

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -174,7 +174,7 @@ protected:
     bool have_user_context;
 
     /** Track current calling convention scope. */
-    bool extern_c_open;
+    bool extern_c_open = false;
 
     /** True if at least one gpu-based for loop is used. */
     bool uses_gpu_for_loops;
@@ -259,13 +259,13 @@ protected:
 
     /** Are we inside an atomic node that uses mutex locks?
         This is used for detecting deadlocks from nested atomics. */
-    bool inside_atomic_mutex_node;
+    bool inside_atomic_mutex_node = false;
 
     /** Emit atomic store instructions? */
-    bool emit_atomic_stores;
+    bool emit_atomic_stores = false;
 
     /** true if add_vector_typedefs() has been called. */
-    bool using_vector_typedefs;
+    bool using_vector_typedefs = false;
 
     void emit_argv_wrapper(const std::string &function_name,
                            const std::vector<LoweredArgument> &args);

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -81,11 +81,11 @@ class IsBufferConstant : public IRVisitor {
     }
 
 public:
-    bool result;
+    bool result = true;
     const std::string &buffer;
 
     IsBufferConstant(const std::string &b)
-        : result(true), buffer(b) {
+        : buffer(b) {
     }
 };
 }  // namespace

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -174,22 +174,7 @@ llvm::GlobalValue::LinkageTypes llvm_linkage(LinkageType t) {
 }  // namespace
 
 CodeGen_LLVM::CodeGen_LLVM(const Target &t)
-    : function(nullptr), context(nullptr),
-      builder(nullptr),
-      value(nullptr),
-      very_likely_branch(nullptr),
-      default_fp_math_md(nullptr),
-      strict_fp_math_md(nullptr),
-      target(t),
-      void_t(nullptr), i1_t(nullptr), i8_t(nullptr),
-      i16_t(nullptr), i32_t(nullptr), i64_t(nullptr),
-      f16_t(nullptr), f32_t(nullptr), f64_t(nullptr),
-      halide_buffer_t_type(nullptr),
-      metadata_t_type(nullptr),
-      argument_t_type(nullptr),
-      scalar_value_t_type(nullptr),
-      device_interface_t_type(nullptr),
-      pseudostack_slot_t_type(nullptr),
+    : target(t),
 
       wild_u1x_(Variable::make(UInt(1, 0), "*")),
       wild_i8x_(Variable::make(Int(8, 0), "*")),
@@ -215,13 +200,8 @@ CodeGen_LLVM::CodeGen_LLVM(const Target &t)
       wild_f32_(Variable::make(Float(32), "*")),
       wild_f64_(Variable::make(Float(64), "*")),
 
-      inside_atomic_mutex_node(false),
-      emit_atomic_stores(false),
-
-      destructor_block(nullptr),
       strict_float(t.has_feature(Target::StrictFloat)),
-      llvm_large_code_model(t.has_feature(Target::LLVMLargeCodeModel)),
-      effective_vscale(0) {
+      llvm_large_code_model(t.has_feature(Target::LLVMLargeCodeModel)) {
     initialize_llvm();
 }
 

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -157,13 +157,13 @@ protected:
     virtual Type upgrade_type_for_argument_passing(const Type &) const;
 
     std::unique_ptr<llvm::Module> module;
-    llvm::Function *function;
-    llvm::LLVMContext *context;
-    llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter> *builder;
-    llvm::Value *value;
-    llvm::MDNode *very_likely_branch;
-    llvm::MDNode *default_fp_math_md;
-    llvm::MDNode *strict_fp_math_md;
+    llvm::Function *function = nullptr;
+    llvm::LLVMContext *context = nullptr;
+    llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter> *builder = nullptr;
+    llvm::Value *value = nullptr;
+    llvm::MDNode *very_likely_branch = nullptr;
+    llvm::MDNode *default_fp_math_md = nullptr;
+    llvm::MDNode *strict_fp_math_md = nullptr;
     std::vector<LoweredArgument> current_function_args;
     //@}
 
@@ -208,16 +208,16 @@ protected:
 
     /** Some useful llvm types */
     // @{
-    llvm::Type *void_t, *i1_t, *i8_t, *i16_t, *i32_t, *i64_t, *f16_t, *f32_t, *f64_t;
-    llvm::StructType *halide_buffer_t_type,
-        *type_t_type,
-        *dimension_t_type,
-        *metadata_t_type,
-        *argument_t_type,
-        *scalar_value_t_type,
-        *device_interface_t_type,
-        *pseudostack_slot_t_type,
-        *semaphore_t_type;
+    llvm::Type *void_t = nullptr, *i1_t = nullptr, *i8_t = nullptr, *i16_t = nullptr, *i32_t = nullptr, *i64_t = nullptr, *f16_t = nullptr, *f32_t = nullptr, *f64_t = nullptr;
+    llvm::StructType *halide_buffer_t_type = nullptr,
+                     *type_t_type,
+                     *dimension_t_type,
+                     *metadata_t_type = nullptr,
+                     *argument_t_type = nullptr,
+                     *scalar_value_t_type = nullptr,
+                     *device_interface_t_type = nullptr,
+                     *pseudostack_slot_t_type = nullptr,
+                     *semaphore_t_type;
 
     // @}
 
@@ -508,10 +508,10 @@ protected:
 
     /** Are we inside an atomic node that uses mutex locks?
         This is used for detecting deadlocks from nested atomics & illegal vectorization. */
-    bool inside_atomic_mutex_node;
+    bool inside_atomic_mutex_node = false;
 
     /** Emit atomic store instructions? */
-    bool emit_atomic_stores;
+    bool emit_atomic_stores = false;
 
     /** Can we call this operation with float16 type?
         This is used to avoid "emulated" equivalent code-gen in case target has FP16 feature **/
@@ -542,7 +542,7 @@ private:
     /** A basic block to branch to on error that triggers all
      * destructors. As destructors are registered, code gets added
      * to this block. */
-    llvm::BasicBlock *destructor_block;
+    llvm::BasicBlock *destructor_block = nullptr;
 
     /** Turn off all unsafe math flags in scopes while this is set. */
     bool strict_float;
@@ -553,7 +553,7 @@ private:
     /** Cache the result of target_vscale from architecture specific implementation
      * as this is used on every Halide to LLVM type conversion.
      */
-    int effective_vscale;
+    int effective_vscale = 0;
 
     /** Embed an instance of halide_filter_metadata_t in the code, using
      * the given name (by convention, this should be ${FUNCTIONNAME}_metadata)

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -29,7 +29,7 @@ public:
     StoreCollector(const std::string &name, int stride, int ms,
                    std::vector<Stmt> &lets, std::vector<Stmt> &ss)
         : store_name(name), store_stride(stride), max_stores(ms),
-          let_stmts(lets), stores(ss), collecting(true) {
+          let_stmts(lets), stores(ss) {
     }
 
 private:
@@ -57,7 +57,7 @@ private:
         return op;
     }
 
-    bool collecting;
+    bool collecting = true;
     // These are lets that we've encountered since the last collected
     // store. If we collect another store, these "potential" lets
     // become lets used by the collected stores.

--- a/src/ExprUsesVar.h
+++ b/src/ExprUsesVar.h
@@ -87,10 +87,10 @@ class ExprUsesVars : public IRGraphVisitor {
 
 public:
     ExprUsesVars(const Scope<T> &v, const Scope<Expr> *s = nullptr)
-        : vars(v), result(false) {
+        : vars(v) {
         scope.set_containing_scope(s);
     }
-    bool result;
+    bool result = false;
 };
 
 /** Test if a statement or expression references or defines any of the

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2811,10 +2811,9 @@ Func::operator Stage() const {
 namespace {
 class CountImplicitVars : public Internal::IRGraphVisitor {
 public:
-    int count;
+    int count = 0;
 
-    CountImplicitVars(const vector<Expr> &exprs)
-        : count(0) {
+    CountImplicitVars(const vector<Expr> &exprs) {
         for (const auto &e : exprs) {
             e.accept(this);
         }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -129,8 +129,8 @@ class NormalizeDimensionality : public IRMutator {
     const ExtractBlockSize &block_size;
     const DeviceAPI device_api;
 
-    int depth;
-    int max_depth;
+    int depth = 0;
+    int max_depth = 0;
 
     Stmt wrap(Stmt s) {
         if (depth != 0) {
@@ -181,7 +181,7 @@ class NormalizeDimensionality : public IRMutator {
 
 public:
     NormalizeDimensionality(const ExtractBlockSize &e, DeviceAPI device_api)
-        : block_size(e), device_api(device_api), depth(0), max_depth(0) {
+        : block_size(e), device_api(device_api) {
     }
 };
 
@@ -293,9 +293,9 @@ public:
 private:
     map<string, SharedAllocation *> shared;
 
-    bool in_threads;
+    bool in_threads = false;
 
-    int barrier_stage;
+    int barrier_stage = 0;
 
     const DeviceAPI device_api;
 
@@ -1022,9 +1022,7 @@ public:
     }
 
     ExtractSharedAndHeapAllocations(DeviceAPI d)
-        : in_threads(false),
-          barrier_stage(0),
-          device_api(d),
+        : device_api(d),
           thread_id_var_name(unique_name('t')),
           num_threads_var_name(unique_name('t')),
           may_merge_allocs_of_different_type(device_api != DeviceAPI::OpenGLCompute &&
@@ -1201,7 +1199,7 @@ public:
 };
 
 class InjectThreadBarriers : public IRMutator {
-    bool in_threads, injected_barrier;
+    bool in_threads = false, injected_barrier;
 
     using IRMutator::visit;
 
@@ -1349,8 +1347,7 @@ class InjectThreadBarriers : public IRMutator {
 
 public:
     InjectThreadBarriers(ExtractSharedAndHeapAllocations &sha, ExtractRegisterAllocations &ra)
-        : in_threads(false),
-          block_allocs(sha),
+        : block_allocs(sha),
           register_allocs(ra) {
     }
 };

--- a/src/Introspection.cpp
+++ b/src/Introspection.cpp
@@ -62,7 +62,7 @@ typedef uint64_t llvm_offset_t;
 
 class DebugSections {
 
-    bool calibrated;
+    bool calibrated = false;
 
     struct FieldFormat {
         uint64_t name = 0, form = 0;
@@ -190,10 +190,9 @@ class DebugSections {
     vector<TypeInfo> types;
 
 public:
-    bool working;
+    bool working = false;
 
-    DebugSections(const std::string &binary)
-        : calibrated(false), working(false) {
+    DebugSections(const std::string &binary) {
         std::string binary_path = binary;
 #ifdef __APPLE__
         size_t last_slash = binary_path.rfind('/');

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -20,8 +20,6 @@
 #include "PythonExtensionGen.h"
 #include "StmtToHtml.h"
 
-using Halide::Internal::debug;
-
 namespace Halide {
 namespace Internal {
 

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -19,7 +19,7 @@ struct ParameterContents {
     const int dimensions;
     const std::string name;
     Buffer<> buffer;
-    uint64_t data;
+    uint64_t data = 0;
     int host_alignment;
     std::vector<BufferConstraint> buffer_constraints;
     Expr scalar_default, scalar_min, scalar_max, scalar_estimate;
@@ -27,7 +27,7 @@ struct ParameterContents {
     MemoryType memory_type = MemoryType::Auto;
 
     ParameterContents(Type t, bool b, int d, const std::string &n)
-        : type(t), dimensions(d), name(n), buffer(Buffer<>()), data(0),
+        : type(t), dimensions(d), name(n), buffer(Buffer<>()),
           host_alignment(t.bytes()), buffer_constraints(dimensions), is_buffer(b) {
         // stride_constraint[0] defaults to 1. This is important for
         // dense vectorization. You can unset it by setting it to a

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -227,9 +227,9 @@ class ExprUsesInvalidBuffers : public IRVisitor {
 
 public:
     ExprUsesInvalidBuffers(const Scope<> &buffers)
-        : invalid_buffers(buffers), invalid(false) {
+        : invalid_buffers(buffers) {
     }
-    bool invalid;
+    bool invalid = false;
 };
 
 /** Check if any references to buffers in an expression is invalid. */

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -32,13 +32,13 @@ namespace {
 class PrintLoopNest : public IRVisitor {
 public:
     PrintLoopNest(std::ostream &output, const map<string, Function> &e)
-        : out(output), env(e), indent(0) {
+        : out(output), env(e) {
     }
 
 private:
     std::ostream &out;
     const map<string, Function> &env;
-    int indent;
+    int indent = 0;
 
     Scope<Expr> constants;
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -901,9 +901,9 @@ class IsUsedInStmt : public IRVisitor {
     }
 
 public:
-    bool result;
+    bool result = false;
     explicit IsUsedInStmt(const Function &f)
-        : func(f.name()), result(false) {
+        : func(f.name()) {
     }
 };
 
@@ -925,10 +925,10 @@ class IsRealizedInStmt : public IRVisitor {
     }
 
 public:
-    bool result;
+    bool result = false;
 
     explicit IsRealizedInStmt(const Function &f)
-        : func(f.name()), result(false) {
+        : func(f.name()) {
     }
 };
 
@@ -942,11 +942,11 @@ bool function_is_already_realized_in_stmt(const Function &f, const Stmt &s) {
 class InjectStmt : public IRMutator {
 public:
     const Stmt &injected_stmt;
-    bool found_level;
+    bool found_level = false;
     const LoopLevel &level;
 
     InjectStmt(const Stmt &s, const LoopLevel &level)
-        : injected_stmt(s), found_level(false), level(level) {
+        : injected_stmt(s), level(level) {
     }
 
 private:
@@ -1811,10 +1811,10 @@ public:
         LoopLevel loop_level;
     };
     vector<Site> sites_allowed;
-    bool found;
+    bool found = false;
 
     ComputeLegalSchedules(Function f, const map<string, Function> &env)
-        : found(false), func(std::move(f)), env(env) {
+        : func(std::move(f)), env(env) {
     }
 
 private:

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -20,7 +20,7 @@ int Simplify::debug_indent = 0;
 #endif
 
 Simplify::Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemainder> *ai)
-    : remove_dead_code(r), no_float_simplify(false) {
+    : remove_dead_code(r) {
 
     // Only respect the constant bounds from the containing scope.
     for (auto iter = bi->cbegin(); iter != bi->cend(); ++iter) {

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -159,7 +159,7 @@ public:
 #endif
 
     bool remove_dead_code;
-    bool no_float_simplify;
+    bool no_float_simplify = false;
 
     HALIDE_ALWAYS_INLINE
     bool may_simplify(const Type &t) const {

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -45,17 +45,16 @@ public:
     PredicateFinder(const string &b, bool s)
         : predicate(const_false()),
           buffer(b),
-          varies(false),
-          treat_selects_as_guards(s),
-          in_produce(false) {
+
+          treat_selects_as_guards(s) {
     }
 
 private:
     using IRVisitor::visit;
     string buffer;
-    bool varies;
+    bool varies = false;
     bool treat_selects_as_guards;
-    bool in_produce;
+    bool in_produce = false;
     Scope<> varying;
     Scope<> in_pipeline;
     Scope<> local_buffers;
@@ -332,7 +331,7 @@ private:
 class StageSkipper : public IRMutator {
 public:
     StageSkipper(const string &f)
-        : func(f), in_vector_loop(false) {
+        : func(f) {
     }
 
 private:
@@ -340,7 +339,7 @@ private:
     using IRMutator::visit;
 
     Scope<> vector_vars;
-    bool in_vector_loop;
+    bool in_vector_loop = false;
 
     Stmt visit(const For *op) override {
         bool old_in_vector_loop = in_vector_loop;

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -50,11 +50,11 @@ class ExprDependsOnVar : public IRVisitor {
     }
 
 public:
-    bool result;
+    bool result = false;
     string var;
 
     ExprDependsOnVar(string v)
-        : result(false), var(std::move(v)) {
+        : var(std::move(v)) {
     }
 };
 

--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -35,7 +35,7 @@ bool no_overflow_int(Type t) {
 class SolveExpression : public IRMutator {
 public:
     SolveExpression(const string &v, const Scope<Expr> &es)
-        : failed(false), var(v), uses_var(false), external_scope(es) {
+        : var(v), external_scope(es) {
     }
 
     using IRMutator::mutate;
@@ -62,14 +62,14 @@ public:
     }
 
     // Has the solve failed.
-    bool failed;
+    bool failed = false;
 
 private:
     // The variable we're solving for.
     string var;
 
     // Whether or not the just-mutated expression uses the variable.
-    bool uses_var;
+    bool uses_var = false;
 
     // A cache of mutated results. Fortunately the mutator is
     // stateless, so we can cache everything.

--- a/src/StmtToHtml.cpp
+++ b/src/StmtToHtml.cpp
@@ -29,7 +29,7 @@ class StmtToHtml : public IRVisitor {
     static const std::string css, js;
 
     // This allows easier access to individual elements.
-    int id_count;
+    int id_count = 0;
 
 private:
     std::ofstream stream;
@@ -1000,7 +1000,7 @@ public:
     }
 
     StmtToHtml(const string &filename)
-        : id_count(0), context_stack(1, 0) {
+        : context_stack(1, 0) {
         stream.open(filename.c_str());
         stream << "<head>";
         stream << "<style type='text/css'>" << css << "</style>\n";

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -374,8 +374,8 @@ class PredicateLoadStore : public IRMutator {
     string var;
     Expr vector_predicate;
     int lanes;
-    bool valid;
-    bool vectorized;
+    bool valid = true;
+    bool vectorized = false;
 
     using IRMutator::visit;
 
@@ -461,7 +461,7 @@ class PredicateLoadStore : public IRMutator {
 
 public:
     PredicateLoadStore(string v, const Expr &vpred)
-        : var(std::move(v)), vector_predicate(vpred), lanes(vpred.type().lanes()), valid(true), vectorized(false) {
+        : var(std::move(v)), vector_predicate(vpred), lanes(vpred.type().lanes()) {
         internal_assert(lanes > 1);
     }
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1842,7 +1842,9 @@ void wasm_jit_malloc_callback(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
     size_t size = args[0]->Int32Value(context).ToChecked() + kExtraMallocSlop;
     wasm32_ptr_t p = v8_WasmMemoryObject_malloc(context, size);
-    if (p) { p += kExtraMallocSlop; }
+    if (p) {
+        p += kExtraMallocSlop;
+    }
     args.GetReturnValue().Set(load_scalar(context, p));
 }
 
@@ -1851,7 +1853,9 @@ void wasm_jit_free_callback(const v8::FunctionCallbackInfo<v8::Value> &args) {
     HandleScope scope(isolate);
     Local<Context> context = isolate->GetCurrentContext();
     wasm32_ptr_t p = args[0]->Int32Value(context).ToChecked();
-    if (p) { p -= kExtraMallocSlop; }
+    if (p) {
+        p -= kExtraMallocSlop;
+    }
     v8_WasmMemoryObject_free(context, p);
 }
 

--- a/src/autoschedulers/common/cmdline.h
+++ b/src/autoschedulers/common/cmdline.h
@@ -730,7 +730,7 @@ private:
         option_without_value(const std::string &name,
                              char short_name,
                              const std::string &desc)
-            : nam(name), snam(short_name), desc(desc), has(false) {
+            : nam(name), snam(short_name), desc(desc) {
         }
         ~option_without_value() override = default;
 
@@ -779,7 +779,7 @@ private:
         std::string nam;
         char snam;
         std::string desc;
-        bool has;
+        bool has = false;
     };
 
     template<class T>
@@ -790,7 +790,7 @@ private:
                           bool need,
                           const T &def,
                           const std::string &desc)
-            : nam(name), snam(short_name), need(need), has(false), def(def), actual(def) {
+            : nam(name), snam(short_name), need(need), def(def), actual(def) {
             this->desc = full_description(desc);
         }
         ~option_with_value() override = default;
@@ -868,7 +868,7 @@ private:
         bool need;
         std::string desc;
 
-        bool has;
+        bool has = false;
         T def;
         T actual;
     };

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -255,14 +255,12 @@ class Context {
     void *user_context;
 
 public:
-    CUcontext context;
-    int error;
+    CUcontext context = nullptr;
+    int error = CUDA_SUCCESS;
 
     // Constructor sets 'error' if any occurs.
     ALWAYS_INLINE Context(void *user_context)
-        : user_context(user_context),
-          context(nullptr),
-          error(CUDA_SUCCESS) {
+        : user_context(user_context) {
 #ifdef DEBUG_RUNTIME
         halide_start_clock(user_context);
 #endif

--- a/src/runtime/internal/block_allocator.h
+++ b/src/runtime/internal/block_allocator.h
@@ -188,7 +188,9 @@ MemoryRegion *BlockAllocator::reserve(void *user_context, const MemoryRequest &r
 void BlockAllocator::reclaim(void *user_context, MemoryRegion *memory_region) {
     halide_abort_if_false(user_context, memory_region != nullptr);
     RegionAllocator *allocator = RegionAllocator::find_allocator(user_context, memory_region);
-    if (allocator == nullptr) { return; }
+    if (allocator == nullptr) {
+        return;
+    }
     allocator->reclaim(user_context, memory_region);
 }
 
@@ -331,7 +333,9 @@ void BlockAllocator::destroy_region_allocator(void *user_context, RegionAllocato
                         << "user_context=" << (void *)(user_context) << " "
                         << "region_allocator=" << (void *)(region_allocator) << ")...\n";
 #endif
-    if (region_allocator == nullptr) { return; }
+    if (region_allocator == nullptr) {
+        return;
+    }
     RegionAllocator::destroy(user_context, region_allocator);
 }
 

--- a/src/runtime/internal/block_storage.h
+++ b/src/runtime/internal/block_storage.h
@@ -140,8 +140,12 @@ BlockStorage &BlockStorage::operator=(const BlockStorage &other) {
 }
 
 bool BlockStorage::operator==(const BlockStorage &other) const {
-    if (config.entry_size != other.config.entry_size) { return false; }
-    if (count != other.count) { return false; }
+    if (config.entry_size != other.config.entry_size) {
+        return false;
+    }
+    if (count != other.count) {
+        return false;
+    }
     return memcmp(this->ptr, other.ptr, this->size() * config.entry_size) == 0;
 }
 

--- a/src/runtime/internal/linked_list.h
+++ b/src/runtime/internal/linked_list.h
@@ -100,8 +100,12 @@ void LinkedList::initialize(void *user_context, uint32_t entry_size, uint32_t ca
 
 void LinkedList::destroy(void *user_context) {
     clear(nullptr);
-    if (link_arena) { MemoryArena::destroy(nullptr, link_arena); }
-    if (data_arena) { MemoryArena::destroy(nullptr, data_arena); }
+    if (link_arena) {
+        MemoryArena::destroy(nullptr, link_arena);
+    }
+    if (data_arena) {
+        MemoryArena::destroy(nullptr, data_arena);
+    }
     link_arena = nullptr;
     data_arena = nullptr;
     front_ptr = nullptr;

--- a/src/runtime/internal/pointer_table.h
+++ b/src/runtime/internal/pointer_table.h
@@ -74,7 +74,9 @@ PointerTable::PointerTable(void *user_context, size_t initial_capacity, const Sy
     : allocator(sma) {
     halide_abort_if_false(user_context, allocator.allocate != nullptr);
     halide_abort_if_false(user_context, allocator.deallocate != nullptr);
-    if (initial_capacity) { reserve(user_context, initial_capacity); }
+    if (initial_capacity) {
+        reserve(user_context, initial_capacity);
+    }
 }
 
 PointerTable::PointerTable(const PointerTable &other)
@@ -122,7 +124,9 @@ PointerTable &PointerTable::operator=(const PointerTable &other) {
 }
 
 bool PointerTable::operator==(const PointerTable &other) const {
-    if (count != other.count) { return false; }
+    if (count != other.count) {
+        return false;
+    }
     return memcmp(this->ptr, other.ptr, this->size() * sizeof(void *)) == 0;
 }
 

--- a/src/runtime/internal/region_allocator.h
+++ b/src/runtime/internal/region_allocator.h
@@ -214,7 +214,9 @@ BlockRegion *RegionAllocator::find_block_region(void *user_context, const Memory
 }
 
 bool RegionAllocator::can_coalesce(BlockRegion *block_region) {
-    if (block_region == nullptr) { return false; }
+    if (block_region == nullptr) {
+        return false;
+    }
     if (block_region->prev_ptr && (block_region->prev_ptr->status == AllocationStatus::Available)) {
         return true;
     }

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -10,15 +10,23 @@ namespace Internal {
 // Static utility functions for dealing with string data
 struct StringUtils {
     static bool is_empty(const char *str) {
-        if (str == nullptr) { return true; }
-        if (str[0] == '\0') { return true; }
+        if (str == nullptr) {
+            return true;
+        }
+        if (str[0] == '\0') {
+            return true;
+        }
         return false;
     }
 
     // count the number of delimited string tokens
     static size_t count_tokens(const char *str, const char *delim) {
-        if (StringUtils::is_empty(str)) { return 0; }
-        if (StringUtils::is_empty(delim)) { return 1; }  // no delim ... string is one token
+        if (StringUtils::is_empty(str)) {
+            return 0;
+        }
+        if (StringUtils::is_empty(delim)) {
+            return 1;
+        }  // no delim ... string is one token
 
         size_t count = 0;
         const char *ptr = str;
@@ -33,7 +41,9 @@ struct StringUtils {
 
     // retuns true if s1 contains s2 (within n characters)
     static bool contains(const char *s1, const char *s2, size_t n) {
-        if (is_empty(s2)) { return true; }  // s2 is empty ... return true to match strstr
+        if (is_empty(s2)) {
+            return true;
+        }  // s2 is empty ... return true to match strstr
         char starts_with = *s2;
         for (size_t length = strlen(s2); length <= n; n--, s1++) {
             if (*s1 == starts_with) {
@@ -105,7 +115,9 @@ private:
 
 StringStorage::StringStorage(void *user_context, uint32_t capacity, const SystemMemoryAllocatorFns &sma)
     : contents(user_context, {sizeof(char), 32, 32}, sma) {
-    if (capacity) { contents.reserve(user_context, capacity); }
+    if (capacity) {
+        contents.reserve(user_context, capacity);
+    }
 }
 
 StringStorage::~StringStorage() {
@@ -142,21 +154,29 @@ StringStorage &StringStorage::operator=(const StringStorage &other) {
 }
 
 bool StringStorage::contains(const char *str) const {
-    if (contents.empty()) { return false; }
+    if (contents.empty()) {
+        return false;
+    }
     const char *this_str = static_cast<const char *>(contents.data());
     return StringUtils::contains(this_str, str, contents.size());
 }
 
 bool StringStorage::contains(const StringStorage &other) const {
-    if (contents.empty()) { return false; }
-    if (other.contents.empty()) { return false; }
+    if (contents.empty()) {
+        return false;
+    }
+    if (other.contents.empty()) {
+        return false;
+    }
     const char *this_str = static_cast<const char *>(contents.data());
     const char *other_str = static_cast<const char *>(other.contents.data());
     return StringUtils::contains(this_str, other_str, contents.size());
 }
 
 bool StringStorage::operator==(const StringStorage &other) const {
-    if (contents.size() != other.contents.size()) { return false; }
+    if (contents.size() != other.contents.size()) {
+        return false;
+    }
     const char *this_str = static_cast<const char *>(contents.data());
     const char *other_str = static_cast<const char *>(other.contents.data());
     return strncmp(this_str, other_str, contents.size()) == 0;
@@ -180,16 +200,24 @@ void StringStorage::assign(void *user_context, char ch) {
 }
 
 void StringStorage::assign(void *user_context, const char *str, size_t length) {
-    if (StringUtils::is_empty(str)) { return; }
-    if (length == 0) { length = strlen(str); }
+    if (StringUtils::is_empty(str)) {
+        return;
+    }
+    if (length == 0) {
+        length = strlen(str);
+    }
     reserve(user_context, length);
     contents.replace(user_context, 0, str, length);
     terminate(user_context, length);
 }
 
 void StringStorage::append(void *user_context, const char *str, size_t length) {
-    if (StringUtils::is_empty(str)) { return; }
-    if (length == 0) { length = strlen(str); }
+    if (StringUtils::is_empty(str)) {
+        return;
+    }
+    if (length == 0) {
+        length = strlen(str);
+    }
     const size_t old_length = StringUtils::count_length(data(), contents.size());
     size_t new_length = old_length + length;
     reserve(user_context, new_length);
@@ -206,8 +234,12 @@ void StringStorage::append(void *user_context, char ch) {
 }
 
 void StringStorage::prepend(void *user_context, const char *str, size_t length) {
-    if (StringUtils::is_empty(str)) { return; }
-    if (length == 0) { length = strlen(str); }
+    if (StringUtils::is_empty(str)) {
+        return;
+    }
+    if (length == 0) {
+        length = strlen(str);
+    }
     const size_t old_length = StringUtils::count_length(data(), contents.size());
     size_t new_length = old_length + length;
     reserve(user_context, new_length);

--- a/src/runtime/internal/string_table.h
+++ b/src/runtime/internal/string_table.h
@@ -70,7 +70,9 @@ StringTable::StringTable(const SystemMemoryAllocatorFns &sma)
 StringTable::StringTable(void *user_context, size_t capacity, const SystemMemoryAllocatorFns &sma)
     : contents(user_context, capacity, sma),
       pointers(user_context, capacity, sma) {
-    if (capacity) { resize(user_context, capacity); }
+    if (capacity) {
+        resize(user_context, capacity);
+    }
 }
 
 StringTable::StringTable(void *user_context, const char **array, size_t count, const SystemMemoryAllocatorFns &sma)
@@ -128,7 +130,9 @@ void StringTable::fill(void *user_context, const char **array, size_t count) {
 }
 
 void StringTable::assign(void *user_context, size_t index, const char *str, size_t length) {
-    if (length == 0) { length = strlen(str); }
+    if (length == 0) {
+        length = strlen(str);
+    }
     if (index < contents.size()) {
         StringStorage *storage_ptr = static_cast<StringStorage *>(contents[index]);
         storage_ptr->assign(user_context, str, length);
@@ -151,12 +155,16 @@ void StringTable::prepend(void *user_context, const char *str, size_t length) {
 }
 
 size_t StringTable::parse(void *user_context, const char *str, const char *delim) {
-    if (StringUtils::is_empty(str)) { return 0; }
+    if (StringUtils::is_empty(str)) {
+        return 0;
+    }
 
     size_t delim_length = strlen(delim);
     size_t total_length = strlen(str);
     size_t entry_count = StringUtils::count_tokens(str, delim);
-    if (entry_count < 1) { return 0; }
+    if (entry_count < 1) {
+        return 0;
+    }
 
     resize(user_context, entry_count);
 
@@ -179,7 +187,9 @@ size_t StringTable::parse(void *user_context, const char *str, const char *delim
 }
 
 bool StringTable::contains(const char *str) const {
-    if (StringUtils::is_empty(str)) { return false; }
+    if (StringUtils::is_empty(str)) {
+        return false;
+    }
     for (size_t n = 0; n < contents.size(); ++n) {
         StringStorage *storage_ptr = static_cast<StringStorage *>(contents[n]);
         if (storage_ptr->contains(str)) {

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -252,16 +252,13 @@ class ClContext {
     void *user_context;
 
 public:
-    cl_context context;
-    cl_command_queue cmd_queue;
-    cl_int error_code;
+    cl_context context = nullptr;
+    cl_command_queue cmd_queue = nullptr;
+    cl_int error_code = CL_SUCCESS;
 
     // Constructor sets 'error_code' if any occurs.
     ALWAYS_INLINE ClContext(void *user_context)
-        : user_context(user_context),
-          context(nullptr),
-          cmd_queue(nullptr),
-          error_code(CL_SUCCESS) {
+        : user_context(user_context) {
         if (clCreateContext == nullptr) {
             load_libopencl(user_context);
         }

--- a/test/runtime/common.h
+++ b/test/runtime/common.h
@@ -41,7 +41,9 @@ void *allocate_system(void *user_context, size_t bytes) {
     constexpr size_t header_size = 2 * sizeof(size_t);
     size_t alloc_size = bytes + header_size + (alignment - 1);
     void *raw_ptr = malloc(alloc_size);
-    if (raw_ptr == nullptr) { return nullptr; }
+    if (raw_ptr == nullptr) {
+        return nullptr;
+    }
     void *aligned_ptr = align_up(raw_ptr, header_size, alignment);
     size_t aligned_offset = (size_t)((size_t)aligned_ptr - (size_t)raw_ptr);
     *((size_t *)aligned_ptr - 1) = aligned_offset;

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1755,7 +1755,7 @@ struct halide_tiff_header {
 template<typename ElemType, int BUFFER_SIZE = 1024>
 struct ElemWriter {
     ElemWriter(FileOpener *f)
-        : f(f), next(&buf[0]), ok(true) {
+        : f(f), next(&buf[0]) {
     }
     ~ElemWriter() {
         flush();
@@ -1788,7 +1788,7 @@ struct ElemWriter {
     FileOpener *const f;
     ElemType buf[BUFFER_SIZE];
     ElemType *next;
-    bool ok;
+    bool ok = true;
 };
 
 // Note that this is a fairly simpleminded TIFF writer that doesn't

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1755,7 +1755,7 @@ struct halide_tiff_header {
 template<typename ElemType, int BUFFER_SIZE = 1024>
 struct ElemWriter {
     ElemWriter(FileOpener *f)
-        : f(f), next(&buf[0]) {
+        : f(f) {
     }
     ~ElemWriter() {
         flush();
@@ -1787,7 +1787,7 @@ struct ElemWriter {
 
     FileOpener *const f;
     ElemType buf[BUFFER_SIZE];
-    ElemType *next;
+    ElemType *next = &buf[0];
     bool ok = true;
 };
 


### PR DESCRIPTION
With LLVM16 being branched off, that means we'll be dropping LLVM13 in the months ahead; this PR proposes to upgrade our required versions of clang-tidy and clang-format to those for LLVM14 (so that no one will have to build or install LLVM13 just for those).

The changes for clang-format are insignificant (it appears to be a bit more aggressive about fixing single-line if statements, which is good).

The changes for clang-tidy include an update to the `modernize-use-default-member-init` which I think is arguably a good thing, so I elected to leave it enabled and have clang-tidy fix it. Basically, it prefers that member variables that are inited to constant values do so using the `member = value;` style, rather than the old `ctor() : member(value){}` style, e.g.

```
struct A {
  A() : i(5) {}
  A(int i) : i(i) {}
  int i;
};

// becomes

struct A {
  A() {}
  A(int i) : i(i) {}
  int i = 5;
};
```
