### PR TITLE
Small refactor to remove confusion between CodeGen_LLVM and CodeGen_Internal.

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1,4 +1,3 @@
-
 #include <set>
 #include <sstream>
 

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1,3 +1,4 @@
+
 #include <set>
 #include <sstream>
 
@@ -77,12 +78,10 @@ protected:
     string mattrs() const override;
     bool use_soft_float_abi() const override;
     int native_vector_bits() const override;
-    int target_vscale() const override;
 
-    // NEON can be disabled for older processors and if SVE is used with longer vectors.
+    // NEON can be disabled for older processors.
     bool neon_intrinsics_disabled() {
-        return target.has_feature(Target::NoNEON) ||
-               (target.features_any_of({Target::SVE, Target::SVE2}) && target.vector_bits != 128);
+        return target.has_feature(Target::NoNEON);
     }
 
     bool is_float16_and_has_feature(const Type &t) const {
@@ -1483,24 +1482,7 @@ bool CodeGen_ARM::use_soft_float_abi() const {
 }
 
 int CodeGen_ARM::native_vector_bits() const {
-    if (target.vector_bits != 0 &&
-        (target.has_feature(Target::SVE) ||
-         target.has_feature(Target::SVE2))) {
-        return target.vector_bits;
-    }
-
     return 128;
-}
-
-int CodeGen_ARM::target_vscale() const {
-    if (target.vector_bits != 0 &&
-        (target.has_feature(Target::SVE) ||
-         target.has_feature(Target::SVE2))) {
-        internal_assert((target.vector_bits % 128) == 0);
-        return target.vector_bits / 128;
-    }
-
-    return 0;
 }
 
 bool CodeGen_ARM::supports_call_as_float16(const Call *op) const {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1620,7 +1620,7 @@ Value *CodeGen_Hexagon::vdelta(Value *lut, const vector<int> &indices) {
 Value *CodeGen_Hexagon::create_vector(llvm::Type *ty, int val) {
     llvm::Type *scalar_ty = ty->getScalarType();
     Constant *value = ConstantInt::get(scalar_ty, val);
-    return ConstantVector::getSplat(element_count(get_vector_num_elements(ty)), value);
+    return get_splat(get_vector_num_elements(ty), value);
 }
 
 Value *CodeGen_Hexagon::vlut(Value *lut, Value *idx, int min_index, int max_index) {

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -16,16 +16,6 @@ using std::string;
 
 using namespace llvm;
 
-int get_vector_num_elements(llvm::Type *t) {
-    if (t->isVectorTy()) {
-        auto *vt = dyn_cast<llvm::FixedVectorType>(t);
-        internal_assert(vt) << "Called get_vector_num_elements on a scalable vector type\n";
-        return vt->getNumElements();
-    } else {
-        return 1;
-    }
-}
-
 llvm::Type *get_vector_element_type(llvm::Type *t) {
     if (t->isVectorTy()) {
         return dyn_cast<llvm::VectorType>(t)->getElementType();

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -16,48 +16,13 @@ using std::string;
 
 using namespace llvm;
 
-llvm::Type *llvm_type_of(LLVMContext *c, Halide::Type t,
-                         int effective_vscale) {
-    if (t.lanes() == 1) {
-        if (t.is_float() && !t.is_bfloat()) {
-            switch (t.bits()) {
-            case 16:
-                return llvm::Type::getHalfTy(*c);
-            case 32:
-                return llvm::Type::getFloatTy(*c);
-            case 64:
-                return llvm::Type::getDoubleTy(*c);
-            default:
-                internal_error << "There is no llvm type matching this floating-point bit width: " << t << "\n";
-                return nullptr;
-            }
-        } else if (t.is_handle()) {
-            return llvm::Type::getInt8PtrTy(*c);
-        } else {
-            return llvm::Type::getIntNTy(*c, t.bits());
-        }
+int get_vector_num_elements(llvm::Type *t) {
+    if (t->isVectorTy()) {
+        auto *vt = dyn_cast<llvm::FixedVectorType>(t);
+        internal_assert(vt) << "Called get_vector_num_elements on a scalable vector type\n";
+        return vt->getNumElements();
     } else {
-        llvm::Type *element_type = llvm_type_of(c, t.element_of(), 0);
-        bool scalable = false;
-        int lanes = t.lanes();
-        if (effective_vscale != 0) {
-            int total_bits = t.bits() * t.lanes();
-            scalable = ((total_bits % effective_vscale) == 0);
-            if (scalable) {
-                lanes /= effective_vscale;
-            } else {
-                // TODO(zvookin): This error indicates that the requested number of vector lanes
-                // is not expressible exactly via vscale. This will be fairly unusual unless
-                // non-power of two, or very short, vector sizes are used in a schedule.
-                // It is made an error, instead of passing the fixed non-vscale vector type to LLVM,
-                // to catch the case early while developing vscale backends.
-                // We may need to change this to allow the case so if one hits this error in situation
-                // where it should pass through a fixed width vector type, please discuss.
-                internal_error << "Failed to make vscale vector type with bits " << t.bits() << " lanes " << t.lanes()
-                               << " effective_vscale " << effective_vscale << " total_bits " << total_bits << "\n";
-            }
-        }
-        return get_vector_type(element_type, lanes, scalable);
+        return 1;
     }
 }
 
@@ -67,14 +32,6 @@ llvm::Type *get_vector_element_type(llvm::Type *t) {
     } else {
         return t;
     }
-}
-
-llvm::ElementCount element_count(int e) {
-    return llvm::ElementCount::getFixed(e);
-}
-
-llvm::Type *get_vector_type(llvm::Type *t, int n, bool scalable) {
-    return VectorType::get(t, n, scalable);
 }
 
 // Returns true if the given function name is one of the Halide runtime

--- a/src/CodeGen_Internal.h
+++ b/src/CodeGen_Internal.h
@@ -37,22 +37,9 @@ struct Target;
 
 namespace Internal {
 
-/** Get the llvm type equivalent to a given halide type. If
- * effective_vscale is nonzero and the type is a vector type with lanes
- * a multiple of effective_vscale, a scalable vector type is generated
- * with total lanes divided by effective_vscale. That is a scalable
- * vector intended to be used with a fixed vscale of effective_vscale.
- */
-llvm::Type *llvm_type_of(llvm::LLVMContext *context, Halide::Type t,
-                         int effective_vscale);
-
 /** Get the scalar type of an llvm vector type. Returns the argument
  * if it's not a vector type. */
 llvm::Type *get_vector_element_type(llvm::Type *);
-
-llvm::ElementCount element_count(int e);
-
-llvm::Type *get_vector_type(llvm::Type *, int n, bool scalable = false);
 
 /** Which built-in functions require a user-context first argument? */
 bool function_takes_user_context(const std::string &name);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -252,25 +252,14 @@ std::unique_ptr<CodeGen_LLVM> CodeGen_LLVM::new_for_target(const Target &target,
     return result;
 }
 
-void CodeGen_LLVM::initialize_llvm(const Target &target) {
+void CodeGen_LLVM::initialize_llvm() {
     static std::once_flag init_llvm_once;
-    std::call_once(init_llvm_once, [&target]() {
+    std::call_once(init_llvm_once, []() {
         // You can hack in command-line args to llvm with the
         // environment variable HL_LLVM_ARGS, e.g. HL_LLVM_ARGS="-print-after-all"
         std::string args = get_env_variable("HL_LLVM_ARGS");
-        if (!args.empty() || target.vector_bits != 0) {
-            vector<std::string> arg_vec;
-            if (!args.empty()) {
-                arg_vec = split_string(args, " ");
-            }
-            if (target.vector_bits != 0) {
-                std::string arm_min_vector_width_arg = "-aarch64-sve-vector-bits-min=" + std::to_string(target.vector_bits);
-                arg_vec.push_back(arm_min_vector_width_arg);
-                std::string rvv_min_vector_width_arg = "-riscv-v-vector-bits-min=" + std::to_string(target.vector_bits);
-                arg_vec.push_back(rvv_min_vector_width_arg);
-                std::string rvv_max_vector_width_arg = "-riscv-v-vector-bits-max=" + std::to_string(target.vector_bits);
-                arg_vec.push_back(rvv_max_vector_width_arg);
-            }
+        if (!args.empty()) {
+            vector<std::string> arg_vec = split_string(args, " ");
             vector<const char *> c_arg_vec;
             c_arg_vec.push_back("llc");
             for (const std::string &s : arg_vec) {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -252,14 +252,25 @@ std::unique_ptr<CodeGen_LLVM> CodeGen_LLVM::new_for_target(const Target &target,
     return result;
 }
 
-void CodeGen_LLVM::initialize_llvm() {
+void CodeGen_LLVM::initialize_llvm(const Target &target) {
     static std::once_flag init_llvm_once;
-    std::call_once(init_llvm_once, []() {
+    std::call_once(init_llvm_once, [&target]() {
         // You can hack in command-line args to llvm with the
         // environment variable HL_LLVM_ARGS, e.g. HL_LLVM_ARGS="-print-after-all"
         std::string args = get_env_variable("HL_LLVM_ARGS");
-        if (!args.empty()) {
-            vector<std::string> arg_vec = split_string(args, " ");
+        if (!args.empty() || target.vector_bits != 0) {
+            vector<std::string> arg_vec;
+            if (!args.empty()) {
+                arg_vec = split_string(args, " ");
+            }
+            if (target.vector_bits != 0) {
+                std::string arm_min_vector_width_arg = "-aarch64-sve-vector-bits-min=" + std::to_string(target.vector_bits);
+                arg_vec.push_back(arm_min_vector_width_arg);
+                std::string rvv_min_vector_width_arg = "-riscv-v-vector-bits-min=" + std::to_string(target.vector_bits);
+                arg_vec.push_back(rvv_min_vector_width_arg);
+                std::string rvv_max_vector_width_arg = "-riscv-v-vector-bits-max=" + std::to_string(target.vector_bits);
+                arg_vec.push_back(rvv_max_vector_width_arg);
+            }
             vector<const char *> c_arg_vec;
             c_arg_vec.push_back("llc");
             for (const std::string &s : arg_vec) {
@@ -1083,7 +1094,7 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
 }
 
 llvm::Type *CodeGen_LLVM::llvm_type_of(const Type &t) const {
-    return Internal::llvm_type_of(context, t, effective_vscale);
+    return llvm_type_of(context, t, effective_vscale);
 }
 
 void CodeGen_LLVM::optimize_module() {
@@ -1321,10 +1332,18 @@ Value *CodeGen_LLVM::codegen(const Expr &e) {
     // implementation of prefetch.
     // See https://github.com/halide/Halide/issues/4211.
     const bool is_prefetch = Call::as_intrinsic(e, {Call::prefetch});
-    internal_assert(is_bool_vector || is_prefetch ||
-                    e.type().is_handle() ||
-                    value->getType()->isVoidTy() ||
-                    value->getType() == llvm_type_of(e.type()))
+    bool types_match = is_bool_vector || is_prefetch ||
+                       e.type().is_handle() ||
+                       value->getType()->isVoidTy() ||
+                       value->getType() == llvm_type_of(e.type());
+    if (!types_match && debug::debug_level() > 0) {
+        debug(1) << "Unexpected LLVM type for generated expression. Expected (llvm_type_of(e.type())): ";
+        llvm_type_of(e.type())->print(dbgs(), true);
+        debug(1) << " got (value->getType()): ";
+        value->print(dbgs(), true);
+        debug(1) << "\n";
+    }
+    internal_assert(types_match)
         << "Codegen of Expr " << e
         << " of type " << e.type()
         << " did not produce llvm IR of the corresponding llvm type.\n";
@@ -2133,7 +2152,7 @@ llvm::Value *CodeGen_LLVM::create_broadcast(llvm::Value *v, int lanes) {
     Constant *poison = PoisonValue::get(get_vector_type(v->getType(), lanes));
     Constant *zero = ConstantInt::get(i32_t, 0);
     v = builder->CreateInsertElement(poison, v, zero);
-    Constant *zeros = ConstantVector::getSplat(element_count(lanes), zero);
+    Constant *zeros = get_splat(lanes, zero);
     return builder->CreateShuffleVector(v, poison, zeros);
 }
 
@@ -2359,6 +2378,7 @@ llvm::Value *CodeGen_LLVM::codegen_dense_vector_load(const Type &type, const std
         int slice_lanes = std::min(native_lanes, load_lanes - i);
         Expr slice_base = simplify(base + i);
         Expr slice_stride = make_one(slice_base.type());
+
         Expr slice_index = slice_lanes == 1 ? slice_base : Ramp::make(slice_base, slice_stride, slice_lanes);
         llvm::Type *slice_type = get_vector_type(llvm_type_of(type.element_of()), slice_lanes);
         Value *elt_ptr = codegen_buffer_pointer(name, type.element_of(), slice_base);
@@ -2849,7 +2869,14 @@ void CodeGen_LLVM::visit(const Call *op) {
                 intrin += "sub.sat.";
             }
             if (op->type.lanes() > 1) {
-                intrin += "v" + std::to_string(op->type.lanes());
+                int lanes = op->type.lanes();
+                llvm::Type *llvm_type = llvm_type_of(op->type);
+                if (isa<ScalableVectorType>(llvm_type)) {
+                    internal_assert((effective_vscale != 0) && ((lanes % effective_vscale) == 0));
+                    intrin += "nx";
+                    lanes /= effective_vscale;
+                }
+                intrin += "v" + std::to_string(lanes);
             }
             intrin += "i" + std::to_string(op->type.bits());
             value = call_intrin(op->type, op->type.lanes(), intrin, op->args);
@@ -4455,7 +4482,7 @@ Value *CodeGen_LLVM::call_intrin(const Type &result_type, int intrin_lanes,
 
     return call_intrin(t,
                        intrin_lanes,
-                       name, arg_values);
+                       name, arg_values, isa<llvm::ScalableVectorType>(t));
 }
 
 Value *CodeGen_LLVM::call_intrin(const Type &result_type, int intrin_lanes,
@@ -4486,10 +4513,10 @@ Value *CodeGen_LLVM::call_intrin(const llvm::Type *result_type, int intrin_lanes
         if (intrin_lanes > 1) {
             if (scalable_vector_result && effective_vscale != 0) {
                 intrinsic_result_type = get_vector_type(result_type->getScalarType(),
-                                                        intrin_lanes / effective_vscale, true);
+                                                        intrin_lanes / effective_vscale, VectorTypeConstraint::VScale);
             } else {
                 intrinsic_result_type = get_vector_type(result_type->getScalarType(),
-                                                        intrin_lanes);
+                                                        intrin_lanes, VectorTypeConstraint::Fixed);
             }
         }
         FunctionType *func_t = FunctionType::get(intrinsic_result_type, arg_types, false);
@@ -4768,20 +4795,20 @@ llvm::Value *CodeGen_LLVM::fixed_to_scalable_vector_type(llvm::Value *fixed_arg)
     auto lanes = fixed->getNumElements();
 
     const llvm::ScalableVectorType *scalable = cast<llvm::ScalableVectorType>(get_vector_type(fixed->getElementType(),
-                                                                                              lanes / effective_vscale, true));
+                                                                                              lanes / effective_vscale, VectorTypeConstraint::VScale));
     internal_assert(fixed != nullptr);
 
     internal_assert(fixed->getElementType() == scalable->getElementType());
     internal_assert(lanes == (scalable->getMinNumElements() * effective_vscale));
 
-    // E.g. <vscale x 2 x i64> llvm.experimental.vector.insert.nxv2i64.v4i64(<vscale x 2 x i64>, <4 x i64>, i64)
+    // E.g. <vscale x 2 x i64> llvm.vector.insert.nxv2i64.v4i64(<vscale x 2 x i64>, <4 x i64>, i64)
     const char *type_designator;
     if (fixed->getElementType()->isIntegerTy()) {
         type_designator = "i";
     } else {
         type_designator = "f";
     }
-    std::string intrin = "llvm.experimental.vector.insert.nxv" + std::to_string(scalable->getMinNumElements());
+    std::string intrin = "llvm.vector.insert.nxv" + std::to_string(scalable->getMinNumElements());
     intrin += type_designator;
     std::string bits_designator = std::to_string(fixed->getScalarSizeInBits());
     intrin += bits_designator;
@@ -4803,13 +4830,13 @@ llvm::Value *CodeGen_LLVM::scalable_to_fixed_vector_type(llvm::Value *scalable_a
     internal_assert(scalable != nullptr);
 
     const llvm::FixedVectorType *fixed = cast<llvm::FixedVectorType>(get_vector_type(scalable->getElementType(),
-                                                                                     scalable->getMinNumElements() * effective_vscale, false));
+                                                                                     scalable->getMinNumElements() * effective_vscale, VectorTypeConstraint::Fixed));
     internal_assert(fixed != nullptr);
 
     internal_assert(fixed->getElementType() == scalable->getElementType());
     internal_assert(fixed->getNumElements() == (scalable->getMinNumElements() * effective_vscale));
 
-    // E.g. <64 x i8> @llvm.experimental.vector.extract.v64i8.nxv8i8(<vscale x 8 x i8> %vresult, i64 0)
+    // E.g. <64 x i8> @llvm.vector.extract.v64i8.nxv8i8(<vscale x 8 x i8> %vresult, i64 0)
     const char *type_designator;
     if (scalable->getElementType()->isIntegerTy()) {
         type_designator = "i";
@@ -4817,7 +4844,7 @@ llvm::Value *CodeGen_LLVM::scalable_to_fixed_vector_type(llvm::Value *scalable_a
         type_designator = "f";
     }
     std::string bits_designator = std::to_string(fixed->getScalarSizeInBits());
-    std::string intrin = "llvm.experimental.vector.extract.v" + std::to_string(fixed->getNumElements()) + type_designator + bits_designator;
+    std::string intrin = "llvm.vector.extract.v" + std::to_string(fixed->getNumElements()) + type_designator + bits_designator;
     intrin += ".nxv" + std::to_string(scalable->getMinNumElements()) + type_designator + bits_designator;
     std::vector<llvm::Value *> args;
     args.push_back(scalable_arg);
@@ -4837,6 +4864,99 @@ int CodeGen_LLVM::get_vector_num_elements(const llvm::Type *t) {
     } else {
         return 1;
     }
+}
+
+llvm::Type *CodeGen_LLVM::llvm_type_of(LLVMContext *c, Halide::Type t,
+                                       int effective_vscale) const {
+    if (t.lanes() == 1) {
+        if (t.is_float() && !t.is_bfloat()) {
+            switch (t.bits()) {
+            case 16:
+                return llvm::Type::getHalfTy(*c);
+            case 32:
+                return llvm::Type::getFloatTy(*c);
+            case 64:
+                return llvm::Type::getDoubleTy(*c);
+            default:
+                internal_error << "There is no llvm type matching this floating-point bit width: " << t << "\n";
+                return nullptr;
+            }
+        } else if (t.is_handle()) {
+            return llvm::Type::getInt8PtrTy(*c);
+        } else {
+            return llvm::Type::getIntNTy(*c, t.bits());
+        }
+    } else {
+        llvm::Type *element_type = llvm_type_of(c, t.element_of(), 0);
+        bool scalable = false;
+        int lanes = t.lanes();
+        if (effective_vscale != 0) {
+            int total_bits = t.bits() * t.lanes();
+            scalable = ((total_bits % effective_vscale) == 0);
+            if (scalable) {
+                lanes /= effective_vscale;
+            } else {
+                // TODO(zvookin): This error indicates that the requested number of vector lanes
+                // is not expressible exactly via vscale. This will be fairly unusual unless
+                // non-power of two, or very short, vector sizes are used in a schedule.
+                // It is made an error, instead of passing the fixed non-vscale vector type to LLVM,
+                // to catch the case early while developing vscale backends.
+                // We may need to change this to allow the case so if one hits this error in situation
+                // where it should pass through a fixed width vector type, please discuss.
+                internal_error << "Failed to make vscale vector type with bits " << t.bits() << " lanes " << t.lanes()
+                               << " effective_vscale " << effective_vscale << " total_bits " << total_bits << "\n";
+            }
+        }
+        return get_vector_type(element_type, lanes,
+                               scalable ? VectorTypeConstraint::VScale : VectorTypeConstraint::Fixed);
+    }
+}
+
+llvm::Type *CodeGen_LLVM::get_vector_type(llvm::Type *t, int n,
+                                          VectorTypeConstraint type_constraint) const {
+    bool scalable;
+  
+    switch (type_constraint) {
+      case VectorTypeConstraint::None:
+        scalable = effective_vscale != 0 &&
+                   ((n % effective_vscale) == 0);
+        if (scalable) {
+            n = n / effective_vscale;
+        }
+        break;
+      case VectorTypeConstraint::Fixed:
+        scalable = false;
+        break;
+      case VectorTypeConstraint::VScale:
+        scalable = true;
+        break;
+    }
+      
+    return VectorType::get(t, n, scalable);
+}
+
+llvm::Constant *CodeGen_LLVM::get_splat(int lanes, llvm::Constant *value,
+                                        VectorTypeConstraint type_constraint) const {
+    bool scalable = false;
+    switch (type_constraint) {
+      case VectorTypeConstraint::None:
+        scalable = effective_vscale != 0 &&
+                   ((lanes % effective_vscale) == 0);
+        if (scalable) {
+            lanes = lanes / effective_vscale;
+        }
+        break;
+      case VectorTypeConstraint::Fixed:
+        scalable = false;
+        break;
+      case VectorTypeConstraint::VScale:
+        scalable = true;
+        break;
+    }
+    
+    llvm::ElementCount ec = scalable ? llvm::ElementCount::getScalable(lanes) :
+                                       llvm::ElementCount::getFixed(lanes);
+    return ConstantVector::getSplat(ec, value);
 }
 
 }  // namespace Internal

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2367,7 +2367,6 @@ llvm::Value *CodeGen_LLVM::codegen_dense_vector_load(const Type &type, const std
         int slice_lanes = std::min(native_lanes, load_lanes - i);
         Expr slice_base = simplify(base + i);
         Expr slice_stride = make_one(slice_base.type());
-
         Expr slice_index = slice_lanes == 1 ? slice_base : Ramp::make(slice_base, slice_stride, slice_lanes);
         llvm::Type *slice_type = get_vector_type(llvm_type_of(type.element_of()), slice_lanes);
         Value *elt_ptr = codegen_buffer_pointer(name, type.element_of(), slice_base);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4915,23 +4915,23 @@ llvm::Type *CodeGen_LLVM::llvm_type_of(LLVMContext *c, Halide::Type t,
 llvm::Type *CodeGen_LLVM::get_vector_type(llvm::Type *t, int n,
                                           VectorTypeConstraint type_constraint) const {
     bool scalable;
-  
+
     switch (type_constraint) {
-      case VectorTypeConstraint::None:
+    case VectorTypeConstraint::None:
         scalable = effective_vscale != 0 &&
                    ((n % effective_vscale) == 0);
         if (scalable) {
             n = n / effective_vscale;
         }
         break;
-      case VectorTypeConstraint::Fixed:
+    case VectorTypeConstraint::Fixed:
         scalable = false;
         break;
-      case VectorTypeConstraint::VScale:
+    case VectorTypeConstraint::VScale:
         scalable = true;
         break;
     }
-      
+
     return VectorType::get(t, n, scalable);
 }
 
@@ -4939,21 +4939,21 @@ llvm::Constant *CodeGen_LLVM::get_splat(int lanes, llvm::Constant *value,
                                         VectorTypeConstraint type_constraint) const {
     bool scalable = false;
     switch (type_constraint) {
-      case VectorTypeConstraint::None:
+    case VectorTypeConstraint::None:
         scalable = effective_vscale != 0 &&
                    ((lanes % effective_vscale) == 0);
         if (scalable) {
             lanes = lanes / effective_vscale;
         }
         break;
-      case VectorTypeConstraint::Fixed:
+    case VectorTypeConstraint::Fixed:
         scalable = false;
         break;
-      case VectorTypeConstraint::VScale:
+    case VectorTypeConstraint::VScale:
         scalable = true;
         break;
     }
-    
+
     llvm::ElementCount ec = scalable ? llvm::ElementCount::getScalable(lanes) :
                                        llvm::ElementCount::getFixed(lanes);
     return ConstantVector::getSplat(ec, value);

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -555,7 +555,7 @@ protected:
         VScale,  /// For use of scalable vectors.
     };
     llvm::Type *get_vector_type(llvm::Type *, int n,
-                                VectorTypeConstraint type_constraint = VectorTypeConstraint::None) const ;
+                                VectorTypeConstraint type_constraint = VectorTypeConstraint::None) const;
     // @}
     
     llvm::Constant *get_splat(int lanes, llvm::Constant *value,

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -557,7 +557,7 @@ protected:
     llvm::Type *get_vector_type(llvm::Type *, int n,
                                 VectorTypeConstraint type_constraint = VectorTypeConstraint::None) const;
     // @}
-    
+
     llvm::Constant *get_splat(int lanes, llvm::Constant *value,
                               VectorTypeConstraint type_constraint = VectorTypeConstraint::None) const;
 

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -72,12 +72,8 @@ public:
     /** Tell the code generator which LLVM context to use. */
     void set_context(llvm::LLVMContext &context);
 
-    /* TODO(zalman): Passing a target here is a total hack to allow setting
-     * SVE vector register width for fixed size compilation. This will need
-     * to be fixed -- likely by a change to LLVM making the option part of
-     * the TargetMachine -- if this PR is to be merged to main. */
     /** Initialize internal llvm state for the enabled targets. */
-    static void initialize_llvm(const Target &target = Target());
+    static void initialize_llvm();
 
     static std::unique_ptr<llvm::Module> compile_trampolines(
         const Target &target,

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -72,8 +72,12 @@ public:
     /** Tell the code generator which LLVM context to use. */
     void set_context(llvm::LLVMContext &context);
 
+    /* TODO(zalman): Passing a target here is a total hack to allow setting
+     * SVE vector register width for fixed size compilation. This will need
+     * to be fixed -- likely by a change to LLVM making the option part of
+     * the TargetMachine -- if this PR is to be merged to main. */
     /** Initialize internal llvm state for the enabled targets. */
-    static void initialize_llvm();
+    static void initialize_llvm(const Target &target = Target());
 
     static std::unique_ptr<llvm::Module> compile_trampolines(
         const Target &target,
@@ -165,7 +169,6 @@ protected:
     llvm::MDNode *default_fp_math_md;
     llvm::MDNode *strict_fp_math_md;
     std::vector<LoweredArgument> current_function_args;
-    //@}
 
     /** The target we're generating code for */
     Halide::Target target;
@@ -393,6 +396,15 @@ protected:
      * current context. */
     virtual llvm::Type *llvm_type_of(const Type &) const;
 
+    /** Get the llvm type equivalent to a given halide type. If
+     * effective_vscale is nonzero and the type is a vector type with lanes
+     * a multiple of effective_vscale, a scalable vector type is generated
+     * with total lanes divided by effective_vscale. That is a scalable
+     * vector intended to be used with a fixed vscale of effective_vscale.
+     */
+    llvm::Type *llvm_type_of(llvm::LLVMContext *context, Halide::Type t,
+                             int effective_vscale) const;
+
     /** Perform an alloca at the function entrypoint. Will be cleaned
      * on function exit. */
     llvm::Value *create_alloca_at_entry(llvm::Type *type, int n,
@@ -529,6 +541,25 @@ protected:
 
     /** Get number of vector elements, taking into account scalable vectors. Returns 1 for scalars. */
     int get_vector_num_elements(const llvm::Type *t);
+
+    /** Interface to abstract vector code generation as LLVM is now
+     * providing multiple options to express even simple vector
+     * operations. Specifically traditional fixed length vectors, vscale
+     * based variable length vectors, and the vector predicate based approach
+     * where an explict length is passed with each instruction.
+     */
+    // @{
+    enum class VectorTypeConstraint {
+        None,    /// Use default for current target.
+        Fixed,   /// Force use of fixed size vectors.
+        VScale,  /// For use of scalable vectors.
+    };
+    llvm::Type *get_vector_type(llvm::Type *, int n,
+                                VectorTypeConstraint type_constraint = VectorTypeConstraint::None) const ;
+    // @}
+    
+    llvm::Constant *get_splat(int lanes, llvm::Constant *value,
+                              VectorTypeConstraint type_constraint = VectorTypeConstraint::None) const;
 
 private:
     /** All the values in scope at the current code location during


### PR DESCRIPTION
Also remove ```element_count``` as it was only used in a single pattern which is now in the ```CodeGen_LLVM::get_splat``` routine.

Also allows control of vscale vs. fixed types for vector types based on state in CodeGen_LLVM.