### PR TITLE
Improve error-handling in Python Extensions

### DIFF
--- a/python_bindings/test/correctness/multi_method_module_test.py
+++ b/python_bindings/test/correctness/multi_method_module_test.py
@@ -31,7 +31,21 @@ def test_user_context():
     multi_method_module.user_context(None, ord('q'), output)
     assert output == bytearray("qqqq", "ascii")
 
+def test_aot_call_failure_throws_exception():
+    buffer_input = np.zeros([2, 2], dtype=np.uint8)
+    func_input = np.zeros([2, 2], dtype=np.float32)  # wrong type
+    float_arg = 3.5
+    simple_output = np.zeros([2, 2], dtype=np.float32)
+
+    try:
+        multi_method_module.simple(buffer_input, func_input, float_arg, simple_output)
+    except RuntimeError as e:
+        assert 'Halide Runtime Error: -3 (Input buffer func_input has type uint8 but type of the buffer passed in is float32)' in str(e), str(e)
+    else:
+        assert False, 'Did not see expected exception, saw: ' + str(e)
 
 if __name__ == "__main__":
     test_simple()
     test_user_context()
+    test_aot_call_failure_throws_exception()
+

--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -300,11 +300,7 @@ PyModuleDef _moduledef = {
     nullptr,                                                        // free
 };
 
-}  // namespace
-
-extern "C" {
-
-void halide_error(void *user_context, const char *msg) {
+void _module_halide_error(void *user_context, const char *msg) {
     using Halide::PythonRuntime::current_error;
     if (current_error.empty()) {
         // fprintf(stderr, "Setting current_error=(%s)\n", msg);
@@ -314,9 +310,13 @@ void halide_error(void *user_context, const char *msg) {
     }
 }
 
-void halide_print(void *user_context, const char *msg) {
+void _module_halide_print(void *user_context, const char *msg) {
     PySys_FormatStdout("%s", msg);
 }
+
+}  // namespace
+
+extern "C" {
 
 #ifdef HALIDE_PYTHON_EXTENSION_INCLUDE_RUNTIME_SUBMODULE
 extern PyObject *_halide_runtime_submodule_impl(PyObject *module);
@@ -327,6 +327,8 @@ HALIDE_EXPORT_SYMBOL PyObject *_HALIDE_EXPAND_AND_CONCAT(PyInit_, HALIDE_PYTHON_
 #ifdef HALIDE_PYTHON_EXTENSION_INCLUDE_RUNTIME_SUBMODULE
     (void)_halide_runtime_submodule_impl(m);
 #endif
+    halide_set_error_handler(_module_halide_error);
+    halide_set_custom_print(_module_halide_print);
     return m;
 }
 

--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -318,15 +318,8 @@ void _module_halide_print(void *user_context, const char *msg) {
 
 extern "C" {
 
-#ifdef HALIDE_PYTHON_EXTENSION_INCLUDE_RUNTIME_SUBMODULE
-extern PyObject *_halide_runtime_submodule_impl(PyObject *module);
-#endif
-
 HALIDE_EXPORT_SYMBOL PyObject *_HALIDE_EXPAND_AND_CONCAT(PyInit_, HALIDE_PYTHON_EXTENSION_MODULE)() {
     PyObject *m = PyModule_Create(&_moduledef);
-#ifdef HALIDE_PYTHON_EXTENSION_INCLUDE_RUNTIME_SUBMODULE
-    (void)_halide_runtime_submodule_impl(m);
-#endif
     halide_set_error_handler(_module_halide_error);
     halide_set_custom_print(_module_halide_print);
     return m;
@@ -334,7 +327,7 @@ HALIDE_EXPORT_SYMBOL PyObject *_HALIDE_EXPAND_AND_CONCAT(PyInit_, HALIDE_PYTHON_
 
 }  // extern "C"
 
-#endif  //HALIDE_PYTHON_EXTENSION_OMIT_MODULE_DEFINITION
+#endif  // HALIDE_PYTHON_EXTENSION_OMIT_MODULE_DEFINITION
 )INLINE_CODE";
 }
 


### PR DESCRIPTION
Currently, Python Extensions don't make any effort to override `halide_error`, so the default (which aborts) is generally used... this is very unfriendly. This modifies the standard Python Extension glue code to hook halide_error, saving the text in a thread local, and then throwing a Python exception after the extension's AOT call is finished (if an error occurred, of course).

Also does a drive-by default hooking of `halide_print` to ensure that it goes to whatever Python thinks that `stdout` is.

(Note that it would be really nice if we could use closures of some sort for halide_error, halide_print, etc so that we could save context in the actual Python module, rather than in a thread-local global var, but this currently isn't possible without nontrivial refactoring in the Halide runtime.)