### PR TITLE
Fix possible overflow in saturating_cast bounds inference

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1436,9 +1436,9 @@ private:
                 // make two calls for the min and the max.
                 interval = Interval(
                     Call::make(t, op->name, {i.min}, op->call_type,
-                            op->func, op->value_index, op->image, op->param),
+                               op->func, op->value_index, op->image, op->param),
                     Call::make(t, op->name, {i.max}, op->call_type,
-                            op->func, op->value_index, op->image, op->param));
+                               op->func, op->value_index, op->image, op->param));
             } else {
                 bounds_of_type(t);
             }

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1218,10 +1218,16 @@ private:
             Interval a_interval = interval;
             bounds_of_type(t);
             if (a_interval.has_lower_bound()) {
-                interval.min = saturating_cast(t, a_interval.min);
+                Expr e = simplify(a_interval.min);
+                if (!is_signed_integer_overflow(e)) {
+                    interval.min = saturating_cast(t, e);
+                }
             }
             if (a_interval.has_upper_bound()) {
-                interval.max = saturating_cast(t, a_interval.max);
+                Expr e = simplify(a_interval.max);
+                if (!is_signed_integer_overflow(e)) {
+                    interval.max = saturating_cast(t, e);
+                }
             }
             return;
         } else if (op->is_intrinsic(Call::unsafe_promise_clamped) ||

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -4,6 +4,7 @@
 #include "CodeGen_GPU_Dev.h"
 #include "Debug.h"
 #include "Deinterleave.h"
+#include "FindIntrinsics.h"
 #include "IRMatch.h"
 #include "IRMutator.h"
 #include "IROperator.h"
@@ -466,6 +467,10 @@ void CodeGen_OpenGLCompute_C::visit(const Call *op) {
         print_assignment(op->type, print_expr(op->args[0]) + " / " + print_expr(op->args[1]));
     } else if (op->is_intrinsic(Call::mod_round_to_zero)) {
         print_assignment(op->type, print_expr(op->args[0]) + " % " + print_expr(op->args[1]));
+    } else if (op->is_intrinsic(Call::saturating_cast)) {
+        Expr e = lower_intrinsic(op);
+        print_expr(e);
+        return;
     } else {
         auto it = builtin.find(op->name);
         if (it == builtin.end()) {


### PR DESCRIPTION
The issue @steven-johnson noted on #6900 is a result of bounds inference producing integer overflow in the calculation of func value bounds. This PR should fix that issue.