### PR TITLE
Remove add_python_aot_extension() rule in CMake

### DIFF
--- a/README_cmake.md
+++ b/README_cmake.md
@@ -807,6 +807,7 @@ add_halide_library(<target> FROM <generator-target>
                    [PLUGINS plugin1 [plugin2 ...]]
                    [AUTOSCHEDULER scheduler-name]
                    [GRADIENT_DESCENT]
+                   [PYTHON_EXTENSION_LIBRARY]
                    [C_BACKEND]
                    [REGISTRATION OUTVAR]
                    [HEADER OUTVAR]
@@ -868,6 +869,13 @@ If `GRADIENT_DESCENT` is set, then the module will be built suitably for
 gradient descent calculation in TensorFlow or PyTorch. See
 `Generator::build_gradient_module()` for more documentation. This corresponds to
 passing `-d 1` at the generator command line.
+
+If `PYTHON_EXTENSION_LIBRARY` is set, then a Python Extension will be built that
+wraps the C/C++ call with CPython glue to allow use of the generated code from
+Python 3.x. The result will be a a shared library of the form
+`<target>.<soabi>.so`, where <soabi> describes the specific Python version and
+platform (e.g., `cpython-310-darwin` for Python 3.10 on OSX.) See
+`README_python.md` for examples of use.
 
 If the `C_BACKEND` option is set, this command will invoke the configured C++
 compiler on a generated source. Note that a `<target>.runtime` target is _not_

--- a/README_python.md
+++ b/README_python.md
@@ -172,7 +172,7 @@ objects without any explicit conversion necessary.
 
 ## Using Halide Generators from Python
 
-### Compiling a C++ Generator for Python
+### Using a C++ Generator from Python
 
 Let's say we have a very simple Generator:
 
@@ -192,12 +192,13 @@ HALIDE_REGISTER_GENERATOR(MyFilter, my_filter)
 ```
 
 If you are using CMake, the simplest thing is to use
-`add_python_aot_extension()`, defined in PythonExtensionHelpers.cmake:
+`add_halide_library()` (defined in HalideGeneratorHelpers.cmake) with the `PYTHON_EXTENSION_LIBRARY` option:
 
 ```
-add_python_aot_extension(my_filter
+add_halide_library(my_filter
                          GENERATOR my_filter_generator
                          SOURCES my_filter_generator.cpp
+                         PYTHON_EXTENSION_LIBRARY
                          [ FEATURES ... ]
                          [ PARAMS ... ])
 ```

--- a/python_bindings/test/CMakeLists.txt
+++ b/python_bindings/test/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
+    message(WARNING "Python tests are skipped under WASM.")
+    return()
+endif ()
+
 add_subdirectory(apps)
 add_subdirectory(correctness)
 add_subdirectory(generators)

--- a/python_bindings/test/generators/CMakeLists.txt
+++ b/python_bindings/test/generators/CMakeLists.txt
@@ -27,11 +27,19 @@ set(GENPARAMS_simple
     func_input.type=uint8)
 
 foreach (GEN IN LISTS GENERATORS)
-    add_python_aot_extension(py_aot_${GEN}
-                             GENERATOR ${GEN}
-                             FEATURES ${FEATURES_${GEN}}
-                             PARAMS ${GENPARAMS_${GEN}}
-                             SOURCES ${GEN}_generator.cpp)
+    add_halide_generator(py_aot_${GEN}.generator
+                         SOURCES ${GEN}_generator.cpp)
+
+    add_halide_library(py_aot_${GEN}
+                       FROM py_aot_${GEN}.generator
+                       GENERATOR ${GEN}
+                       FUNCTION_NAME ${GEN}
+                       # Note that PYTHON_EXTENSION_LIBRARY doesn't take
+                       # an argument; it will always produce a file of the form
+                       # ${TARGET}.${Python3_SOABI}.so (or .pyd on Windows)
+                       PYTHON_EXTENSION_LIBRARY
+                       FEATURES ${FEATURES_${GEN}}
+                       PARAMS ${GENPARAMS_${GEN}})
 
     add_python_stub_extension(py_stub_${GEN}
                               SOURCES ${GEN}_generator.cpp


### PR DESCRIPTION
Move it into `add_halide_library` instead, as another output option.

(add_python_stub_extension will likely be moved as well, in a subsequent PR)