### PR TITLE
Generate dot() in the Metal backend

### DIFF
--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -225,7 +225,7 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Min *op) {
 }
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const VectorReduce *op) {
-    if (op->op == VectorReduce::Add && (op->type.lanes() == 1)) {
+    if (op->op == VectorReduce::Add && op->type.is_float() && (op->type.lanes() == 1)) {
         if (const Mul *maybe_mul = op->value.as<Mul>()) {
             string a = print_expr(maybe_mul->a);
             string b = print_expr(maybe_mul->b);

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -91,6 +91,7 @@ protected:
         void visit(const Allocate *op) override;
         void visit(const Free *op) override;
         void visit(const Cast *op) override;
+        void visit(const VectorReduce *op) override;
         void visit(const Atomic *op) override;
     };
 
@@ -221,6 +222,20 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Max *op) {
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Min *op) {
     print_expr(Call::make(op->type, "min", {op->a, op->b}, Call::Extern));
+}
+
+void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const VectorReduce *op) {
+    if (op->op == VectorReduce::Add && (op->type.lanes() == 1)) {
+        if (const Mul *maybe_mul = op->value.as<Mul>()) {
+            string a = print_expr(maybe_mul->a);
+            string b = print_expr(maybe_mul->b);
+            ostringstream rhs;
+            rhs << "dot(" << a << ", " << b << ")";
+            print_assignment(op->type, rhs.str());
+            return;
+        }
+    }
+    CodeGen_GPU_C::visit(op);
 }
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Div *op) {


### PR DESCRIPTION
Basically, it will generate dot() call for vector_reduce(Add, mul(float, float)). I've tested it locally to make sure it is actually generated. It'd be nice to have something similar to simd_op_check for GPU targets, but  it doesn't exist (#7084).