### PR TITLE
[HVX] Simplify constant factor before distributing

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -2197,8 +2197,10 @@ private:
             }
         } else if (op->is_intrinsic(Call::widening_shift_left)) {
             if (const uint64_t *const_b = as_const_uint(op->args[1])) {
+                const uint64_t const_m = 1ull << *const_b;
+                Expr b = make_const(op->type, const_m);
                 Expr a = Cast::make(op->type, op->args[0]);
-                return mutate(distribute(a, make_one(a.type()) << *const_b));
+                return mutate(distribute(a, b));
             }
         }
         return IRMutator::visit(op);

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -514,6 +514,7 @@ public:
         check("v*.h += vmpy(v*.ub,r*.b)", hvx_width / 1, i16_1 + 127 * i16(u8_1));
         check("v*.uw += vmpy(v*.uh,r*.uh)", hvx_width / 2, u32_1 + 65535 * u32(u16_1));
 
+        check("v*.h += vmpy(v*.b,v*.b)", hvx_width / 1, i16_1 + 2 * i16(i8_1));
         check("v*.h += vmpy(v*.ub,r*.b)", hvx_width / 1, i16_1 - i16(u8_1) * -127);
         check("v*.h += vmpyi(v*.h,r*.b)", hvx_width / 2, i16_1 - i16_2 * -127);
 


### PR DESCRIPTION
The handling of `widening_shift_left` in HexagonOptimize's `DistributeShiftsAsMuls` was not properly producing `widening_mul`s. This PR fixes that. Here's a small illustrative example:
```
ImageParam in_i8(Int(8), 1);
Func kernel("kernel");
Var x("x");

kernel(x) = i16(in_i8(x - 1)) + 2 * i16(in_i8(x)) + i16(in_i8(x + 1));
kernel.vectorize(x, 128);
```
Compiled with target="hexagon-64-noos-no_bounds_query-no_asserts-hvx_128-hvx_v66".

Before `DistributeShiftsAsMuls`:
```
kernel[ramp(kernel.s0.x.x*128, 1, 128) aligned(128, 0)] = ((int16x128)widening_shift_left(p0[ramp(t6, 1, 128)], x128((uint8)1)) + int16x128(p0[ramp(t6 + -1, 1, 128)])) + int16x128(p0[ramp(t6 + 1, 1, 128)])
```

Previously, after `DistributeShiftsAsMuls`:
```
kernel[ramp(kernel.s0.x.x*128, 1, 128) aligned(128, 0)] = ((int16x128(p0[ramp(t6, 1, 128)])*x128((int16)2)) + int16x128(p0[ramp(t6 + -1, 1, 128)])) + int16x128(p0[ramp(t6 + 1, 1, 128)])
```

Previously, codegen: 3 `vsxt` and 2 `vmpyihb.acc`

Now, after `DistributeShiftsAsMuls`:
```
kernel[ramp(kernel.s0.x.x*128, 1, 128) aligned(128, 0)] = ((int16x128)widening_mul(p0[ramp(t6, 1, 128)], x128((int8)2)) + int16x128(p0[ramp(t6 + -1, 1, 128)])) + int16x128(p0[ramp(t6 + 1, 1, 128)])
```

Now, codegen: 2 `vsxt` and 1 `vmpybv.acc`

I also added a test to simd_op_check_hvx.