### PR TITLE
Couple small fixes to update RISC V to current LLVM flags and enable vscale use.

### DIFF
--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -25,6 +25,7 @@ protected:
     string mabi() const override;
     bool use_soft_float_abi() const override;
     int native_vector_bits() const override;
+    int target_vscale() const override;
 };
 
 CodeGen_RISCV::CodeGen_RISCV(const Target &t)
@@ -50,7 +51,7 @@ string CodeGen_RISCV::mattrs() const {
     string arch_flags = "+m,+a,+f,+d,+c";
 
     if (target.has_feature(Target::RVV)) {
-        arch_flags += ",+experimental-v";
+        arch_flags += ",+v";
     }
     return arch_flags;
 }
@@ -73,7 +74,21 @@ bool CodeGen_RISCV::use_soft_float_abi() const {
 }
 
 int CodeGen_RISCV::native_vector_bits() const {
-    return 128;
+    if (target.vector_bits != 0 &&
+        target.has_feature(Target::RVV)) {
+        return target.vector_bits;
+    }
+    return 0;
+}
+
+int CodeGen_RISCV::target_vscale() const {
+    if (target.vector_bits != 0 &&
+        target.has_feature(Target::RVV)) {
+        internal_assert((target.vector_bits % 64) == 0);
+        return target.vector_bits / 64;
+    }
+
+    return 0;
 }
 
 }  // namespace


### PR DESCRIPTION
The vector extension is no longer experimental and the logic for picking the vector size and vscale was not hooked up.