### PR TITLE
Fix PyExt error handling

### DIFF
--- a/python_bindings/test/correctness/multi_method_module_test.py
+++ b/python_bindings/test/correctness/multi_method_module_test.py
@@ -33,7 +33,7 @@ def test_aot_call_failure_throws_exception():
     try:
         multi_method_module.simplecpp(buffer_input, float_arg, simple_output)
     except RuntimeError as e:
-        assert 'Halide Runtime Error: -3 (Input buffer buffer_input has type uint8 but type of the buffer passed in is float32)' in str(e), str(e)
+        assert 'Halide Runtime Error: -3' in str(e), str(e)
     else:
         assert False, 'Did not see expected exception, saw: ' + str(e)
 


### PR DESCRIPTION
The current PythonExtensionGen code attempts to provide verbose error (exception) messages by overriding halide_error and saving the message in a thread_local. This isn't safe or correct, however, and (in general) is wrong for any Halide code using multiple threads. #6994 proposes ways to mitigate this (and there are experiments in place to implement it), but unless/until those enhancements land, we can't leave the code in its current state. So:
- Don't try to save the text at all.
- Optionally log the text to stderr.
- Just throw an exception with the numeric error code. This is suboptimal, but better than the existing usually-incorrect-message behavior.
- Bonus: wrap both the error and print overloads with `PyGILState_Ensure()`, as we are supposed to, to ensure we don't die.