### PR TITLE
Remove everything flagged with HALIDE_ATTRIBUTE_DEPRECATED

### DIFF
--- a/python_bindings/src/halide/halide_/PyFunc.cpp
+++ b/python_bindings/src/halide/halide_/PyFunc.cpp
@@ -163,22 +163,6 @@ void define_func(py::module &m) {
             .def("defined", &Func::defined)
             .def("outputs", &Func::outputs)
 
-            .def("output_type", [](Func &f) {
-                // HALIDE_ATTRIBUTE_DEPRECATED("Func::output_type() is deprecated; call Func::type() instead.")
-                PyErr_WarnEx(PyExc_DeprecationWarning,
-                             "Func.output_type() is deprecated; use Func.type() instead.",
-                             1);
-                return f.type();
-            })
-
-            .def("output_types", [](Func &f) {
-                // HALIDE_ATTRIBUTE_DEPRECATED("Func::output_types() is deprecated; call Func::types() instead.")
-                PyErr_WarnEx(PyExc_DeprecationWarning,
-                             "Func.output_types() is deprecated; use Func.types() instead.",
-                             1);
-                return f.types();
-            })
-
             .def("type", &Func::type)
             .def("types", &Func::types)
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -1225,15 +1225,6 @@ public:
     const std::vector<Type> &types() const;
     // @}
 
-    HALIDE_ATTRIBUTE_DEPRECATED("Func::output_type() is deprecated; use Func::type() instead.")
-    const Type &output_type() const {
-        return type();
-    }
-    HALIDE_ATTRIBUTE_DEPRECATED("Func::output_types() is deprecated; use Func::types() instead.")
-    const std::vector<Type> &output_types() const {
-        return types();
-    }
-
     /** Get the number of outputs of this Func. Corresponds to the
      * size of the Tuple this Func was defined to return.
      * If the Func isn't yet defined, but was specified with required types,

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1972,16 +1972,6 @@ public:
     HALIDE_FORWARD_METHOD_CONST(Func, dimensions)
     HALIDE_FORWARD_METHOD_CONST(Func, has_update_definition)
     HALIDE_FORWARD_METHOD_CONST(Func, num_update_definitions)
-    HALIDE_ATTRIBUTE_DEPRECATED("Func::output_type() is deprecated; use Func::type() instead.")
-    const Type &output_type() const {
-        this->check_gio_access();
-        return this->as<Func>().type();
-    }
-    HALIDE_ATTRIBUTE_DEPRECATED("Func::output_types() is deprecated; use Func::types() instead.")
-    const std::vector<Type> &output_types() const {
-        this->check_gio_access();
-        return this->as<Func>().types();
-    }
     HALIDE_FORWARD_METHOD_CONST(Func, outputs)
     HALIDE_FORWARD_METHOD_CONST(Func, rvars)
     HALIDE_FORWARD_METHOD_CONST(Func, type)
@@ -2347,16 +2337,6 @@ public:
     HALIDE_FORWARD_METHOD(Func, in)
     HALIDE_FORWARD_METHOD(Func, memoize)
     HALIDE_FORWARD_METHOD_CONST(Func, num_update_definitions)
-    HALIDE_ATTRIBUTE_DEPRECATED("Func::output_type() is deprecated; use Func::type() instead.")
-    const Type &output_type() const {
-        this->check_gio_access();
-        return this->as<Func>().type();
-    }
-    HALIDE_ATTRIBUTE_DEPRECATED("Func::output_types() is deprecated; use Func::types() instead.")
-    const std::vector<Type> &output_types() const {
-        this->check_gio_access();
-        return this->as<Func>().types();
-    }
     HALIDE_FORWARD_METHOD_CONST(Func, outputs)
     HALIDE_FORWARD_METHOD(Func, parallel)
     HALIDE_FORWARD_METHOD(Func, prefetch)
@@ -3090,21 +3070,6 @@ public:
 #else
     const AutoschedulerParams &autoscheduler_params() const {
         return autoscheduler_params_;
-    }
-#endif
-
-    HALIDE_ATTRIBUTE_DEPRECATED("Call GeneratorContext::target() instead of GeneratorContext::get_target().")
-    const Target &get_target() const {
-        return target_;
-    }
-#ifdef HALIDE_ALLOW_LEGACY_AUTOSCHEDULER_API
-    HALIDE_ATTRIBUTE_DEPRECATED("Call GeneratorContext::auto_schedule() instead of GeneratorContext::get_auto_schedule().")
-    bool get_auto_schedule() const {
-        return auto_schedule_;
-    }
-    HALIDE_ATTRIBUTE_DEPRECATED("Call GeneratorContext::machine_params() instead of GeneratorContext::get_machine_params().")
-    const MachineParams &get_machine_params() const {
-        return machine_params_;
     }
 #endif
 

--- a/src/Realization.h
+++ b/src/Realization.h
@@ -37,20 +37,6 @@ public:
         return (*this)[0].as<T, Dims>();
     }
 
-    /** Construct a Realization that acts as a reference to some
-     * existing Buffers. The element type of the Buffers may not be
-     * const. */
-    template<typename T,
-             int Dims,
-             typename T2,
-             int Dims2,
-             typename... Args,
-             typename = typename std::enable_if<Internal::all_are_convertible<Buffer<void>, Args...>::value>::type>
-    HALIDE_ATTRIBUTE_DEPRECATED("Call Realization() with an explicit vector of Buffer<> instead.")
-    Realization(Buffer<T, Dims> &a, Buffer<T2, Dims2> &b, Args &&...args)
-        : Realization(std::vector<Buffer<void>>({a, b, args...})) {
-    }
-
     /** Construct a Realization that acts as a reference to a single
      * existing Buffer. The element type of the Buffer may not be
      * const. */


### PR DESCRIPTION
These APIs were announced as being removed in Halide 16, so let's remove them.