### PR TITLE
Slightly improve error message for non-integer RDom min/extent

### DIFF
--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -92,10 +92,10 @@ bool is_parallel(ForType for_type) {
 Range::Range(const Expr &min_in, const Expr &extent_in)
     : min(lossless_cast(Int(32), min_in)), extent(lossless_cast(Int(32), extent_in)) {
     if (min_in.defined() && !min.defined()) {
-        user_error << "Min cannot be losslessly cast to an int32: " << min_in;
+        user_error << "Range min is not representable as an int32: " << min_in;
     }
     if (extent_in.defined() && !extent.defined()) {
-        user_error << "Extent cannot be losslessly cast to an int32: " << extent_in;
+        user_error << "Range extent is not representable as an int32: " << extent_in;
     }
 }
 

--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -126,6 +126,13 @@ public:
 };
 }  // namespace
 
+void RDom::validate_min_extent(const Expr &min, const Expr &extent) {
+    user_assert(lossless_cast(Int(32), min).defined())
+        << "RDom min cannot be represented as an int32: " << min;
+    user_assert(lossless_cast(Int(32), extent).defined())
+        << "RDom extent cannot be represented as an int32: " << extent;
+}
+
 void RDom::initialize_from_region(const Region &region, string name) {
     if (name.empty()) {
         name = make_entity_name(this, "Halide:.*:RDom", 'r');

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -195,10 +195,12 @@ class RDom {
 
     void init_vars(const std::string &name);
 
+    void validate_min_extent(const Expr &min, const Expr &extent);
     void initialize_from_region(const Region &region, std::string name = "");
 
     template<typename... Args>
     HALIDE_NO_USER_CODE_INLINE void initialize_from_region(Region &region, const Expr &min, const Expr &extent, Args &&...args) {
+        validate_min_extent(min, extent);
         region.push_back({min, extent});
         initialize_from_region(region, std::forward<Args>(args)...);
     }


### PR DESCRIPTION
Fixes #6948 

Before: 

Extent cannot be losslessly cast to an int32: 3.400000f

After: 

RDom extent cannot be represented as an int32: 3.400000f
