### PR TITLE
Fix two warnings found with clang 16

### DIFF
--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -740,7 +740,6 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                                    update_args, i);
                 }
 
-                int count = 0;
                 // Traverse the expressions in reverse order
                 for (auto it = expr_list.rbegin(); it != expr_list.rend(); it++) {
                     if (it->type().is_handle()) {
@@ -749,7 +748,6 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                     }
                     // Propagate adjoints
                     it->accept(this);
-                    count++;
                 }
             }
         }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -1188,7 +1188,7 @@ public:
 
     Stmt rewrap(Stmt body, const string &loop_var) {
         for (RegisterAllocation &alloc : allocations) {
-            if ((!loop_var.empty() && ends_with(alloc.loop_var, loop_var)) |
+            if ((!loop_var.empty() && ends_with(alloc.loop_var, loop_var)) ||
                 (loop_var.empty() && alloc.loop_var.empty())) {
                 body = Allocate::make(alloc.name, alloc.type, alloc.memory_type, {alloc.size}, const_true(), body);
             }


### PR DESCRIPTION
- variable 'count' set but not used
- warning: use of bitwise '|' with boolean operands