### PR TITLE
C Backend should call halide_buffer_to_string()

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -78,6 +78,8 @@ const string globals = R"INLINE_CODE(
 extern "C" {
 int64_t halide_current_time_ns(void *ctx);
 void halide_profiler_pipeline_end(void *, void *);
+struct halide_buffer_t;
+char *halide_buffer_to_string(char *, char *, const halide_buffer_t *);
 }
 
 #ifdef _WIN32
@@ -1875,6 +1877,7 @@ void CodeGen_C::compile(const LoweredFunc &f, const MetadataNameMap &metadata_na
 
             // Return success.
             stream << get_indent() << "return 0;\n";
+            cache.clear();
         }
 
         indent -= 1;
@@ -2508,24 +2511,35 @@ void CodeGen_C::visit(const Call *op) {
         string format_string = "";
         for (size_t i = 0; i < op->args.size(); i++) {
             Type t = op->args[i].type();
-            printf_args.push_back(print_expr(op->args[i]));
-            if (t.is_int()) {
-                format_string += "%lld";
-                printf_args[i] = "(long long)(" + printf_args[i] + ")";
-            } else if (t.is_uint()) {
-                format_string += "%llu";
-                printf_args[i] = "(long long unsigned)(" + printf_args[i] + ")";
-            } else if (t.is_float()) {
-                if (t.bits() == 32) {
-                    format_string += "%f";
-                } else {
-                    format_string += "%e";
-                }
-            } else if (op->args[i].as<StringImm>()) {
+            if (t == type_of<halide_buffer_t *>()) {
+                string buf_name = unique_name('b');
+                printf_args.push_back(buf_name);
+                // In Codegen_LLVM, we use 512 as a guesstimate for halide_buffer_t space:
+                // Not a strict upper bound (there isn't one), but ought to be enough for most buffers.
+                constexpr int buf_size = 512;
+                stream << get_indent() << "char " << buf_name << "[" << buf_size << "];\n";
+                stream << get_indent() << "halide_buffer_to_string(" << buf_name << ", " << buf_name << " + " << buf_size << ", " << print_expr(op->args[i]) << ");\n";
                 format_string += "%s";
             } else {
-                internal_assert(t.is_handle());
-                format_string += "%p";
+                printf_args.push_back(print_expr(op->args[i]));
+                if (t.is_int()) {
+                    format_string += "%lld";
+                    printf_args[i] = "(long long)(" + printf_args[i] + ")";
+                } else if (t.is_uint()) {
+                    format_string += "%llu";
+                    printf_args[i] = "(long long unsigned)(" + printf_args[i] + ")";
+                } else if (t.is_float()) {
+                    if (t.bits() == 32) {
+                        format_string += "%f";
+                    } else {
+                        format_string += "%e";
+                    }
+                } else if (op->args[i].as<StringImm>()) {
+                    format_string += "%s";
+                } else {
+                    internal_assert(t.is_handle());
+                    format_string += "%p";
+                }
             }
         }
         string buf_name = unique_name('b');


### PR DESCRIPTION
Just assume that this is present and call it for stringify() on buffers in the C backend. (If it's missing, the user will be expected to provide an implementation, as is usual for runtime with the C backend.)