### PR TITLE
Fixes for Xcode "new" build system.

### DIFF
--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -462,6 +462,10 @@ function(add_halide_python_extension_library TARGET)
                           VISIBILITY_INLINES_HIDDEN ON
                           POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(${TARGET}_module_definition PRIVATE Halide::Runtime Python3::Module)
+
+    list(GET ARG_HALIDE_LIBRARIES 0 module_definition_lib)
+    add_dependencies(${TARGET}_module_definition ${module_definition_lib})
+
     # Compile it with the right preprocessor definitions to provide the module defs,
     # but not the function implementations
     target_compile_definitions(${TARGET}_module_definition PRIVATE

--- a/cmake/TargetExportScript.cmake
+++ b/cmake/TargetExportScript.cmake
@@ -20,6 +20,18 @@ function(target_export_script TARGET)
         return()
     endif ()
 
+    if (XCODE)
+        # There is a bug in Xcode where -Xlinker flags in the OTHER_LDFLAGS
+        # property creates a bogus dependency on a file named -Xlinker. No
+        # idea how this happens. CMake translates the EXPORTED_SYMBOLS_FLAG
+        # below to -Xlinker -exported_symbols_list -Xlinker ${ARG_APPLE_LD}
+        # which by rights should work, and in fact Xcode prints a link line
+        # that DOES work, but the aforementioned bug breaks the check. Going
+        # through the "official" Xcode attribute is a reasonable workaround.
+        set_property(TARGET "${TARGET}" PROPERTY XCODE_ATTRIBUTE_EXPORTED_SYMBOLS_FILE "${ARG_APPLE_LD}")
+        return()
+    endif ()
+
     ## More linkers support the GNU syntax (ld, lld, gold), so try it first.
     set(VERSION_SCRIPT_FLAG "LINKER:--version-script=${ARG_GNU_LD}")
     check_linker_flag(CXX "${VERSION_SCRIPT_FLAG}" LINKER_HAS_FLAG_VERSION_SCRIPT)


### PR DESCRIPTION
1. `TargetExportScript` was running into an Xcode bug with its handling of linker flags. Now using `XCODE_ATTRIBUTE_EXPORTED_SYMBOLS_LIST` as a workaround.
2. Added a missing dependency in Python module definition code.

Fixes #6987