### PR TITLE
Add `auto_schedule` label to Adams2019 and Li2018 tests in CMake

### DIFF
--- a/src/autoschedulers/adams2019/CMakeLists.txt
+++ b/src/autoschedulers/adams2019/CMakeLists.txt
@@ -68,7 +68,7 @@ add_test(NAME demo_apps_autoscheduler
 
 set_tests_properties(demo_apps_autoscheduler
                      PROPERTIES
-                     LABELS Adams2019
+                     LABELS "Adams2019;auto_schedule"
                      ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
 
 # =================================================================
@@ -89,7 +89,7 @@ add_test(NAME demo_included_schedule_file
 
 set_tests_properties(demo_included_schedule_file
                      PROPERTIES
-                     LABELS Adams2019
+                     LABELS "Adams2019;auto_schedule"
                      ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
 
 # ====================================================
@@ -112,10 +112,10 @@ if (BUILD_SHARED_LIBS)
     target_link_libraries(test_apps_autoscheduler PRIVATE Halide::Halide Halide::Tools ${CMAKE_DL_LIBS})
 
     add_test(NAME test_apps_autoscheduler
-             COMMAND test_apps_autoscheduler $<TARGET_FILE:Halide_Adams2019>)
+             COMMAND test_apps_autoscheduler $<TARGET_FILE:Halide_Adams2019> ${CMAKE_CURRENT_SOURCE_DIR}/baseline.weights)
 
     set_tests_properties(test_apps_autoscheduler PROPERTIES
-                         LABELS "Adams2019;multithreaded"
+                         LABELS "Adams2019;multithreaded;auto_schedule"
                          ENVIRONMENT "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:Halide_Adams2019>:$ENV{LD_LIBRARY_PATH};HL_TARGET=${Halide_TARGET}")
 endif ()
 
@@ -126,7 +126,7 @@ add_executable(test_perfect_hash_map test_perfect_hash_map.cpp)
 add_test(NAME test_perfect_hash_map COMMAND test_perfect_hash_map)
 set_tests_properties(test_perfect_hash_map
                      PROPERTIES
-                     LABELS Adams2019
+                     LABELS "Adams2019;auto_schedule"
                      ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
 
 ##
@@ -137,5 +137,5 @@ target_link_libraries(test_function_dag PRIVATE ASLog Halide::Halide Halide::Too
 add_test(NAME test_function_dag COMMAND test_function_dag)
 set_tests_properties(test_function_dag
                      PROPERTIES
-                     LABELS Adams2019
+                     LABELS "Adams2019;auto_schedule"
                      ENVIRONMENT "HL_TARGET=${Halide_TARGET}")

--- a/src/autoschedulers/li2018/CMakeLists.txt
+++ b/src/autoschedulers/li2018/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries(demo_gradient_autoscheduler PRIVATE demo_gradient Halide::
 add_test(NAME demo_gradient_autoscheduler
          COMMAND demo_gradient_autoscheduler --benchmarks=all --benchmark_min_time=1 --estimate_all)
 
-set_tests_properties(demo_gradient_autoscheduler PROPERTIES LABELS "Li2018;multithreaded")
+set_tests_properties(demo_gradient_autoscheduler PROPERTIES LABELS "Li2018;multithreaded;auto_schedule")
 
 ##
 
@@ -31,7 +31,7 @@ if (BUILD_SHARED_LIBS)
     add_test(NAME gradient_autoscheduler_test_cpp
              COMMAND gradient_autoscheduler_test_cpp $<TARGET_FILE:Halide_Li2018>)
 
-    set_tests_properties(gradient_autoscheduler_test_cpp PROPERTIES LABELS Li2018)
+    set_tests_properties(gradient_autoscheduler_test_cpp PROPERTIES LABELS "Li2018;auto_schedule")
 endif ()
 
 ##
@@ -60,7 +60,7 @@ if (WITH_PYTHON_BINDINGS)
         set(_PATH "$<SHELL_PATH:$<TARGET_FILE_DIR:Halide_Li2018>>;$<SHELL_PATH:$<TARGET_FILE_DIR:Halide::Halide>>;$ENV{PATH}")
         string(REPLACE ";" "${SEP}" _PATH "${_PATH}")
         set_tests_properties(gradient_autoscheduler_test_py PROPERTIES
-                             LABELS Li2018
+                             LABELS "Li2018;auto_schedule"
                              ENVIRONMENT "PYTHONPATH=${PYTHONPATH};PATH=${_PATH}")
     endif ()
 endif ()


### PR DESCRIPTION
These were ~never getting tested on the buildbots (and still aren't, I need to update it to run `auto_schedule` tests) but conceptually these tests should be in the same group as for Mullapudi.

Also, drive-by fix to broken test_apps_autoscheduler injected in https://github.com/halide/Halide/pull/6861.