### PR TITLE
Implement _halide_buffer_to_string for C Backend, plus other fixes

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -273,7 +273,6 @@ void _halide_buffer_to_string(char* dst, size_t n, const halide_buffer_t *buf) {
 } // namespace
 )INLINE_CODE";
 
-
 class TypeInfoGatherer : public IRGraphVisitor {
 private:
     using IRGraphVisitor::include;
@@ -1931,7 +1930,6 @@ void CodeGen_C::compile(const LoweredFunc &f, const MetadataNameMap &metadata_na
 
             // Return success.
             stream << get_indent() << "return 0;\n";
-
         }
 
         // Ensure we use open/close_scope, so that the cache doesn't try to linger
@@ -2094,7 +2092,6 @@ void CodeGen_C::open_scope() {
     stream << get_indent();
     indent++;
     stream << "{\n";
-
 }
 
 void CodeGen_C::close_scope(const std::string &comment) {

--- a/src/runtime/to_string.cpp
+++ b/src/runtime/to_string.cpp
@@ -265,6 +265,9 @@ WEAK char *halide_type_to_string(char *dst, char *end, const halide_type_t *t) {
     case halide_type_handle:
         code_name = "handle";
         break;
+    case halide_type_bfloat:
+        code_name = "bfloat";
+        break;
     default:
         code_name = "bad_type_code";
         break;


### PR DESCRIPTION
The `debug` feature flag is great for debugging in odd situations where you just don't know what is actually being passed to the code... except that the C backend didn't actually emit all the yummy details of the buffer, just its pointer. This fixes that. It also includes two driveby fixes:
- We didn't call `cache.clear()` between internal functions in the C backend, so the cache could try to re-use something declared in a previous (internal, closure) function and would fail to compile. Easy fix. (I'm surprised we haven't seen this fail before now.)
- the runtime `halide_type_to_string` function didn't handle `bfloat`.