### PR TITLE
[Codegen_LLVM] Arguments/Loads/Returns are well-defined

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -711,6 +711,16 @@ void set_function_attributes_from_halide_target_options(llvm::Function &fn) {
     // But asserts and external calls *might* abort.
     fn.setMustProgress();
 
+    // All parameters and return values are well-defined,
+    // do not have any undef bits, and are not poison in execution.
+    if (!fn.getReturnType()->isVoidTy())
+        fn.addRetAttr(Attribute::NoUndef);
+    for (Argument &A : fn.args()) {
+        if (!A.hasAttribute(Attribute::ImmArg)) {
+            A.addAttr(Attribute::NoUndef);
+        }
+    }
+
     // Turn off approximate reciprocals for division. It's too
     // inaccurate even for us.
     fn.addFnAttr("reciprocal-estimates", "none");

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -19,7 +19,7 @@ namespace llvm {
 class ConstantFolder;
 class ElementCount;
 class Function;
-class IRBuilderDefaultInserter;
+class IRBuilderCallbackInserter;
 class LLVMContext;
 class Module;
 class StructType;

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -12,7 +12,7 @@ class Value;
 class Module;
 class Function;
 class FunctionType;
-class IRBuilderDefaultInserter;
+class IRBuilderCallbackInserter;
 class ConstantFolder;
 template<typename, typename>
 class IRBuilder;
@@ -159,7 +159,10 @@ protected:
     std::unique_ptr<llvm::Module> module;
     llvm::Function *function;
     llvm::LLVMContext *context;
-    llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderDefaultInserter> *builder;
+    using IRBuilderTy =
+        llvm::IRBuilder<llvm::ConstantFolder, llvm::IRBuilderCallbackInserter>;
+    static void irbuilder_inserter_callback(llvm::Instruction *I);
+    IRBuilderTy *builder;
     llvm::Value *value;
     llvm::MDNode *very_likely_branch;
     llvm::MDNode *default_fp_math_md;


### PR DESCRIPTION
https://llvm.org/docs/LangRef.html#well-defined-values:
```
Given a program execution, a value is well defined if the value
does not have an undef bit and is not poison in the execution.
An aggregate value or vector is well defined if its elements
are well defined. The padding of an aggregate isn’t considered,
since it isn’t visible without storing it into memory and
loading it with a different type.
```

Same story as with https://github.com/halide/Halide/pull/6897,
this matches //my// understanding of Halide's semantics,
but this may very well not be what the reality is.
(@alexreinking/@abadams ?)

To be noted, even //if// this is correct, i do believe
this has a very high chance to cause issues.
I'm also not sure how this plays with MSan.

Notably, while annotating function arguments/return is trivial,
for load's this only annotates the `load` instructions that we
actually create, i.e. it misses loads in the IR that we precompiled
and then link into our module.