### PR TITLE
Fix subtle CMake Install bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,9 +84,23 @@ endif ()
 # Enable the SPIR-V target if requested (must declare before processing dependencies)
 option(TARGET_SPIRV "Include SPIR-V target" OFF)
 
-# Declare all options before we add any subdirectories, since some
-# (eg WITH_UTILS) are referenced in multiple subdirectories, and if we don't
-# declare them ahead of time, they will quietly be "false".
+##
+# Import dependencies
+##
+
+add_subdirectory(dependencies)
+
+##
+# Declare options
+##
+
+# Declare these options after we include dependencies (since it declares Halide_ENABLE_RTTI etc)
+# but before we add any subdirectories, since any option you test before it is defined is
+# implicitly false the *first* time that the build file is processed, and there are some
+# out-of-order dependencies here (e.g, code in src/ eventually checks WITH_UTILS).
+# This is especially subtle since it means that some options can end up with different
+# values if you build a target as part of the initial CMake run, so (e.g.) a `make install`
+# from as totally clean build might neglect to install some pieces.
 
 option(WITH_TESTS "Build tests" "${PROJECT_IS_TOP_LEVEL}")
 option(WITH_TUTORIALS "Build tutorials" "${PROJECT_IS_TOP_LEVEL}")
@@ -97,12 +111,6 @@ cmake_dependent_option(
     "Halide_ENABLE_RTTI AND Halide_ENABLE_EXCEPTIONS" OFF
 )
 
-
-##
-# Import dependencies
-##
-
-add_subdirectory(dependencies)
 
 ##
 # Add source directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,20 @@ endif ()
 # Enable the SPIR-V target if requested (must declare before processing dependencies)
 option(TARGET_SPIRV "Include SPIR-V target" OFF)
 
+# Declare all options before we add any subdirectories, since some
+# (eg WITH_UTILS) are referenced in multiple subdirectories, and if we don't
+# declare them ahead of time, they will quietly be "false".
+
+option(WITH_TESTS "Build tests" "${PROJECT_IS_TOP_LEVEL}")
+option(WITH_TUTORIALS "Build tutorials" "${PROJECT_IS_TOP_LEVEL}")
+option(WITH_DOCS "Build documentation" OFF)
+option(WITH_UTILS "Build utils" "${PROJECT_IS_TOP_LEVEL}")
+cmake_dependent_option(
+    WITH_PYTHON_BINDINGS "Build Python bindings" "${PROJECT_IS_TOP_LEVEL}"
+    "Halide_ENABLE_RTTI AND Halide_ENABLE_EXCEPTIONS" OFF
+)
+
+
 ##
 # Import dependencies
 ##
@@ -101,7 +115,6 @@ add_subdirectory(tools)
 # Add tests, tutorials, etc. if we're not being imported into another CMake project.
 ##
 
-option(WITH_TESTS "Build tests" "${PROJECT_IS_TOP_LEVEL}")
 if (WITH_TESTS)
     message(STATUS "Building tests enabled")
     add_subdirectory(test)
@@ -109,10 +122,6 @@ else ()
     message(STATUS "Building tests disabled")
 endif ()
 
-cmake_dependent_option(
-    WITH_PYTHON_BINDINGS "Build Python bindings" "${PROJECT_IS_TOP_LEVEL}"
-    "Halide_ENABLE_RTTI AND Halide_ENABLE_EXCEPTIONS" OFF
-)
 if (WITH_PYTHON_BINDINGS)
     message(STATUS "Building Python bindings enabled")
     add_subdirectory(python_bindings)
@@ -120,7 +129,6 @@ else ()
     message(STATUS "Building Python bindings disabled")
 endif ()
 
-option(WITH_TUTORIALS "Build tutorials" "${PROJECT_IS_TOP_LEVEL}")
 if (WITH_TUTORIALS)
     message(STATUS "Building tutorials enabled")
     add_subdirectory(tutorial)
@@ -128,7 +136,6 @@ else ()
     message(STATUS "Building tutorials disabled")
 endif ()
 
-option(WITH_DOCS "Build documentation" OFF)
 if (WITH_DOCS)
     message(STATUS "Building docs enabled")
     add_subdirectory(doc)
@@ -136,7 +143,6 @@ else ()
     message(STATUS "Building docs disabled")
 endif ()
 
-option(WITH_UTILS "Build utils" "${PROJECT_IS_TOP_LEVEL}")
 if (WITH_UTILS)
     message(STATUS "Building utils enabled")
     add_subdirectory(util)


### PR DESCRIPTION
- The `WITH_UTIL` option was relied upon inside the autoscheduler subdir, but wasn't defined until after that subdir was processed. This had the unfortunate effect of making the undefined option (effectively) always false the first time it was encountered, but appropriately true | false on subsequent runs; the upshot was that if you did a `make install` as the *FIRST* build from a build-from-scratch, you would (quietly) get an install that omitted the adams2019 tools from the installer. (This seems like a crazy misfeature on CMake's part, but I'm sure it's unfixable now...)

