### PR TITLE
Revert "Temporarily disable testing for apps/fft (#7033)"

### DIFF
--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -43,12 +43,10 @@ set_tests_properties(fft_aot_test PROPERTIES
                      PASS_REGULAR_EXPRESSION "Success!"
                      SKIP_REGULAR_EXPRESSION "\\[SKIP\\]")
 
-# TODO(srj): temporarily disable pending fix for https://github.com/halide/Halide/issues/7033,
-# to avoid unrelated buildbot failures
-# foreach (i IN ITEMS 8 12 16 24 32 48)
-#     add_test(NAME bench${i}x${i} COMMAND bench_fft ${i} ${i} "${CMAKE_CURRENT_BINARY_DIR}")
-#     set_tests_properties(bench${i}x${i}
-#                          PROPERTIES
-#                          LABELS fft
-#                          ENVIRONMENT "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:Halide::Halide>>")
-# endforeach ()
+foreach (i IN ITEMS 8 12 16 24 32 48)
+    add_test(NAME bench${i}x${i} COMMAND bench_fft ${i} ${i} "${CMAKE_CURRENT_BINARY_DIR}")
+    set_tests_properties(bench${i}x${i}
+                         PROPERTIES
+                         LABELS fft
+                         ENVIRONMENT "PATH=$<SHELL_PATH:$<TARGET_FILE_DIR:Halide::Halide>>")
+endforeach ()

--- a/apps/fft/Makefile
+++ b/apps/fft/Makefile
@@ -75,19 +75,13 @@ clean:
 fft_aot_test: $(BIN)/$(HL_TARGET)/fft_aot_test
 	$^
 
-# TODO(srj): temporarily disable pending fix for https://github.com/halide/Halide/issues/7033,
-# to avoid unrelated buildbot failures
-#all: fft_aot_test bench_16x16 bench_32x32 bench_48x48 bench_64x64
-all: fft_aot_test
+all: fft_aot_test bench_16x16 bench_32x32 bench_48x48 bench_64x64
 
 # Ensure these are run sequentially and not in parallel
 test: $(BIN)/$(HL_TARGET)/bench_fft
-
-# TODO(srj): temporarily disable pending fix for https://github.com/halide/Halide/issues/7033,
-# to avoid unrelated buildbot failures
-# 	$< 8 8 $(<D)
-# 	$< 12 12 $(<D)
-# 	$< 16 16 $(<D)
-# 	$< 24 24 $(<D)
-# 	$< 32 32 $(<D)
-# 	$< 48 48 $(<D)
+	$< 8 8 $(<D)
+	$< 12 12 $(<D)
+	$< 16 16 $(<D)
+	$< 24 24 $(<D)
+	$< 32 32 $(<D)
+	$< 48 48 $(<D)


### PR DESCRIPTION
Reverts halide/Halide#7035 -- should be fixed in LLVM commit e664dea1821ab1277e62f0b4074fb02867636e6e