### PR TITLE
CMake packaging fixes

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -184,6 +184,12 @@ write_basic_package_version_file(HalideHelpersConfigVersion.cmake
                                  COMPATIBILITY SameMajorVersion
                                  ARCH_INDEPENDENT)
 
+# Compute a hint to make it easier to find HalideHelpers from find_package(Halide)
+# This is read by configure_file below.
+file(RELATIVE_PATH HalideHelpers_HINT
+     "${CMAKE_CURRENT_BINARY_DIR}/${Halide_INSTALL_CMAKEDIR}"
+     "${CMAKE_CURRENT_BINARY_DIR}/${Halide_INSTALL_HELPERSDIR}")
+
 configure_file(common/HalideConfig.cmake HalideConfig.cmake @ONLY)
 configure_file(common/HalideHelpersConfig.cmake HalideHelpersConfig.cmake @ONLY)
 

--- a/packaging/common/HalideConfig.cmake
+++ b/packaging/common/HalideConfig.cmake
@@ -12,14 +12,9 @@ macro(Halide_find_component_dependency comp dep)
         set(Halide_quiet QUIET)
     endif ()
 
-    set(Halide_required)
-    if (${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED_${comp})
-        set(Halide_required REQUIRED)
-    endif ()
+    find_package(${dep} ${ARGN} ${Halide_quiet})
 
-    find_package(${dep} ${ARGN} ${Halide_quiet} ${Halide_required})
-
-    if (NOT ${dep}_FOUND)
+    if (NOT ${dep}_FOUND AND ${CMAKE_FIND_PACKAGE_NAME}_FIND_REQUIRED_${comp})
         Halide_fail("${CMAKE_FIND_PACKAGE_NAME} could not be found because dependency ${dep} could not be found.")
     endif ()
 endmacro()

--- a/packaging/common/HalideConfig.cmake
+++ b/packaging/common/HalideConfig.cmake
@@ -49,12 +49,6 @@ if (Halide_comp_static AND Halide_comp_shared)
 endif ()
 
 # Set configured variables
-set(Halide_VERSION @Halide_VERSION@)
-set(Halide_VERSION_MAJOR @Halide_VERSION_MAJOR@)
-set(Halide_VERSION_MINOR @Halide_VERSION_MINOR@)
-set(Halide_VERSION_PATCH @Halide_VERSION_PATCH@)
-set(Halide_VERSION_TWEAK @Halide_VERSION_TWEAK@)
-
 set(Halide_ENABLE_EXCEPTIONS @Halide_ENABLE_EXCEPTIONS@)
 set(Halide_ENABLE_RTTI @Halide_ENABLE_RTTI@)
 

--- a/packaging/common/HalideConfig.cmake
+++ b/packaging/common/HalideConfig.cmake
@@ -109,3 +109,37 @@ else ()
         Halide_load_targets(shared)
     endif ()
 endif ()
+
+## Hide variables and helper macros that are not part of our API.
+
+# Delete internal component tracking
+foreach (comp IN LISTS Halide_known_components)
+  unset(Halide_comp_${comp})
+endforeach ()
+
+unset(Halide_components)
+unset(Halide_known_components)
+
+# Delete paths to generated CMake files
+unset(Halide_shared_deps)
+unset(Halide_shared_targets)
+unset(Halide_static_deps)
+unset(Halide_static_targets)
+
+# Delete internal macros -- CMake saves redefined macros and functions with a
+# single underscore prefixed so, for example, Halide_fail is still available as
+# _Halide_fail after one redefinition. Doing it twice overwrites both since the
+# saving behavior doesn't continue past the first.
+foreach (i RANGE 0 1)
+    macro(Halide_fail)
+        message(FATAL_ERROR "Cannot call internal API: Halide_fail")
+    endmacro()
+
+    macro(Halide_find_component_dependency)
+        message(FATAL_ERROR "Cannot call internal API: Halide_find_component_dependency")
+    endmacro()
+
+    macro(Halide_load_targets)
+        message(FATAL_ERROR "Cannot call internal API: Halide_load_targets")
+    endmacro()
+endforeach ()

--- a/packaging/common/HalideConfig.cmake
+++ b/packaging/common/HalideConfig.cmake
@@ -56,7 +56,10 @@ set(Halide_ASAN_ENABLED "@Halide_ASAN_ENABLED@")
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(HalideHelpers "${Halide_VERSION}" EXACT)
+find_dependency(
+    HalideHelpers "@Halide_VERSION@" EXACT
+    HINTS "${CMAKE_CURRENT_LIST_DIR}/@HalideHelpers_HINT@"
+)
 
 if (Halide_comp_PNG)
     Halide_find_component_dependency(PNG PNG)

--- a/packaging/common/HalideConfig.cmake
+++ b/packaging/common/HalideConfig.cmake
@@ -48,9 +48,12 @@ if (Halide_comp_static AND Halide_comp_shared)
     Halide_fail("Halide `static` and `shared` components are mutually exclusive.")
 endif ()
 
-# Set configured variables
-set(Halide_ENABLE_EXCEPTIONS @Halide_ENABLE_EXCEPTIONS@)
-set(Halide_ENABLE_RTTI @Halide_ENABLE_RTTI@)
+# Inform downstreams of potential compatibility issues. For instance, exceptions
+# and RTTI must both be enabled to build Python bindings and ASAN builds should
+# not be mixed with non-ASAN builds.
+set(Halide_ENABLE_EXCEPTIONS "@Halide_ENABLE_EXCEPTIONS@")
+set(Halide_ENABLE_RTTI "@Halide_ENABLE_RTTI@")
+set(Halide_ASAN_ENABLED "@Halide_ASAN_ENABLED@")
 
 ##
 ## Find dependencies based on components


### PR DESCRIPTION
This PR makes a few fixes to our CMake package (as used by `find_package`).

* The package now includes a hint as to the location of `HalideHelpers`, so that errors regarding not being able to find it are rarer (e.g. setting `Halide_DIR` instead of `Halide_ROOT`).
* `Halide_ASAN_ENABLED` is added to the package to allow consumers to confirm that they found the right Halide when they are using ASAN in their own projects.
* The handling of optional components was fixed. Previously, it incorrectly used the `REQUIRED`-ness of the whole Halide package itself, not the individual component.
  * PNG and JPEG dependencies are now optional by default. If any are missing, `find_package(Halide REQUIRED)` will still succeed. If you need a specific dependency for `Halide::ImageIO`, you can make it required by writing, e.g. `find_package(Halide REQUIRED PNG)`.
* Variables and macros that are internal to `HalideConfig.cmake` are now explicitly deleted with `unset` and a re-definition trick. This keeps our package API in line with what's documented.