### PR TITLE
Migrate from MCJIT to ORC JIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ LLVM_STATIC_LIBFILES = \
 	linker \
 	ipo \
 	passes \
-	mcjit \
+	orcjit \
 	$(X86_LLVM_CONFIG_LIB) \
 	$(ARM_LLVM_CONFIG_LIB) \
 	$(OPENCL_LLVM_CONFIG_LIB) \

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -53,7 +53,7 @@ endif ()
 # Create options for including or excluding LLVM backends.
 ##
 
-set(active_components mcjit bitwriter linker passes)
+set(active_components orcjit bitwriter linker passes)
 set(known_components AArch64 AMDGPU ARM Hexagon Mips NVPTX PowerPC RISCV WebAssembly X86)
 
 foreach (comp IN LISTS known_components)

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -289,15 +289,6 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
                        << target_data_layout.getStringRepresentation() << ")\n";
     }
 
-    // Do any target-specific initialization
-    std::vector<llvm::JITEventListener *> listeners;
-
-    if (target.arch == Target::X86) {
-        listeners.push_back(llvm::JITEventListener::createIntelJITEventListener());
-    }
-    // TODO: If this ever works in LLVM, this would allow profiling of JIT code with symbols with oprofile.
-    // listeners.push_back(llvm::createOProfileJITEventListener());
-
     // Create LLJIT
     const auto compilerBuilder = [&](const llvm::orc::JITTargetMachineBuilder & /*jtmb*/)
         -> llvm::Expected<std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
@@ -377,8 +368,6 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
     for (const auto &requested_export : requested_exports) {
         exports[requested_export] = compile_and_get_function(*JIT, requested_export);
     }
-
-    listeners.clear();
 
     // TODO: I don't think this is necessary, we shouldn't have any static constructors
     err = ctorRunner.run();

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -257,10 +257,7 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
     llvm::orc::JITTargetMachineBuilder tm_builder(llvm::Triple(m->getTargetTriple()));
     tm_builder.setOptions(options);
     tm_builder.setCodeGenOptLevel(CodeGenOpt::Aggressive);
-    // Workaround for "JIT session error: Unsupported i386 relocation:4" (R_386_PLT32)
-    if (target.arch == Target::Arch::X86 && target.bits == 32) {
-        tm_builder.setRelocationModel(llvm::Reloc::Static);
-    }
+    tm_builder.setCodeModel(llvm::CodeModel::Medium);
 
     auto tm = tm_builder.createTargetMachine();
     internal_assert(tm) << llvm::toString(tm.takeError()) << "\n";

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -37,8 +37,8 @@
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
-#include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/Constant.h>

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -40,6 +40,7 @@
 #include <llvm/ExecutionEngine/Orc/Core.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
+#include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -35,9 +35,7 @@
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
-#include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
-#include <llvm/ExecutionEngine/Orc/Core.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -37,7 +37,9 @@
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
-#include <llvm/ExecutionEngine/MCJIT.h>
+#include <llvm/ExecutionEngine/Orc/LLJIT.h>
+#include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/IR/Constant.h>
 #include <llvm/IR/Constants.h>

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
     }
 
     if (call_counter2 != 32 * 32) {
-        printf("C function my_func2 was called %d times instead of %d\n", call_counter, 32 * 32);
+        printf("C function my_func2 was called %d times instead of %d\n", call_counter2, 32 * 32);
         return -1;
     }
 


### PR DESCRIPTION
resolves https://github.com/halide/Halide/issues/7161
resolves https://github.com/halide/Halide/issues/7078

* Migrate from MCJIT to ORC JIT
* Enables JIT on RISC-V (related: https://github.com/llvm/llvm-project/issues/58979)
* i386 is also on ORC JIT but fallbacks to RTDyld. Other targets uses JITLink. (track https://github.com/llvm/llvm-project/issues/58978)