### PR TITLE
Fix Python handling of boolean buffers

### DIFF
--- a/python_bindings/test/correctness/bit_test.py
+++ b/python_bindings/test/correctness/bit_test.py
@@ -1,22 +1,28 @@
-import array
 import bit
-import sys
+import numpy as np
 
 
 def test():
-    bool_constant = True
-    input_u1 = array.array('B', [0, 1, 0, 1])
-    output_u1 = array.array('B', [0, 1, 0, 1])
+    # Note that in Halide, Buffer<bool> and Buffer<uint8> have identical memory
+    # layout -- a bool takes an entire byte in a buffer -- but distinct types,
+    # so we must construct a Buffer here that has that correct type. (If we
+    # passed in a uint8 buffer, we'd fail with 'wrong type' exception.)
+    #
+    # Python's `array` module doesn't support boolean entries, but libraries
+    # that support Buffer Protocol (eg numpy.ndarray) do, so we'll use one of those.
+    input_bools = np.ndarray([4], dtype=bool)
+    output_bools = np.ndarray([4], dtype=bool)
 
-    try:
-        bit.bit(
-            input_u1, bool_constant, output_u1
-        )
-    except NotImplementedError:
-        pass  # OK - that's what we expected.
-    else:
-        print("Expected Exception not raised.", file=sys.stderr)
-        exit(1)
+    for i in range(0, 4):
+        input_bools[i] = (i & 1) != 0
+
+    bit.bit(input_bools, True, output_bools)
+    for i in range(0, 4):
+        assert output_bools[i] == True
+
+    bit.bit(input_bools, False, output_bools)
+    for i in range(0, 4):
+        assert output_bools[i] == ((i & 1) != 0)
 
 if __name__ == "__main__":
     test()

--- a/python_bindings/test/generators/bit_generator.cpp
+++ b/python_bindings/test/generators/bit_generator.cpp
@@ -11,7 +11,7 @@ public:
     Var x, y, z;
 
     void generate() {
-        bit_output(x) = bit_input(x) + bit_constant;
+        bit_output(x) = bit_input(x) | bit_constant;
     }
 
     void schedule() {


### PR DESCRIPTION
The Python Extension code didn't handle boolean buffers correctly, making it impossible to construct one in Python and pass it thru to Halide-generated code. This fixes that, and also fixes the test that just expected it to fail (!).