### PR TITLE
Add stack-size-canary test to apps/fft's CMake file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ ifneq ($(TEST_METAL), )
 # tests to be valid Objective-C++, e.g. avoiding using the identifier "id"
 # in certain ways. In practice this is not enough of a problem to justify
 # the work to limit which files are compiled this way.
-TEST_CXX_FLAGS += -DTEST_METAL -ObjC++
+TEST_CXX_FLAGS += -DTEST_METAL -ObjC++ -Werror,-Wunused-command-line-argument
 endif
 
 ifneq ($(TEST_CUDA), )

--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -33,7 +33,7 @@ add_halide_library(fft_inverse_c2c FROM fft.generator
 # flag on os x, and testing this on one platform is sufficient.
 set(LDFLAGS "")
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    set(LDFLAGS "-Wl,-stack_size;-Wl,0x100000")
+    set(LDFLAGS "LINKER:-stack_size,0x100000")
 endif()
 
 # Main executable

--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -28,13 +28,23 @@ add_halide_library(fft_inverse_c2c FROM fft.generator
                    GENERATOR fft
                    PARAMS direction=frequency_to_samples size0=16 size1=16 input_number_type=complex output_number_type=complex)
 
+# Use a small stack, to stress out the compiler and act as a canary
+# for stack bloat problems. This can be accomplished with a linker
+# flag on os x, and testing this on one platform is sufficient.
+set(LDFLAGS "")
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+    set(LDFLAGS "-Wl,-stack_size;-Wl,0x100000")
+endif()
+
 # Main executable
 add_executable(fft_aot_test fft_aot_test.cpp)
 target_link_libraries(fft_aot_test PRIVATE Halide::ImageIO fft_forward_r2c fft_inverse_c2r fft_forward_c2c fft_inverse_c2c)
+target_link_options(fft_aot_test PRIVATE "${LDFLAGS}")
 
 # Benchmarking executable
 add_executable(bench_fft main.cpp fft.cpp)
 target_link_libraries(bench_fft PRIVATE Halide::Halide Halide::Tools)
+target_link_options(bench_fft PRIVATE "${LDFLAGS}")
 
 # Test that the app actually works!
 add_test(NAME fft_aot_test COMMAND fft_aot_test)
@@ -50,3 +60,4 @@ foreach (i IN ITEMS 8 12 16 24 32 48)
                          LABELS fft
                          ENVIRONMENT "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:Halide::Halide>>")
 endforeach ()
+


### PR DESCRIPTION
This was apparently meant as a canary for stack size usage, but the necessary setting only happened in the Makefile, not the CMake file.

Also, drive-by fix in Makefile to ignore warnings about `-ObjC++` being ignored, which apparently can be the case with current AppleClang configs.