### PR TITLE
Revert "Update pip.yml to use LLVM 15.0.2"

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LLVM_VER: 15.0.2
+  LLVM_VER: 15.0.1
 
 jobs:
   pip-linux:


### PR DESCRIPTION
Reverts halide/Halide#7097 -- manylinux containers for arm64 haven't added 15.0.2 yet (still on 15.0.1)