### PR TITLE
Clean up Adams2019 CMake file

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -80,7 +80,7 @@ else ()
 endif ()
 
 if (TARGET Halide_Adams2019)
-    set(autoscheduler_utils retrain_cost_model featurization_to_sample get_host_target weightsdir_to_weightsfile)
+    set(autoscheduler_utils adams2019_retrain_cost_model adams2019_featurization_to_sample adams2019_get_host_target adams2019_weightsdir_to_weightsfile)
     if (NOT CMAKE_INSTALL_RPATH)
         set_target_properties(${autoscheduler_utils} PROPERTIES INSTALL_RPATH "${rbase};${rbase}/${lib_dir}")
     endif ()

--- a/src/autoschedulers/adams2019/CMakeLists.txt
+++ b/src/autoschedulers/adams2019/CMakeLists.txt
@@ -1,6 +1,31 @@
 ##
-# Resources for the autoscheduler library
+# Build rules for the Adams2019 autoscheduler library
 ##
+
+function(add_adams2019_test NAME)
+    set(options "")
+    set(oneValueArgs ENVIRONMENT)
+    set(multiValueArgs COMMAND LABELS)
+    cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT ARGS_COMMAND)
+        set(ARGS_COMMAND ${NAME})
+    endif()
+
+    if (NOT ARGS_LABELS)
+        set(ARGS_LABELS "")
+    endif()
+    list(APPEND ARGS_LABELS Adams2019)
+    list(APPEND ARGS_LABELS auto_schedule)
+
+    add_test(NAME ${NAME}
+             COMMAND ${ARGS_COMMAND})
+    set_tests_properties(${NAME}
+                         PROPERTIES
+                         LABELS "${ARGS_LABELS}"
+                         ENVIRONMENT "${ENVIRONMENT}")
+endfunction()
+
 
 # weights
 set(WF_CPP baseline.cpp)
@@ -10,25 +35,29 @@ add_custom_command(OUTPUT ${WF_CPP}
                    DEPENDS baseline.weights binary2cpp
                    VERBATIM)
 
-add_library(Adams2019_weights_obj OBJECT ${WF_CPP})
+add_library(adams2019_weights_obj OBJECT ${WF_CPP})
 
 # cost_model, train_cost_model
-add_executable(cost_model.generator cost_model_generator.cpp)
-target_link_libraries(cost_model.generator PRIVATE Halide::Generator)
+add_executable(adams2019_cost_model.generator cost_model_generator.cpp)
+target_link_libraries(adams2019_cost_model.generator PRIVATE Halide::Generator)
 
-add_halide_library(cost_model FROM cost_model.generator
+add_halide_library(adams2019_cost_model FROM adams2019_cost_model.generator
+                   GENERATOR cost_model
+                   FUNCTION_NAME cost_model
                    TARGETS cmake)
-add_halide_library(train_cost_model FROM cost_model.generator
+add_halide_library(adams2019_train_cost_model FROM adams2019_cost_model.generator
+                   GENERATOR train_cost_model
+                   FUNCTION_NAME train_cost_model
                    TARGETS cmake
-                   USE_RUNTIME cost_model.runtime)
+                   USE_RUNTIME adams2019_cost_model.runtime)
 
 # retrain_cost_model
-add_executable(retrain_cost_model
+add_executable(adams2019_retrain_cost_model
                DefaultCostModel.cpp
                Weights.cpp
                retrain_cost_model.cpp
-               $<TARGET_OBJECTS:Adams2019_weights_obj>)
-target_link_libraries(retrain_cost_model PRIVATE ASLog cost_model train_cost_model Halide::Halide Halide::Plugin)
+               $<TARGET_OBJECTS:adams2019_weights_obj>)
+target_link_libraries(adams2019_retrain_cost_model PRIVATE ASLog adams2019_cost_model adams2019_train_cost_model Halide::Halide Halide::Plugin)
 
 ##
 # Main autoscheduler library
@@ -43,9 +72,9 @@ add_autoscheduler(NAME Adams2019
                   LoopNest.cpp
                   State.cpp
                   Weights.cpp
-                  $<TARGET_OBJECTS:Adams2019_weights_obj>)
+                  $<TARGET_OBJECTS:adams2019_weights_obj>)
 
-target_link_libraries(Halide_Adams2019 PRIVATE ASLog ParamParser cost_model train_cost_model)
+target_link_libraries(Halide_Adams2019 PRIVATE ASLog ParamParser adams2019_cost_model adams2019_train_cost_model)
 
 ##
 # Tests and demos
