### PR TITLE
Ensure autoscheduler plugins are built with -rdynamic or equiv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1903,6 +1903,14 @@ correctness_opencl_runtime: $(BIN_DIR)/$(TARGET)/correctness_opencl_runtime
 	cd $(TMP_DIR) ; $(CURDIR)/$<
 	@-echo
 
+correctness_load_plugin: $(BIN_DIR)/correctness_load_plugin autoschedulers
+	@-mkdir -p $(TMP_DIR)
+	cd $(TMP_DIR) ; $(CURDIR)/$< \
+		$(ROOT_DIR)/$(DISTRIB_DIR)/lib/libautoschedule_adams2019.$(SHARED_EXT) \
+		$(ROOT_DIR)/$(DISTRIB_DIR)/lib/libautoschedule_li2018.$(SHARED_EXT) \
+		$(ROOT_DIR)/$(DISTRIB_DIR)/lib/libautoschedule_mullapudi2016.$(SHARED_EXT)
+	@-echo
+
 quiet_correctness_%: $(BIN_DIR)/correctness_%
 	@-mkdir -p $(TMP_DIR)
 	@cd $(TMP_DIR) ; ( $(CURDIR)/$< 2>stderr_$*.txt > stdout_$*.txt && echo -n . ) || ( echo ; echo FAILED TEST: $* ; cat stdout_$*.txt stderr_$*.txt ; false )

--- a/Makefile
+++ b/Makefile
@@ -1915,6 +1915,15 @@ quiet_correctness_%: $(BIN_DIR)/correctness_%
 	@-mkdir -p $(TMP_DIR)
 	@cd $(TMP_DIR) ; ( $(CURDIR)/$< 2>stderr_$*.txt > stdout_$*.txt && echo -n . ) || ( echo ; echo FAILED TEST: $* ; cat stdout_$*.txt stderr_$*.txt ; false )
 
+quiet_correctness_load_plugin: $(BIN_DIR)/correctness_load_plugin autoschedulers
+	@-mkdir -p $(TMP_DIR)
+	@cd $(TMP_DIR) ; ( $(CURDIR)/$< \
+		$(ROOT_DIR)/$(DISTRIB_DIR)/lib/libautoschedule_adams2019.$(SHARED_EXT) \
+		$(ROOT_DIR)/$(DISTRIB_DIR)/lib/libautoschedule_li2018.$(SHARED_EXT) \
+		$(ROOT_DIR)/$(DISTRIB_DIR)/lib/libautoschedule_mullapudi2016.$(SHARED_EXT) \
+		2>stderr_$*.txt > stdout_$*.txt && echo -n . ) || ( echo ; echo FAILED TEST: $* ; cat stdout_$*.txt stderr_$*.txt ; false )
+	@-echo
+
 valgrind_%: $(BIN_DIR)/correctness_%
 	@-mkdir -p $(TMP_DIR)
 	cd $(TMP_DIR) ; valgrind --error-exitcode=-1 $(CURDIR)/$<

--- a/src/autoschedulers/adams2019/Makefile
+++ b/src/autoschedulers/adams2019/Makefile
@@ -77,7 +77,6 @@ $(BIN)/libautoschedule_adams2019.$(SHARED_EXT): $(SRC)/AutoSchedule.cpp \
 				$(SRC)/PerfectHashMap.h \
 				$(AUTOSCHED_WEIGHT_OBJECTS) \
 				$(AUTOSCHED_COST_MODEL_LIBS) \
-				$(GENERATOR_DEPS) \
 				$(BIN)/auto_schedule_runtime.a
 	@mkdir -p $(@D)
 	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) -I $(BIN)/cost_model $(filter-out %.h $(LIBHALIDE_LDFLAGS),$^) -o $@ $(HALIDE_SYSTEM_LIBS) $(HALIDE_RPATH_FOR_LIB)

