### PR TITLE
Revise PyGen API to have implicit GeneratorContext

### DIFF
--- a/python_bindings/src/halide/__init__.py
+++ b/python_bindings/src/halide/__init__.py
@@ -1,3 +1,5 @@
 from .halide_ import *
 from .halide_ import _, _1, _2, _3, _4, _5, _6, _7, _8, _9
-from ._generator_helpers import GeneratorParam, InputBuffer, InputScalar, OutputBuffer, OutputScalar, Generator, alias, generator, _find_python_generator_class, _get_python_generator_names
+from ._generator_helpers import GeneratorParam, InputBuffer, InputScalar, OutputBuffer, \
+     OutputScalar, Generator, alias, generator, set_context, \
+     _get_python_generator_names, _create_python_generator, _get_generator_context

--- a/python_bindings/src/halide/__init__.py
+++ b/python_bindings/src/halide/__init__.py
@@ -1,5 +1,6 @@
 from .halide_ import *
 from .halide_ import _, _1, _2, _3, _4, _5, _6, _7, _8, _9
 from ._generator_helpers import GeneratorParam, InputBuffer, InputScalar, OutputBuffer, \
-     OutputScalar, Generator, alias, generator, set_context, \
-     _get_python_generator_names, _create_python_generator, _get_generator_context
+     OutputScalar, Generator, alias, generator, \
+     _get_python_generator_names, _create_python_generator, \
+     _get_generator_context, _generatorcontext_enter, _generatorcontext_exit

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -377,9 +377,7 @@ _halide_generator_context = ContextVar('halide_generator_context', default=None)
 def set_context(context:GeneratorContext):
     token = _halide_generator_context.set(context)
     try:
-        _print("activating context: ", context)
         yield context
-        _print("deactivating context: ", context)
     finally:
         _halide_generator_context.reset(token)
 

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from contextvars import ContextVar
 from enum import Enum
 from functools import total_ordering
 from .halide_ import *
@@ -14,16 +16,16 @@ import sys
 
 # 'print()' is consumed by `halide.print()` which is implicitly present;
 # here's our quick-n-dirty wrapper for debugging:
-# def _print(*args):
+def _print(*args):
 
-#     def write(data):
-#         sys.stdout.write(str(data))
+    def write(data):
+        sys.stdout.write(str(data))
 
-#     for i, arg in enumerate(args):
-#         if i:
-#             write(" ")
-#         write(arg)
-#     write('\n')
+    for i, arg in enumerate(args):
+        if i:
+            write(" ")
+        write(arg)
+    write('\n')
 
 
 # Everything below here is implicitly in the `halide._generator_helpers` package
@@ -44,6 +46,9 @@ def _is_valid_name(name: str) -> bool:
     # -- initial _ is forbidden (rather than merely "reserved")
     # -- two underscores in a row is also forbidden
     if not name:
+        return False
+    # We forbid this to avoid ambiguity in arguments to call()
+    if name == "generator_params":
         return False
     # TODO: use regex instead?
     s = str(name)
@@ -366,6 +371,24 @@ def _unsorted_cls_dir(cls):
         yield (k, v)
 
 
+_halide_generator_context = ContextVar('halide_generator_context', default=None)
+
+@contextmanager
+def set_context(context:GeneratorContext):
+    token = _halide_generator_context.set(context)
+    try:
+        _print("activating context: ", context)
+        yield context
+        _print("deactivating context: ", context)
+    finally:
+        _halide_generator_context.reset(token)
+
+def _get_generator_context() -> GeneratorContext:
+    context = _halide_generator_context.get()
+    _check(isinstance(context, GeneratorContext), "There is no active GeneratorContext")
+    return context
+
+
 class Generator(ABC):
     """Base class for Halide Generators in Python"""
 
@@ -385,9 +408,8 @@ class Generator(ABC):
         return self.target().natural_vector_size(type)
 
     @classmethod
