### PR TITLE
add 'reverse_axes' options to Buffer conversions

### DIFF
--- a/python_bindings/src/halide/halide_/PyBuffer.cpp
+++ b/python_bindings/src/halide/halide_/PyBuffer.cpp
@@ -233,7 +233,6 @@ py::object buffer_setitem_operator(Buffer<> &buf, const std::vector<int> &pos, c
         throw py::value_error("Incorrect number of dimensions.");
     }
 // TODO: add bounds checking?
-
 #define HANDLE_BUFFER_TYPE(TYPE)       \
     if (buf.type() == type_of<TYPE>()) \
         return py::cast(buf.as<TYPE>()(pos.data()) = value_cast<TYPE>(value));

--- a/python_bindings/src/halide/halide_/PyBuffer.cpp
+++ b/python_bindings/src/halide/halide_/PyBuffer.cpp
@@ -310,7 +310,7 @@ py::buffer_info to_buffer_info(Buffer<> &b, bool reverse_axes = true) {
     for (int i = 0; i < d; i++) {
         const int dst_axis = reverse_axes ? (d - i - 1) : i;
         shape[dst_axis] = (Py_ssize_t)b.raw_buffer()->dim[i].extent;
-        strides[dst_axis] = (Py_ssize_t)(b.raw_buffer()->dim[i].stride * bytes);
+        strides[dst_axis] = (Py_ssize_t)b.raw_buffer()->dim[i].stride * (Py_ssize_t)bytes;
     }
 
     return py::buffer_info(

--- a/python_bindings/src/halide/halide_/PyBuffer.cpp
+++ b/python_bindings/src/halide/halide_/PyBuffer.cpp
@@ -232,7 +232,7 @@ py::object buffer_setitem_operator(Buffer<> &buf, const std::vector<int> &pos, c
     if ((size_t)pos.size() != (size_t)buf.dimensions()) {
         throw py::value_error("Incorrect number of dimensions.");
     }
-    // TODO: add bounds checking?
+// TODO: add bounds checking?
 
 #define HANDLE_BUFFER_TYPE(TYPE)       \
     if (buf.type() == type_of<TYPE>()) \

--- a/python_bindings/src/halide/halide_/PyBuffer.cpp
+++ b/python_bindings/src/halide/halide_/PyBuffer.cpp
@@ -161,19 +161,6 @@ std::string type_to_format_descriptor(const Type &type) {
     return std::string();
 }
 
-void check_out_of_bounds(Buffer<> &buf, const std::vector<int> &pos) {
-    const int d = buf.dimensions();
-    if ((size_t)pos.size() != (size_t)d) {
-        throw py::value_error("Incorrect number of dimensions.");
-    }
-    for (int i = 0; i < d; i++) {
-        const auto &dim = buf.dim(i);
-        if (pos[i] < dim.min() || pos[i] > dim.max()) {
-            throw py::value_error("Out-of-bounds access in dimension " + std::to_string(i));
-        }
-    }
-}
-
 }  // namespace
 
 Type format_descriptor_to_type(const std::string &fd) {
@@ -209,7 +196,10 @@ Type format_descriptor_to_type(const std::string &fd) {
 }
 
 py::object buffer_getitem_operator(Buffer<> &buf, const std::vector<int> &pos) {
-    check_out_of_bounds(buf, pos);
+    if ((size_t)pos.size() != (size_t)buf.dimensions()) {
+        throw py::value_error("Incorrect number of dimensions.");
+    }
+    // TODO: add bounds checking?
 
 #define HANDLE_BUFFER_TYPE(TYPE)       \
     if (buf.type() == type_of<TYPE>()) \
@@ -239,7 +229,10 @@ py::object buffer_getitem_operator(Buffer<> &buf, const std::vector<int> &pos) {
 namespace {
 
 py::object buffer_setitem_operator(Buffer<> &buf, const std::vector<int> &pos, const py::object &value) {
-    check_out_of_bounds(buf, pos);
+    if ((size_t)pos.size() != (size_t)buf.dimensions()) {
+        throw py::value_error("Incorrect number of dimensions.");
+    }
+    // TODO: add bounds checking?
 
 #define HANDLE_BUFFER_TYPE(TYPE)       \
     if (buf.type() == type_of<TYPE>()) \

--- a/python_bindings/src/halide/halide_/PyBuffer.cpp
+++ b/python_bindings/src/halide/halide_/PyBuffer.cpp
@@ -161,6 +161,19 @@ std::string type_to_format_descriptor(const Type &type) {
     return std::string();
 }
 
+void check_out_of_bounds(Buffer<> &buf, const std::vector<int> &pos) {
+    const int d = buf.dimensions();
+    if ((size_t)pos.size() != (size_t)d) {
+        throw py::value_error("Incorrect number of dimensions.");
+    }
+    for (int i = 0; i < d; i++) {
+        const auto &dim = buf.dim(i);
+        if (pos[i] < dim.min() || pos[i] > dim.max()) {
+            throw py::value_error("Out-of-bounds access in dimension " + std::to_string(i));
+        }
+    }
+}
+
 }  // namespace
 
 Type format_descriptor_to_type(const std::string &fd) {
@@ -196,10 +209,7 @@ Type format_descriptor_to_type(const std::string &fd) {
 }
 
 py::object buffer_getitem_operator(Buffer<> &buf, const std::vector<int> &pos) {
-    if ((size_t)pos.size() != (size_t)buf.dimensions()) {
-        throw py::value_error("Incorrect number of dimensions.");
-    }
-    // TODO: add bounds checking?
+    check_out_of_bounds(buf, pos);
 
 #define HANDLE_BUFFER_TYPE(TYPE)       \
     if (buf.type() == type_of<TYPE>()) \
@@ -229,10 +239,8 @@ py::object buffer_getitem_operator(Buffer<> &buf, const std::vector<int> &pos) {
 namespace {
 
 py::object buffer_setitem_operator(Buffer<> &buf, const std::vector<int> &pos, const py::object &value) {
-    if ((size_t)pos.size() != (size_t)buf.dimensions()) {
-        throw py::value_error("Incorrect number of dimensions.");
-    }
-// TODO: add bounds checking?
+    check_out_of_bounds(buf, pos);
+
 #define HANDLE_BUFFER_TYPE(TYPE)       \
     if (buf.type() == type_of<TYPE>()) \
         return py::cast(buf.as<TYPE>()(pos.data()) = value_cast<TYPE>(value));
@@ -264,8 +272,8 @@ py::object buffer_setitem_operator(Buffer<> &buf, const std::vector<int> &pos, c
 class PyBuffer : public Buffer<> {
     py::buffer_info info;
 
-    PyBuffer(py::buffer_info &&info, const std::string &name)
-        : Buffer<>(pybufferinfo_to_halidebuffer(info), name),
+    PyBuffer(py::buffer_info &&info, const std::string &name, bool reverse_axes)
+        : Buffer<>(pybufferinfo_to_halidebuffer(info, reverse_axes), name),
           info(std::move(info)) {
     }
 
@@ -278,8 +286,8 @@ public:
         : Buffer<>(b), info() {
     }
 
-    PyBuffer(const py::buffer &buffer, const std::string &name)
-        : PyBuffer(buffer.request(/*writable*/ true), name) {
+    PyBuffer(const py::buffer &buffer, const std::string &name, bool reverse_axes)
+        : PyBuffer(buffer.request(/*writable*/ true), name, reverse_axes) {
         // Default to setting host-dirty on any PyBuffer we create from an existing py::buffer;
         // this allows (e.g.) code like
         //
@@ -299,6 +307,30 @@ public:
     ~PyBuffer() override = default;
 };
 
+py::buffer_info to_buffer_info(Buffer<> &b, bool reverse_axes = true) {
+    if (b.data() == nullptr) {
+        throw py::value_error("Cannot convert a Buffer<> with null host ptr to a Python buffer.");
+    }
+
+    const int d = b.dimensions();
+    const int bytes = b.type().bytes();
+    std::vector<Py_ssize_t> shape(d), strides(d);
+    for (int i = 0; i < d; i++) {
+        const int dst_axis = reverse_axes ? (d - i - 1) : i;
+        shape[dst_axis] = (Py_ssize_t)b.raw_buffer()->dim[i].extent;
+        strides[dst_axis] = (Py_ssize_t)(b.raw_buffer()->dim[i].stride * bytes);
+    }
+
+    return py::buffer_info(
+        b.data(),                             // Pointer to buffer
+        bytes,                                // Size of one scalar
+        type_to_format_descriptor(b.type()),  // Python struct-style format descriptor
+        d,                                    // Number of dimensions
+        shape,                                // Buffer dimensions
+        strides                               // Strides (in bytes) for each index
+    );
+}
+
 }  // namespace
 
 void define_buffer(py::module &m) {
@@ -317,34 +349,12 @@ void define_buffer(py::module &m) {
             // Note that this allows us to convert a Buffer<> to any buffer-like object in Python;
             // most notably, we can convert to an ndarray by calling numpy.array()
             .def_buffer([](Buffer<> &b) -> py::buffer_info {
-                if (b.data() == nullptr) {
-                    throw py::value_error("Cannot convert a Buffer<> with null host ptr to a Python buffer.");
-                }
-
-                const int d = b.dimensions();
-                const int bytes = b.type().bytes();
-                std::vector<Py_ssize_t> shape, strides;
-                // Halide's default indexing convention is col-major (the most rapidly varying index comes first);
-                // Numpy's default is row-major (most rapidly varying comes last).
-                // We want to reverse the order so that most-varying comes first.
-                for (int i = d - 1; i >= 0; i--) {
-                    shape.push_back((Py_ssize_t)b.raw_buffer()->dim[i].extent);
-                    strides.push_back((Py_ssize_t)(b.raw_buffer()->dim[i].stride * bytes));
-                }
-
-                return py::buffer_info(
-                    b.data(),                             // Pointer to buffer
-                    bytes,                                // Size of one scalar
-                    type_to_format_descriptor(b.type()),  // Python struct-style format descriptor
-                    d,                                    // Number of dimensions
-                    shape,                                // Buffer dimensions
-                    strides                               // Strides (in bytes) for each index
-                );
+                return to_buffer_info(b, /*reverse_axes*/ true);
             })
 
             // This allows us to use any buffer-like python entity to create a Buffer<>
             // (most notably, an ndarray)
-            .def(py::init_alias<py::buffer, const std::string &>(), py::arg("buffer"), py::arg("name") = "")
+            .def(py::init_alias<py::buffer, const std::string &, bool>(), py::arg("buffer"), py::arg("name") = "", py::arg("reverse_axes") = true)
             .def(py::init_alias<>())
             .def(py::init_alias<const Buffer<> &>())
             .def(py::init([](Type type, const std::vector<int> &sizes, const std::string &name) -> Buffer<> {
@@ -407,6 +417,14 @@ void define_buffer(py::module &m) {
 
             .def("copy", &Buffer<>::copy)
             .def("copy_from", &Buffer<>::copy_from<void, Buffer<>::AnyDims>)
+            .def("reverse_axes", [](Buffer<> &b) -> Buffer<> {
+                const int d = b.dimensions();
+                std::vector<int> order;
+                for (int i = 0; i < b.dimensions(); i++) {
+                    order.push_back(d - i - 1);
+                }
+                return b.transposed(order);
+            })
 
             .def("add_dimension", (void(Buffer<>::*)()) & Buffer<>::add_dimension)
 

--- a/python_bindings/src/halide/halide_/PyBuffer.h
+++ b/python_bindings/src/halide/halide_/PyBuffer.h
@@ -15,7 +15,7 @@ py::object buffer_getitem_operator(Buffer<> &buf, const std::vector<int> &pos);
 template<typename T = void,
          int Dims = AnyDims,
          int InClassDimStorage = (Dims == AnyDims ? 4 : std::max(Dims, 1))>
-Halide::Runtime::Buffer<T, Dims, InClassDimStorage> pybufferinfo_to_halidebuffer(const py::buffer_info &info) {
+Halide::Runtime::Buffer<T, Dims, InClassDimStorage> pybufferinfo_to_halidebuffer(const py::buffer_info &info, bool reverse_axes) {
     const Type t = format_descriptor_to_type(info.format);
     halide_dimension_t *dims = (halide_dimension_t *)alloca(info.ndim * sizeof(halide_dimension_t));
     _halide_user_assert(dims);
@@ -25,8 +25,9 @@ Halide::Runtime::Buffer<T, Dims, InClassDimStorage> pybufferinfo_to_halidebuffer
         }
         // Halide's default indexing convention is col-major (the most rapidly varying index comes first);
         // Numpy's default is row-major (most rapidly varying comes last).
-        // We want to reverse the order so that most-varying comes first.
-        dims[info.ndim - i - 1] = {0, (int32_t)info.shape[i], (int32_t)(info.strides[i] / t.bytes())};
+        // We usually want to reverse the order so that most-varying comes first.
+        const int dst_axis = reverse_axes ? (info.ndim - i - 1) : i;
+        dims[dst_axis] = {0, (int32_t)info.shape[i], (int32_t)(info.strides[i] / t.bytes())};
     }
     return Halide::Runtime::Buffer<T, Dims, InClassDimStorage>(t, info.ptr, (int)info.ndim, dims);
 }
@@ -34,8 +35,8 @@ Halide::Runtime::Buffer<T, Dims, InClassDimStorage> pybufferinfo_to_halidebuffer
 template<typename T = void,
          int Dims = AnyDims,
          int InClassDimStorage = (Dims == AnyDims ? 4 : std::max(Dims, 1))>
-Halide::Runtime::Buffer<T, Dims, InClassDimStorage> pybuffer_to_halidebuffer(const py::buffer &pyb, bool writable) {
-    return pybufferinfo_to_halidebuffer(pyb.request(writable));
+Halide::Runtime::Buffer<T, Dims, InClassDimStorage> pybuffer_to_halidebuffer(const py::buffer &pyb, bool writable, bool reverse_axes) {
+    return pybufferinfo_to_halidebuffer(pyb.request(writable), reverse_axes);
 }
 
 }  // namespace PythonBindings

--- a/python_bindings/src/halide/halide_/PyCallable.cpp
+++ b/python_bindings/src/halide/halide_/PyCallable.cpp
@@ -92,7 +92,10 @@ public:
                     argv[slot] = b.raw_buffer();
                 } else {
                     const bool writable = c_arg.is_output();
-                    buffers.buffers[slot] = pybuffer_to_halidebuffer<void, AnyDims, MaxFastDimensions>(cast_to<py::buffer>(value), writable);
+                    const bool reverse_axes = true;
+                    buffers.buffers[slot] =
+                        pybuffer_to_halidebuffer<void, AnyDims, MaxFastDimensions>(
+                            cast_to<py::buffer>(value), writable, reverse_axes);
                     argv[slot] = buffers.buffers[slot].raw_buffer();
                 }
                 cci[slot] = Callable::make_buffer_qcci();

--- a/python_bindings/test/correctness/buffer.py
+++ b/python_bindings/test/correctness/buffer.py
@@ -4,83 +4,131 @@ import numpy as np
 import gc
 import sys
 
-def test_ndarray_to_buffer():
+def test_ndarray_to_buffer(reverse_axes = True):
     a0 = np.ones((200, 300), dtype=np.int32)
 
     # Buffer always shares data (when possible) by default,
     # and maintains the shape of the data source. (note that
     # the ndarray is col-major by default!)
-    b0 = hl.Buffer(a0, "float32_test_buffer")
+    b0 = hl.Buffer(a0, "float32_test_buffer", reverse_axes)
     assert b0.type() == hl.Int(32)
     assert b0.name() == "float32_test_buffer"
     assert b0.all_equal(1)
 
-    assert b0.dim(1).min() == 0
-    assert b0.dim(1).max() == 199
-    assert b0.dim(1).extent() == 200
-    assert b0.dim(1).stride() == 300
+    if reverse_axes:
+        assert b0.dim(0).min() == 0
+        assert b0.dim(0).max() == 299
+        assert b0.dim(0).extent() == 300
+        assert b0.dim(0).stride() == 1
 
-    assert b0.dim(0).min() == 0
-    assert b0.dim(0).max() == 299
-    assert b0.dim(0).extent() == 300
-    assert b0.dim(0).stride() == 1
+        assert b0.dim(1).min() == 0
+        assert b0.dim(1).max() == 199
+        assert b0.dim(1).extent() == 200
+        assert b0.dim(1).stride() == 300
 
-    a0[12, 34] = 56
-    assert b0[34, 12] == 56
+        a0[12, 34] = 56
+        assert b0[34, 12] == 56
 
-    b0[56, 34] = 12
-    assert a0[34, 56] == 12
+        b0[56, 34] = 12
+        assert a0[34, 56] == 12
+    else:
+        assert b0.dim(0).min() == 0
+        assert b0.dim(0).max() == 199
+        assert b0.dim(0).extent() == 200
+        assert b0.dim(0).stride() == 300
+
+        assert b0.dim(1).min() == 0
+        assert b0.dim(1).max() == 299
+        assert b0.dim(1).extent() == 300
+        assert b0.dim(1).stride() == 1
+
+        a0[12, 34] = 56
+        assert b0[12, 34] == 56
+
+        b0[56, 34] = 12
+        assert a0[56, 34] == 12
 
 
-def test_buffer_to_ndarray():
-    buf = hl.Buffer(hl.Int(16), [4, 4])
-    assert buf.type() == hl.Int(16)
-    buf.fill(0)
-    buf[1, 2] = 42
-    assert buf[1, 2] == 42
+def test_buffer_to_ndarray(reverse_axes = True):
+    buf0 = hl.Buffer(hl.Int(16), [4, 6])
+    assert buf0.type() == hl.Int(16)
+    buf0.fill(0)
+    buf0[1, 2] = 42
+    assert buf0[1, 2] == 42
+
+    # This is subtle: the default behavior when converting
+    # a Buffer to an np.array (or ndarray, etc) is to reverse the
+    # order of the axes, since Halide prefers column-major and
+    # the rest of Python prefers row-major. By calling reverse_axes()
+    # before that conversion, we end up doing a *double* reverse, i.e,
+    # not reversing at all. So the 'not' here is correct.
+    buf = buf0.reverse_axes() if not reverse_axes else buf0
 
     # Should share storage with buf
     array_shared = np.array(buf, copy = False)
-    assert array_shared.shape == (4, 4)
     assert array_shared.dtype == np.int16
-    assert array_shared[2, 1] == 42
+    if reverse_axes:
+        assert array_shared.shape == (6, 4)
+        assert array_shared[2, 1] == 42
+    else:
+        assert array_shared.shape == (4, 6)
+        assert array_shared[1, 2] == 42
 
     # Should *not* share storage with buf
     array_copied = np.array(buf, copy = True)
-    assert array_copied.shape == (4, 4)
     assert array_copied.dtype == np.int16
-    assert array_copied[2, 1] == 42
+    if reverse_axes:
+        assert array_copied.shape == (6, 4)
+        assert array_copied[2, 1] == 42
+    else:
+        assert array_copied.shape == (4, 6)
+        assert array_copied[1, 2] == 42
 
-    buf[1, 2] = 3
-    assert array_shared[2, 1] == 3
-    assert array_copied[2, 1] == 42
+    # Should affect array_shared but not array_copied
+    buf0[1, 2] = 3
+    if reverse_axes:
+        assert array_shared[2, 1] == 3
+        assert array_copied[2, 1] == 42
+    else:
+        assert array_shared[1, 2] == 3
+        assert array_copied[1, 2] == 42
 
     # Ensure that Buffers that have nonzero mins get converted correctly,
     # since the Python Buffer Protocol doesn't have the 'min' concept
-    cropped = buf.copy()
-    cropped.crop(dimension = 0, min = 1, extent = 2)
+    cropped_buf0 = buf0.copy()
+    cropped_buf0.crop(dimension = 0, min = 1, extent = 2)
+    cropped_buf = cropped_buf0.reverse_axes() if not reverse_axes else cropped_buf0
 
     # Should share storage with cropped (and buf)
-    cropped_array_shared = np.array(cropped, copy = False)
-    assert cropped_array_shared.shape == (4, 2)
+    cropped_array_shared = np.array(cropped_buf, copy = False)
     assert cropped_array_shared.dtype == np.int16
-    assert cropped_array_shared[2, 0] == 3
+    if reverse_axes:
+        assert cropped_array_shared.shape == (6, 2)
+        assert cropped_array_shared[2, 0] == 3
+    else:
+        assert cropped_array_shared.shape == (2, 6)
+        assert cropped_array_shared[0, 2] == 3
 
     # Should *not* share storage with anything
-    cropped_array_copied = np.array(cropped, copy = True)
-    assert cropped_array_copied.shape == (4, 2)
+    cropped_array_copied = np.array(cropped_buf, copy = True)
     assert cropped_array_copied.dtype == np.int16
-    assert cropped_array_copied[2, 0] == 3
+    if reverse_axes:
+        assert cropped_array_copied.shape == (6, 2)
+        assert cropped_array_copied[2, 0] == 3
+    else:
+        assert cropped_array_copied.shape == (2, 6)
+        assert cropped_array_copied[0, 2] == 3
 
-    cropped[1, 2] = 5
-
-    assert buf[1, 2] == 3
-    assert array_shared[2, 1] == 3
-    assert array_copied[2, 1] == 42
-
-    assert cropped[1, 2] == 5
-    assert cropped_array_shared[2, 0] == 5
-    assert cropped_array_copied[2, 0] == 3
+    cropped_buf0[1, 2] = 5
+    assert cropped_buf0[1, 2] == 5
+    if reverse_axes:
+        assert cropped_buf[1, 2] == 5
+        assert cropped_array_shared[2, 0] == 5
+        assert cropped_array_copied[2, 0] == 3
+    else:
+        assert cropped_buf[2, 1] == 5
+        assert cropped_array_shared[0, 2] == 5
+        assert cropped_array_copied[0, 2] == 3
 
 
 def _assert_fn(e):
@@ -289,8 +337,10 @@ def test_scalar_buffers():
 if __name__ == "__main__":
     test_make_interleaved()
     test_interleaved_ndarray()
-    test_ndarray_to_buffer()
-    test_buffer_to_ndarray()
+    test_ndarray_to_buffer(reverse_axes = True)
+    test_ndarray_to_buffer(reverse_axes = False)
+    test_buffer_to_ndarray(reverse_axes = True)
+    test_buffer_to_ndarray(reverse_axes = False)
     test_for_each_element()
     test_fill_all_equal()
     test_bufferinfo_sharing()


### PR DESCRIPTION
This adds some options to the changes in #7127 to allow for easier backwards compatibility with previous versions of the Python bindings:
- The default when creating `hl.Buffer` from a Python buffer is to reverse the axes. There is now an optional named arg to that ctor that you can specify `reverse_axes = False` if you want the behavior of pre-Halide-15 (ie, don't reverse).
- The default when creating `np.array`, `np.ndarray` etc from an `hl.Buffer` is to reverse the axes. There is now a new method on `hl.Buffer`, `reverse_axes()`, which simply returns another Buffer that is a view onto the same memory, but with the order of the axes reverse. This allows you to keep the behavior of pre-Halide-15 (ie, don't reverse) by doing something like `np.array(halidebug.reverse_axes(), ...)`.