### PR TITLE
Add "argv_signature" to C header generation

### DIFF
--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -124,6 +124,9 @@ HALIDE_FUNCTION_ATTRS
 int test1_argv(void **args);
 
 HALIDE_FUNCTION_ATTRS
+inline const char *test1_argv_signature() { return "fi#"; }
+
+HALIDE_FUNCTION_ATTRS
 const struct halide_filter_metadata_t *test1_metadata();
 
 #ifdef __cplusplus
@@ -204,6 +207,9 @@ int test2(void const *__user_context, float _alpha, int32_t _beta, struct halide
 
 HALIDE_FUNCTION_ATTRS
 int test2_argv(void **args);
+
+HALIDE_FUNCTION_ATTRS
+inline const char *test2_argv_signature() { return "Pfi#"; }
 
 HALIDE_FUNCTION_ATTRS
 const struct halide_filter_metadata_t *test2_metadata();

--- a/test/generator/argvcall_aottest.cpp
+++ b/test/generator/argvcall_aottest.cpp
@@ -3,6 +3,7 @@
 
 #include <math.h>
 #include <stdio.h>
+#include <string>
 
 #include "argvcall.h"
 
@@ -36,6 +37,12 @@ int main(int argc, char **argv) {
         exit(-1);
     }
     verify(output, 1.2f, 3.4f);
+
+    std::string sig = argvcall_argv_signature();
+    if (sig != "ff#") {
+        fprintf(stderr, "Incorrect signature: %s\n", sig.c_str());
+        exit(-1);
+    }
 
     // verify that calling via the _argv entry point
     // also produces the correct result

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -1505,14 +1505,24 @@ int main(int argc, char **argv) {
     verify(input, output0, output1, output_scalar, output_array[0], output_array[1], untyped_output_buffer, tupled_output_buffer0, tupled_output_buffer1);
 
     check_metadata(*metadata_tester_metadata(), false);
-    if (!strcmp(metadata_tester_metadata()->name, "metadata_tester_metadata")) {
-        std::cerr << "Expected name metadata_tester_metadata\n";
+    if (strcmp(metadata_tester_metadata()->name, "metadata_tester")) {
+        std::cerr << "Expected name metadata_tester, got " << metadata_tester_metadata()->name << "\n";
         exit(-1);
     }
 
     check_metadata(*metadata_tester_ucon_metadata(), true);
-    if (!strcmp(metadata_tester_ucon_metadata()->name, "metadata_tester_ucon_metadata")) {
-        std::cerr << "Expected name metadata_tester_ucon_metadata\n";
+    if (strcmp(metadata_tester_ucon_metadata()->name, "metadata_tester_ucon")) {
+        std::cerr << "Expected name metadata_tester_ucon, got " << metadata_tester_ucon_metadata()->name << "\n";
+        exit(-1);
+    }
+
+    if (strcmp(metadata_tester_argv_signature(), "@@@@i?bhiqBHIQfdP@@@@@@@bbbbhhhhiiiiPP@@@@@@@@@@@@@@@@@@B#############################")) {
+        std::cerr << "Incorrect argv_signature for metadata_tester_argv_signature\n";
+        exit(-1);
+    }
+
+    if (strcmp(metadata_tester_ucon_argv_signature(), "P@@@@i?bhiqBHIQfdP@@@@@@@bbbbhhhhiiiiPP@@@@@@@@@@@@@@@@@@B#############################")) {
+        std::cerr << "Incorrect argv_signature for metadata_tester_ucon_argv_signature\n";
         exit(-1);
     }
 

--- a/test/generator/user_context_aottest.cpp
+++ b/test/generator/user_context_aottest.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <math.h>
 #include <stdio.h>
+#include <string>
 
 #include "HalideBuffer.h"
 #include "HalideRuntime.h"
@@ -69,6 +70,13 @@ int main(int argc, char **argv) {
 
     // verify that calling via the _argv entry point
     // also produces the correct result
+
+    std::string sig = user_context_argv_signature();
+    if (sig != "P@#") {
+        fprintf(stderr, "Incorrect signature: %s\n", sig.c_str());
+        exit(-1);
+    }
+
     const void *arg0 = context_pointer;
     void *args[3] = {&arg0, input.raw_buffer(), output.raw_buffer()};
     called_error = false;


### PR DESCRIPTION
Add a new call, `$funcname_argv_signature()`, to our generated C header files. This returns a const char * one character per expected argument to the 'argv' call; each character is used to indicate the type of the argument. The character encoding is (mostly) borrowed from Python/NumPy, with some minor extensions.

This is intended to provide a lightweight mechanism to write reusable marshal/unmarshal code across language/processor/etc boundaries. (Note that while the existing metadata provides equivalent information, it is also heavier-weight to process, and hard to replicate from scratch; this, on the other hand, provides a convention that can be constructed simply by inspection, or even copy/pasted into source files that may not easily be able to process halide metadata.)

Note that this is being implemented as an inline function, rather than a constant or a #define; I think this is the safest way to implement this in a way that works with C (C99 or later) as well as C++.

This doesn't need to land yet, but I'm about to try building something on top of it and if there are loud objections I'd rather hear sooner than later.

```
!   bfloat16
e   float16
f   float32
d   float64
b   int8
h   int16
i   int32
q   int64
?   bool
B   uint8
H   uint16
I   uint32
Q   uint64
P   void * / handle
@   halide_buffer_t * (as input)
#   halide_buffer_t * (as output)

```