### PR TITLE
Fix SpecificExpr canonicalization

### DIFF
--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -208,7 +208,7 @@ struct SpecificExpr {
 
     // What is the weakest and strongest IR node this could possibly be
     constexpr static IRNodeType min_node_type = IRNodeType::IntImm;
-    constexpr static IRNodeType max_node_type = IRNodeType::Shuffle;
+    constexpr static IRNodeType max_node_type = StrongestExprNodeType;
     constexpr static bool canonical = true;
 
     const BaseExprNode &expr;


### PR DESCRIPTION
`SpecificExpr` should have the same min/max node types as a `Wild`, it's missing VectorReduce in the current range.