### PR TITLE
Fix wrong install path for *.py files

### DIFF
--- a/python_bindings/src/halide/CMakeLists.txt
+++ b/python_bindings/src/halide/CMakeLists.txt
@@ -50,9 +50,6 @@ if (WIN32 AND BUILD_SHARED_LIBS)
                        VERBATIM)
 endif ()
 
-# HALIDE_PYTHON_PATH is what you need to add to PYTHONPATH to use our bindings
-set(HALIDE_PYTHON_PATH "${HALIDE_PYTHON_PATH}")
-
 ##
 # Packaging
 ##

--- a/python_bindings/src/halide/CMakeLists.txt
+++ b/python_bindings/src/halide/CMakeLists.txt
@@ -50,6 +50,9 @@ if (WIN32 AND BUILD_SHARED_LIBS)
                        VERBATIM)
 endif ()
 
+# HALIDE_PYTHON_PATH is what you need to add to PYTHONPATH to use our bindings
+set(HALIDE_PYTHON_PATH "${HALIDE_PYTHON_PATH}")
+
 ##
 # Packaging
 ##
@@ -60,7 +63,7 @@ include(GNUInstallDirs)
 set(Halide_INSTALL_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}/python3/site-packages"
     CACHE STRING "Path to the Python site-packages folder")
 
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/halide"
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         DESTINATION "${Halide_INSTALL_PYTHONDIR}"
         COMPONENT Halide_Python
         FILES_MATCHING


### PR DESCRIPTION
We were looking in a nonexistent dir, so we never copied `__init__.py` as we should have.