### PR TITLE
Change an assert to match code, hopefully.

### DIFF
--- a/src/CanonicalizeGPUVars.cpp
+++ b/src/CanonicalizeGPUVars.cpp
@@ -128,7 +128,7 @@ class CanonicalizeGPUVars : public IRMutator {
             (op->for_type == ForType::GPULane)) {
 
             vector<string> v = split_string(op->name, ".");
-            internal_assert(v.size() > 2);
+            internal_assert(v.size() >= 2);
 
             CountGPUBlocksThreads counter(v[0] + "." + v[1]);
             op->body.accept(&counter);


### PR DESCRIPTION
Ran into this assert. The entire destructuring of For names things has to go, but the code only accesses two elements here and I'm not sure why a two level loop next shouldn't be applicable here. 