### PR TITLE
Build fixes for manylinux2014

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -30,7 +30,7 @@ set(PYBIND11_VER 2.6.2 CACHE STRING "The pybind11 version to use (or download)")
 # Dependencies
 ##
 
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 
 if (PYBIND11_USE_FETCHCONTENT)
     include(FetchContent)

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -30,6 +30,10 @@ set(PYBIND11_VER 2.6.2 CACHE STRING "The pybind11 version to use (or download)")
 # Dependencies
 ##
 
+# The plain Development component is the same as requesting both
+# Development.Module and Development.Embed. We don't need the Embed
+# part, so only requesting Module avoids failures when Embed is not
+# available, as is the case in the manylinux Docker images.
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 
 if (PYBIND11_USE_FETCHCONTENT)

--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -48,6 +48,8 @@ setup(
         "-DHalide_INSTALL_PYTHONDIR=src",
         "-DCMAKE_INSTALL_RPATH=$ORIGIN",
         "-DHalide_Python_INSTALL_IMPORTED_DEPS=ON",
+        "-DWITH_TESTS=NO",
+        "-DWITH_TUTORIALS=NO",
         "--no-warn-unused-cli",
     ],
 )

--- a/src/autoschedulers/li2018/CMakeLists.txt
+++ b/src/autoschedulers/li2018/CMakeLists.txt
@@ -40,7 +40,7 @@ if (WITH_PYTHON_BINDINGS)
     # TODO(#4053): rework this as an app under python_bindings.
     # TODO(#4876): Disabled due to issue #4876
     if (FALSE)
-        find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+        find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 
         add_test(NAME gradient_autoscheduler_test_py
                  COMMAND Python3::Interpreter "${CMAKE_CURRENT_SOURCE_DIR}/test.py")


### PR DESCRIPTION
The `Development` component is the combination of two sub-components:

1. `Development.Module` - the parts necessary to create native Python modules
2. `Development.Embed` - the parts necessary to embed the Python interpreter into your application.

The manylinux images don't include `Development.Embed` and we don't need it anyway. So this fixes the build in that scenario. 

Also disables building tests and tutorials when building wheels because they're not needed.