### PR TITLE
Use CMake target to handle vendored SPIRV headers

### DIFF
--- a/dependencies/spirv/CMakeLists.txt
+++ b/dependencies/spirv/CMakeLists.txt
@@ -1,3 +1,3 @@
-
-set(SPIRV_INCLUDE_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/include" CACHE INTERNAL "Location of SPIR-V include directory")
-message(STATUS "Using SPIR-V headers from: ${SPIRV_INCLUDE_DIR}...")
+add_library(Halide_SPIRV INTERFACE)
+add_library(Halide::SPIRV ALIAS Halide_SPIRV)
+target_include_directories(Halide_SPIRV SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -529,8 +529,10 @@ if (TARGET_OPENGLCOMPUTE)
 endif ()
 
 if (TARGET_SPIRV)
+    # Our vendored SPIRV headers are only used internally; users do not need
+    # them installed.
     target_compile_definitions(Halide PRIVATE WITH_SPIRV)
-    target_include_directories(Halide SYSTEM PRIVATE "${SPIRV_INCLUDE_DIR}")
+    target_link_libraries(Halide PRIVATE "$<BUILD_INTERFACE:Halide::SPIRV>")
 endif ()
 
 ##


### PR DESCRIPTION
I think I did a bad job communicating the expected implementation in my review of #6882, but this is what I meant. Skipping buildbots because they don't test SPIRV yet. I have tested this locally.

Pinging @derek-gerstmann in case there's something I'm missing about the way it was previously done.