### PR TITLE
Prohibit C99 VLA usage in runtime code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1012,7 +1012,26 @@ RUNTIME_TRIPLE_WIN_GENERIC_64 = "le64-unknown-windows-unknown"
 # standard but still skip threadsafe guards for static initialization in our runtime code)
 #
 # `-fno-rtti` is necessary to allow us to use classes with virtual functions in the runtime code
-RUNTIME_CXX_FLAGS = -std=c++17 -O3 -fno-vectorize -ffreestanding -fno-blocks -fno-exceptions -fno-unwind-tables -fno-threadsafe-statics -fno-rtti
+RUNTIME_CXX_FLAGS = \
+    -O3 \
+    -std=c++17 \
+    -ffreestanding \
+    -fno-blocks \
+    -fno-exceptions \
+    -fno-unwind-tables \
+    -fno-vectorize \
+    -fno-threadsafe-statics \
+    -fno-rtti \
+    -Wall \
+    -Wcast-qual \
+    -Werror \
+    -Wignored-qualifiers \
+    -Wno-comment \
+    -Wno-psabi \
+    -Wno-unknown-warning-option \
+    -Wno-unused-function \
+    -Wno-vla \
+    -Wsign-compare
 
 $(BUILD_DIR)/initmod.windows_%_x86_32.ll: $(SRC_DIR)/runtime/windows_%_x86.cpp $(BUILD_DIR)/clang_ok
 	@mkdir -p $(@D)

--- a/Makefile
+++ b/Makefile
@@ -1030,7 +1030,7 @@ RUNTIME_CXX_FLAGS = \
     -Wno-psabi \
     -Wno-unknown-warning-option \
     -Wno-unused-function \
-    -Wno-vla \
+    -Wvla \
     -Wsign-compare
 
 $(BUILD_DIR)/initmod.windows_%_x86_32.ll: $(SRC_DIR)/runtime/windows_%_x86.cpp $(BUILD_DIR)/clang_ok

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -160,6 +160,7 @@ set(RUNTIME_CXX_FLAGS
     -Wno-psabi
     -Wno-unknown-warning-option
     -Wno-unused-function
+    -Wno-vla
     -Wsign-compare
 )
 

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -160,7 +160,7 @@ set(RUNTIME_CXX_FLAGS
     -Wno-psabi
     -Wno-unknown-warning-option
     -Wno-unused-function
-    -Wno-vla
+    -Wvla
     -Wsign-compare
 )
 


### PR DESCRIPTION
AFAICT we aren't doing this in Halide at present, but some experimental code in Google runtime was doing so; this caused some issues with some experimental Clang patches, but also was never really intended to be used in the first place. Adding the flag here to be sure no unintended use creeps back in.

While I was there, took the time to ensure that the flags for runtime are unified across CMake and Make.