### PR TITLE
Add reinterpret simplifications

### DIFF
--- a/src/Simplify_Reinterpret.cpp
+++ b/src/Simplify_Reinterpret.cpp
@@ -17,6 +17,14 @@ Expr Simplify::visit(const Reinterpret *op, ExprInfo *bounds) {
     } else if (const_uint(a, &ua) && op->type.is_int() && !vector) {
         // uint -> int
         return make_const(op->type, (int64_t)ua);
+    } else if (const Reinterpret *as_r = a.as<Reinterpret>()) {
+        // Fold double-reinterprets.
+        return mutate(reinterpret(op->type, as_r->value), bounds);
+    } else if ((op->type.bits() == a.type().bits()) &&
+               op->type.is_int_or_uint() &&
+               a.type().is_int_or_uint()) {
+        // Normalize to casts for non-lane-changing reinterprets.
+        return cast(op->type, a);
     } else if (a.same_as(op->value)) {
         return op;
     } else {


### PR DESCRIPTION
Folds double-reinterprets (which can be produced in FindIntrinsics sometimes) and converts (u)int to (u)int reinterprets to casts.