### PR TITLE
Upgrade clang-format and clang-tidy to v14 (v2)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,11 @@ Checks: >
     modernize-make-unique,
     modernize-redundant-void-arg,
     modernize-use-bool-literals,
-    modernize-use-default-member-init,
+    # Disabled: there is not consensus on whether the Clang-14 behavior
+    # of this checker is always desirable or not, and there isn't currently
+    # a way to revert to the Clang-13 behavior. We may revisit this
+    # check the next time we examine clang-tidy options.
+    # modernize-use-default-member-init,
     modernize-use-emplace,
     modernize-use-equals-default,
     modernize-use-equals-delete,
@@ -54,7 +58,7 @@ Checks: >
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 FormatStyle: 'file'
-CheckOptions:
-    - key:   modernize-use-default-member-init.UseAssignment
-      value: 1
+#CheckOptions:
+#    - key:   modernize-use-default-member-init.UseAssignment
+#      value: 1
 ...

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.13
+      - uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: '.'
           extensions: 'h,c,cpp'
-          clangFormatVersion: 13
+          clangFormatVersion: 14
   check_clang_tidy:
     name: Check clang-tidy
     runs-on: ubuntu-20.04
@@ -30,14 +30,14 @@ jobs:
           # from apt.llvm.org
           # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
-          sudo apt-add-repository "deb https://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-13 main"
+          sudo apt-add-repository "deb https://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-14 main"
           sudo apt-get update
-          sudo apt-get install llvm-13 clang-13 liblld-13-dev libclang-13-dev clang-tidy-13 ninja-build
+          sudo apt-get install llvm-14 clang-14 liblld-14-dev libclang-14-dev clang-tidy-14 ninja-build
       - name: Run clang-tidy
         run: |
-          export CC=clang-13
-          export CXX=clang++-13
-          export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-13
+          export CC=clang-14
+          export CXX=clang++-14
+          export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-14
           ./run-clang-tidy.sh
   check_cmake_file_lists:
     name: Check CMake file lists

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -4,23 +4,23 @@ set -e
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# We are currently standardized on using LLVM/Clang13 for this script.
+# We are currently standardized on using LLVM/Clang14 for this script.
 # Note that this is totally independent of the version of LLVM that you
-# are using to build Halide itself. If you don't have LLVM13 installed,
+# are using to build Halide itself. If you don't have LLVM14 installed,
 # you can usually install what you need easily via:
 #
-# sudo apt-get install llvm-13 clang-13 libclang-13-dev clang-tidy-13
-# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-13
+# sudo apt-get install llvm-14 clang-14 libclang-14-dev clang-tidy-14
+# export CLANG_FORMAT_LLVM_INSTALL_DIR=/usr/lib/llvm-14
 
 [ -z "$CLANG_FORMAT_LLVM_INSTALL_DIR" ] && echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_FORMAT_LLVM_INSTALL_DIR = ${CLANG_FORMAT_LLVM_INSTALL_DIR}
 
 VERSION=$(${CLANG_FORMAT_LLVM_INSTALL_DIR}/bin/clang-format --version)
-if [[ ${VERSION} =~ .*version\ 13.* ]]
+if [[ ${VERSION} =~ .*version\ 14.* ]]
 then
-    echo "clang-format version 13 found."
+    echo "clang-format version 14 found."
 else
-    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 13 install!"
+    echo "CLANG_FORMAT_LLVM_INSTALL_DIR must point to an LLVM 14 install!"
     exit 1
 fi
 

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -8,23 +8,23 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 FIX=$1
 
-# We are currently standardized on using LLVM/Clang12 for this script.
+# We are currently standardized on using LLVM/Clang14 for this script.
 # Note that this is totally independent of the version of LLVM that you
-# are using to build Halide itself. If you don't have LLVM12 installed,
+# are using to build Halide itself. If you don't have LLVM14 installed,
 # you can usually install what you need easily via:
 #
