### PR TITLE
Codegen_C for user_context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1559,6 +1559,11 @@ $(FILTERS_DIR)/user_context_insanity.a: $(BIN_DIR)/user_context_insanity.generat
 	@mkdir -p $(@D)
 	$(CURDIR)/$< -g user_context_insanity $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-user_context
 
+# ditto for async_parallel
+$(FILTERS_DIR)/async_parallel.a: $(BIN_DIR)/async_parallel.generator
+	@mkdir -p $(@D)
+	$(CURDIR)/$< -g async_parallel $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-user_context
+
 # Some .generators have additional dependencies (usually due to define_extern usage).
 # These typically require two extra dependencies:
 # (1) Ensuring the extra _generator.cpp is built into the .generator.

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2069,7 +2069,12 @@ void CodeGen_C::visit(const Variable *op) {
         // This is the name of a global, so we can't modify it.
         id = op->name;
     } else {
-        id = print_name(op->name);
+        // This substitution ensures const correctness for all calls
+        if (op->name == "__user_context") {
+            id = "_ucon";
+        } else {
+            id = print_name(op->name);
+        }
     }
 }
 
@@ -2755,7 +2760,7 @@ void CodeGen_C::visit(const Store *op) {
 void CodeGen_C::visit(const Let *op) {
     string id_value = print_expr(op->value);
     Expr body = op->body;
-    if (op->value.type().is_handle()) {
+    if (op->value.type().is_handle() && op->name != "__user_context") {
         // The body might contain a Load that references this directly
         // by name, so we can't rewrite the name.
         std::string name = print_name(op->name);
@@ -2850,7 +2855,7 @@ void CodeGen_C::visit(const LetStmt *op) {
     string id_value = print_expr(op->value);
     Stmt body = op->body;
 
-    if (op->value.type().is_handle()) {
+    if (op->value.type().is_handle() && op->name != "__user_context") {
         // The body might contain a Load or Store that references this
         // directly by name, so we can't rewrite the name.
         std::string name = print_name(op->name);

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -133,6 +133,7 @@ halide_define_aot_test(argvcall)
 halide_define_aot_test(async_parallel
                        # Requires threading support, not yet available for wasm tests
                        ENABLE_IF NOT ${USING_WASM}
+                       FEATURES user_context
                        GROUPS multithreaded)
 
 # autograd_aottest.cpp

--- a/test/generator/async_parallel_aottest.cpp
+++ b/test/generator/async_parallel_aottest.cpp
@@ -54,7 +54,7 @@ last_call *all_thread_lasts = nullptr;
 
 thread_local last_call thread_last = {};
 
-extern "C" int sleeper(int loc, int x, int y, int z, int v) {
+extern "C" int sleeper(void *user_context, int loc, int x, int y, int z, int v) {
     last_update++;
 
     thread_last.loc = loc;
@@ -140,7 +140,7 @@ int main(int argc, char **argv) {
         sleeps = start++;
         Halide::Runtime::Buffer<int, 3> out(8, 8, 8);
 
-        async_parallel(out);
+        async_parallel(/*user_context*/ nullptr, out);
     }
 
     {

--- a/test/generator/async_parallel_generator.cpp
+++ b/test/generator/async_parallel_generator.cpp
@@ -1,7 +1,20 @@
 #include "Halide.h"
 
+// The convenience macros only go up to 5 arguments; we need 6 here,
+// so we'll just extend it.
+#define HalideExtern_6(rt, name, t0, t1, t2, t3, t4, t5)                                                                                                                \
+    Halide::Expr name(const Halide::Expr &a0, const Halide::Expr &a1, const Halide::Expr &a2, const Halide::Expr &a3, const Halide::Expr &a4, const Halide::Expr &a5) { \
+        _halide_check_arg_type(Halide::type_of<t0>(), name, a0, 1);                                                                                                     \
+        _halide_check_arg_type(Halide::type_of<t1>(), name, a1, 2);                                                                                                     \
+        _halide_check_arg_type(Halide::type_of<t2>(), name, a2, 3);                                                                                                     \
+        _halide_check_arg_type(Halide::type_of<t3>(), name, a3, 4);                                                                                                     \
+        _halide_check_arg_type(Halide::type_of<t4>(), name, a4, 5);                                                                                                     \
+        _halide_check_arg_type(Halide::type_of<t5>(), name, a5, 6);                                                                                                     \
+        return Halide::Internal::Call::make(Halide::type_of<rt>(), #name, {a0, a1, a2, a3, a4, a5}, Halide::Internal::Call::Extern);                                    \
+    }
+
 namespace Ext {
-HalideExtern_5(int, sleeper, int, int, int, int, int)
+HalideExtern_6(int, sleeper, void *, int, int, int, int, int)
 }
 
 using namespace Halide;
@@ -20,11 +33,12 @@ public:
 
         Var x, y, z;
 
-        producer_1(x, y, z) = x + y + Ext::sleeper(0, x, y, z, z);
-        consumer_1(x, y, z) = Ext::sleeper(1, x, y, z, producer_1(x - 1, y, z)) + Ext::sleeper(2, x, y, z, producer_1(x + 1, y, z));
-        producer_2(x, y, z) = Ext::sleeper(3, x, y, z, consumer_1(x, y - 1, z)) + Ext::sleeper(4, x, y, z, consumer_1(x, y + 1, z));
-        consumer_2(x, y, z) = Ext::sleeper(5, x, y, z, producer_2(x - 1, y, z)) + Ext::sleeper(6, x, y, z, producer_2(x + 1, y, z));
-        output(x, y, z) = Ext::sleeper(7, x, y, z, consumer_2(x, y, z));
+        Expr ucon = user_context_value();
+        producer_1(x, y, z) = x + y + Ext::sleeper(ucon, 0, x, y, z, z);
+        consumer_1(x, y, z) = Ext::sleeper(ucon, 1, x, y, z, producer_1(x - 1, y, z)) + Ext::sleeper(ucon, 2, x, y, z, producer_1(x + 1, y, z));
+        producer_2(x, y, z) = Ext::sleeper(ucon, 3, x, y, z, consumer_1(x, y - 1, z)) + Ext::sleeper(ucon, 4, x, y, z, consumer_1(x, y + 1, z));
+        consumer_2(x, y, z) = Ext::sleeper(ucon, 5, x, y, z, producer_2(x - 1, y, z)) + Ext::sleeper(ucon, 6, x, y, z, producer_2(x + 1, y, z));
+        output(x, y, z) = Ext::sleeper(ucon, 7, x, y, z, consumer_2(x, y, z));
 
         consumer_2.compute_at(output, z);
         producer_2.store_at(consumer_2, y).compute_at(consumer_2, x).async();


### PR DESCRIPTION
While adding a user_context to the `async_parallel` generator for other purposes, I found some subtle bugs in Codegen_C regarding possible aliasing and/or const-correctness of the internal 'ucon' arguments when calling or unpacking a closure for async usage. This fixes it.