### PR TITLE
Apply 'Black' formatter to py/test/correctness and py/test/generators

### DIFF
--- a/python_bindings/test/correctness/addconstant_test.py
+++ b/python_bindings/test/correctness/addconstant_test.py
@@ -39,7 +39,7 @@ def test(addconstant_impl_func, offset):
     input_float = numpy.array([3.14, 2.718, 1.618], dtype=numpy.float32)
     input_double = numpy.array([3.14, 2.718, 1.618], dtype=numpy.float64)
     input_half = numpy.array([3.14, 2.718, 1.618], dtype=numpy.float16)
-    input_2d = numpy.array([[1, 2, 3], [4, 5, 6]], dtype=numpy.int8, order='F')
+    input_2d = numpy.array([[1, 2, 3], [4, 5, 6]], dtype=numpy.int8, order="F")
     input_3d = numpy.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]], dtype=numpy.int8)
 
     output_u8 = numpy.zeros((3,), dtype=numpy.uint8)
@@ -53,20 +53,47 @@ def test(addconstant_impl_func, offset):
     output_float = numpy.zeros((3,), dtype=numpy.float32)
     output_double = numpy.zeros((3,), dtype=numpy.float64)
     output_half = numpy.zeros((3,), dtype=numpy.float16)
-    output_2d = numpy.zeros((2, 3), dtype=numpy.int8, order='F')
+    output_2d = numpy.zeros((2, 3), dtype=numpy.int8, order="F")
     output_3d = numpy.zeros((2, 2, 2), dtype=numpy.int8)
 
     addconstant_impl_func(
         scalar_u1,
-        scalar_u8, scalar_u16, scalar_u32, scalar_u64,
-        scalar_i8, scalar_i16, scalar_i32, scalar_i64,
-        scalar_float, scalar_double,
-        input_u8, input_u16, input_u32, input_u64,
-        input_i8, input_i16, input_i32, input_i64,
-        input_float, input_double, input_half, input_2d, input_3d,
-        output_u8, output_u16, output_u32, output_u64,
-        output_i8, output_i16, output_i32, output_i64,
-        output_float, output_double, output_half, output_2d, output_3d,
+        scalar_u8,
+        scalar_u16,
+        scalar_u32,
+        scalar_u64,
+        scalar_i8,
+        scalar_i16,
+        scalar_i32,
+        scalar_i64,
+        scalar_float,
+        scalar_double,
+        input_u8,
+        input_u16,
+        input_u32,
+        input_u64,
+        input_i8,
+        input_i16,
+        input_i32,
+        input_i64,
+        input_float,
+        input_double,
+        input_half,
+        input_2d,
+        input_3d,
+        output_u8,
+        output_u16,
+        output_u32,
+        output_u64,
+        output_i8,
+        output_i16,
+        output_i32,
+        output_i64,
+        output_float,
+        output_double,
+        output_half,
+        output_2d,
+        output_3d,
     )
 
     combinations = [
@@ -102,20 +129,47 @@ def test(addconstant_impl_func, offset):
         scalar_i32 = 0
         addconstant_impl_func(
             scalar_u1,
-            scalar_u8, scalar_u16, scalar_u32, scalar_u64,
-            scalar_i8, scalar_i16, scalar_i32, scalar_i64,
-            scalar_float, scalar_double,
-            input_u8, input_u16, input_u32, input_u64,
-            input_i8, input_i16, input_i32, input_i64,
-            input_float, input_double, input_half, input_2d, input_3d,
-            output_u8, output_u16, output_u32, output_u64,
-            output_i8, output_i16, output_i32, output_i64,
-            output_float, output_double, output_half, output_2d, output_3d,
+            scalar_u8,
+            scalar_u16,
+            scalar_u32,
+            scalar_u64,
+            scalar_i8,
+            scalar_i16,
+            scalar_i32,
+            scalar_i64,
+            scalar_float,
+            scalar_double,
+            input_u8,
+            input_u16,
+            input_u32,
+            input_u64,
+            input_i8,
+            input_i16,
+            input_i32,
+            input_i64,
+            input_float,
+            input_double,
+            input_half,
+            input_2d,
+            input_3d,
+            output_u8,
+            output_u16,
+            output_u32,
+            output_u64,
+            output_i8,
+            output_i16,
+            output_i32,
+            output_i64,
+            output_float,
+            output_double,
+            output_half,
+            output_2d,
+            output_3d,
         )
     except RuntimeError as e:
         assert str(e) == "Halide Runtime Error: -27", e
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Expected requirement failure #2 -- note that for AOT-compiled
@@ -124,20 +178,47 @@ def test(addconstant_impl_func, offset):
         scalar_i32 = -1
         addconstant_impl_func(
             scalar_u1,
-            scalar_u8, scalar_u16, scalar_u32, scalar_u64,
-            scalar_i8, scalar_i16, scalar_i32, scalar_i64,
-            scalar_float, scalar_double,
-            input_u8, input_u16, input_u32, input_u64,
-            input_i8, input_i16, input_i32, input_i64,
-            input_float, input_double, input_half, input_2d, input_3d,
-            output_u8, output_u16, output_u32, output_u64,
-            output_i8, output_i16, output_i32, output_i64,
-            output_float, output_double, output_half, output_2d, output_3d,
+            scalar_u8,
+            scalar_u16,
+            scalar_u32,
+            scalar_u64,
+            scalar_i8,
+            scalar_i16,
+            scalar_i32,
+            scalar_i64,
+            scalar_float,
+            scalar_double,
+            input_u8,
+            input_u16,
+            input_u32,
+            input_u64,
+            input_i8,
+            input_i16,
+            input_i32,
+            input_i64,
+            input_float,
+            input_double,
+            input_half,
+            input_2d,
+            input_3d,
+            output_u8,
+            output_u16,
+            output_u32,
+            output_u64,
+            output_i8,
+            output_i16,
+            output_i32,
+            output_i64,
+            output_float,
+            output_double,
+            output_half,
+            output_2d,
+            output_3d,
         )
     except RuntimeError as e:
         assert str(e) == "Halide Runtime Error: -27", e
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
 
 if __name__ == "__main__":

--- a/python_bindings/test/correctness/atomics.py
+++ b/python_bindings/test/correctness/atomics.py
@@ -1,9 +1,10 @@
 import halide as hl
 
+
 def test_atomics():
-    x = hl.Var('x')
-    im = hl.Func('im')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    im = hl.Func("im")
+    f = hl.Func("f")
     im[x] = (x * x) % 5
     r = hl.RDom([(0, 100)])
     f[x] = 0
@@ -16,7 +17,8 @@ def test_atomics():
         idx = (i * i) % 5
         ref[idx] += 1
     for i in range(5):
-        assert(b[i] == ref[i])
+        assert b[i] == ref[i]
+
 
 if __name__ == "__main__":
     test_atomics()

--- a/python_bindings/test/correctness/autodiff.py
+++ b/python_bindings/test/correctness/autodiff.py
@@ -1,13 +1,14 @@
 import halide as hl
 
+
 def test_autodiff():
-    x = hl.Var('x')
+    x = hl.Var("x")
     b = hl.Buffer(hl.Float(32), [3])
-    p = hl.Param(hl.Float(32), 'p', 1)
+    p = hl.Param(hl.Float(32), "p", 1)
     b[0] = 1.0
     b[1] = 2.0
     b[2] = 3.0
-    f, g, h = hl.Func('f'), hl.Func('g'), hl.Func('h')
+    f, g, h = hl.Func("f"), hl.Func("g"), hl.Func("h")
     f[x] = b[x]
     f[0] = 4.0
     g[x] = f[x] * 5.0 * p
@@ -20,47 +21,48 @@ def test_autodiff():
     # gradient w.r.t. the initialization of f
     d_f_init = d[f]
     d_f_init_buf = d_f_init.realize([3])
-    assert(d_f_init_buf[0] == 0.0)
-    assert(d_f_init_buf[1] == 5.0)
-    assert(d_f_init_buf[2] == 5.0)
-    d_f_init = d[f]# test different interface
+    assert d_f_init_buf[0] == 0.0
+    assert d_f_init_buf[1] == 5.0
+    assert d_f_init_buf[2] == 5.0
+    d_f_init = d[f]  # test different interface
     d_f_init_buf = d_f_init.realize([3])
-    assert(d_f_init_buf[0] == 0.0)
-    assert(d_f_init_buf[1] == 5.0)
-    assert(d_f_init_buf[2] == 5.0)
+    assert d_f_init_buf[0] == 0.0
+    assert d_f_init_buf[1] == 5.0
+    assert d_f_init_buf[2] == 5.0
 
     # gradient w.r.t. the updated f
     d_f_update_0 = d[f, 0]
     d_f_update_0_buf = d_f_update_0.realize([3])
-    assert(d_f_update_0_buf[0] == 5.0)
-    assert(d_f_update_0_buf[1] == 5.0)
-    assert(d_f_update_0_buf[2] == 5.0)
+    assert d_f_update_0_buf[0] == 5.0
+    assert d_f_update_0_buf[1] == 5.0
+    assert d_f_update_0_buf[2] == 5.0
     d_f_update_0 = d[f, 0]
     d_f_update_0_buf = d_f_update_0.realize([3])
-    assert(d_f_update_0_buf[0] == 5.0)
-    assert(d_f_update_0_buf[1] == 5.0)
-    assert(d_f_update_0_buf[2] == 5.0)
+    assert d_f_update_0_buf[0] == 5.0
+    assert d_f_update_0_buf[1] == 5.0
+    assert d_f_update_0_buf[2] == 5.0
 
     # gradient w.r.t. the buffer
     d_b = d[b]
     d_b_buf = d_b.realize([3])
-    assert(d_b_buf[0] == 0.0)
-    assert(d_b_buf[1] == 5.0)
-    assert(d_b_buf[2] == 5.0)
+    assert d_b_buf[0] == 0.0
+    assert d_b_buf[1] == 5.0
+    assert d_b_buf[2] == 5.0
     d_b = d[b]
     d_b_buf = d_b.realize([3])
-    assert(d_b_buf[0] == 0.0)
-    assert(d_b_buf[1] == 5.0)
-    assert(d_b_buf[2] == 5.0)
+    assert d_b_buf[0] == 0.0
+    assert d_b_buf[1] == 5.0
+    assert d_b_buf[2] == 5.0
 
     # gradient w.r.t. the param
     d_p = d[p]
     d_p_buf = d_p.realize()
     # 5 * (4 + 2 + 3)
-    assert(abs(d_p_buf[()] - 45.0) < 1e-6)
+    assert abs(d_p_buf[()] - 45.0) < 1e-6
     d_p = d[p]
     d_p_buf = d_p.realize()
-    assert(abs(d_p_buf[()] - 45.0) < 1e-6)
+    assert abs(d_p_buf[()] - 45.0) < 1e-6
+
 
 if __name__ == "__main__":
     test_autodiff()

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -1,24 +1,28 @@
-
 import halide as hl
 import numpy as np
 
+
 def test_compiletime_error():
-    x = hl.Var('x')
-    y = hl.Var('y')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    y = hl.Var("y")
+    f = hl.Func("f")
     f[x, y] = hl.u16(x + y)
     # Deliberate type-mismatch error
     buf = hl.Buffer(hl.UInt(8), [2, 2])
     try:
         f.realize(buf)
     except hl.HalideError as e:
-        assert 'Output buffer f has type uint16 but type of the buffer passed in is uint8' in str(e)
+        assert (
+            "Output buffer f has type uint16 but type of the buffer passed in is uint8"
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
+
 
 def test_runtime_error():
-    x = hl.Var('x')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    f = hl.Func("f")
     f[x] = hl.u8(x)
     f.bound(x, 0, 1)
     # Deliberate runtime error
@@ -26,124 +30,132 @@ def test_runtime_error():
     try:
         f.realize(buf)
     except hl.HalideError as e:
-        assert 'do not cover required region' in str(e)
+        assert "do not cover required region" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
+
 
 def test_misused_and():
-    x = hl.Var('x')
-    y = hl.Var('y')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    y = hl.Var("y")
+    f = hl.Func("f")
     try:
-        f[x, y] = hl.print_when(x == 0 and y == 0, 0, "x=",x, "y=", y)
+        f[x, y] = hl.print_when(x == 0 and y == 0, 0, "x=", x, "y=", y)
         f.realize([10, 10])
     except ValueError as e:
-        assert 'cannot be converted to a bool' in str(e)
+        assert "cannot be converted to a bool" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
+
 
 def test_misused_or():
-    x = hl.Var('x')
-    y = hl.Var('y')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    y = hl.Var("y")
+    f = hl.Func("f")
     try:
-        f[x, y] = hl.print_when(x == 0 or y == 0, 0, "x=",x, "y=", y)
+        f[x, y] = hl.print_when(x == 0 or y == 0, 0, "x=", x, "y=", y)
         f.realize([10, 10])
     except ValueError as e:
-        assert 'cannot be converted to a bool' in str(e)
+        assert "cannot be converted to a bool" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
+
 
 def test_basics():
-    input = hl.ImageParam(hl.UInt(16), 2, 'input')
-    x, y = hl.Var('x'), hl.Var('y')
+    input = hl.ImageParam(hl.UInt(16), 2, "input")
+    x, y = hl.Var("x"), hl.Var("y")
 
-    blur_x = hl.Func('blur_x')
-    blur_xx = hl.Func('blur_xx')
-    blur_y = hl.Func('blur_y')
+    blur_x = hl.Func("blur_x")
+    blur_xx = hl.Func("blur_xx")
+    blur_y = hl.Func("blur_y")
 
     yy = hl.i32(1)
     assert yy.type() == hl.Int(32)
 
     z = x + 1
-    input[x,y]
-    input[0,0]
-    input[z,y]
-    input[x+1,y]
-    input[x,y]+input[x+1,y]
+    input[x, y]
+    input[0, 0]
+    input[z, y]
+    input[x + 1, y]
+    input[x, y] + input[x + 1, y]
 
     if False:
-        aa = blur_x[x,y]
-        bb = blur_x[x,y+1]
+        aa = blur_x[x, y]
+        bb = blur_x[x, y + 1]
         aa + bb
-        blur_x[x,y]+blur_x[x,y+1]
+        blur_x[x, y] + blur_x[x, y + 1]
 
-    (input[x,y]+input[x+1,y]) / 2
-    blur_x[x,y]
-    blur_xx[x,y] = input[x,y]
+    (input[x, y] + input[x + 1, y]) / 2
+    blur_x[x, y]
+    blur_xx[x, y] = input[x, y]
 
-    blur_x[x,y] = (input[x,y]+input[x+1,y]+input[x+2,y])/3
-    blur_y[x,y] = (blur_x[x,y]+blur_x[x,y+1]+blur_x[x,y+2])/3
+    blur_x[x, y] = (input[x, y] + input[x + 1, y] + input[x + 2, y]) / 3
+    blur_y[x, y] = (blur_x[x, y] + blur_x[x, y + 1] + blur_x[x, y + 2]) / 3
 
-    xi, yi = hl.Var('xi'), hl.Var('yi')
+    xi, yi = hl.Var("xi"), hl.Var("yi")
     blur_y.tile(x, y, xi, yi, 8, 4).parallel(y).vectorize(xi, 8)
     blur_x.compute_at(blur_y, x).vectorize(x, 8)
     blur_y.compile_jit()
 
 
 def test_basics2():
-    input = hl.ImageParam(hl.Float(32), 3, 'input')
-    r_sigma = hl.Param(hl.Float(32), 'r_sigma', 0.1)
+    input = hl.ImageParam(hl.Float(32), 3, "input")
+    r_sigma = hl.Param(hl.Float(32), "r_sigma", 0.1)
     s_sigma = 8
 
-    x = hl.Var('x')
-    y = hl.Var('y')
-    z = hl.Var('z')
-    c = hl.Var('c')
+    x = hl.Var("x")
+    y = hl.Var("y")
+    z = hl.Var("z")
+    c = hl.Var("c")
 
     # Add a boundary condition
-    clamped = hl.Func('clamped')
-    clamped[x, y] = input[hl.clamp(x, 0, input.width()-1),
-                          hl.clamp(y, 0, input.height()-1),0]
+    clamped = hl.Func("clamped")
+    clamped[x, y] = input[
+        hl.clamp(x, 0, input.width() - 1), hl.clamp(y, 0, input.height() - 1), 0
+    ]
 
     # Construct the bilateral grid
-    r = hl.RDom([(0, s_sigma), (0, s_sigma)], 'r')
+    r = hl.RDom([(0, s_sigma), (0, s_sigma)], "r")
     val0 = clamped[x * s_sigma, y * s_sigma]
     val00 = clamped[x * s_sigma * hl.i32(1), y * s_sigma * hl.i32(1)]
-    val22 = clamped[x * s_sigma - hl.i32(s_sigma//2),
-                    y * s_sigma - hl.i32(s_sigma//2)]
-    val2 = clamped[x * s_sigma - s_sigma//2, y * s_sigma - s_sigma//2]
-    val3 = clamped[x * s_sigma + r.x - s_sigma//2, y * s_sigma + r.y - s_sigma//2]
+    val22 = clamped[
+        x * s_sigma - hl.i32(s_sigma // 2), y * s_sigma - hl.i32(s_sigma // 2)
+    ]
+    val2 = clamped[x * s_sigma - s_sigma // 2, y * s_sigma - s_sigma // 2]
+    val3 = clamped[x * s_sigma + r.x - s_sigma // 2, y * s_sigma + r.y - s_sigma // 2]
 
     try:
-        val1 = clamped[x * s_sigma - s_sigma/2, y * s_sigma - s_sigma/2]
+        val1 = clamped[x * s_sigma - s_sigma / 2, y * s_sigma - s_sigma / 2]
     except hl.HalideError as e:
-        assert 'Implicit cast from float32 to int' in str(e)
+        assert "Implicit cast from float32 to int" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
 
 def test_basics3():
-    input = hl.ImageParam(hl.Float(32), 3, 'input')
-    r_sigma = hl.Param(hl.Float(32), 'r_sigma', 0.1) # Value needed if not generating an executable
-    s_sigma = 8 # This is passed during code generation in the C++ version
+    input = hl.ImageParam(hl.Float(32), 3, "input")
+    r_sigma = hl.Param(
+        hl.Float(32), "r_sigma", 0.1
+    )  # Value needed if not generating an executable
+    s_sigma = 8  # This is passed during code generation in the C++ version
 
-    x = hl.Var('x')
-    y = hl.Var('y')
-    z = hl.Var('z')
-    c = hl.Var('c')
+    x = hl.Var("x")
+    y = hl.Var("y")
+    z = hl.Var("z")
+    c = hl.Var("c")
 
     # Add a boundary condition
-    clamped = hl.Func('clamped')
-    clamped[x, y] = input[hl.clamp(x, 0, input.width()-1),
-                          hl.clamp(y, 0, input.height()-1),0]
+    clamped = hl.Func("clamped")
+    clamped[x, y] = input[
+        hl.clamp(x, 0, input.width() - 1), hl.clamp(y, 0, input.height() - 1), 0
+    ]
 
     # Construct the bilateral grid
-    r = hl.RDom([(0, s_sigma), (0, s_sigma)], 'r')
-    val = clamped[x * s_sigma + r.x - s_sigma//2, y * s_sigma + r.y - s_sigma//2]
+    r = hl.RDom([(0, s_sigma), (0, s_sigma)], "r")
+    val = clamped[x * s_sigma + r.x - s_sigma // 2, y * s_sigma + r.y - s_sigma // 2]
     val = hl.clamp(val, 0.0, 1.0)
     zi = hl.i32((val / r_sigma) + 0.5)
-    histogram = hl.Func('histogram')
+    histogram = hl.Func("histogram")
     histogram[x, y, z, c] = 0.0
 
     ss = hl.select(c == 0, val, 1.0)
@@ -151,12 +163,13 @@ def test_basics3():
     left += 5
     left += ss
 
+
 def test_basics4():
     # Test for f[g[r]] = ...
     # See https://github.com/halide/Halide/issues/4285
-    x = hl.Var('x')
-    f = hl.Func('f')
-    g = hl.Func('g')
+    x = hl.Var("x")
+    f = hl.Func("f")
+    g = hl.Func("g")
     g[x] = 1
     f[x] = 0.0
     r = hl.RDom([(0, 100)])
@@ -164,12 +177,13 @@ def test_basics4():
     f.compute_root()
     f.compile_jit()
 
+
 def test_basics5():
     # Test Func.in_()
-    x, y = hl.Var('x'), hl.Var('y')
-    f = hl.Func('f')
-    g = hl.Func('g')
-    h = hl.Func('h')
+    x, y = hl.Var("x"), hl.Var("y")
+    f = hl.Func("f")
+    g = hl.Func("g")
+    h = hl.Func("h")
     f[x, y] = y
     r = hl.RDom([(0, 100)])
     g[x] = 0
@@ -183,22 +197,23 @@ def test_basics5():
     p = hl.Pipeline([g, h])
     p.compile_jit()
 
+
 def test_float_or_int():
-    x = hl.Var('x')
-    i32, f32 =  hl.Int(32), hl.Float(32)
+    x = hl.Var("x")
+    i32, f32 = hl.Int(32), hl.Float(32)
 
     assert hl.Expr(x).type() == i32
-    assert (x*2).type() == i32
-    assert (x/2).type() == i32
-    assert ((x//2) - 1 + 2*(x%2)).type() == i32
-    assert ((x/2) - 1 + 2*(x%2)).type() == i32
-    assert ((x/2)).type() == i32
-    assert ((x/2.0)).type() == f32
-    assert ((x//2)).type() == i32
-    assert ((x//2) - 1).type() == i32
-    assert ((x%2)).type() == i32
-    assert (2*(x%2)).type() == i32
-    assert ((x//2) - 1 + 2*(x%2)).type() == i32
+    assert (x * 2).type() == i32
+    assert (x / 2).type() == i32
+    assert ((x // 2) - 1 + 2 * (x % 2)).type() == i32
+    assert ((x / 2) - 1 + 2 * (x % 2)).type() == i32
+    assert ((x / 2)).type() == i32
+    assert ((x / 2.0)).type() == f32
+    assert ((x // 2)).type() == i32
+    assert ((x // 2) - 1).type() == i32
+    assert ((x % 2)).type() == i32
+    assert (2 * (x % 2)).type() == i32
+    assert ((x // 2) - 1 + 2 * (x % 2)).type() == i32
 
     assert type(x) == hl.Var
     assert (hl.Expr(x)).type() == i32
@@ -225,28 +240,30 @@ def test_float_or_int():
 
 
 def test_operator_order():
-    x = hl.Var('x')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    f = hl.Func("f")
     x + 1
     1 + x
-    f[x] = x ** 2
+    f[x] = x**2
     f[x] + 1
     hl.Expr(1) + f[x]
     1 + f[x]
 
+
 def _check_is_u16(e):
     assert e.type() == hl.UInt(16), e.type()
+
 
 def test_int_promotion():
     # Verify that (Exprlike op literal) correctly matches the type
     # of the literal to the Exprlike (rather than promoting the result to int32).
     # All types that use add_binary_operators() should be tested here.
 
-    x = hl.Var('x')
+    x = hl.Var("x")
     # All the binary ops are handled the same, so + is good enough
 
     # Exprlike = FuncRef
-    f = hl.Func('f')
+    f = hl.Func("f")
     f[x] = hl.u16(x)
     _check_is_u16(f[x] + 2)
     _check_is_u16(2 + f[x])
@@ -265,130 +282,142 @@ def test_int_promotion():
     # Exprlike = Var
     # (skipped, since these can never have values of any type other than int32)
 
+
 def test_vector_tile():
     # Test Func.tile() and Stage.tile() with vector arguments
-    x,  y,  z  = [ hl.Var(c    ) for c in 'xyz' ]
-    xi, yi, zi = [ hl.Var(c+"i") for c in 'xyz' ]
-    xo, yo, zo = [ hl.Var(c+"o") for c in 'xyz' ]
-    f = hl.Func('f')
-    g = hl.Func('g')
-    h = hl.Func('h')
+    x, y, z = [hl.Var(c) for c in "xyz"]
+    xi, yi, zi = [hl.Var(c + "i") for c in "xyz"]
+    xo, yo, zo = [hl.Var(c + "o") for c in "xyz"]
+    f = hl.Func("f")
+    g = hl.Func("g")
+    h = hl.Func("h")
     f[x, y] = y
     f[x, y] += x
     g[x, y, z] = x + y
     g[x, y, z] += z
-    f.tile([x,y], [xo,yo], [x,y], [8,8])
-    f.update(0).tile([x,y], [xo,yo], [xi,yi], [8,8])
-    g.tile([x,y], [xo,yo], [x,y], [8,8], hl.TailStrategy.RoundUp)
-    g.update(0).tile([x,y], [xo,yo], [xi,yi], [8,8], hl.TailStrategy.GuardWithIf)
+    f.tile([x, y], [xo, yo], [x, y], [8, 8])
+    f.update(0).tile([x, y], [xo, yo], [xi, yi], [8, 8])
+    g.tile([x, y], [xo, yo], [x, y], [8, 8], hl.TailStrategy.RoundUp)
+    g.update(0).tile([x, y], [xo, yo], [xi, yi], [8, 8], hl.TailStrategy.GuardWithIf)
     p = hl.Pipeline([f, g])
     p.compile_jit()
 
-def test_scalar_funcs():
-    input = hl.ImageParam(hl.UInt(16), 0, 'input')
 
-    f = hl.Func('f')
-    g = hl.Func('g')
+def test_scalar_funcs():
+    input = hl.ImageParam(hl.UInt(16), 0, "input")
+
+    f = hl.Func("f")
+    g = hl.Func("g")
 
     input[()]
 
-    (input[()]+input[()]) / 2
+    (input[()] + input[()]) / 2
     f[()]
     g[()]
 
-    f[()] = (input[()]+input[()]+input[()])/3
-    g[()] = (f[()]+f[()]+f[()])/3
+    f[()] = (input[()] + input[()] + input[()]) / 3
+    g[()] = (f[()] + f[()] + f[()]) / 3
 
     g.compile_jit()
 
+
 def test_bool_conversion():
-    x = hl.Var('x')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    f = hl.Func("f")
     f[x] = x
     s = bool(True)
     # Verify that this doesn't fail with 'Argument passed to specialize must be of type bool'
     f.compute_root().specialize(True)
 
-def test_typed_funcs():
-    x = hl.Var('x')
-    y = hl.Var('y')
 
-    f = hl.Func('f')
+def test_typed_funcs():
+    x = hl.Var("x")
+    y = hl.Var("y")
+
+    f = hl.Func("f")
     assert not f.defined()
     try:
         assert f.type() == Int(32)
     except hl.HalideError as e:
-        assert 'it is undefined' in str(e)
+        assert "it is undefined" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         assert f.outputs() == 0
     except hl.HalideError as e:
-        assert 'it is undefined' in str(e)
+        assert "it is undefined" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         assert f.dimensions() == 0
     except hl.HalideError as e:
-        assert 'it is undefined' in str(e)
+        assert "it is undefined" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
-
-    f = hl.Func(hl.Int(32), 2, 'f')
+    f = hl.Func(hl.Int(32), 2, "f")
     assert not f.defined()
     assert f.type() == hl.Int(32)
     assert f.types() == [hl.Int(32)]
     assert f.outputs() == 1
     assert f.dimensions() == 2
 
-    f = hl.Func([hl.Int(32), hl.Float(64)], 3, 'f')
+    f = hl.Func([hl.Int(32), hl.Float(64)], 3, "f")
     assert not f.defined()
     try:
         assert f.type() == hl.Int(32)
     except hl.HalideError as e:
-        assert 'it returns a Tuple' in str(e)
+        assert "it returns a Tuple" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     assert f.types() == [hl.Int(32), hl.Float(64)]
     assert f.outputs() == 2
     assert f.dimensions() == 3
 
-    f = hl.Func(hl.Int(32), 1, 'f')
+    f = hl.Func(hl.Int(32), 1, "f")
     try:
-        f[x, y] = hl.i32(0);
+        f[x, y] = hl.i32(0)
         f.realize([10, 10])
     except hl.HalideError as e:
-        assert 'is constrained to have exactly 1 dimensions, but is defined with 2 dimensions' in str(e)
+        assert (
+            "is constrained to have exactly 1 dimensions, but is defined with 2 dimensions"
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
-    f = hl.Func(hl.Int(32), 2, 'f')
+    f = hl.Func(hl.Int(32), 2, "f")
     try:
-        f[x, y] = hl.i16(0);
+        f[x, y] = hl.i16(0)
         f.realize([10, 10])
     except hl.HalideError as e:
-        assert 'is constrained to only hold values of type int32 but is defined with values of type int16' in str(e)
+        assert (
+            "is constrained to only hold values of type int32 but is defined with values of type int16"
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
-    f = hl.Func((hl.Int(32), hl.Float(32)), 2, 'f')
+    f = hl.Func((hl.Int(32), hl.Float(32)), 2, "f")
     try:
         f[x, y] = (hl.i16(0), hl.f64(0))
         f.realize([10, 10])
     except hl.HalideError as e:
-        assert 'is constrained to only hold values of type (int32, float32) but is defined with values of type (int16, float64)' in str(e)
+        assert (
+            "is constrained to only hold values of type (int32, float32) but is defined with values of type (int16, float64)"
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
 
 def test_requirements():
-    delta = hl.Param(hl.Int(32), 'delta')
-    x = hl.Var('x')
-    f = hl.Func('f_requirements')
+    delta = hl.Param(hl.Int(32), "delta")
+    x = hl.Var("x")
+    f = hl.Func("f_requirements")
     f[x] = x + delta
 
     # Add a requirement
@@ -403,17 +432,18 @@ def test_requirements():
         delta.set(0)
         p.realize([10])
     except hl.HalideError as e:
-        assert 'Requirement Failed: (false)' in str(e)
+        assert "Requirement Failed: (false)" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         delta.set(-1)
         p.realize([10])
     except hl.HalideError as e:
-        assert 'Requirement Failed: (false) negative values are bad -1' in str(e)
+        assert "Requirement Failed: (false) negative values are bad -1" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
+
 
 if __name__ == "__main__":
     test_compiletime_error()

--- a/python_bindings/test/correctness/bit_test.py
+++ b/python_bindings/test/correctness/bit_test.py
@@ -24,6 +24,7 @@ def test(fn):
     for i in range(0, 4):
         assert output_bools[i] == ((i & 1) != 0)
 
+
 if __name__ == "__main__":
     test(bitcpp.bitcpp)
     test(bitpy.bitpy)

--- a/python_bindings/test/correctness/boundary_conditions.py
+++ b/python_bindings/test/correctness/boundary_conditions.py
@@ -1,4 +1,3 @@
-
 import halide as hl
 
 test_exterior = 42
@@ -9,7 +8,7 @@ x, y = hl.Var(), hl.Var()
 
 
 def expect_eq(actual, expected):
-    assert expected == actual, 'Failed: expected %d, actual %d' % (expected, actual)
+    assert expected == actual, "Failed: expected %d, actual %d" % (expected, actual)
 
 
 def schedule_test(f, vector_width, target):
@@ -21,8 +20,17 @@ def schedule_test(f, vector_width, target):
         f.gpu_tile(x, y, xo, yo, xi, yi, 2, 2)
 
 
-def realize_and_check(f, checker, input, test_min_x, test_extent_x, test_min_y,
-                      test_extent_y, vector_width, target):
+def realize_and_check(
+    f,
+    checker,
+    input,
+    test_min_x,
+    test_extent_x,
+    test_min_y,
+    test_extent_y,
+    vector_width,
+    target,
+):
     result = hl.Buffer(hl.UInt(8), [test_extent_x, test_extent_y])
     result.set_min([test_min_x, test_min_y])
     f2 = hl.lambda_func(x, y, f[x, y])
@@ -91,58 +99,100 @@ def test_all(vector_width, target):
     input = hl.Buffer(hl.UInt(8), [W, H])
     for r in range(H):
         for c in range(W):
-            input[c, r] = (c + r * W) & 0xff
+            input[c, r] = (c + r * W) & 0xFF
 
     input_f = hl.Func()
     input_f[x, y] = input[x, y]
 
     tests = [
-            (hl.BoundaryConditions.constant_exterior, check_constant_exterior),
-            (hl.BoundaryConditions.repeat_edge, check_repeat_edge),
-            (hl.BoundaryConditions.repeat_image, check_repeat_image),
-            (hl.BoundaryConditions.mirror_image, check_mirror_image),
-            (hl.BoundaryConditions.mirror_interior, check_mirror_interior),
+        (hl.BoundaryConditions.constant_exterior, check_constant_exterior),
+        (hl.BoundaryConditions.repeat_edge, check_repeat_edge),
+        (hl.BoundaryConditions.repeat_image, check_repeat_image),
+        (hl.BoundaryConditions.mirror_image, check_mirror_image),
+        (hl.BoundaryConditions.mirror_interior, check_mirror_interior),
     ]
 
     for bc, checker in tests:
         # print('  Testing %s:%d...' % (bc.__name__, vector_width))
-        func_input_args = {'f': input_f, 'bounds': [(0, W), (0, H)]}
-        image_input_args = {'f': input, 'bounds': [(0, W), (0, H)]}
-        undef_min_args = {'f': input, 'bounds': [(hl.Expr(), hl.Expr()), (0, H)]}
-        undef_max_args = {'f': input, 'bounds': [(0, W), (hl.Expr(), hl.Expr())]}
-        implicit_bounds_args = {'f': input}
+        func_input_args = {"f": input_f, "bounds": [(0, W), (0, H)]}
+        image_input_args = {"f": input, "bounds": [(0, W), (0, H)]}
+        undef_min_args = {"f": input, "bounds": [(hl.Expr(), hl.Expr()), (0, H)]}
+        undef_max_args = {"f": input, "bounds": [(0, W), (hl.Expr(), hl.Expr())]}
+        implicit_bounds_args = {"f": input}
 
         if bc == hl.BoundaryConditions.constant_exterior:
-            func_input_args['exterior'] = test_exterior
-            image_input_args['exterior'] = test_exterior
-            undef_min_args['exterior'] = test_exterior
-            undef_max_args['exterior'] = test_exterior
-            implicit_bounds_args['exterior'] = test_exterior
+            func_input_args["exterior"] = test_exterior
+            image_input_args["exterior"] = test_exterior
+            undef_min_args["exterior"] = test_exterior
+            undef_max_args["exterior"] = test_exterior
+            implicit_bounds_args["exterior"] = test_exterior
 
         realize_and_check(
-                bc(**func_input_args), checker, input, test_min, test_extent, test_min,
-                test_extent, vector_width, target)
+            bc(**func_input_args),
+            checker,
+            input,
+            test_min,
+            test_extent,
+            test_min,
+            test_extent,
+            vector_width,
+            target,
+        )
         realize_and_check(
-                bc(**image_input_args), checker, input, test_min, test_extent, test_min,
-                test_extent, vector_width, target)
+            bc(**image_input_args),
+            checker,
+            input,
+            test_min,
+            test_extent,
+            test_min,
+            test_extent,
+            vector_width,
+            target,
+        )
         realize_and_check(
-                bc(**undef_min_args), checker, input, 0, W, test_min, test_extent,
-                vector_width, target)
+            bc(**undef_min_args),
+            checker,
+            input,
+            0,
+            W,
+            test_min,
+            test_extent,
+            vector_width,
+            target,
+        )
         realize_and_check(
-                bc(**undef_max_args), checker, input, test_min, test_extent, 0, H,
-                vector_width, target)
+            bc(**undef_max_args),
+            checker,
+            input,
+            test_min,
+            test_extent,
+            0,
+            H,
+            vector_width,
+            target,
+        )
         realize_and_check(
-                bc(**implicit_bounds_args), checker, input, test_min, test_extent,
-                test_min, test_extent, vector_width, target)
+            bc(**implicit_bounds_args),
+            checker,
+            input,
+            test_min,
+            test_extent,
+            test_min,
+            test_extent,
+            vector_width,
+            target,
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     target = hl.get_jit_target_from_environment()
 
     vector_width_power_max = 6
     # https://github.com/halide/Halide/issues/2148
-    if target.has_feature(hl.TargetFeature.Metal) or target.has_feature(hl.TargetFeature.D3D12Compute):
-        vector_width_power_max = 3;
+    if target.has_feature(hl.TargetFeature.Metal) or target.has_feature(
+        hl.TargetFeature.D3D12Compute
+    ):
+        vector_width_power_max = 3
 
     for i in range(0, vector_width_power_max):
         vector_width = 1 << i

--- a/python_bindings/test/correctness/buffer.py
+++ b/python_bindings/test/correctness/buffer.py
@@ -1,10 +1,10 @@
-
 import halide as hl
 import numpy as np
 import gc
 import sys
 
-def test_ndarray_to_buffer(reverse_axes = True):
+
+def test_ndarray_to_buffer(reverse_axes=True):
     a0 = np.ones((200, 300), dtype=np.int32)
 
     # Buffer always shares data (when possible) by default,
@@ -49,7 +49,7 @@ def test_ndarray_to_buffer(reverse_axes = True):
         assert a0[56, 34] == 12
 
 
-def test_buffer_to_ndarray(reverse_axes = True):
+def test_buffer_to_ndarray(reverse_axes=True):
     buf0 = hl.Buffer(hl.Int(16), [4, 6])
     assert buf0.type() == hl.Int(16)
     buf0.fill(0)
@@ -65,7 +65,7 @@ def test_buffer_to_ndarray(reverse_axes = True):
     buf = buf0.reverse_axes() if not reverse_axes else buf0
 
     # Should share storage with buf
-    array_shared = np.array(buf, copy = False)
+    array_shared = np.array(buf, copy=False)
     assert array_shared.dtype == np.int16
     if reverse_axes:
         assert array_shared.shape == (6, 4)
@@ -75,7 +75,7 @@ def test_buffer_to_ndarray(reverse_axes = True):
         assert array_shared[1, 2] == 42
 
     # Should *not* share storage with buf
-    array_copied = np.array(buf, copy = True)
+    array_copied = np.array(buf, copy=True)
     assert array_copied.dtype == np.int16
     if reverse_axes:
         assert array_copied.shape == (6, 4)
@@ -96,11 +96,11 @@ def test_buffer_to_ndarray(reverse_axes = True):
     # Ensure that Buffers that have nonzero mins get converted correctly,
     # since the Python Buffer Protocol doesn't have the 'min' concept
     cropped_buf0 = buf0.copy()
-    cropped_buf0.crop(dimension = 0, min = 1, extent = 2)
+    cropped_buf0.crop(dimension=0, min=1, extent=2)
     cropped_buf = cropped_buf0.reverse_axes() if not reverse_axes else cropped_buf0
 
     # Should share storage with cropped (and buf)
-    cropped_array_shared = np.array(cropped_buf, copy = False)
+    cropped_array_shared = np.array(cropped_buf, copy=False)
     assert cropped_array_shared.dtype == np.int16
     if reverse_axes:
         assert cropped_array_shared.shape == (6, 2)
@@ -110,7 +110,7 @@ def test_buffer_to_ndarray(reverse_axes = True):
         assert cropped_array_shared[0, 2] == 3
 
     # Should *not* share storage with anything
-    cropped_array_copied = np.array(cropped_buf, copy = True)
+    cropped_array_copied = np.array(cropped_buf, copy=True)
     assert cropped_array_copied.dtype == np.int16
     if reverse_axes:
         assert cropped_array_copied.shape == (6, 2)
@@ -134,8 +134,10 @@ def test_buffer_to_ndarray(reverse_axes = True):
 def _assert_fn(e):
     assert e
 
+
 def _is_64bits():
     return sys.maxsize > 2**32
+
 
 def test_for_each_element():
     buf = hl.Buffer(hl.Float(32), [3, 4])
@@ -143,7 +145,10 @@ def test_for_each_element():
         for y in range(4):
             buf[x, y] = x + y
     # Can't use 'assert' in a lambda, but can call a fn that uses it.
-    buf.for_each_element(lambda pos, buf=buf: _assert_fn(buf[pos[0], pos[1]] == pos[0] + pos[1]))
+    buf.for_each_element(
+        lambda pos, buf=buf: _assert_fn(buf[pos[0], pos[1]] == pos[0] + pos[1])
+    )
+
 
 def test_fill_all_equal():
     buf = hl.Buffer(hl.Int(32), [3, 4])
@@ -173,10 +178,12 @@ def test_bufferinfo_sharing():
     b0[56, 34] = 12
     assert b0[56, 34] == 12
 
+
 def test_float16():
-    array_in = np.zeros((256, 256, 3), dtype=np.float16, order='F')
+    array_in = np.zeros((256, 256, 3), dtype=np.float16, order="F")
     hl_img = hl.Buffer(array_in)
-    array_out = np.array(hl_img, copy = False)
+    array_out = np.array(hl_img, copy=False)
+
 
 # TODO: https://github.com/halide/Halide/issues/6849
 # def test_bfloat16():
@@ -192,17 +199,19 @@ def test_float16():
 #     else:
 #         assert False, "This should not happen"
 
+
 def test_int64():
-    array_in = np.zeros((256, 256, 3), dtype=np.int64, order='F')
+    array_in = np.zeros((256, 256, 3), dtype=np.int64, order="F")
     hl_img = hl.Buffer(array_in)
-    array_out = np.array(hl_img, copy = False)
+    array_out = np.array(hl_img, copy=False)
+
 
 def test_make_interleaved():
     w = 7
     h = 13
     c = 3
 
-    b = hl.Buffer.make_interleaved(type = hl.UInt(8), width = w, height = h, channels = c)
+    b = hl.Buffer.make_interleaved(type=hl.UInt(8), width=w, height=h, channels=c)
 
     assert b.dim(0).min() == 0
     assert b.dim(0).extent() == w
@@ -216,21 +225,22 @@ def test_make_interleaved():
     assert b.dim(2).extent() == c
     assert b.dim(2).stride() == 1
 
-    a = np.array(b, copy = False)
+    a = np.array(b, copy=False)
     # NumPy shape order is opposite that of Halide shape order
     assert a.shape == (c, h, w)
-    assert a.strides == (1, w*c, c)
+    assert a.strides == (1, w * c, c)
     assert a.dtype == np.uint8
+
 
 def test_interleaved_ndarray():
     w = 7
     h = 13
     c = 3
 
-    a = np.ndarray(dtype=np.uint8, shape=(w, h, c), strides=(c, w*c, 1))
+    a = np.ndarray(dtype=np.uint8, shape=(w, h, c), strides=(c, w * c, 1))
 
     assert a.shape == (w, h, c)
-    assert a.strides == (c, w*c, 1)
+    assert a.strides == (c, w * c, 1)
     assert a.dtype == np.uint8
 
     b = hl.Buffer(a)
@@ -248,13 +258,14 @@ def test_interleaved_ndarray():
     assert b.dim(2).extent() == w
     assert b.dim(2).stride() == c
 
+
 def test_reorder():
     W = 7
     H = 5
     C = 3
     Z = 2
 
-    a = hl.Buffer(type = hl.UInt(8), sizes = [W, H, C], storage_order = [2, 0, 1])
+    a = hl.Buffer(type=hl.UInt(8), sizes=[W, H, C], storage_order=[2, 0, 1])
     assert a.dim(0).extent() == W
     assert a.dim(1).extent() == H
     assert a.dim(2).extent() == C
@@ -292,6 +303,7 @@ def test_reorder():
     assert b.dim(2).stride() == b2.dim(2).stride()
     assert b.dim(3).stride() == b2.dim(3).stride()
 
+
 def test_overflow():
     # Don't bother testing this on 32-bit systems (our "huge" size is too large there)
     if not _is_64bits():
@@ -313,13 +325,15 @@ def test_overflow():
     try:
         hl.Buffer(size_over_intmax)
     except ValueError as e:
-        assert 'Out of range dimensions in buffer conversion' in str(e)
+        assert "Out of range dimensions in buffer conversion" in str(e)
+
 
 def test_buffer_to_str():
     b = hl.Buffer()
-    assert str(b) == '<undefined halide.Buffer>'
+    assert str(b) == "<undefined halide.Buffer>"
     b = hl.Buffer(hl.Int(32), [128, 256])
-    assert str(b) == '<halide.Buffer of type int32 shape:[[0,128,1],[0,256,128]]>'
+    assert str(b) == "<halide.Buffer of type int32 shape:[[0,128,1],[0,256,128]]>"
+
 
 def test_scalar_buffers():
     buf = hl.Buffer.make_scalar(hl.Float(32))
@@ -334,6 +348,7 @@ def test_scalar_buffers():
     buf.fill(32)
     assert buf[()] == 32
 
+
 def test_oob():
     buf = hl.Buffer(hl.Int(16), [4, 6])
     buf.fill(0)
@@ -342,38 +357,38 @@ def test_oob():
     try:
         print(buf[-1, 2])
     except IndexError as e:
-        assert 'index -1 is out of bounds for axis 0 with min=0, extent=4' in str(e)
+        assert "index -1 is out of bounds for axis 0 with min=0, extent=4" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     # getitem above max
     try:
         print(buf[1, 6])
     except IndexError as e:
-        assert 'index 6 is out of bounds for axis 1 with min=0, extent=6' in str(e)
+        assert "index 6 is out of bounds for axis 1 with min=0, extent=6" in str(e)
 
     # setitem below min
     try:
         buf[-1, 2] = 42
     except IndexError as e:
-        assert 'index -1 is out of bounds for axis 0 with min=0, extent=4' in str(e)
+        assert "index -1 is out of bounds for axis 0 with min=0, extent=4" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     # setitem above max
     try:
         buf[1, 6] = 42
     except IndexError as e:
-        assert 'index 6 is out of bounds for axis 1 with min=0, extent=6' in str(e)
+        assert "index 6 is out of bounds for axis 1 with min=0, extent=6" in str(e)
 
 
 if __name__ == "__main__":
     test_make_interleaved()
     test_interleaved_ndarray()
-    test_ndarray_to_buffer(reverse_axes = True)
-    test_ndarray_to_buffer(reverse_axes = False)
-    test_buffer_to_ndarray(reverse_axes = True)
-    test_buffer_to_ndarray(reverse_axes = False)
+    test_ndarray_to_buffer(reverse_axes=True)
+    test_ndarray_to_buffer(reverse_axes=False)
+    test_buffer_to_ndarray(reverse_axes=True)
+    test_buffer_to_ndarray(reverse_axes=False)
     test_for_each_element()
     test_fill_all_equal()
     test_bufferinfo_sharing()

--- a/python_bindings/test/correctness/callable.py
+++ b/python_bindings/test/correctness/callable.py
@@ -4,14 +4,15 @@ import numpy as np
 from simplepy_generator import SimplePy
 import simplecpp_pystub  # Needed for create_callable_from_generator("simplecpp") to work
 
+
 def test_callable():
     p_int16 = hl.Param(hl.Int(16), 42)
     p_float = hl.Param(hl.Float(32), 1.0)
     p_img = hl.ImageParam(hl.UInt(8), 2)
 
-    x = hl.Var('x')
-    y = hl.Var('y')
-    f = hl.Func('f')
+    x = hl.Var("x")
+    y = hl.Var("y")
+    f = hl.Func("f")
 
     f[x, y] = p_img[x, y] + hl.u8(p_int16 / p_float)
 
@@ -23,7 +24,7 @@ def test_callable():
             in1[i, j] = i + j * 10
             in2[i, j] = i * 10 + j
 
-    c = f.compile_to_callable([p_img, p_int16, p_float]);
+    c = f.compile_to_callable([p_img, p_int16, p_float])
 
     out1 = hl.Buffer(hl.UInt(8), [10, 10])
     c(in1, 42, 1.0, out1)
@@ -57,6 +58,7 @@ def test_callable():
     assert in1.dim(0).extent() == 10
     assert in1.dim(1).extent() == 10
 
+
 def test_simple(callable_factory):
     x, y = hl.Var(), hl.Var()
     target = hl.get_jit_target_from_environment()
@@ -68,7 +70,7 @@ def test_simple(callable_factory):
 
     b_out = hl.Buffer(hl.Float(32), [2, 2])
 
-    def _check(offset = 0):
+    def _check(offset=0):
         assert b_out[0, 0] == float_in + offset + 123
         assert b_out[0, 1] == float_in + offset + 123
         assert b_out[1, 0] == float_in + offset + 123
@@ -113,33 +115,33 @@ def test_simple(callable_factory):
         # too many positional args
         simple(b_in, float_in, 4, b_out)
     except hl.HalideError as e:
-        assert 'Expected at most 3 positional arguments, but saw 4.' in str(e)
+        assert "Expected at most 3 positional arguments, but saw 4." in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # too few positional args
         simple(b_in)
     except hl.HalideError as e:
-        assert 'Expected exactly 3 positional arguments, but saw 1.' in str(e)
+        assert "Expected exactly 3 positional arguments, but saw 1." in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Inputs that can't be converted to what the receiver needs (positional)
         simple(hl.f32(3.141592), "happy", b_out)
     except hl.HalideError as e:
-        assert 'is not an instance of' in str(e)
+        assert "is not an instance of" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Inputs that can't be converted to what the receiver needs (named)
         simple(b_in, float_in, simple_output="bogus")
     except hl.HalideError as e:
-        assert 'is not an instance of' in str(e)
+        assert "is not an instance of" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Bad keyword argument
@@ -147,23 +149,27 @@ def test_simple(callable_factory):
     except hl.HalideError as e:
         assert "Unknown argument 'funk_input' specified via keyword." in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # too few keyword args
         simple(float_arg=float_in, simple_output=b_out)
     except hl.HalideError as e:
-        assert 'Argument buffer_input was not specified by either positional or keyword argument.' in str(e)
+        assert (
+            "Argument buffer_input was not specified by either positional or keyword argument."
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Arg specified by pos + kw
         simple(b_in, buffer_input=b_in, float_arg=float_in, simple_output=b_out)
     except hl.HalideError as e:
-        assert 'Argument buffer_input specified multiple times.' in str(e)
+        assert "Argument buffer_input specified multiple times." in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
+
 
 if __name__ == "__main__":
     # test_callable()

--- a/python_bindings/test/correctness/compile_to.py
+++ b/python_bindings/test/correctness/compile_to.py
@@ -1,6 +1,7 @@
 import os, shutil, tempfile
 import halide as hl
 
+
 def main():
     x = hl.Var("x")
 

--- a/python_bindings/test/correctness/division.py
+++ b/python_bindings/test/correctness/division.py
@@ -1,11 +1,12 @@
 import halide as hl
 
-f32 = hl.Param(hl.Float(32), 'f32', -32.0)
-f64 = hl.Param(hl.Float(64), 'f64', 64.0)
-i16 = hl.Param(hl.Int(16), 'i16', -16)
-i32 = hl.Param(hl.Int(32), 'i32', 32)
-u16 = hl.Param(hl.UInt(16), 'u16', 16)
-u32 = hl.Param(hl.UInt(32), 'u32', 32)
+f32 = hl.Param(hl.Float(32), "f32", -32.0)
+f64 = hl.Param(hl.Float(64), "f64", 64.0)
+i16 = hl.Param(hl.Int(16), "i16", -16)
+i32 = hl.Param(hl.Int(32), "i32", 32)
+u16 = hl.Param(hl.UInt(16), "u16", 16)
+u32 = hl.Param(hl.UInt(32), "u32", 32)
+
 
 def test_types():
     # Verify that the types match the rules in match_types()
@@ -29,6 +30,7 @@ def test_types():
 
     assert (i16 / f64).type() == hl.Float(64)
     assert (i16 // f64).type() == hl.Float(64)
+
 
 def test_division():
     # Verify that division semantics match those for Halide
@@ -54,6 +56,7 @@ def test_division():
     assert hl.evaluate(i16 / f64) == -0.25
     assert hl.evaluate(i16 // f64) == -1.0
 
+
 def test_division_tupled():
     # Same as test_division, but using the tuple variant
     assert hl.evaluate((f32 / f64, f32 // f64)) == (-0.5, -1.0)
@@ -62,6 +65,7 @@ def test_division_tupled():
     assert hl.evaluate((u16 / i32, i32 // u16)) == (0, 2)
     assert hl.evaluate((u16 / f32, u16 // f32)) == (-0.5, -1.0)
     assert hl.evaluate((i16 / f64, i16 // f64)) == (-0.25, -1.0)
+
 
 def test_division_gpu():
     # Allow GPU usage -- don't use f64 since not all GPU backends support that
@@ -72,6 +76,7 @@ def test_division_gpu():
     assert hl.evaluate_may_gpu((u16 / i32, i32 // u16)) == (0, 2)
     assert hl.evaluate_may_gpu((u16 / f32, u16 // f32)) == (-0.5, -1.0)
     assert hl.evaluate_may_gpu((i16 / f, i16 // f)) == (-0.25, -1.0)
+
 
 if __name__ == "__main__":
     test_types()

--- a/python_bindings/test/correctness/extern.py
+++ b/python_bindings/test/correctness/extern.py
@@ -33,26 +33,25 @@ def test_extern():
     try:
         sort_func.compile_jit()
     except hl.HalideError:
-        assert 'cannot be converted to a bool' in str(e)
+        assert "cannot be converted to a bool" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
-
+        assert False, "Did not see expected exception!"
 
     import ctypes
+
     sort_lib = ctypes.CDLL("the_sort_function.so")
     print(sort_lib.the_sort_func)
 
     try:
         sort_func.compile_jit()
     except hl.HalideError:
-        assert 'cannot be converted to a bool' in str(e)
+        assert "cannot be converted to a bool" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     lib_path = "the_sort_function.so"
     load_error = load_library_into_llvm(lib_path)
     assert load_error == False
-
 
     sort_func.compile_jit()
 
@@ -63,6 +62,7 @@ def test_extern():
     assert np.isclose(expected_result, output_data)
 
     return
+
 
 if __name__ == "__main__":
 

--- a/python_bindings/test/correctness/iroperator.py
+++ b/python_bindings/test/correctness/iroperator.py
@@ -13,42 +13,50 @@ def _redirect_stdout(out):
     finally:
         sys.stdout = old_out
 
+
 def test_print_expr():
-    x = hl.Var('x')
-    f = hl.Func('f')
-    f[x] = hl.print(hl.cast(hl.UInt(8), x), 'is what', 'the', 1, 'and', hl.f32(3.1415), 'saw')
+    x = hl.Var("x")
+    f = hl.Func("f")
+    f[x] = hl.print(
+        hl.cast(hl.UInt(8), x), "is what", "the", 1, "and", hl.f32(3.1415), "saw"
+    )
     buf = hl.Buffer(hl.UInt(8), [1])
     output = StringIO()
     with _redirect_stdout(output):
         f.realize(buf)
-        expected = '0 is what the 1 and 3.141500 saw\n'
+        expected = "0 is what the 1 and 3.141500 saw\n"
         actual = output.getvalue()
         assert expected == actual, "Expected: %s, Actual: %s" % (expected, actual)
 
+
 def test_print_when():
-    x = hl.Var('x')
-    f = hl.Func('f')
-    f[x] = hl.print_when(x == 3, hl.cast(hl.UInt(8), x*x), 'is result at', x)
+    x = hl.Var("x")
+    f = hl.Func("f")
+    f[x] = hl.print_when(x == 3, hl.cast(hl.UInt(8), x * x), "is result at", x)
     buf = hl.Buffer(hl.UInt(8), [10])
     output = StringIO()
     with _redirect_stdout(output):
         f.realize(buf)
-        expected = '9 is result at 3\n'
+        expected = "9 is result at 3\n"
         actual = output.getvalue()
         assert expected == actual, "Expected: %s, Actual: %s" % (expected, actual)
+
 
 def test_select():
     x = hl.Var()
     f = hl.Func()
+    # fmt: off
     f[x] = hl.select(x == 0, 31,
                      x == 2, (x * 24),
                      x == 2, 999,  # should be ignored: first condition wins
                              x)
+    # fmt: on
     b = f.realize([4])
     assert b[0] == 31
     assert b[1] == 1
     assert b[2] == 48
     assert b[3] == 3
+
 
 def test_mux():
     c = hl.Var()
@@ -59,6 +67,7 @@ def test_mux():
     assert b[1] == 456
     assert b[2] == 2
     assert b[3] == 3
+
 
 def test_mux_tuple():
     f = hl.Func()
@@ -73,19 +82,23 @@ def test_mux_tuple():
     assert b[0, 2] == 0
     assert b[0, 3] == 0
 
+
 def test_minmax():
     x = hl.Var()
     f = hl.Func()
+    # fmt: off
     f[x] = hl.select(x == 0,              hl.min(x, 1),
                      (x == 2) | (x == 4), hl.i32(hl.min(hl.f32(x), hl.f32(3.2), x*hl.f32(2.1))),
                      x == 3,              hl.max(x, x * 3, 1, x * 4),
                                           x)
+    # fmt: on
     b = f.realize([5])
     assert b[0] == 0
-    assert b[1] == 1,b[1]
+    assert b[1] == 1, b[1]
     assert b[2] == 2
     assert b[3] == 12
     assert b[4] == 3
+
 
 if __name__ == "__main__":
     test_print_expr()

--- a/python_bindings/test/correctness/multi_method_module_test.py
+++ b/python_bindings/test/correctness/multi_method_module_test.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import multi_method_module
 
+
 def test_simplecpp():
     buffer_input = np.ndarray([2, 2], dtype=np.uint8)
     buffer_input[0, 0] = 123
@@ -20,25 +21,27 @@ def test_simplecpp():
     assert simple_output[1, 0] == 3.5 + 123
     assert simple_output[1, 1] == 3.5 + 123
 
+
 def test_user_context():
     output = bytearray("\0\0\0\0", "ascii")
-    multi_method_module.user_context(None, ord('q'), output)
+    multi_method_module.user_context(None, ord("q"), output)
     assert output == bytearray("qqqq", "ascii")
 
+
 def test_aot_call_failure_throws_exception():
-    buffer_input = np.zeros([2, 2], dtype=np.float32) # wrong type
+    buffer_input = np.zeros([2, 2], dtype=np.float32)  # wrong type
     float_arg = 3.5
     simple_output = np.zeros([2, 2], dtype=np.float32)
 
     try:
         multi_method_module.simplecpp(buffer_input, float_arg, simple_output)
     except RuntimeError as e:
-        assert 'Halide Runtime Error: -3' in str(e), str(e)
+        assert "Halide Runtime Error: -3" in str(e), str(e)
     else:
-        assert False, 'Did not see expected exception, saw: ' + str(e)
+        assert False, "Did not see expected exception, saw: " + str(e)
+
 
 if __name__ == "__main__":
     test_simplecpp()
     test_user_context()
     test_aot_call_failure_throws_exception()
-

--- a/python_bindings/test/correctness/multipass_constraints.py
+++ b/python_bindings/test/correctness/multipass_constraints.py
@@ -1,5 +1,5 @@
-
 import halide as hl
+
 
 def test_multipass_constraints():
     input = hl.ImageParam(hl.Float(32), 2, "input")
@@ -8,7 +8,7 @@ def test_multipass_constraints():
     x = hl.Var("x")
     y = hl.Var("y")
 
-    f[x, y] = input[x+1, y+1] + input[x-1, y-1]
+    f[x, y] = input[x + 1, y + 1] + input[x - 1, y - 1]
     f[x, y] += 3.0
     f.update().vectorize(x, 4)
 
@@ -16,42 +16,48 @@ def test_multipass_constraints():
 
     # Now make some hard-to-resolve constraints
     input.dim(0).set_bounds(
-        min = input.dim(1).min() - 5,
-        extent = input.dim(1).extent() + o.dim(0).extent()
+        min=input.dim(1).min() - 5, extent=input.dim(1).extent() + o.dim(0).extent()
     )
 
-    o.dim(0).set_bounds(min = 0,
-                        extent = hl.select(o.dim(0).extent() < 22,
-                                           o.dim(0).extent() + 1,
-                                           o.dim(0).extent()))
+    o.dim(0).set_bounds(
+        min=0,
+        extent=hl.select(
+            o.dim(0).extent() < 22, o.dim(0).extent() + 1, o.dim(0).extent()
+        ),
+    )
 
     # Make a bounds query buffer
-    query_buf = hl.Buffer.make_bounds_query(type = hl.Float(32), sizes = [7, 8])
+    query_buf = hl.Buffer.make_bounds_query(type=hl.Float(32), sizes=[7, 8])
     query_buf.set_min([2, 2])
 
     f.infer_input_bounds(query_buf)
 
-    if  input.get().dim(0).min() != -4 or \
-        input.get().dim(0).extent() != 34 or \
-        input.get().dim(1).min() != 1 or \
-        input.get().dim(1).extent() != 10 or \
-        query_buf.dim(0).min() != 0 or \
-        query_buf.dim(0).extent() != 24 or \
-        query_buf.dim(1).min() != 2 or \
-        query_buf.dim(1).extent() != 8:
+    if (
+        input.get().dim(0).min() != -4
+        or input.get().dim(0).extent() != 34
+        or input.get().dim(1).min() != 1
+        or input.get().dim(1).extent() != 10
+        or query_buf.dim(0).min() != 0
+        or query_buf.dim(0).extent() != 24
+        or query_buf.dim(1).min() != 2
+        or query_buf.dim(1).extent() != 8
+    ):
 
-        print("Constraints not correctly satisfied:\n",
-               "in:",
-               input.get().dim(0).min(),
-               input.get().dim(0).extent(),
-               input.get().dim(1).min(),
-               input.get().dim(1).extent(),
-               "out:",
-               query_buf.dim(0).min(),
-               query_buf.dim(0).extent(),
-               query_buf.dim(1).min(),
-               query_buf.dim(1).extent())
+        print(
+            "Constraints not correctly satisfied:\n",
+            "in:",
+            input.get().dim(0).min(),
+            input.get().dim(0).extent(),
+            input.get().dim(1).min(),
+            input.get().dim(1).extent(),
+            "out:",
+            query_buf.dim(0).min(),
+            query_buf.dim(0).extent(),
+            query_buf.dim(1).min(),
+            query_buf.dim(1).extent(),
+        )
         assert False
+
 
 if __name__ == "__main__":
     test_multipass_constraints()

--- a/python_bindings/test/correctness/negate_test.py
+++ b/python_bindings/test/correctness/negate_test.py
@@ -1,12 +1,13 @@
 import halide as hl
 
-def test_free_logical_not_function():
-    x = hl.Var('x')
 
-    f = hl.Func('f')
+def test_free_logical_not_function():
+    x = hl.Var("x")
+
+    f = hl.Func("f")
     f[x] = x > 5
 
-    not_f = hl.Func('not_f')
+    not_f = hl.Func("not_f")
     not_f[x] = hl.logical_not(f[x])
 
     f_out = f.realize([10])
@@ -18,12 +19,12 @@ def test_free_logical_not_function():
 
 
 def test_member_logical_not_function():
-    x = hl.Var('x')
+    x = hl.Var("x")
 
-    f = hl.Func('f')
+    f = hl.Func("f")
     f[x] = x > 5
 
-    not_f = hl.Func('not_f')
+    not_f = hl.Func("not_f")
     not_f[x] = f[x].logical_not()
 
     f_out = f.realize([10])
@@ -32,6 +33,7 @@ def test_member_logical_not_function():
     for i in range(10):
         assert f_out[i] == (i > 5)
         assert not_f_out[i] == (i <= 5)
+
 
 if __name__ == "__main__":
     test_free_logical_not_function()

--- a/python_bindings/test/correctness/pystub.py
+++ b/python_bindings/test/correctness/pystub.py
@@ -67,33 +67,36 @@ def test_simple(cls):
         # too many positional args
         f = cls.call(b_in, 3.5, 4)
     except hl.HalideError as e:
-        assert 'allows at most 2 positional args, but 3 were specified.' in str(e)
+        assert "allows at most 2 positional args, but 3 were specified." in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # too few positional args
         f = cls.call(b_in)
     except hl.HalideError as e:
-        assert 'requires 2 args, but 1 were specified.' in str(e)
+        assert "requires 2 args, but 1 were specified." in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Inputs that can't be converted to what the receiver needs (positional)
         f = cls.call(hl.f32(3.141592), "happy")
     except hl.HalideError as e:
-        assert 'Input buffer_input requires an ImageParam or Buffer argument' in str(e)
+        assert "Input buffer_input requires an ImageParam or Buffer argument" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Inputs that can't be converted to what the receiver needs (named)
         f = cls.call(b_in, float_arg="bogus")
     except hl.HalideError as e:
-        assert 'Input float_arg requires a Param (or scalar literal) argument when using call' in str(e)
+        assert (
+            "Input float_arg requires a Param (or scalar literal) argument when using call"
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Input specified by both pos and kwarg
@@ -101,7 +104,7 @@ def test_simple(cls):
     except hl.HalideError as e:
         assert "Input float_arg specified multiple times." in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # generator_params is not a dict
@@ -109,7 +112,7 @@ def test_simple(cls):
     except hl.HalideError as e:
         assert "generator_params must be a dict" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Bad gp name
@@ -117,32 +120,35 @@ def test_simple(cls):
     except hl.HalideError as e:
         assert "has no GeneratorParam" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Bad input name
-        f = cls.call(buzzer_input=b_in,
-                     float_arg=3.5,
-                     generator_params=gp)
+        f = cls.call(buzzer_input=b_in, float_arg=3.5, generator_params=gp)
     except hl.HalideError as e:
         assert "Unknown input 'buzzer_input' specified via keyword argument" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     try:
         # Bad gp name
-        f = cls.call(buffer_input=b_in,
-                     float_arg=3.5,
-                     generator_params=gp,
-                     nonexistent_generator_param="wat")
+        f = cls.call(
+            buffer_input=b_in,
+            float_arg=3.5,
+            generator_params=gp,
+            nonexistent_generator_param="wat",
+        )
     except hl.HalideError as e:
-        assert "Unknown input 'nonexistent_generator_param' specified via keyword argument" in str(e)
+        assert (
+            "Unknown input 'nonexistent_generator_param' specified via keyword argument"
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
 
 def _make_constant_image(type):
-    constant_image = hl.Buffer(type, [32, 32, 3], 'constant_image')
+    constant_image = hl.Buffer(type, [32, 32, 3], "constant_image")
     for x in range(32):
         for y in range(32):
             for c in range(3):
@@ -150,10 +156,10 @@ def _make_constant_image(type):
     return constant_image
 
 
-def test_complex(cls, extra_input_name = ""):
+def test_complex(cls, extra_input_name=""):
     constant_image = _make_constant_image(hl.UInt(8))
     constant_image_u16 = _make_constant_image(hl.UInt(16))
-    input = hl.ImageParam(hl.UInt(8), 3, 'input')
+    input = hl.ImageParam(hl.UInt(8), 3, "input")
     input.set(constant_image)
 
     x, y, c = hl.Var(), hl.Var(), hl.Var()
@@ -184,8 +190,15 @@ def test_complex(cls, extra_input_name = ""):
 
     # return value is a tuple; unpack separately to avoid
     # making the callsite above unreadable
-    (simple_output, tuple_output, typed_buffer_output, untyped_buffer_output,
-     static_compiled_buffer_output, scalar_output, extra_func_output) = r
+    (
+        simple_output,
+        tuple_output,
+        typed_buffer_output,
+        untyped_buffer_output,
+        static_compiled_buffer_output,
+        scalar_output,
+        extra_func_output,
+    ) = r
 
     b = simple_output.realize([32, 32, 3], target)
     assert b.type() == hl.Float(32)
@@ -194,8 +207,7 @@ def test_complex(cls, extra_input_name = ""):
             for c in range(3):
                 expected = constant_image[x, y, c]
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected,
-                                                                      actual)
+                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
     b = tuple_output.realize([32, 32, 3], target)
     assert b[0].type() == hl.Float(32)
@@ -208,9 +220,13 @@ def test_complex(cls, extra_input_name = ""):
                 expected2 = expected1 + int_arg
                 actual1, actual2 = b[0][x, y, c], b[1][x, y, c]
                 assert expected1 == actual1, "Expected1 %s Actual1 %s" % (
-                    expected1, actual1)
+                    expected1,
+                    actual1,
+                )
                 assert expected2 == actual2, "Expected2 %s Actual1 %s" % (
-                    expected2, actual2)
+                    expected2,
+                    actual2,
+                )
 
     # TODO: Output<Buffer<>> has additional behaviors useful when a Stub
     # is used within another Generator; this isn't yet implemented since there
@@ -223,8 +239,7 @@ def test_complex(cls, extra_input_name = ""):
             for c in range(3):
                 expected = constant_image[x, y, c]
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected,
-                                                                      actual)
+                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
     b = untyped_buffer_output.realize([32, 32, 3], target)
     assert b.type() == hl.UInt(8)
@@ -233,8 +248,7 @@ def test_complex(cls, extra_input_name = ""):
             for c in range(3):
                 expected = constant_image[x, y, c]
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected,
-                                                                      actual)
+                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
     b = static_compiled_buffer_output.realize([4, 4, 1], target)
     assert b.type() == hl.UInt(8)
@@ -243,8 +257,7 @@ def test_complex(cls, extra_input_name = ""):
             for c in range(1):
                 expected = constant_image[x, y, c] + 42
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected,
-                                                                      actual)
+                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
     b = scalar_output.realize([], target)
     assert b.type() == hl.Float(32)
@@ -259,8 +272,7 @@ def test_complex(cls, extra_input_name = ""):
             else:
                 expected = 0
             actual = b[x, y]
-            assert expected == actual, "Expected %s Actual %s" % (expected,
-                                                                  actual)
+            assert expected == actual, "Expected %s Actual %s" % (expected, actual)
 
 
 if __name__ == "__main__":
@@ -268,7 +280,7 @@ if __name__ == "__main__":
     with hl.GeneratorContext(target):
         test_simple(simplecpp_pystub)
         test_complex(complexcpp_pystub)
-        test_complex(complexcpp_pystub, extra_input_name = "foo_input")
+        test_complex(complexcpp_pystub, extra_input_name="foo_input")
         test_simple(SimplePy)
         test_complex(ComplexPy)
-        test_complex(ComplexPy, extra_input_name = "foo_input")
+        test_complex(ComplexPy, extra_input_name="foo_input")

--- a/python_bindings/test/correctness/rdom.py
+++ b/python_bindings/test/correctness/rdom.py
@@ -1,5 +1,6 @@
 import halide as hl
 
+
 def test_rdom():
     x = hl.Var("x")
     y = hl.Var("y")
@@ -42,6 +43,7 @@ def test_rdom():
         pass
 
     return 0
+
 
 if __name__ == "__main__":
     test_rdom()

--- a/python_bindings/test/correctness/realize_warnings.py
+++ b/python_bindings/test/correctness/realize_warnings.py
@@ -12,8 +12,10 @@ def test_warnings():
     g = hl.Func("g")
     g[i] = f[i * i]
 
-    expected_warning = "Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] because " \
-                       "the function is scheduled inline.\n"
+    expected_warning = (
+        "Warning: It is meaningless to bound dimension v0 of function f to be within [0, 127] because "
+        "the function is scheduled inline.\n"
+    )
 
     buffer = StringIO()
     with redirect_stdout(buffer):
@@ -24,5 +26,5 @@ def test_warnings():
     assert stdout_lines == [expected_warning] * 3
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_warnings()

--- a/python_bindings/test/correctness/target.py
+++ b/python_bindings/test/correctness/target.py
@@ -44,10 +44,21 @@ def test_target():
     assert hl.Target.validate_target_string(ts)
 
     # Full specification round-trip, crazy features
-    t1 = hl.Target(hl.TargetOS.Android, hl.TargetArch.ARM, 32,
-                   [hl.TargetFeature.JIT, hl.TargetFeature.SSE41, hl.TargetFeature.AVX, hl.TargetFeature.AVX2,
-                    hl.TargetFeature.CUDA, hl.TargetFeature.OpenCL, hl.TargetFeature.OpenGLCompute,
-                    hl.TargetFeature.Debug])
+    t1 = hl.Target(
+        hl.TargetOS.Android,
+        hl.TargetArch.ARM,
+        32,
+        [
+            hl.TargetFeature.JIT,
+            hl.TargetFeature.SSE41,
+            hl.TargetFeature.AVX,
+            hl.TargetFeature.AVX2,
+            hl.TargetFeature.CUDA,
+            hl.TargetFeature.OpenCL,
+            hl.TargetFeature.OpenGLCompute,
+            hl.TargetFeature.Debug,
+        ],
+    )
     ts = t1.to_string()
     assert ts == "arm-32-android-avx-avx2-cuda-debug-jit-opencl-openglcompute-sse41"
     assert hl.Target.validate_target_string(ts)
@@ -92,16 +103,23 @@ def test_target():
 
     # with_feature
     t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [hl.TargetFeature.SSE41])
-    t2 = t1.with_feature(hl.TargetFeature.NoAsserts).with_feature(hl.TargetFeature.NoBoundsQuery)
+    t2 = t1.with_feature(hl.TargetFeature.NoAsserts).with_feature(
+        hl.TargetFeature.NoBoundsQuery
+    )
     ts = t2.to_string()
     assert ts == "x86-32-linux-no_asserts-no_bounds_query-sse41"
 
     # without_feature
-    t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [
-                   hl.TargetFeature.SSE41, hl.TargetFeature.NoAsserts])
+    t1 = hl.Target(
+        hl.TargetOS.Linux,
+        hl.TargetArch.X86,
+        32,
+        [hl.TargetFeature.SSE41, hl.TargetFeature.NoAsserts],
+    )
     # Note that NoBoundsQuery wasn't set here, so 'without' is a no-op
     t2 = t1.without_feature(hl.TargetFeature.NoAsserts).without_feature(
-        hl.TargetFeature.NoBoundsQuery)
+        hl.TargetFeature.NoBoundsQuery
+    )
     ts = t2.to_string()
     assert ts == "x86-32-linux-sse41"
 
@@ -120,7 +138,12 @@ def test_target():
     assert not t2.has_gpu_feature()
 
     # has_large_buffers & maximum_buffer_size
-    t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 64, [hl.TargetFeature.LargeBuffers])
+    t1 = hl.Target(
+        hl.TargetOS.Linux,
+        hl.TargetArch.X86,
+        64,
+        [hl.TargetFeature.LargeBuffers],
+    )
     t2 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 64, [])
     assert t1.has_large_buffers()
     assert t1.maximum_buffer_size() == 9223372036854775807
@@ -146,7 +169,9 @@ def test_target():
     assert not t2.supports_type(hl.Float(64), hl.DeviceAPI.Metal)
 
     # target_feature_for_device_api
-    assert hl.target_feature_for_device_api(hl.DeviceAPI.OpenCL) == hl.TargetFeature.OpenCL
+    assert (
+        hl.target_feature_for_device_api(hl.DeviceAPI.OpenCL) == hl.TargetFeature.OpenCL
+    )
 
     # with_feature with non-convertible lists
     try:
@@ -154,7 +179,8 @@ def test_target():
     except TypeError as e:
         assert "incompatible constructor arguments" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
+
 
 if __name__ == "__main__":
     test_target()

--- a/python_bindings/test/correctness/tuple_select.py
+++ b/python_bindings/test/correctness/tuple_select.py
@@ -3,80 +3,89 @@ import numpy as np
 
 
 def test_tuple_select():
-    x = hl.Var('x')
-    y = hl.Var('y')
+    x = hl.Var("x")
+    y = hl.Var("y")
 
     # ternary tuple_select with Expr condition
-    f = hl.Func('f')
-    f[x, y] = hl.tuple_select(x + y < 30, (x, y), (x-1, y-2))
+    f = hl.Func("f")
+    f[x, y] = hl.tuple_select(x + y < 30, (x, y), (x - 1, y - 2))
 
     a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
-            correct_a = xx if xx + yy < 30 else xx-1
-            correct_b = yy if xx + yy < 30 else yy-2
+            correct_a = xx if xx + yy < 30 else xx - 1
+            correct_b = yy if xx + yy < 30 else yy - 2
             assert a[xx, yy] == correct_a
             assert b[xx, yy] == correct_b
 
     # ternary tuple_select with Tuple condition
-    f = hl.Func('f')
-    f[x, y] = hl.tuple_select((x < 30, y < 30), (x, y), (x-1, y-2))
+    f = hl.Func("f")
+    f[x, y] = hl.tuple_select((x < 30, y < 30), (x, y), (x - 1, y - 2))
 
     a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
-            correct_a = xx if xx < 30 else xx-1
-            correct_b = yy if yy < 30 else yy-2
+            correct_a = xx if xx < 30 else xx - 1
+            correct_b = yy if yy < 30 else yy - 2
             assert a[xx, yy] == correct_a
             assert b[xx, yy] == correct_b
 
     # multiway tuple_select with Expr condition
-    f = hl.Func('f')
+    f = hl.Func("f")
+    # fmt: off
     f[x, y] = hl.tuple_select(x + y < 30,  (x, y),
                               x + y < 100, (x-1, y-2),
                                            (x-100, y-200))
+    # fmt: on
 
     a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
-            correct_a = xx if xx + yy < 30 else xx-1 if xx + yy < 100 else xx - 100
-            correct_b = yy if xx + yy < 30 else yy-2 if xx + yy < 100 else yy - 200
+            correct_a = xx if xx + yy < 30 else xx - 1 if xx + yy < 100 else xx - 100
+            correct_b = yy if xx + yy < 30 else yy - 2 if xx + yy < 100 else yy - 200
             assert a[xx, yy] == correct_a
             assert b[xx, yy] == correct_b
 
     # multiway tuple_select with Tuple condition
-    f = hl.Func('f')
+    f = hl.Func("f")
+    # fmt: off
     f[x, y] = hl.tuple_select((x < 30, y < 30),   (x, y),
                               (x < 100, y < 100), (x-1, y-2),
                                                   (x-100, y-200))
+    # fmt: on
 
     a, b = f.realize([200, 200])
     for xx in range(a.height()):
         for yy in range(a.width()):
-            correct_a = xx if xx < 30 else xx-1 if xx < 100 else xx - 100
-            correct_b = yy if yy < 30 else yy-2 if yy < 100 else yy - 200
+            correct_a = xx if xx < 30 else xx - 1 if xx < 100 else xx - 100
+            correct_b = yy if yy < 30 else yy - 2 if yy < 100 else yy - 200
             assert a[xx, yy] == correct_a
             assert b[xx, yy] == correct_b
 
     # Failure case: mixing Expr and Tuple in multiway
     try:
-        f = hl.Func('f')
+        f = hl.Func("f")
+        # fmt: off
         f[x, y] = hl.tuple_select((x < 30, y < 30), (x, y),
                                    x + y < 100,     (x-1, y-2),
                                                     (x-100, y-200))
+        # fmt: on
     except hl.HalideError as e:
-        assert 'tuple_select() may not mix Expr and Tuple for the condition elements.' in str(e)
+        assert (
+            "tuple_select() may not mix Expr and Tuple for the condition elements."
+            in str(e)
+        )
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
     # Failure case: Tuples of mixed sizes
     try:
-        f = hl.Func('f')
+        f = hl.Func("f")
         f[x, y] = hl.tuple_select((x < 30, y < 30), (x, y, 0), (1, 2, 3, 4))
     except hl.HalideError as e:
-        assert 'tuple_select() requires all Tuples to have identical sizes' in str(e)
+        assert "tuple_select() requires all Tuples to have identical sizes" in str(e)
     else:
-        assert False, 'Did not see expected exception!'
+        assert False, "Did not see expected exception!"
 
 
 if __name__ == "__main__":

--- a/python_bindings/test/correctness/type.py
+++ b/python_bindings/test/correctness/type.py
@@ -1,5 +1,6 @@
 import halide as hl
 
+
 def test_type():
     t1 = hl.Type()
     assert t1.code() == hl.TypeCode.Handle
@@ -78,6 +79,7 @@ def test_type():
     assert repr(i32) == "<halide.Type int32>"
     assert str(vi32x8) == "int32x8"
     assert repr(vi32x8) == "<halide.Type int32x8>"
+
 
 if __name__ == "__main__":
     test_type()

--- a/python_bindings/test/correctness/user_context_test.py
+++ b/python_bindings/test/correctness/user_context_test.py
@@ -4,7 +4,7 @@ import user_context
 
 def test():
     output = bytearray("\0\0\0\0", "ascii")
-    user_context.user_context(None, ord('q'), output)
+    user_context.user_context(None, ord("q"), output)
     assert output == bytearray("qqqq", "ascii")
 
 

--- a/python_bindings/test/correctness/var.py
+++ b/python_bindings/test/correctness/var.py
@@ -1,5 +1,6 @@
 import halide as hl
 
+
 def test_var():
     v1 = hl.Var()
     v2 = hl.Var()
@@ -42,7 +43,7 @@ def test_var():
     assert outermost.name() == "__outermost"
 
     # repr() and str()
-    x = hl.Var('x')
+    x = hl.Var("x")
     assert str(x) == "x"
     assert repr(x) == "<halide.Var 'x'>"
 
@@ -51,6 +52,7 @@ def test_var():
 
     # This verifies that halide.Var is explicitly convertible to halide.Expr
     r = hl.random_int(hl.Expr(x))
+
 
 if __name__ == "__main__":
     test_var()

--- a/python_bindings/test/generators/addconstantpy_generator.py
+++ b/python_bindings/test/generators/addconstantpy_generator.py
@@ -1,14 +1,15 @@
 import halide as hl
 
-x = hl.Var('x')
-y = hl.Var('y')
-z = hl.Var('z')
+x = hl.Var("x")
+y = hl.Var("y")
+z = hl.Var("z")
+
 
 @hl.alias(
-    addconstantpy_with_offset_42={'extra_int':42},
-    addconstantpy_with_negative_offset={'extra_int': -1}
+    addconstantpy_with_offset_42={"extra_int": 42},
+    addconstantpy_with_negative_offset={"extra_int": -1},
 )
-@hl.generator(name = "addconstantpy")
+@hl.generator(name="addconstantpy")
 class AddConstantGenerator:
     extra_int = hl.GeneratorParam(0)
 
@@ -71,6 +72,6 @@ class AddConstantGenerator:
         g.output_2d[x, y] = g.input_2d[x, y] + g.scalar_int8
         g.output_3d[x, y, z] = g.input_3d[x, y, z] + g.scalar_int8 + g.extra_int
 
+
 if __name__ == "__main__":
     hl.main()
-

--- a/python_bindings/test/generators/bitpy_generator.py
+++ b/python_bindings/test/generators/bitpy_generator.py
@@ -1,9 +1,10 @@
 import halide as hl
 
-x = hl.Var('x')
-y = hl.Var('y')
+x = hl.Var("x")
+y = hl.Var("y")
 
-@hl.generator(name = "bitpy")
+
+@hl.generator(name="bitpy")
 class BitGenerator:
     # We can use `bool` as an alias for `hl.Bool()` if we like
     bit_input = hl.InputBuffer(bool, 1)
@@ -13,8 +14,8 @@ class BitGenerator:
 
     def generate(self):
         g = self
-        g.bit_output[x] = g.bit_input[x] | g.bit_constant;
+        g.bit_output[x] = g.bit_input[x] | g.bit_constant
+
 
 if __name__ == "__main__":
     hl.main()
-

--- a/python_bindings/test/generators/complexpy_generator.py
+++ b/python_bindings/test/generators/complexpy_generator.py
@@ -1,8 +1,8 @@
 import halide as hl
 
-x = hl.Var('x')
-y = hl.Var('y')
-c = hl.Var('c')
+x = hl.Var("x")
+y = hl.Var("y")
+c = hl.Var("c")
 
 # Note that this Generator explicitly inherits from hl.Generator;
 # this isn't necessary (the decorator will inject the base class for you),
@@ -10,7 +10,8 @@ c = hl.Var('c')
 # as pytype. Thus, this is left here as a test to verify that this option
 # remains functional.
 
-@hl.generator(name = "complexpy")
+
+@hl.generator(name="complexpy")
 class ComplexPy(hl.Generator):
     vectorize = hl.GeneratorParam(True)
     extra_input_name = hl.GeneratorParam("")
@@ -40,12 +41,18 @@ class ComplexPy(hl.Generator):
 
         g.simple_output[x, y, c] = hl.f32(g.simple_input[x, y, c])
         g.typed_buffer_output[x, y, c] = hl.f32(g.typed_buffer_input[x, y, c])
-        g.untyped_buffer_output[x, y, c] = hl.cast(g.untyped_buffer_output.type(), g.untyped_buffer_input[x, y, c])
+        g.untyped_buffer_output[x, y, c] = hl.cast(
+            g.untyped_buffer_output.type(),
+            g.untyped_buffer_input[x, y, c],
+        )
 
         intermediate = hl.Func("intermediate")
         intermediate[x, y, c] = g.simple_input[x, y, c] * g.float_arg
 
-        g.tuple_output[x, y, c] = (intermediate[x, y, c], intermediate[x, y, c] + g.int_arg)
+        g.tuple_output[x, y, c] = (
+            intermediate[x, y, c],
+            intermediate[x, y, c] + g.int_arg,
+        )
 
         # This should be compiled into the Generator product itself,
         # and not produce another input for the Stub or AOT filter.
@@ -65,9 +72,13 @@ class ComplexPy(hl.Generator):
 
         g.scalar_output[()] = g.float_arg + g.int_arg
 
-        intermediate.compute_at(g.tuple_output, y);
-        intermediate.specialize(g.vectorize).vectorize(x, g.natural_vector_size(hl.Float(32)));
+        intermediate.compute_at(g.tuple_output, y)
+        (
+            intermediate.specialize(g.vectorize).vectorize(
+                x, g.natural_vector_size(hl.Float(32))
+            )
+        )
+
 
 if __name__ == "__main__":
     hl.main()
-

--- a/python_bindings/test/generators/complexpy_generator.py
+++ b/python_bindings/test/generators/complexpy_generator.py
@@ -72,11 +72,10 @@ class ComplexPy(hl.Generator):
 
         g.scalar_output[()] = g.float_arg + g.int_arg
 
-        intermediate.compute_at(g.tuple_output, y)
         (
-            intermediate.specialize(g.vectorize).vectorize(
-                x, g.natural_vector_size(hl.Float(32))
-            )
+            intermediate.compute_at(g.tuple_output, y)
+            .specialize(g.vectorize)
+            .vectorize(x, g.natural_vector_size(hl.Float(32)))
         )
 
 

--- a/python_bindings/test/generators/simplepy_generator.py
+++ b/python_bindings/test/generators/simplepy_generator.py
@@ -1,9 +1,10 @@
 import halide as hl
 
-x = hl.Var('x')
-y = hl.Var('y')
+x = hl.Var("x")
+y = hl.Var("y")
 
-@hl.generator(name = "simplepy")
+
+@hl.generator(name="simplepy")
 class SimplePy:
     offset = hl.GeneratorParam(0)
 
@@ -20,6 +21,6 @@ class SimplePy:
         g.simple_output[x, y] = hl.f32(g.offset + g.buffer_input[x, y]) + g.float_arg
         g.simple_output.compute_root()
 
+
 if __name__ == "__main__":
     hl.main()
-


### PR DESCRIPTION
Trying to regularize all our Python code to a common style. Should be no functional changes here, just autoformatting + a few tweaks.