### PR TITLE
Fix readnone attribute for llvm 16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,10 @@ LLVM_BINDIR = $(shell $(LLVM_CONFIG) --bindir | sed -e 's/\\/\//g' -e 's/\([a-zA
 LLVM_LIBDIR = $(shell $(LLVM_CONFIG) --libdir | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g')
 # Apparently there is no llvm_config flag to get canonical paths to tools,
 # so we'll just construct one relative to --src-root and hope that is stable everywhere.
-LLVM_GIT_LLD_INCLUDE_DIR = $(shell $(LLVM_CONFIG) --src-root | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g')/../lld/include
 LLVM_SYSTEM_LIBS=$(shell ${LLVM_CONFIG} --system-libs --link-static | sed -e 's/[\/&]/\\&/g' | sed 's/-llibxml2.tbd/-lxml2/')
 LLVM_AS = $(LLVM_BINDIR)/llvm-as
 LLVM_NM = $(LLVM_BINDIR)/llvm-nm
-LLVM_CXX_FLAGS = -std=c++17  $(filter-out -O% -g -fomit-frame-pointer -pedantic -W% -W, $(shell $(LLVM_CONFIG) --cxxflags | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g;s/-D/ -D/g;s/-O/ -O/;s/c++14/c++17/g')) -I$(LLVM_GIT_LLD_INCLUDE_DIR)
+LLVM_CXX_FLAGS = -std=c++17  $(filter-out -O% -g -fomit-frame-pointer -pedantic -W% -W, $(shell $(LLVM_CONFIG) --cxxflags | sed -e 's/\\/\//g' -e 's/\([a-zA-Z]\):/\/\1/g;s/-D/ -D/g;s/-O/ -O/;s/c++14/c++17/g'))
 OPTIMIZE ?= -O3
 OPTIMIZE_FOR_BUILD_TIME ?= -O0
 

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1517,7 +1517,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_ARM(const Target &target) {
     return std::make_unique<CodeGen_ARM>(target);
 }
 
-#else   // WITH_ARM || WITH_AARCH64
+#else  // WITH_ARM || WITH_AARCH64
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_ARM(const Target &target) {
     user_error << "ARM not enabled for this build of Halide.\n";

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -758,7 +758,7 @@ void CodeGen_ARM::init_module() {
                 intrin_impl = get_llvm_intrin(ret_type, mangled_name, arg_types, scalars_are_vectors);
             }
 
-            intrin_impl->addFnAttr(llvm::Attribute::ReadNone);
+            function_does_not_access_memory(intrin_impl);
             intrin_impl->addFnAttr(llvm::Attribute::NoUnwind);
             declare_intrin_overload(intrin.name, ret_type, intrin_impl, arg_types);
             if (intrin.flags & ArmIntrinsic::AllowUnsignedOp1) {
@@ -1517,7 +1517,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_ARM(const Target &target) {
     return std::make_unique<CodeGen_ARM>(target);
 }
 
-#else  // WITH_ARM || WITH_AARCH64
+#else   // WITH_ARM || WITH_AARCH64
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_ARM(const Target &target) {
     user_error << "ARM not enabled for this build of Halide.\n";

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1763,7 +1763,7 @@ Value *CodeGen_Hexagon::call_intrin(Type result_type, const string &name,
             fn = fn2;
         }
     }
-    fn->addFnAttr(llvm::Attribute::ReadNone);
+    function_does_not_access_memory(fn);
     fn->addFnAttr(llvm::Attribute::NoUnwind);
     return CodeGen_Posix::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
                                       fn, std::move(args));
@@ -1786,7 +1786,7 @@ Value *CodeGen_Hexagon::call_intrin(llvm::Type *result_type, const string &name,
             fn = fn2;
         }
     }
-    fn->addFnAttr(llvm::Attribute::ReadNone);
+    function_does_not_access_memory(fn);
     fn->addFnAttr(llvm::Attribute::NoUnwind);
     return CodeGen_Posix::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
                                       fn, std::move(args));
@@ -2282,7 +2282,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
     return std::make_unique<CodeGen_Hexagon>(target);
 }
 
-#else  // WITH_HEXAGON
+#else   // WITH_HEXAGON
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
     user_error << "hexagon not enabled for this build of Halide.\n";

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2282,7 +2282,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
     return std::make_unique<CodeGen_Hexagon>(target);
 }
 
-#else   // WITH_HEXAGON
+#else  // WITH_HEXAGON
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
     user_error << "hexagon not enabled for this build of Halide.\n";

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2502,7 +2502,7 @@ void CodeGen_LLVM::codegen_predicated_load(const Load *op) {
         value = codegen_dense_vector_load(op, vpred);
     } else if (use_llvm_vp_intrinsics && stride) {  // Case only handled by vector predication, otherwise must scalarize.
         Value *vpred = codegen(op->predicate);
-        Value *llvm_stride = codegen(stride);       // Not 1 (dense) as that was caught above.
+        Value *llvm_stride = codegen(stride);  // Not 1 (dense) as that was caught above.
         value = codegen_vector_load(op->type, op->name, ramp->base, op->image, op->param,
                                     op->alignment, vpred, true, llvm_stride);
     } else if (ramp && stride && stride->value == -1) {

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -326,6 +326,10 @@ protected:
         return n;
     }
 
+    /** Add the appropriate function attribute to tell LLVM that the function
+     * doesn't access memory. */
+    void function_does_not_access_memory(llvm::Function *fn);
+
     using IRVisitor::visit;
 
     /** Generate code for various IR nodes. These can be overridden by

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -830,7 +830,7 @@ std::unique_ptr<CodeGen_GPU_Dev> new_CodeGen_PTX_Dev(const Target &target) {
     return std::make_unique<CodeGen_PTX_Dev>(target);
 }
 
-#else   // WITH_PTX
+#else  // WITH_PTX
 
 std::unique_ptr<CodeGen_GPU_Dev> new_CodeGen_PTX_Dev(const Target &target) {
     user_error << "PTX not enabled for this build of Halide.\n";

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -251,7 +251,7 @@ void CodeGen_PTX_Dev::init_module() {
 
     for (auto &&i : ptx_intrins) {
         auto *fn = declare_intrin_overload(i.name, i.ret_type, i.intrin_name, std::move(i.arg_types));
-        fn->addFnAttr(llvm::Attribute::ReadNone);
+        function_does_not_access_memory(fn);
         fn->addFnAttr(llvm::Attribute::NoUnwind);
     }
 }
@@ -830,7 +830,7 @@ std::unique_ptr<CodeGen_GPU_Dev> new_CodeGen_PTX_Dev(const Target &target) {
     return std::make_unique<CodeGen_PTX_Dev>(target);
 }
 
-#else  // WITH_PTX
+#else   // WITH_PTX
 
 std::unique_ptr<CodeGen_GPU_Dev> new_CodeGen_PTX_Dev(const Target &target) {
     user_error << "PTX not enabled for this build of Halide.\n";

--- a/src/CodeGen_PowerPC.cpp
+++ b/src/CodeGen_PowerPC.cpp
@@ -199,7 +199,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_PowerPC(const Target &target) {
     return std::make_unique<CodeGen_PowerPC>(target);
 }
 
-#else   // WITH_POWERPC
+#else  // WITH_POWERPC
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_PowerPC(const Target &target) {
     user_error << "PowerPC not enabled for this build of Halide.\n";

--- a/src/CodeGen_PowerPC.cpp
+++ b/src/CodeGen_PowerPC.cpp
@@ -117,7 +117,7 @@ void CodeGen_PowerPC::init_module() {
         }
 
         auto *fn = declare_intrin_overload(i.name, ret_type, i.intrin_name, std::move(arg_types));
-        fn->addFnAttr(llvm::Attribute::ReadNone);
+        function_does_not_access_memory(fn);
         fn->addFnAttr(llvm::Attribute::NoUnwind);
     }
 }
@@ -199,7 +199,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_PowerPC(const Target &target) {
     return std::make_unique<CodeGen_PowerPC>(target);
 }
 
-#else  // WITH_POWERPC
+#else   // WITH_POWERPC
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_PowerPC(const Target &target) {
     user_error << "PowerPC not enabled for this build of Halide.\n";

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -378,7 +378,7 @@ llvm::Function *CodeGen_RISCV::define_riscv_intrinsic_wrapper(const RISCVIntrins
 
     builder->restoreIP(here);
 
-    wrapper->addFnAttr(llvm::Attribute::ReadNone);
+    function_does_not_access_memory(wrapper);
     wrapper->addFnAttr(llvm::Attribute::NoUnwind);
 
     llvm::verifyFunction(*wrapper);
@@ -391,7 +391,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_RISCV(const Target &target) {
     return std::make_unique<CodeGen_RISCV>(target);
 }
 
-#else  // WITH_RISCV
+#else   // WITH_RISCV
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_RISCV(const Target &target) {
     user_error << "RISCV not enabled for this build of Halide.\n";

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -391,7 +391,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_RISCV(const Target &target) {
     return std::make_unique<CodeGen_RISCV>(target);
 }
 
-#else   // WITH_RISCV
+#else  // WITH_RISCV
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_RISCV(const Target &target) {
     user_error << "RISCV not enabled for this build of Halide.\n";

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -135,7 +135,7 @@ void CodeGen_WebAssembly::init_module() {
         }
 
         auto *fn = declare_intrin_overload(i.name, ret_type, i.intrin_name, std::move(arg_types));
-        fn->addFnAttr(llvm::Attribute::ReadNone);
+        function_does_not_access_memory(fn);
         fn->addFnAttr(llvm::Attribute::NoUnwind);
     }
 }
@@ -360,7 +360,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target) {
     return std::make_unique<CodeGen_WebAssembly>(target);
 }
 
-#else  // WITH_WEBASSEMBLY
+#else   // WITH_WEBASSEMBLY
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target) {
     user_error << "WebAssembly not enabled for this build of Halide.\n";

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -360,7 +360,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target) {
     return std::make_unique<CodeGen_WebAssembly>(target);
 }
 
-#else   // WITH_WEBASSEMBLY
+#else  // WITH_WEBASSEMBLY
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target) {
     user_error << "WebAssembly not enabled for this build of Halide.\n";

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -991,7 +991,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_X86(const Target &target) {
     return std::make_unique<CodeGen_X86>(target);
 }
 
-#else   // WITH_X86
+#else  // WITH_X86
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_X86(const Target &target) {
     user_error << "x86 not enabled for this build of Halide.\n";

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -288,7 +288,7 @@ void CodeGen_X86::init_module() {
 
         auto *fn = declare_intrin_overload(i.name, ret_type, i.intrin_name, std::move(arg_types));
         if ((i.flags & x86Intrinsic::AccessesMemory) == 0) {
-            fn->addFnAttr(llvm::Attribute::ReadNone);
+            function_does_not_access_memory(fn);
         }
         fn->addFnAttr(llvm::Attribute::NoUnwind);
     }
@@ -991,7 +991,7 @@ std::unique_ptr<CodeGen_Posix> new_CodeGen_X86(const Target &target) {
     return std::make_unique<CodeGen_X86>(target);
 }
 
-#else  // WITH_X86
+#else   // WITH_X86
 
 std::unique_ptr<CodeGen_Posix> new_CodeGen_X86(const Target &target) {
     user_error << "x86 not enabled for this build of Halide.\n";


### PR DESCRIPTION
The readnone flag was changed to memory(none) when applied to functions. llvm-as dynamically upgrades readnone applied to functions, so our .ll is fine for now, but there were places in the compiler we were manually sticking 'readnone' on a function.

Also did a driveby makefile fix to remove some vestigial wasm stuff that was throwing errors with newer versions of llvm-config