### PR TITLE
Avoid deprecation warnings in imageio

### DIFF
--- a/python_bindings/test/apps/bilateral_grid_shell.py
+++ b/python_bindings/test/apps/bilateral_grid_shell.py
@@ -6,7 +6,7 @@ from bilateral_grid import bilateral_grid
 from bilateral_grid_Adams2019 import bilateral_grid_Adams2019
 from bilateral_grid_Li2018 import bilateral_grid_Li2018
 from bilateral_grid_Mullapudi2016 import bilateral_grid_Mullapudi2016
-import imageio
+import imageio.v2 as imageio
 import numpy as np
 import os
 import sys

--- a/python_bindings/test/apps/blur.py
+++ b/python_bindings/test/apps/blur.py
@@ -1,7 +1,7 @@
 import halide as hl
 
 import numpy as np
-import imageio
+import imageio.v2 as imageio
 import os.path
 
 # Return the directory to look in for test images:

--- a/python_bindings/test/apps/erode.py
+++ b/python_bindings/test/apps/erode.py
@@ -5,7 +5,7 @@ Erode application using Python Halide bindings
 import halide as hl
 
 import numpy as np
-import imageio
+import imageio.v2 as imageio
 import os.path
 
 # Return the directory to look in for test images:

--- a/python_bindings/test/apps/interpolate.py
+++ b/python_bindings/test/apps/interpolate.py
@@ -5,7 +5,7 @@ Fast image interpolation using a pyramid.
 import halide as hl
 
 from datetime import datetime
-import imageio
+import imageio.v2 as imageio
 import numpy as np
 import os.path
 

--- a/python_bindings/test/apps/local_laplacian.py
+++ b/python_bindings/test/apps/local_laplacian.py
@@ -5,7 +5,7 @@ Local Laplacian, see e.g. Aubry et al 2011, "Fast and Robust Pyramid-based Image
 import halide as hl
 
 import numpy as np
-import imageio
+import imageio.v2 as imageio
 import os.path
 
 # Return the directory to look in for test images:

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -8,7 +8,7 @@
 
 import halide as hl
 import numpy as np
-import imageio
+import imageio.v2 as imageio
 import os.path
 
 

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -10,7 +10,7 @@
 
 import halide as hl
 
-import imageio
+import imageio.v2 as imageio
 import numpy as np
 import os.path
 

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -12,7 +12,7 @@ from datetime import datetime
 
 import halide as hl
 
-import imageio
+import imageio.v2 as imageio
 import numpy as np
 import os.path
 

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -10,7 +10,7 @@
 
 import halide as hl
 
-import imageio
+import imageio.v2 as imageio
 import os.path
 import struct
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cmake>=3.22
-imageio
+imageio>=2.16
 ninja; platform_system!='Windows'
 numpy
 pillow


### PR DESCRIPTION
(Cherry-picked from WIP #7109)

It seems that as of imageio v2.16, they offer new and old apis, which must be imported as imageio.v3 or imageio.v2 respectively; if you just import and use the naked imageio but have 2.16+ installed, you get a noisy and puzzling deprecation warning emitted to stdout, which is not great, especially for tutorials.

All the options here seem bad:

- We could just leave stuff as-is, but that would mean that folks running with a newer (Feb 2022 +) install of imageio would get a distracting deprecation warning
- We could play nicely with both older and newer versions of imageio by wrapping the import in a try block; that would work, but would be a distracting wart at the top of each tutorial
- We could settle on using either the v2 or v3 API, but that means that folks with older imageio installs fail outright

- For the moment, I settled on the last one (using v2), along with requirements.txt... which forced me to upgrade the version on all the buildbots, since they were mostly running 2.9.

I'd welcome feedback on this.