### PR TITLE
Add a struct with type signatures to output, as compile-time-only alternative to #7149

### DIFF
--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -272,6 +272,8 @@ protected:
     void emit_metadata_getter(const std::string &function_name,
                               const std::vector<LoweredArgument> &args,
                               const MetadataNameMap &metadata_name_map);
+    void emit_function_signature_struct(const std::string &function_name,
+                                        const std::vector<LoweredArgument> &args);
 };
 
 }  // namespace Internal


### PR DESCRIPTION
The idea here is that we emit info about the call signatures via the type system, rather than as data.

Pros:
    - Can encode more info (eg, buffer input/output but also time and dimensions)
    - Guaranteed not to add to code size if unused
    - In theory, could generate a lot of interesting stuff via metaprogramming using this

Cons:
    - Not usable from straight C
    - Template metaprogramming to make use of this can be verbose and fiddly (see the test in metadata_tester_aottest.cpp)