-# sudo apt-get install llvm-13 clang-13 libclang-13-dev clang-tidy-13
-# export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-13
+# sudo apt-get install llvm-14 clang-14 libclang-14-dev clang-tidy-14
+# export CLANG_TIDY_LLVM_INSTALL_DIR=/usr/lib/llvm-14
 
 [ -z "$CLANG_TIDY_LLVM_INSTALL_DIR" ] && echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM installation dir for this script." && exit
 echo CLANG_TIDY_LLVM_INSTALL_DIR = ${CLANG_TIDY_LLVM_INSTALL_DIR}
 
 VERSION=$(${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-tidy --version)
-if [[ ${VERSION} =~ .*version\ 13.* ]]
+if [[ ${VERSION} =~ .*version\ 14.* ]]
 then
-    echo "clang-tidy version 13 found."
+    echo "clang-tidy version 14 found."
 else
-    echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM 13 install!"
+    echo "CLANG_TIDY_LLVM_INSTALL_DIR must point to an LLVM 14 install!"
     exit 1
 fi
 

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -860,7 +860,7 @@ public:
 
         // Do any pure inlining (TODO: This is currently slow)
         for (size_t i = f.size(); i > 0; i--) {
-            Function func = f[i - 1];
+            const Function &func = f[i - 1];
             if (inlined[i - 1]) {
                 for (auto &s : stages) {
                     for (auto &cond_val : s.exprs) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -20,8 +20,6 @@
 #include "PythonExtensionGen.h"
 #include "StmtToHtml.h"
 
-using Halide::Internal::debug;
-
 namespace Halide {
 namespace Internal {
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1842,7 +1842,9 @@ void wasm_jit_malloc_callback(const v8::FunctionCallbackInfo<v8::Value> &args) {
 
     size_t size = args[0]->Int32Value(context).ToChecked() + kExtraMallocSlop;
     wasm32_ptr_t p = v8_WasmMemoryObject_malloc(context, size);
-    if (p) { p += kExtraMallocSlop; }
+    if (p) {
+        p += kExtraMallocSlop;
+    }
     args.GetReturnValue().Set(load_scalar(context, p));
 }
 
@@ -1851,7 +1853,9 @@ void wasm_jit_free_callback(const v8::FunctionCallbackInfo<v8::Value> &args) {
     HandleScope scope(isolate);
     Local<Context> context = isolate->GetCurrentContext();
     wasm32_ptr_t p = args[0]->Int32Value(context).ToChecked();
-    if (p) { p -= kExtraMallocSlop; }
+    if (p) {
+        p -= kExtraMallocSlop;
+    }
     v8_WasmMemoryObject_free(context, p);
 }
 

--- a/src/runtime/internal/block_allocator.h
+++ b/src/runtime/internal/block_allocator.h
@@ -188,7 +188,9 @@ MemoryRegion *BlockAllocator::reserve(void *user_context, const MemoryRequest &r
 void BlockAllocator::reclaim(void *user_context, MemoryRegion *memory_region) {
     halide_abort_if_false(user_context, memory_region != nullptr);
     RegionAllocator *allocator = RegionAllocator::find_allocator(user_context, memory_region);
-    if (allocator == nullptr) { return; }
+    if (allocator == nullptr) {
+        return;
+    }
     allocator->reclaim(user_context, memory_region);
 }
 
@@ -331,7 +333,9 @@ void BlockAllocator::destroy_region_allocator(void *user_context, RegionAllocato
                         << "user_context=" << (void *)(user_context) << " "
                         << "region_allocator=" << (void *)(region_allocator) << ")...\n";
 #endif
-    if (region_allocator == nullptr) { return; }
+    if (region_allocator == nullptr) {
+        return;
+    }
     RegionAllocator::destroy(user_context, region_allocator);
 }
 

--- a/src/runtime/internal/block_storage.h
+++ b/src/runtime/internal/block_storage.h
@@ -140,8 +140,12 @@ BlockStorage &BlockStorage::operator=(const BlockStorage &other) {
 }
 
 bool BlockStorage::operator==(const BlockStorage &other) const {
-    if (config.entry_size != other.config.entry_size) { return false; }
-    if (count != other.count) { return false; }
+    if (config.entry_size != other.config.entry_size) {
+        return false;
+    }
+    if (count != other.count) {
+        return false;
+    }
     return memcmp(this->ptr, other.ptr, this->size() * config.entry_size) == 0;
 }
 

--- a/src/runtime/internal/linked_list.h
+++ b/src/runtime/internal/linked_list.h
@@ -100,8 +100,12 @@ void LinkedList::initialize(void *user_context, uint32_t entry_size, uint32_t ca
 
 void LinkedList::destroy(void *user_context) {
     clear(nullptr);
-    if (link_arena) { MemoryArena::destroy(nullptr, link_arena); }
-    if (data_arena) { MemoryArena::destroy(nullptr, data_arena); }
+    if (link_arena) {
+        MemoryArena::destroy(nullptr, link_arena);
+    }
+    if (data_arena) {
+        MemoryArena::destroy(nullptr, data_arena);
+    }
     link_arena = nullptr;
     data_arena = nullptr;
     front_ptr = nullptr;

--- a/src/runtime/internal/pointer_table.h
+++ b/src/runtime/internal/pointer_table.h
@@ -74,7 +74,9 @@ PointerTable::PointerTable(void *user_context, size_t initial_capacity, const Sy
     : allocator(sma) {
     halide_abort_if_false(user_context, allocator.allocate != nullptr);
     halide_abort_if_false(user_context, allocator.deallocate != nullptr);
-    if (initial_capacity) { reserve(user_context, initial_capacity); }
+    if (initial_capacity) {
+        reserve(user_context, initial_capacity);
+    }
 }
 
 PointerTable::PointerTable(const PointerTable &other)
@@ -122,7 +124,9 @@ PointerTable &PointerTable::operator=(const PointerTable &other) {
 }
 
 bool PointerTable::operator==(const PointerTable &other) const {
-    if (count != other.count) { return false; }
+    if (count != other.count) {
+        return false;
+    }
     return memcmp(this->ptr, other.ptr, this->size() * sizeof(void *)) == 0;
 }
 

--- a/src/runtime/internal/region_allocator.h
+++ b/src/runtime/internal/region_allocator.h
@@ -214,7 +214,9 @@ BlockRegion *RegionAllocator::find_block_region(void *user_context, const Memory
 }
 
 bool RegionAllocator::can_coalesce(BlockRegion *block_region) {
-    if (block_region == nullptr) { return false; }
+    if (block_region == nullptr) {
+        return false;
+    }
     if (block_region->prev_ptr && (block_region->prev_ptr->status == AllocationStatus::Available)) {
         return true;
     }

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -10,15 +10,23 @@ namespace Internal {
 // Static utility functions for dealing with string data
 struct StringUtils {
     static bool is_empty(const char *str) {
-        if (str == nullptr) { return true; }
-        if (str[0] == '\0') { return true; }
+        if (str == nullptr) {
+            return true;
+        }
+        if (str[0] == '\0') {
+            return true;
+        }
         return false;
     }
 
     // count the number of delimited string tokens
     static size_t count_tokens(const char *str, const char *delim) {
-        if (StringUtils::is_empty(str)) { return 0; }
-        if (StringUtils::is_empty(delim)) { return 1; }  // no delim ... string is one token
+        if (StringUtils::is_empty(str)) {
+            return 0;
+        }
+        if (StringUtils::is_empty(delim)) {
+            return 1;
+        }  // no delim ... string is one token
 
         size_t count = 0;
         const char *ptr = str;
@@ -33,7 +41,9 @@ struct StringUtils {
 
     // retuns true if s1 contains s2 (within n characters)
     static bool contains(const char *s1, const char *s2, size_t n) {
-        if (is_empty(s2)) { return true; }  // s2 is empty ... return true to match strstr
+        if (is_empty(s2)) {
+            return true;
+        }  // s2 is empty ... return true to match strstr
         char starts_with = *s2;
         for (size_t length = strlen(s2); length <= n; n--, s1++) {
             if (*s1 == starts_with) {
@@ -105,7 +115,9 @@ private:
 
 StringStorage::StringStorage(void *user_context, uint32_t capacity, const SystemMemoryAllocatorFns &sma)
     : contents(user_context, {sizeof(char), 32, 32}, sma) {
-    if (capacity) { contents.reserve(user_context, capacity); }
+    if (capacity) {
+        contents.reserve(user_context, capacity);
+    }
 }
 
 StringStorage::~StringStorage() {
@@ -142,21 +154,29 @@ StringStorage &StringStorage::operator=(const StringStorage &other) {
 }
 
 bool StringStorage::contains(const char *str) const {
-    if (contents.empty()) { return false; }
+    if (contents.empty()) {
+        return false;
+    }
     const char *this_str = static_cast<const char *>(contents.data());
     return StringUtils::contains(this_str, str, contents.size());
 }
 
 bool StringStorage::contains(const StringStorage &other) const {
-    if (contents.empty()) { return false; }
-    if (other.contents.empty()) { return false; }
+    if (contents.empty()) {
+        return false;
+    }
+    if (other.contents.empty()) {
+        return false;
+    }
     const char *this_str = static_cast<const char *>(contents.data());
     const char *other_str = static_cast<const char *>(other.contents.data());
     return StringUtils::contains(this_str, other_str, contents.size());
 }
 
 bool StringStorage::operator==(const StringStorage &other) const {
-    if (contents.size() != other.contents.size()) { return false; }
+    if (contents.size() != other.contents.size()) {
+        return false;
+    }
     const char *this_str = static_cast<const char *>(contents.data());
     const char *other_str = static_cast<const char *>(other.contents.data());
     return strncmp(this_str, other_str, contents.size()) == 0;
@@ -180,16 +200,24 @@ void StringStorage::assign(void *user_context, char ch) {
 }
 
 void StringStorage::assign(void *user_context, const char *str, size_t length) {
-    if (StringUtils::is_empty(str)) { return; }
-    if (length == 0) { length = strlen(str); }
+    if (StringUtils::is_empty(str)) {
+        return;
+    }
+    if (length == 0) {
+        length = strlen(str);
+    }
     reserve(user_context, length);
     contents.replace(user_context, 0, str, length);
     terminate(user_context, length);
 }
 
 void StringStorage::append(void *user_context, const char *str, size_t length) {
-    if (StringUtils::is_empty(str)) { return; }
-    if (length == 0) { length = strlen(str); }
+    if (StringUtils::is_empty(str)) {
+        return;
+    }
+    if (length == 0) {
+        length = strlen(str);
+    }
     const size_t old_length = StringUtils::count_length(data(), contents.size());
     size_t new_length = old_length + length;
     reserve(user_context, new_length);
@@ -206,8 +234,12 @@ void StringStorage::append(void *user_context, char ch) {
 }
 
 void StringStorage::prepend(void *user_context, const char *str, size_t length) {
-    if (StringUtils::is_empty(str)) { return; }
-    if (length == 0) { length = strlen(str); }
+    if (StringUtils::is_empty(str)) {
+        return;
+    }
+    if (length == 0) {
+        length = strlen(str);
+    }
     const size_t old_length = StringUtils::count_length(data(), contents.size());
     size_t new_length = old_length + length;
     reserve(user_context, new_length);

--- a/src/runtime/internal/string_table.h
+++ b/src/runtime/internal/string_table.h
@@ -70,7 +70,9 @@ StringTable::StringTable(const SystemMemoryAllocatorFns &sma)
 StringTable::StringTable(void *user_context, size_t capacity, const SystemMemoryAllocatorFns &sma)
     : contents(user_context, capacity, sma),
       pointers(user_context, capacity, sma) {
-    if (capacity) { resize(user_context, capacity); }
+    if (capacity) {
+        resize(user_context, capacity);
+    }
 }
 
 StringTable::StringTable(void *user_context, const char **array, size_t count, const SystemMemoryAllocatorFns &sma)
@@ -128,7 +130,9 @@ void StringTable::fill(void *user_context, const char **array, size_t count) {
 }
 
 void StringTable::assign(void *user_context, size_t index, const char *str, size_t length) {
-    if (length == 0) { length = strlen(str); }
+    if (length == 0) {
+        length = strlen(str);
+    }
     if (index < contents.size()) {
         StringStorage *storage_ptr = static_cast<StringStorage *>(contents[index]);
         storage_ptr->assign(user_context, str, length);
@@ -151,12 +155,16 @@ void StringTable::prepend(void *user_context, const char *str, size_t length) {
 }
 
 size_t StringTable::parse(void *user_context, const char *str, const char *delim) {
-    if (StringUtils::is_empty(str)) { return 0; }
+    if (StringUtils::is_empty(str)) {
+        return 0;
+    }
 
     size_t delim_length = strlen(delim);
     size_t total_length = strlen(str);
     size_t entry_count = StringUtils::count_tokens(str, delim);
-    if (entry_count < 1) { return 0; }
+    if (entry_count < 1) {
+        return 0;
+    }
 
     resize(user_context, entry_count);
 
@@ -179,7 +187,9 @@ size_t StringTable::parse(void *user_context, const char *str, const char *delim
 }
 
 bool StringTable::contains(const char *str) const {
-    if (StringUtils::is_empty(str)) { return false; }
+    if (StringUtils::is_empty(str)) {
+        return false;
+    }
     for (size_t n = 0; n < contents.size(); ++n) {
         StringStorage *storage_ptr = static_cast<StringStorage *>(contents[n]);
         if (storage_ptr->contains(str)) {

--- a/test/runtime/common.h
+++ b/test/runtime/common.h
@@ -41,7 +41,9 @@ void *allocate_system(void *user_context, size_t bytes) {
     constexpr size_t header_size = 2 * sizeof(size_t);
     size_t alloc_size = bytes + header_size + (alignment - 1);
     void *raw_ptr = malloc(alloc_size);
-    if (raw_ptr == nullptr) { return nullptr; }
+    if (raw_ptr == nullptr) {
+        return nullptr;
+    }
     void *aligned_ptr = align_up(raw_ptr, header_size, alignment);
     size_t aligned_offset = (size_t)((size_t)aligned_ptr - (size_t)raw_ptr);
     *((size_t *)aligned_ptr - 1) = aligned_offset;


### PR DESCRIPTION
With LLVM16 being branched off, that means we'll be dropping LLVM13 in the months ahead; this PR proposes to upgrade our required versions of clang-tidy and clang-format to those for LLVM14 (so that no one will have to build or install LLVM13 just for those).

The changes for clang-format are insignificant (it appears to be a bit more aggressive about fixing single-line if statements, which is good).

The changes for clang-tidy are mostly irrelevant, except for changes to `modernize-use-default-member-init` which don't have immediate consensus -- this PR disables that check for now, pending further consideration/investigation. (See https://github.com/halide/Halide/pull/6891 for discussion)