### PR TITLE
Don't cache Halide_ASAN_ENABLED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,11 @@ if (Halide_CCACHE_BUILD)
     message(STATUS "Enabling ccache usage for building.")
 endif ()
 
-# Detect whether or not ASAN is enabled
+# Detect whether or not ASAN is enabled. Don't cache the result to ensure this
+# check happens every time we reconfigure.
+unset(Halide_ASAN_ENABLED CACHE)
 check_cxx_symbol_exists(HALIDE_INTERNAL_USING_ASAN "${Halide_SOURCE_DIR}/src/Util.h" Halide_ASAN_ENABLED)
+
 if (Halide_ASAN_ENABLED)
     set(Halide_ANY_SANITIZERS_ENABLED 1)
 else ()


### PR DESCRIPTION
`check_cxx_symbol_exists` saves its output in the cache and does not run if its destination variable is defined. This is OK when used to test something that necessitates a totally fresh configuration, like any property of the target architecture, which would require changing the toolchain file. However, the result here can change if someone just modifies `CMAKE_CXX_FLAGS`, so it can get out of sync in some cases.