### PR TITLE
Use n32:64 in RISC-V data layout

### DIFF
--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -35,7 +35,6 @@
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Bitcode/BitcodeWriter.h>
-#include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -364,7 +364,11 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
         if (target.bits == 32) {
             return llvm::DataLayout("e-m:e-p:32:32-i64:64-n32-S128");
         } else {
+#if LLVM_VERSION >= 160
+            return llvm::DataLayout("e-m:e-p:64:64-i64:64-i128:128-n32:64-S128");
+#else
             return llvm::DataLayout("e-m:e-p:64:64-i64:64-i128:128-n64-S128");
+#endif
         }
     } else {
         internal_error << "Bad target arch: " << target.arch << "\n";


### PR DESCRIPTION
related: https://github.com/llvm/llvm-project/commit/974e2e690b4024c2677dde26cc76ec31e0047c1d
resolves https://github.com/halide/Halide/issues/7174