@@ -54,90 +83,72 @@ target_link_libraries(Halide_Adams2019 PRIVATE ASLog ParamParser cost_model trai
 
 # =================================================================
 
-add_executable(demo.generator demo_generator.cpp)
-target_link_libraries(demo.generator PRIVATE Halide::Generator)
+add_executable(adams2019_demo.generator demo_generator.cpp)
+target_link_libraries(adams2019_demo.generator PRIVATE Halide::Generator)
 
-add_halide_library(demo FROM demo.generator
+add_halide_library(adams2019_demo FROM adams2019_demo.generator
+                   GENERATOR demo
                    TARGETS cmake
                    AUTOSCHEDULER Halide::Adams2019
                    REGISTRATION DEMO_REGISTRATION_FILE)
 
-add_executable(demo_apps_autoscheduler ${DEMO_REGISTRATION_FILE})
-target_link_libraries(demo_apps_autoscheduler PRIVATE demo Halide::RunGenMain)
+add_executable(adams2019_demo_apps_autoscheduler ${DEMO_REGISTRATION_FILE})
+target_link_libraries(adams2019_demo_apps_autoscheduler PRIVATE adams2019_demo Halide::RunGenMain)
 
-add_test(NAME demo_apps_autoscheduler
-         COMMAND demo_apps_autoscheduler --benchmarks=all --benchmark_min_time=1 --estimate_all)
-
-set_tests_properties(demo_apps_autoscheduler
-                     PROPERTIES
-                     LABELS "Adams2019;auto_schedule"
-                     ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
+add_adams2019_test(adams2019_demo_apps_autoscheduler
+                   COMMAND adams2019_demo_apps_autoscheduler --benchmarks=all --benchmark_min_time=1 --estimate_all)
 
 # =================================================================
 
-add_executable(included_schedule_file.generator included_schedule_file_generator.cpp)
-target_link_libraries(included_schedule_file.generator PRIVATE Halide::Generator)
+add_executable(adams2019_included_schedule_file.generator included_schedule_file_generator.cpp)
+target_link_libraries(adams2019_included_schedule_file.generator PRIVATE Halide::Generator)
 
-add_halide_library(included_schedule_file FROM included_schedule_file.generator
+add_halide_library(adams2019_included_schedule_file FROM adams2019_included_schedule_file.generator
+                   GENERATOR included_schedule_file
                    TARGETS cmake
                    AUTOSCHEDULER Halide::Adams2019
-                   REGISTRATION included_schedule_reg)
+                   REGISTRATION adams2019_included_schedule_reg)
 
-add_executable(demo_included_schedule_file ${included_schedule_reg})
-target_link_libraries(demo_included_schedule_file PRIVATE included_schedule_file Halide::RunGenMain)
+add_executable(adams2019_demo_included_schedule_file ${adams2019_included_schedule_reg})
+target_link_libraries(adams2019_demo_included_schedule_file PRIVATE adams2019_included_schedule_file Halide::RunGenMain)
 
-add_test(NAME demo_included_schedule_file
-         COMMAND demo_included_schedule_file --benchmarks=all --benchmark_min_time=1 --estimate_all)
-
-set_tests_properties(demo_included_schedule_file
-                     PROPERTIES
-                     LABELS "Adams2019;auto_schedule"
-                     ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
+add_adams2019_test(adams2019_demo_included_schedule_file
+                   COMMAND adams2019_demo_included_schedule_file --benchmarks=all --benchmark_min_time=1 --estimate_all)
 
 # ====================================================
 # Auto-tuning support utilities.
 # TODO(#4053): implement auto-tuning support in CMake?
 
-add_executable(featurization_to_sample featurization_to_sample.cpp)
+add_executable(adams2019_featurization_to_sample featurization_to_sample.cpp)
 
-add_executable(get_host_target get_host_target.cpp)
-target_link_libraries(get_host_target PRIVATE Halide::Halide)
+add_executable(adams2019_get_host_target get_host_target.cpp)
+target_link_libraries(adams2019_get_host_target PRIVATE Halide::Halide)
 
-add_executable(weightsdir_to_weightsfile weightsdir_to_weightsfile.cpp Weights.cpp)
-target_link_libraries(weightsdir_to_weightsfile PRIVATE Halide::Runtime)
+add_executable(adams2019_weightsdir_to_weightsfile weightsdir_to_weightsfile.cpp Weights.cpp)
+target_link_libraries(adams2019_weightsdir_to_weightsfile PRIVATE Halide::Runtime)
 
 # =================================================================
 # Smaller tests
 
 if (BUILD_SHARED_LIBS)
-    add_executable(test_apps_autoscheduler test.cpp)
-    target_link_libraries(test_apps_autoscheduler PRIVATE Halide::Halide Halide::Tools ${CMAKE_DL_LIBS})
+    add_executable(adams2019_test_apps_autoscheduler test.cpp)
+    target_link_libraries(adams2019_test_apps_autoscheduler PRIVATE Halide::Halide Halide::Tools ${CMAKE_DL_LIBS})
 
-    add_test(NAME test_apps_autoscheduler
-             COMMAND test_apps_autoscheduler $<TARGET_FILE:Halide_Adams2019> ${CMAKE_CURRENT_SOURCE_DIR}/baseline.weights)
-
-    set_tests_properties(test_apps_autoscheduler PROPERTIES
-                         LABELS "Adams2019;multithreaded;auto_schedule"
-                         ENVIRONMENT "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:Halide_Adams2019>:$ENV{LD_LIBRARY_PATH};HL_TARGET=${Halide_TARGET}")
+    add_adams2019_test(adams2019_test_apps_autoscheduler
+                       COMMAND adams2019_test_apps_autoscheduler $<TARGET_FILE:Halide_Adams2019> ${CMAKE_CURRENT_SOURCE_DIR}/baseline.weights
+                       LABELS multithreaded
+                       ENVIRONMENT "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:Halide_Adams2019>:$ENV{LD_LIBRARY_PATH}")
 endif ()
 
 ##
 
-add_executable(test_perfect_hash_map test_perfect_hash_map.cpp)
+add_executable(adams2019_test_perfect_hash_map test_perfect_hash_map.cpp)
 
-add_test(NAME test_perfect_hash_map COMMAND test_perfect_hash_map)
-set_tests_properties(test_perfect_hash_map
-                     PROPERTIES
-                     LABELS "Adams2019;auto_schedule"
-                     ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
+add_adams2019_test(adams2019_test_perfect_hash_map)
 
 ##
 
-add_executable(test_function_dag test_function_dag.cpp FunctionDAG.cpp)
-target_link_libraries(test_function_dag PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+add_executable(adams2019_test_function_dag test_function_dag.cpp FunctionDAG.cpp)
+target_link_libraries(adams2019_test_function_dag PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
-add_test(NAME test_function_dag COMMAND test_function_dag)
-set_tests_properties(test_function_dag
-                     PROPERTIES
-                     LABELS "Adams2019;auto_schedule"
-                     ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
+add_adams2019_test(adams2019_test_function_dag)

--- a/src/autoschedulers/adams2019/DefaultCostModel.cpp
+++ b/src/autoschedulers/adams2019/DefaultCostModel.cpp
@@ -14,8 +14,8 @@
 #include "DefaultCostModel.h"
 #include "HalideBuffer.h"
 #include "NetworkSize.h"
-#include "cost_model.h"
-#include "train_cost_model.h"
+#include "adams2019_cost_model.h"
+#include "adams2019_train_cost_model.h"
 
 // This is an embedded version of `baseline.weights`.
 // The embedding is done using binary2cpp.

--- a/src/autoschedulers/adams2019/Makefile
+++ b/src/autoschedulers/adams2019/Makefile
@@ -36,8 +36,8 @@ $(BIN)/baseline_weights.o: $(BIN)/baseline_weights.cpp
 	$(CXX) -c $< -o $@
 
 AUTOSCHED_COST_MODEL_LIBS=\
-$(BIN)/cost_model/cost_model.a \
-$(BIN)/cost_model/train_cost_model.a \
+$(BIN)/cost_model/adams2019_cost_model.a \
+$(BIN)/cost_model/adams2019_train_cost_model.a \
 
 $(BIN)/cost_model.generator: $(SRC)/cost_model_generator.cpp \
 				$(SRC)/cost_model_schedule.h \
@@ -50,9 +50,9 @@ $(BIN)/auto_schedule_runtime.a: $(BIN)/cost_model.generator
 	@mkdir -p $(@D)
 	$^ -r auto_schedule_runtime -o $(BIN) target=$(HL_TARGET)
 
-$(BIN)/cost_model/%.a: $(BIN)/cost_model.generator
+$(BIN)/cost_model/adams2019_%.a: $(BIN)/cost_model.generator
 	@mkdir -p $(@D)
-	$^ -g $* -o $(BIN)/cost_model -f $* target=$(HL_TARGET)-no_runtime -e stmt,static_library,h,assembly
+	$^ -g $* -o $(BIN)/cost_model -f $* -n adams2019_$* target=$(HL_TARGET)-no_runtime -e stmt,static_library,h,assembly
 
 # It's important to use dynamic lookups for undefined symbols here: all of libHalide
 # is expected to be present (in the loading binary), so we explicitly make the symbols


### PR DESCRIPTION
This does a few things:
- The main thing it does is add a unique prefix to all the targets in Adams2019; apparently CMake has a global namespace for targets, and when they collide (as happened in #6856) you get amusing results.
- Added `add_adams2019_test` helper to clean up boilerplate. Note that setting HL_TARGET was never necessary for any of these tests.