### PR TITLE
Revert "[HVX] Simplify constant factor before distributing"

### DIFF
--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -2177,10 +2177,8 @@ private:
             }
         } else if (op->is_intrinsic(Call::widening_shift_left)) {
             if (const uint64_t *const_b = as_const_uint(op->args[1])) {
-                const uint64_t const_m = 1ull << *const_b;
-                Expr b = make_const(op->type, const_m);
                 Expr a = Cast::make(op->type, op->args[0]);
-                return mutate(distribute(a, b));
+                return mutate(distribute(a, make_one(a.type()) << *const_b));
             }
         }
         return IRMutator::visit(op);

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -514,7 +514,6 @@ public:
         check("v*.h += vmpy(v*.ub,r*.b)", hvx_width / 1, i16_1 + 127 * i16(u8_1));
         check("v*.uw += vmpy(v*.uh,r*.uh)", hvx_width / 2, u32_1 + 65535 * u32(u16_1));
 
-        check("v*.h += vmpy(v*.b,v*.b)", hvx_width / 1, i16_1 + 2 * i16(i8_1));
         check("v*.h += vmpy(v*.ub,r*.b)", hvx_width / 1, i16_1 - i16(u8_1) * -127);
         check("v*.h += vmpyi(v*.h,r*.b)", hvx_width / 2, i16_1 - i16_2 * -127);
 


### PR DESCRIPTION
Reverts halide/Halide#7009

Injected compilation failure that turns up in some Google-specific code; @vksnk and I will work to get a repro case, but for now we must revert this