### PR TITLE
Allow use of bool|int|float for Generator type args

### DIFF
--- a/README_python.md
+++ b/README_python.md
@@ -15,6 +15,7 @@
         - [hl.OutputBuffer, hl.OutputScalar](#hloutputbuffer-hloutputscalar)
         - [Names](#names)
         - [generate\(\) method](#generate-method)
+        - [Types for Inputs and Outputs](#types-for-inputs-and-outputs)
     - [Using a Generator for JIT compilation](#using-a-generator-for-jit-compilation)
     - [Using a Generator for AOT compilation](#using-a-generator-for-aot-compilation)
     - [Calling Generator-Produced code from Python](#calling-generator-produced-code-from-python)
@@ -380,6 +381,13 @@ It is required that the `generate()` method be defined by the Generator.
 (Note that, by convention, Halide Generators use `g` instead of `self` in their
 `generate()` method to make the expression language terser; this is not in any
 way required, but is recommended to improve readability.)
+
+#### Types for Inputs and Outputs
+
+For all of the Input and Output fields of Generators, you can specify native
+Python types (instead of `hl.Type`) for certain cases that are unambiguous. At
+present, we allow `bool` as an alias for `hl.Bool()`, `int` as an alias for
+`hl.Int(32)`, and `float` as an alias for `hl.Float(32)`.
 
 ### Using a Generator for JIT compilation
 

--- a/python_bindings/test/generators/bitpy_generator.py
+++ b/python_bindings/test/generators/bitpy_generator.py
@@ -5,8 +5,9 @@ y = hl.Var('y')
 
 @hl.generator(name = "bitpy")
 class BitGenerator:
-    bit_input = hl.InputBuffer(hl.Bool(), 1)
-    bit_constant = hl.InputScalar(hl.Bool())
+    # We can use `bool` as an alias for `hl.Bool()` if we like
+    bit_input = hl.InputBuffer(bool, 1)
+    bit_constant = hl.InputScalar(bool)
 
     bit_output = hl.OutputBuffer(hl.Bool(), 1)
 

--- a/python_bindings/test/generators/complexpy_generator.py
+++ b/python_bindings/test/generators/complexpy_generator.py
@@ -13,7 +13,8 @@ class ComplexPy:
     untyped_buffer_input = hl.InputBuffer(None, 3)
     simple_input = hl.InputBuffer(None, 3)
     float_arg = hl.InputScalar(hl.Float(32))
-    int_arg = hl.InputScalar(hl.Int(32))
+    # We can use `int` as an alias for `hl.Int(32)` if we like
+    int_arg = hl.InputScalar(int)
 
     simple_output = hl.OutputBuffer(hl.Float(32), 3)
     tuple_output = hl.OutputBuffer(None, 3)

--- a/python_bindings/test/generators/simplepy_generator.py
+++ b/python_bindings/test/generators/simplepy_generator.py
@@ -8,7 +8,9 @@ class SimplePy:
     offset = hl.GeneratorParam(0)
 
     buffer_input = hl.InputBuffer(hl.UInt(8), 2)
-    float_arg = hl.InputScalar(hl.Float(32))
+
+    # We can use `float` as an alias for `hl.Float(32)` if we like.
+    float_arg = hl.InputScalar(float)
 
     simple_output = hl.OutputBuffer(hl.Float(32), 2)
 


### PR DESCRIPTION
Per suggestion on https://github.com/halide/Halide/pull/6764, this allows these type aliases. How does it look / feel?

(Adding similar aliasing for, at least, NumPy types is probably desirable as well)