### PR TITLE
Give pip.yml permission to read packages

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -19,6 +19,7 @@ env:
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)
+  packages: read  #  to fetch packages (docker)
 
 jobs:
   pip-linux:


### PR DESCRIPTION
Looks like https://github.com/halide/Halide/pull/7136 was too restrictive, breaking wheel building