-    def call(cls, context: GeneratorContext, *args, **kwargs):
-        _check(isinstance(context, GeneratorContext), "The first argument to call() must be a GeneratorContext")
-        generator = cls(context)
+    def call(cls, *args, **kwargs):
+        generator = cls()
 
         # First, fill in all the GeneratorParams
         # (in case some are tied to Inputs).
@@ -439,8 +461,8 @@ class Generator(ABC):
             raise AttributeError("Invalid write to field '%s'" % name)
         super().__setattr__(name, value)
 
-    def __init__(self, context: GeneratorContext):
-        _check(isinstance(context, GeneratorContext), "The first argument to Generator must be a GeneratorContext")
+    def __init__(self):
+        context = _get_generator_context()
 
         self._target = context.target()
         self._autoscheduler = context.autoscheduler_params()
@@ -657,7 +679,12 @@ class Generator(ABC):
         assert not self._input_parameters
         assert not self._output_funcs
 
-        self.generate()
+        # Ensure that the current context is the one in self.
+        # For most Generators this won't matter, but if the Generator
+        # invokes SomeOtherGenerator.call(), it would be nice to have this
+        # be the default, so that the end user doesn't have to mess with it.
+        with set_context(self.context()):
+            self.generate()
 
         self._input_parameters = {n: getattr(self, n).parameter() for n in self._inputs_dict}
         self._output_funcs = {n: getattr(self, n) for n in self._outputs_dict}
@@ -702,6 +729,14 @@ def _get_python_generator_names() -> list[str]:
     return _python_generators.keys()
 
 
+def _create_python_generator(name: str, context: GeneratorContext):
+    cls = _python_generators.get(name, None)
+    if not isclass(cls):
+        return None
+    with context:
+        return cls()
+
+
 def _fqname(o):
     k = o
     m = k.__module__
@@ -709,13 +744,6 @@ def _fqname(o):
     if m == "__main__" or k == "builtins":
         return q
     return m + "." + q
-
-
-def _find_python_generator_class(name: str):
-    cls = _python_generators.get(name, None)
-    if not isclass(cls):
-        cls = None
-    return cls
 
 
 def alias(**kwargs):

--- a/python_bindings/src/halide/halide_/PyGenerator.cpp
+++ b/python_bindings/src/halide/halide_/PyGenerator.cpp
@@ -163,7 +163,7 @@ void define_generator(py::module &m) {
                 auto _generatorcontext_enter = py::module_::import("halide").attr("_generatorcontext_enter");
                 return _generatorcontext_enter(context);
             })
