### PR TITLE
Don't mutate GeneratorParams in PythonGenerators

### DIFF
--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -479,6 +479,7 @@ class Generator(ABC):
         self._requirements = {}
         self._replacements = {}
         self._in_configure = 0
+        self._pipeline_requirements = []
 
         self._advance_to_gp_created()
         if generator_params:
@@ -704,6 +705,8 @@ class Generator(ABC):
             funcs.append(f)
 
         self._pipeline = Pipeline(funcs)
+        for condition, error_args in self._pipeline_requirements:
+            self._pipeline.add_requirement(condition, *error_args)
         self._stage = _Stage.pipeline_built
         return self._pipeline
 

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -394,6 +394,10 @@ class Generator(ABC):
     def natural_vector_size(self, type: Type) -> int:
         return self.target().natural_vector_size(type)
 
+    def add_requirement(self, condition: Expr, *args) -> None:
+        assert self._stage < _Stage.pipeline_built
+        self._pipeline_requirements.append((condition, [*args]))
+
     @classmethod
     def call(cls, *args, **kwargs):
         generator = cls()


### PR DESCRIPTION
They are really only ever defined at the class level, so if you mutate the value, you are mutating the default value for all future instances. Subtle bug.