### PR TITLE
Fix bug when realize condition depends on tuple call

### DIFF
--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -69,10 +69,11 @@ class SplitTuples : public IRMutator {
         if (op->types.size() > 1) {
             // Make a nested set of realize nodes for each tuple element
             Stmt body = mutate(op->body);
+            Expr condition = mutate(op->condition);
             for (int i = (int)op->types.size() - 1; i >= 0; i--) {
                 body = Realize::make(op->name + "." + std::to_string(i),
                                      {op->types[i]}, op->memory_type,
-                                     op->bounds, op->condition, body);
+                                     op->bounds, condition, body);
             }
             return body;
         } else {

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -239,6 +239,7 @@ tests(GROUPS correctness
       pseudostack_shares_slots.cpp
       python_extension_gen.cpp
       pytorch.cpp
+      realize_condition_depends_on_tuple.cpp
       realize_larger_than_two_gigs.cpp
       realize_over_shifted_domain.cpp
       reduction_chain.cpp

--- a/test/correctness/realize_condition_depends_on_tuple.cpp
+++ b/test/correctness/realize_condition_depends_on_tuple.cpp
@@ -1,0 +1,31 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+// This is a test for a bug where the condition on a realize node didn't have
+// tuple-valued calls resolved if the realization was itself tuple-valued.
+
+int main(int argc, char **argv) {
+    Func f;
+    Param<int> p;
+    f() = {p, p};
+
+    Func g;
+    g() = {4, 4};
+
+    Func h;
+    h() = g()[1];
+
+    // h may or may not be necessary to evaluate, depending on a load from f,
+    // which means g in turn may or may not be necessary to allocate.
+    Func out;
+    out() = select(f()[1] == 3, h(), 17);
+
+    f.compute_root();
+    g.compute_root();
+    h.compute_root();
+    out.compile_jit();
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
If the realization is tuple-valued, and the condition on the realization
uses a tuple call (index != 0), then the condition wasn't getting
resolved during the split_tuples pass. The cause was a missing mutate
call.