### PR TITLE
Fix Wasm BulkMemory Codgen + Minor fixes to apps/HelloWasm

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -21,10 +21,16 @@ function(add_app app_name)
     endif ()
 endfunction()
 
+# TODO: most of the apps need to be smartened to be crosscompilable under wasm.
+message(STATUS "Halide_TARGET ${Halide_TARGET}")
+if (Halide_TARGET MATCHES "wasm")
+    message(WARNING "Skipping apps when building under wasm")
+    return()
+endif()
+
 # add_app(HelloAndroid)  # TODO(#5374): missing CMake build
 # add_app(HelloAndroidCamera2)  # TODO(#5374): missing CMake build
 # add_app(HelloPyTorch)  # TODO(#5374): missing CMake build
-# add_app(HelloWasm)  # TODO(#5374): missing CMake build
 # add_app(HelloiOS)  # TODO(#5374): missing CMake build
 # add_app(auto_viz)  # TODO(#5374): missing CMake build
 add_app(bgu)

--- a/apps/HelloWasm/Makefile
+++ b/apps/HelloWasm/Makefile
@@ -31,19 +31,19 @@ $(BIN)/wasm_simd/runtime.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 
 $(BIN)/wasm_threads/reaction_diffusion_%.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_threads-no_runtime threads=true
+	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_bulk_memory-wasm_threads-no_runtime threads=true
 
 $(BIN)/wasm_threads/runtime.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_threads
+	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_bulk_memory-wasm_threads
 
 $(BIN)/wasm_simd_threads/reaction_diffusion_%.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_threads-no_runtime threads=true
+	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_bulk_memory-wasm_threads-no_runtime threads=true
 
 $(BIN)/wasm_simd_threads/runtime.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_threads
+	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_bulk_memory-wasm_threads
 
 $(BIN)/$(HL_TARGET)/reaction_diffusion_%.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)

--- a/apps/HelloWasm/Makefile
+++ b/apps/HelloWasm/Makefile
@@ -31,19 +31,19 @@ $(BIN)/wasm_simd/runtime.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 
 $(BIN)/wasm_threads/reaction_diffusion_%.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_bulk_memory-wasm_threads-no_runtime threads=true
+	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_threads-no_runtime threads=true
 
 $(BIN)/wasm_threads/runtime.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_bulk_memory-wasm_threads
+	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_threads
 
 $(BIN)/wasm_simd_threads/reaction_diffusion_%.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_bulk_memory-wasm_threads-no_runtime threads=true
+	$< -g reaction_diffusion_$* -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_threads-no_runtime threads=true
 
 $(BIN)/wasm_simd_threads/runtime.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)
-	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_bulk_memory-wasm_threads
+	$< -r runtime -o $(@D) target=wasm-32-wasmrt-wasm_simd128-wasm_threads
 
 $(BIN)/$(HL_TARGET)/reaction_diffusion_%.a: $(GENERATOR_BIN)/reaction_diffusion_generator
 	@mkdir -p $(@D)

--- a/apps/HelloWasm/reaction_diffusion_generator.cpp
+++ b/apps/HelloWasm/reaction_diffusion_generator.cpp
@@ -118,6 +118,10 @@ public:
             .tile(x, y, xi, yi, 256, 8)
             .vectorize(xi, natural_vector_size<float>());
 
+        for (int i = 0; i < 5; i++) {
+            new_state.update(i).unscheduled();
+        }
+
         blur
             .compute_at(new_state, xi)
             .vectorize(x);

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -322,7 +322,9 @@ string CodeGen_WebAssembly::mattrs() const {
         sep = ",";
     }
 
-    if (target.has_feature(Target::WasmBulkMemory)) {
+    // Recent Emscripten builds assume that specifying `-pthread` implies bulk-memory too,
+    // so quietly enable it if either of these are specified.
+    if (target.has_feature(Target::WasmBulkMemory) || target.has_feature(Target::WasmThreads)) {
         s << sep << "+bulk-memory";
         sep = ",";
     }


### PR DESCRIPTION
- Emscripten can quietly add the 'atomics' and 'bulk-memory' features if you compile with `-pthreads` enabled; we already included `atomics` but `bulk-memory` was separate. For convenience, we should assume that enabling threads for wasm enables both of the other two.
- Also silence some "unscheduled" warnings about update stages in HelloWasm
