### PR TITLE
[HVX] Fix state_var issue

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -128,6 +128,7 @@ bool function_takes_user_context(const std::string &name) {
         "halide_hexagon_initialize_kernels",
         "halide_hexagon_run",
         "halide_hexagon_device_release",
+        "halide_hexagon_get_module_state",
         "halide_hexagon_power_hvx_on",
         "halide_hexagon_power_hvx_on_mode",
         "halide_hexagon_power_hvx_on_perf",

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -695,12 +695,6 @@ class InjectHexagonRpc : public IRMutator {
 
     Module &device_code;
 
-    Expr state_var(const std::string &name, Type type) {
-        return Let::make(name, state_var_ptr(name, type),
-                         Load::make(type_of<void *>(), name, 0,
-                                    Buffer<>(), Parameter(), const_true(), ModulusRemainder()));
-    }
-
     Expr state_var_ptr(const std::string &name, Type type) {
         Expr &buf = state_bufs[name];
         if (!buf.defined()) {
@@ -712,7 +706,7 @@ class InjectHexagonRpc : public IRMutator {
     }
 
     Expr module_state() {
-        return state_var("hexagon_module_state", type_of<void *>());
+        return Call::make(type_of<void *>(), "halide_hexagon_get_module_state", {state_var_ptr("hexagon_module_state", type_of<void *>())}, Call::Extern);
     }
 
     Expr module_state_ptr() {

--- a/src/runtime/HalideRuntimeHexagonHost.h
+++ b/src/runtime/HalideRuntimeHexagonHost.h
@@ -51,7 +51,7 @@ extern void *halide_hexagon_get_device_handle(void *user_context, struct halide_
 extern uint64_t halide_hexagon_get_device_size(void *user_context, struct halide_buffer_t *buf);
 
 /** Return a pointer to the module_state. */
-extern void *halide_hexagon_get_module_state(void **host);
+extern void *halide_hexagon_get_module_state(void *user_context, void **host);
 
 /** Power HVX on and off. Calling a Halide pipeline will do this
  * automatically on each pipeline invocation; however, it costs a

--- a/src/runtime/HalideRuntimeHexagonHost.h
+++ b/src/runtime/HalideRuntimeHexagonHost.h
@@ -50,6 +50,9 @@ extern int halide_hexagon_detach_device_handle(void *user_context, struct halide
 extern void *halide_hexagon_get_device_handle(void *user_context, struct halide_buffer_t *buf);
 extern uint64_t halide_hexagon_get_device_size(void *user_context, struct halide_buffer_t *buf);
 
+/** Return a pointer to the module_state. */
+extern void *halide_hexagon_get_module_state(void **host);
+
 /** Power HVX on and off. Calling a Halide pipeline will do this
  * automatically on each pipeline invocation; however, it costs a
  * small but possibly significant amount of time for short running

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -755,10 +755,8 @@ WEAK uint64_t halide_hexagon_get_device_size(void *user_context, struct halide_b
     return handle->size;
 }
 
-WEAK void *halide_hexagon_get_module_state(void **host) {
-    if (host == nullptr) {
-        return nullptr;
-    }
+WEAK void *halide_hexagon_get_module_state(void *user_context, void **host) {
+    halide_abort_if_false(user_context, host != nullptr);
     return host[0];
 }
 

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -755,6 +755,13 @@ WEAK uint64_t halide_hexagon_get_device_size(void *user_context, struct halide_b
     return handle->size;
 }
 
+WEAK void *halide_hexagon_get_module_state(void **host) {
+    if (host == nullptr) {
+        return nullptr;
+    }
+    return host[0];
+}
+
 WEAK int halide_hexagon_device_and_host_malloc(void *user_context, struct halide_buffer_t *buf) {
     debug(user_context) << "halide_hexagon_device_and_host_malloc called.\n";
     int result = halide_hexagon_device_malloc(user_context, buf);

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -99,6 +99,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_hexagon_device_release,
     (void *)&halide_hexagon_get_device_handle,
     (void *)&halide_hexagon_get_device_size,
+    (void *)&halide_hexagon_get_module_state,
     (void *)&halide_hexagon_initialize_kernels,
     (void *)&halide_hexagon_finalize_kernels,
     (void *)&halide_hexagon_power_hvx_off,


### PR DESCRIPTION
The issue in #6893 is the result of an attempt to dereference a pointer to the module_state pointer. This PR simply adds a runtime method to dereference the pointer, in order to fix that issue. I'm not necessarily sure if this is the best approach, would love feedback from anyone who knows the HVX runtime better than I do.