-            .def("__exit__", [](const GeneratorContext &context, py::object exc_type, py::object exc_value, py::object exc_traceback) -> bool {
+            .def("__exit__", [](const GeneratorContext &context, const py::object &exc_type, const py::object &exc_value, const py::object &exc_traceback) -> bool {
                 auto _generatorcontext_exit = py::module_::import("halide").attr("_generatorcontext_exit");
                 _generatorcontext_exit(context);
                 return false;

--- a/python_bindings/src/halide/halide_/PyGenerator.cpp
+++ b/python_bindings/src/halide/halide_/PyGenerator.cpp
@@ -32,9 +32,6 @@ class PyGeneratorBase : public AbstractGenerator {
     // The name declared in the Python function's decorator
     const std::string name_;
 
-    // The Python class
-    const py::object class_;
-
     // The instance of the Python class
     py::object generator_;
 
@@ -43,12 +40,11 @@ public:
     // by calling is_valid() later.
     explicit PyGeneratorBase(const GeneratorContext &context, const std::string &name)
         : name_(name),
-          class_(py::module_::import("halide").attr("_find_python_generator_class")(name)),  // could be None!
-          generator_(class_.is(py::none()) ? py::none() : class_(context)) {                 // could be None!
+          generator_(py::module_::import("halide").attr("_create_python_generator")(name, context)) {  // could be None!
     }
 
     bool is_valid() const {
-        if (name_.empty() || class_.is(py::none()) || generator_.is(py::none())) {
+        if (name_.empty() || generator_.is(py::none())) {
             return false;
         }
         return true;

--- a/python_bindings/src/halide/halide_/PyGenerator.cpp
+++ b/python_bindings/src/halide/halide_/PyGenerator.cpp
@@ -143,8 +143,10 @@ void define_generator(py::module &m) {
             .def_readonly("types", &ArgInfo::types)
             .def_readonly("dimensions", &ArgInfo::dimensions);
 
+    // Note that we need py::dynamic_attr() here so that the Python code can add a token stack
+    // for __enter__ and __exit__ handling
     auto generatorcontext_class =
-        py::class_<GeneratorContext>(m, "GeneratorContext")
+        py::class_<GeneratorContext>(m, "GeneratorContext", py::dynamic_attr())
 #ifdef HALIDE_ALLOW_LEGACY_AUTOSCHEDULER_API
             .def(py::init<const Target &, bool, const MachineParams &>(),
                  py::arg("target"), py::arg("auto_schedule") = false, py::arg("machine_params") = MachineParams::generic())
@@ -157,6 +159,15 @@ void define_generator(py::module &m) {
             .def("target", &GeneratorContext::target)
             .def("autoscheduler_params", &GeneratorContext::autoscheduler_params)
 #endif
+            .def("__enter__", [](const GeneratorContext &context) -> py::object {
+                auto _generatorcontext_enter = py::module_::import("halide").attr("_generatorcontext_enter");
+                return _generatorcontext_enter(context);
+            })
+            .def("__exit__", [](const GeneratorContext &context, py::object exc_type, py::object exc_value, py::object exc_traceback) -> bool {
+                auto _generatorcontext_exit = py::module_::import("halide").attr("_generatorcontext_exit");
+                _generatorcontext_exit(context);
+                return false;
+            })
             .def("__repr__", [](const GeneratorContext &context) -> std::string {
                 std::ostringstream o;
                 o << "<halide.GeneratorContext " << context.target() << ">";

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -150,9 +150,10 @@ std::vector<T> to_input_vector(const py::object &value, const std::string &name)
 }
 
 py::object call_impl(const GeneratorFactory &factory,
-                     const GeneratorContext &context,
                      const py::args &args,
                      const py::kwargs &kwargs) {
+    auto _get_generator_context = py::module_::import("halide").attr("_get_generator_context");
+    auto context = _get_generator_context().cast<GeneratorContext>();
     auto generator = factory(context);
 
     // GeneratorParams are always specified as an optional named parameter
@@ -272,10 +273,9 @@ py::object call_impl(const GeneratorFactory &factory,
 
 void pystub_init(pybind11::module &m, const GeneratorFactory &factory) {
     m.def(
-        "call", [factory](const Halide::GeneratorContext &context, const py::args &args, const py::kwargs &kwargs) -> py::object {
-            return call_impl(factory, context, args, kwargs);
-        },
-        py::arg("context"));
+        "call", [factory](const py::args &args, const py::kwargs &kwargs) -> py::object {
+            return call_impl(factory, args, kwargs);
+        });
 }
 
 }  // namespace

--- a/python_bindings/test/correctness/pystub.py
+++ b/python_bindings/test/correctness/pystub.py
@@ -265,8 +265,7 @@ def test_complex(cls, extra_input_name = ""):
 
 if __name__ == "__main__":
     target = hl.get_jit_target_from_environment()
-    ctx = hl.GeneratorContext(target)
-    with hl.set_context(ctx):
+    with hl.GeneratorContext(target):
         test_simple(simple_pystub)
         test_complex(complex_pystub)
         test_complex(complex_pystub, extra_input_name = "foozz_input")

--- a/python_bindings/test/correctness/pystub.py
+++ b/python_bindings/test/correctness/pystub.py
@@ -19,8 +19,6 @@ def _realize_and_check(f, offset=0):
 
 def test_simple(cls):
     x, y = hl.Var(), hl.Var()
-    target = hl.get_jit_target_from_environment()
-    ctx = hl.GeneratorContext(target)
 
     b_in = hl.Buffer(hl.UInt(8), [2, 2])
     b_in.fill(123)
@@ -29,14 +27,14 @@ def test_simple(cls):
             b_in[xx, yy] += xx + yy
 
     # ----------- Inputs by-position
-    f = cls.call(ctx, b_in, 3.5)
+    f = cls.call(b_in, 3.5)
     _realize_and_check(f)
 
     # ----------- Inputs by-name
-    f = cls.call(ctx, buffer_input=b_in, float_arg=3.5)
+    f = cls.call(buffer_input=b_in, float_arg=3.5)
     _realize_and_check(f)
 
-    f = cls.call(ctx, float_arg=3.5, buffer_input=b_in)
+    f = cls.call(float_arg=3.5, buffer_input=b_in)
     _realize_and_check(f)
 
     # ----------- Above set again, w/ GeneratorParam mixed in
@@ -45,29 +43,29 @@ def test_simple(cls):
     gp = {"offset": k}
 
     # (positional)
-    f = cls.call(ctx, b_in, 3.5, generator_params=gp)
+    f = cls.call(b_in, 3.5, generator_params=gp)
     _realize_and_check(f, k)
 
     # (keyword)
-    f = cls.call(ctx, generator_params=gp, buffer_input=b_in, float_arg=3.5)
+    f = cls.call(generator_params=gp, buffer_input=b_in, float_arg=3.5)
     _realize_and_check(f, k)
 
-    f = cls.call(ctx, buffer_input=b_in, generator_params=gp, float_arg=3.5)
+    f = cls.call(buffer_input=b_in, generator_params=gp, float_arg=3.5)
     _realize_and_check(f, k)
 
-    f = cls.call(ctx, buffer_input=b_in, generator_params=gp, float_arg=3.5)
+    f = cls.call(buffer_input=b_in, generator_params=gp, float_arg=3.5)
     _realize_and_check(f, k)
 
-    f = cls.call(ctx, buffer_input=b_in, float_arg=3.5, generator_params=gp)
+    f = cls.call(buffer_input=b_in, float_arg=3.5, generator_params=gp)
 
     # Inputs w/ mixed by-position and by-name should be ok
-    f = cls.call(ctx, b_in, float_arg=3.5, generator_params=gp)
+    f = cls.call(b_in, float_arg=3.5, generator_params=gp)
     _realize_and_check(f, k)
 
     # ----------- Test various failure modes
     try:
         # too many positional args
-        f = cls.call(ctx, b_in, 3.5, 4)
+        f = cls.call(b_in, 3.5, 4)
     except hl.HalideError as e:
         assert 'allows at most 2 positional args, but 3 were specified.' in str(e)
     else:
@@ -75,7 +73,7 @@ def test_simple(cls):
 
     try:
         # too few positional args
-        f = cls.call(ctx, b_in)
+        f = cls.call(b_in)
     except hl.HalideError as e:
         assert 'requires 2 args, but 1 were specified.' in str(e)
     else:
@@ -83,7 +81,7 @@ def test_simple(cls):
 
     try:
         # Inputs that can't be converted to what the receiver needs (positional)
-        f = cls.call(ctx, hl.f32(3.141592), "happy")
+        f = cls.call(hl.f32(3.141592), "happy")
     except hl.HalideError as e:
         assert 'Input buffer_input requires an ImageParam or Buffer argument' in str(e)
     else:
@@ -91,7 +89,7 @@ def test_simple(cls):
 
     try:
         # Inputs that can't be converted to what the receiver needs (named)
-        f = cls.call(ctx, b_in, float_arg="bogus")
+        f = cls.call(b_in, float_arg="bogus")
     except hl.HalideError as e:
         assert 'Input float_arg requires a Param (or scalar literal) argument when using call' in str(e)
     else:
@@ -99,7 +97,7 @@ def test_simple(cls):
 
     try:
         # Input specified by both pos and kwarg
-        f = cls.call(ctx, b_in, 3.5, float_arg=4.5)
+        f = cls.call(b_in, 3.5, float_arg=4.5)
     except hl.HalideError as e:
         assert "Input float_arg specified multiple times." in str(e)
     else:
@@ -107,7 +105,7 @@ def test_simple(cls):
 
     try:
         # generator_params is not a dict
-        f = cls.call(ctx, b_in, 3.5, generator_params=[1, 2, 3])
+        f = cls.call(b_in, 3.5, generator_params=[1, 2, 3])
     except hl.HalideError as e:
         assert "generator_params must be a dict" in str(e)
     else:
@@ -115,7 +113,7 @@ def test_simple(cls):
 
     try:
         # Bad gp name
-        f = cls.call(ctx, b_in, 3.5, generator_params={"foo": 0})
+        f = cls.call(b_in, 3.5, generator_params={"foo": 0})
     except hl.HalideError as e:
         assert "has no GeneratorParam" in str(e)
     else:
@@ -123,8 +121,7 @@ def test_simple(cls):
 
     try:
         # Bad input name
-        f = cls.call(ctx,
-                     buzzer_input=b_in,
+        f = cls.call(buzzer_input=b_in,
                      float_arg=3.5,
                      generator_params=gp)
     except hl.HalideError as e:
@@ -134,8 +131,7 @@ def test_simple(cls):
 
     try:
         # Bad gp name
-        f = cls.call(ctx,
-                     buffer_input=b_in,
+        f = cls.call(buffer_input=b_in,
                      float_arg=3.5,
                      generator_params=gp,
                      nonexistent_generator_param="wat")
@@ -161,8 +157,6 @@ def test_complex(cls, extra_input_name = ""):
     input.set(constant_image)
 
     x, y, c = hl.Var(), hl.Var(), hl.Var()
-    target = hl.get_jit_target_from_environment()
-    ctx = hl.GeneratorContext(target)
 
     float_arg = 1.25
     int_arg = 33
@@ -186,7 +180,7 @@ def test_complex(cls, extra_input_name = ""):
         gp["extra_input_name"] = extra_input_name
         kwargs[extra_input_name] = constant_image_u16
 
-    r = cls.call(ctx, **kwargs)
+    r = cls.call(**kwargs)
 
     # return value is a tuple; unpack separately to avoid
     # making the callsite above unreadable
@@ -270,9 +264,12 @@ def test_complex(cls, extra_input_name = ""):
 
 
 if __name__ == "__main__":
-    test_simple(simple_pystub)
-    test_complex(complex_pystub)
-    test_complex(complex_pystub, extra_input_name = "foozz_input")
-    test_simple(SimplePy)
-    test_complex(ComplexPy)
-    test_complex(ComplexPy, extra_input_name = "foo_input")
+    target = hl.get_jit_target_from_environment()
+    ctx = hl.GeneratorContext(target)
+    with hl.set_context(ctx):
+        test_simple(simple_pystub)
+        test_complex(complex_pystub)
+        test_complex(complex_pystub, extra_input_name = "foozz_input")
+        test_simple(SimplePy)
+        test_complex(ComplexPy)
+        test_complex(ComplexPy, extra_input_name = "foo_input")


### PR DESCRIPTION
This proposes to revise the Python Generator API to have GeneratorContext *never* be an explicit argument; rather, to have an *implicit* current GeneratorContext that is active. This reduces boilerplate when composing code (e.g. via Generator.call). To temporarily push a new GeneratorContext on the active stack, `with hl.set_context(ctx):` is the appropriate thing to do.