### PR TITLE
Fix compiler warnings in Elf.cpp

### DIFF
--- a/src/Elf.cpp
+++ b/src/Elf.cpp
@@ -139,11 +139,11 @@ struct Rel {
     typedef typename T::addr_t addr_t;
     typedef typename T::addr_off_t addr_off_t;
 
-    addr_t r_offset;
-    addr_t r_info;
+    const addr_t r_offset;
+    const addr_t r_info;
 
     uint32_t r_type() const {
-        if (sizeof(addr_t) == 8) {
+        if constexpr (sizeof(addr_t) == 8) {
             return r_info & 0xffffffff;
         } else {
             return r_info & 0xff;
@@ -151,27 +151,11 @@ struct Rel {
     }
 
     uint32_t r_sym() const {
-        if (sizeof(addr_t) == 8) {
+        if constexpr (sizeof(addr_t) == 8) {
             return (uint64_t)r_info >> 32;
         } else {
             return r_info >> 8;
         }
-    }
-
-    static addr_t make_info(uint32_t type, uint32_t sym) {
-        if (sizeof(addr_t) == 8) {
-            return (uint64_t)type | ((uint64_t)sym << 32);
-        } else {
-            return (type & 0xff) | (sym << 8);
-        }
-    }
-
-    void set_r_type(uint32_t type) {
-        r_info = make_info(type, r_sym());
-    }
-
-    void set_r_sym(uint32_t sym) {
-        r_info = make_info(r_type(), sym);
     }
 
     Rel(addr_t offset, addr_t info)
@@ -181,6 +165,15 @@ struct Rel {
     Rel(addr_t offset, uint32_t type, uint32_t sym)
         : r_offset(offset), r_info(make_info(type, sym)) {
     }
+
+private:
+    static addr_t make_info(uint32_t type, uint32_t sym) {
+        if constexpr (sizeof(addr_t) == 8) {
+            return (uint64_t)type | ((uint64_t)sym << 32);
+        } else {
+            return (type & 0xff) | (sym << 8);
+        }
+    }
 };
 
 template<typename T>
@@ -188,7 +181,7 @@ struct Rela : public Rel<T> {
     typedef typename T::addr_t addr_t;
     typedef typename T::addr_off_t addr_off_t;
 
-    addr_off_t r_addend;
+    const addr_off_t r_addend;
 
     Rela(addr_t offset, addr_t info, addr_off_t addend)
         : Rel<T>(offset, info), r_addend(addend) {
@@ -218,15 +211,13 @@ struct Sym<Types<32>> {
         return st_info & 0xf;
     }
 
-    static uint8_t make_info(uint8_t binding, uint8_t type) {
-        return (binding << 4) | (type & 0xf);
+    void set_binding_and_type(uint8_t binding, uint8_t type) {
+        st_info = make_info(binding, type);
     }
 
-    void set_binding(uint8_t binding) {
-        st_info = make_info(binding, get_type());
-    }
-    void set_type(uint8_t type) {
-        st_info = make_info(get_binding(), type);
+private:
+    static uint8_t make_info(uint8_t binding, uint8_t type) {
+        return (binding << 4) | (type & 0xf);
     }
 };
 
@@ -798,8 +789,7 @@ std::vector<char> write_shared_object_internal(Object &obj, Linker *linker, cons
             safe_assign(sym.st_name, strings.get(s->get_name()));
             safe_assign(sym.st_value, value);
             safe_assign(sym.st_size, s->get_size());
-            sym.set_type(s->get_type());
-            sym.set_binding(s->get_binding());
+            sym.set_binding_and_type(s->get_binding(), s->get_type());
             safe_assign(sym.st_other, s->get_visibility());
             sym.st_shndx = section_idxs[s->get_section()];
 

--- a/src/Elf.cpp
+++ b/src/Elf.cpp
@@ -143,7 +143,7 @@ struct Rel {
     const addr_t r_info;
 
     uint32_t r_type() const {
-        if constexpr (sizeof(addr_t) == 8) {
+        if (sizeof(addr_t) == 8) {
             return r_info & 0xffffffff;
         } else {
             return r_info & 0xff;
@@ -151,7 +151,7 @@ struct Rel {
     }
 
     uint32_t r_sym() const {
-        if constexpr (sizeof(addr_t) == 8) {
+        if (sizeof(addr_t) == 8) {
             return (uint64_t)r_info >> 32;
         } else {
             return r_info >> 8;
@@ -168,7 +168,7 @@ struct Rel {
 
 private:
     static addr_t make_info(uint32_t type, uint32_t sym) {
-        if constexpr (sizeof(addr_t) == 8) {
+        if (sizeof(addr_t) == 8) {
             return (uint64_t)type | ((uint64_t)sym << 32);
         } else {
             return (type & 0xff) | (sym << 8);


### PR DESCRIPTION
Some versions of GCC will complain that there is a possible use of uninitialized field `Sym<>::st_info` here; that's technically true, in that it is a bitfield that we previously set via two calls, so it temporarily could use uninitialized bits, but those would immediately be overwritten by well-defined bits. That said, the API could have been misused, so I collapsed Sym::set_type and Sym::set_bindings into a single call to avoid this warning.

While I was there, I did a little hygiene on Rel<> and Rela<> as well, as there was an unused-but-similarly-dubious API there. ~~Also added some C++17 `if constexpr` love.~~