### PR TITLE
Lower saturating_cast in bounds inference

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -7,6 +7,7 @@
 #include "Debug.h"
 #include "Deinterleave.h"
 #include "ExprUsesVar.h"
+#include "FindIntrinsics.h"
 #include "Func.h"
 #include "IR.h"
 #include "IREquality.h"
@@ -1213,16 +1214,8 @@ private:
         } else if (op->is_intrinsic(Call::saturating_cast)) {
             internal_assert(op->args.size() == 1);
 
-            Expr a = op->args[0];
+            Expr a = lower_saturating_cast(op->type, op->args[0]);
             a.accept(this);
-            Interval a_interval = interval;
-            bounds_of_type(t);
-            if (a_interval.has_lower_bound()) {
-                interval.min = saturating_cast(t, a_interval.min);
-            }
-            if (a_interval.has_upper_bound()) {
-                interval.max = saturating_cast(t, a_interval.max);
-            }
             return;
         } else if (op->is_intrinsic(Call::unsafe_promise_clamped) ||
                    op->is_intrinsic(Call::promise_clamped)) {

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -4,6 +4,7 @@
 #include "CodeGen_GPU_Dev.h"
 #include "Debug.h"
 #include "Deinterleave.h"
+#include "FindIntrinsics.h"
 #include "IRMatch.h"
 #include "IRMutator.h"
 #include "IROperator.h"
@@ -466,6 +467,10 @@ void CodeGen_OpenGLCompute_C::visit(const Call *op) {
         print_assignment(op->type, print_expr(op->args[0]) + " / " + print_expr(op->args[1]));
     } else if (op->is_intrinsic(Call::mod_round_to_zero)) {
         print_assignment(op->type, print_expr(op->args[0]) + " % " + print_expr(op->args[1]));
+    } else if (op->is_intrinsic(Call::saturating_cast)) {
+         Expr e = lower_intrinsic(op);
+         print_expr(e);
+         return;
     } else {
         auto it = builtin.find(op->name);
         if (it == builtin.end()) {

--- a/src/CodeGen_OpenGLCompute_Dev.cpp
+++ b/src/CodeGen_OpenGLCompute_Dev.cpp
@@ -468,9 +468,9 @@ void CodeGen_OpenGLCompute_C::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::mod_round_to_zero)) {
         print_assignment(op->type, print_expr(op->args[0]) + " % " + print_expr(op->args[1]));
     } else if (op->is_intrinsic(Call::saturating_cast)) {
-         Expr e = lower_intrinsic(op);
-         print_expr(e);
-         return;
+        Expr e = lower_intrinsic(op);
+        print_expr(e);
+        return;
     } else {
         auto it = builtin.find(op->name);
         if (it == builtin.end()) {


### PR DESCRIPTION
This should revert bounds inference on `saturating_cast` to the behavior of pre - #6900 .

@steven-johnson could you test to see if this fixes things?

The issues detected were not a direct result of #6900 - before that PR, there was still `signed_integer_overflow` inside of Bounds.cpp, but it was being hidden by complex `Cast` handling inside the bounds visitor. @abadams and I are discussing a fix to the underlying issue, but it is incredibly involved and requires possibly using infinite-precision integers in some parts of the compiler.