### PR TITLE
Don't use `-g` for EMCC

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -93,7 +93,6 @@ function(add_wasm_executable TARGET)
     # internal purposes. Consider adding ways to customize this as appropriate.
     set(EMCC_FLAGS
         -O3
-        -g
         -std=c++17
         -Wall
         -Wcast-qual

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -3,6 +3,7 @@
 #include "Util.h"  // for get_env_variable
 
 #include <csignal>
+#include <iostream>
 
 #ifdef _MSC_VER
 #include <io.h>
@@ -172,6 +173,8 @@ ErrorReport::~ErrorReport() noexcept(false) {
     }
 
 #ifdef HALIDE_WITH_EXCEPTIONS
+std::cerr<<"ERR:"<<msg.str()<<"\n"<<std::flush;
+abort();
     if (std::uncaught_exceptions() > 0) {
         // This should never happen - evaluating one of the arguments
         // to the error message would have to throw an

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -3,7 +3,6 @@
 #include "Util.h"  // for get_env_variable
 
 #include <csignal>
-#include <iostream>
 
 #ifdef _MSC_VER
 #include <io.h>
@@ -173,8 +172,6 @@ ErrorReport::~ErrorReport() noexcept(false) {
     }
 
 #ifdef HALIDE_WITH_EXCEPTIONS
-std::cerr<<"ERR:"<<msg.str()<<"\n"<<std::flush;
-abort();
     if (std::uncaught_exceptions() > 0) {
         // This should never happen - evaluating one of the arguments
         // to the error message would have to throw an


### PR DESCRIPTION
Combining `-g` with other default EMCC flags will now emit warning/error messages regarding binaryen optimization, so, don't use that flag in the default settings.