--- a/src/autoschedulers/common/CMakeLists.txt
+++ b/src/autoschedulers/common/CMakeLists.txt
@@ -1,7 +1,14 @@
 add_library(Halide_Plugin INTERFACE)
 add_library(Halide::Plugin ALIAS Halide_Plugin)
 target_include_directories(Halide_Plugin INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
 target_link_libraries(Halide_Plugin INTERFACE Halide::Halide)
+# It's important to use dynamic lookups for undefined symbols here: all of libHalide
+# is expected to be present (in the loading binary), so we explicitly make the symbols
+# undefined rather than dependent on libHalide.so.
+target_link_options(Halide_Plugin INTERFACE
+                    $<$<PLATFORM_ID:Linux>:-rdynamic>
+                    $<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>)
 
 add_library(ASLog STATIC ASLog.cpp)
 target_include_directories(ASLog PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/src/autoschedulers/li2018/Makefile
+++ b/src/autoschedulers/li2018/Makefile
@@ -18,7 +18,10 @@ else
 HALIDE_RPATH_FOR_LIB += '-Wl,-rpath,$$ORIGIN'
 endif
 
-$(BIN)/libautoschedule_li2018.$(SHARED_EXT): $(SRC)/GradientAutoscheduler.cpp $(LIB_HALIDE)
+# It's important to use dynamic lookups for undefined symbols here: all of libHalide
+# is expected to be present (in the loading binary), so we explicitly make the symbols
+# undefined rather than dependent on libHalide.so.
+$(BIN)/libautoschedule_li2018.$(SHARED_EXT): $(SRC)/GradientAutoscheduler.cpp
 	@mkdir -p $(@D)
 	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) $^ -o $@ $(HALIDE_SYSTEM_LIBS) $(HALIDE_RPATH_FOR_LIB)
 

--- a/src/autoschedulers/mullapudi2016/Makefile
+++ b/src/autoschedulers/mullapudi2016/Makefile
@@ -15,6 +15,9 @@ endif
 
 CXXFLAGS += -I$(COMMON_DIR)
 
-$(BIN)/libautoschedule_mullapudi2016.$(SHARED_EXT): $(SRC)/AutoSchedule.cpp $(LIB_HALIDE)
+# It's important to use dynamic lookups for undefined symbols here: all of libHalide
+# is expected to be present (in the loading binary), so we explicitly make the symbols
+# undefined rather than dependent on libHalide.so.
+$(BIN)/libautoschedule_mullapudi2016.$(SHARED_EXT): $(SRC)/AutoSchedule.cpp
 	@mkdir -p $(@D)
 	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) $^ -o $@ $(HALIDE_RPATH_FOR_LIB)

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -371,6 +371,13 @@ tests(GROUPS correctness multithreaded
       unroll_huge_mux.cpp
       )
 
+tests(GROUPS correctness
+      SOURCES
+      load_plugin.cpp
+      ARGS "$<TARGET_FILE:Halide::Adams2019>" "$<TARGET_FILE:Halide::Li2018>" "$<TARGET_FILE:Halide::Mullapudi2016>"
+      )
+add_dependencies(correctness_load_plugin Halide::Adams2019 Halide::Li2018 Halide::Mullapudi2016)
+
 # Make sure the test that needs image_io has it
 target_link_libraries(correctness_image_io PRIVATE Halide::ImageIO)
 

--- a/test/correctness/load_plugin.cpp
+++ b/test/correctness/load_plugin.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
     // Use a fixed target for the analysis to get consistent results from this test.
     Target target("x86-64-linux-sse41-avx-avx2");
 
-    const char* autoscheduler_names[3] = {
+    const char *autoscheduler_names[3] = {
         "Adams2019",
         "Li2018",
         "Mullapudi2016",
@@ -30,8 +30,8 @@ int main(int argc, char **argv) {
         f.set_estimates({{0, 256}, {0, 256}});
         Pipeline p(f);
 
-        printf("Loading: %s\n", argv[i+1]);
-        load_plugin(argv[i+1]);
+        printf("Loading: %s\n", argv[i + 1]);
+        load_plugin(argv[i + 1]);
 
         p.apply_autoscheduler(target, {autoscheduler_names[i], {}});
     }

--- a/test/correctness/load_plugin.cpp
+++ b/test/correctness/load_plugin.cpp
@@ -1,0 +1,41 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        fprintf(stderr, "Usage: %s path-to-adams2019 path-to-li2018 path-to-mullapudi2016\n", argv[0]);
+        exit(-1);
+    }
+
+    // Use a fixed target for the analysis to get consistent results from this test.
+    Target target("x86-64-linux-sse41-avx-avx2");
+
+    const char* autoscheduler_names[3] = {
+        "Adams2019",
+        "Li2018",
+        "Mullapudi2016",
+    };
+
+    // The entire point of this test is to ensure that plugins are built with the equivalent
+    // of -rdynamic linking vs libHalide (i.e., they will never attempt to load their own copies).
+    // Failure to do so can end up with the plugin's libHalide having a separate set of global vars,
+    // meaning that the global list of available autoschedulers is never set in the 'host' libHalide,
+    // so calls to apply_autoscheduler() would fail in that case.
+    for (int i = 0; i < 3; i++) {
+        Func f("f");
+        Var x("x"), y("y");
+        f(x, y) = x + y;
+        f.set_estimates({{0, 256}, {0, 256}});
+        Pipeline p(f);
+
+        printf("Loading: %s\n", argv[i+1]);
+        load_plugin(argv[i+1]);
+
+        p.apply_autoscheduler(target, {autoscheduler_names[i], {}});
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Autoscheduler plugins are supposed to be built with `-rdynamic` or the equivalent, so that they never attempt to load any libraries to resolve symbols. However:
- Our Make builds used the right flags, but also included libHalide in the linker path, so we could end up with it loaded if you had things configured the right (wrong?) way; this could end up with the plugin registering itself in a 'captive' libHalide with its own globals. Oops.
- Our CMake build never attempted to set these flags at all.

Note that (AFAICT) this isn't an issue on Windows, where `-rdynamic` behavior is more of the default.