### PR TITLE
Don't try to fold saturating_sub of VectorReduce

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2832,7 +2832,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         internal_assert(op->args.size() == 2);
 
         // Try to fold the vector reduce for a call to saturating_add
-        const bool folded = try_to_fold_vector_reduce<Call>(op->args[0], op->args[1]);
+        const bool folded = op->is_intrinsic(Call::saturating_add) && try_to_fold_vector_reduce<Call>(op->args[0], op->args[1]);
 
         if (!folded) {
             std::string intrin;


### PR DESCRIPTION
We should only try to fold the pattern:
```
saturating_add(x, VectorReduce(SaturatingAdd, y))
```
Currently, we also try to fold this pattern (incorrectly):
```
saturating_sub(x, VectorReduce(SaturatingAdd, y))
```

Fixes #6883 