### PR TITLE
Tweak the import paths in Python apps & tests

### DIFF
--- a/python_bindings/apps/bilateral_grid_app.py
+++ b/python_bindings/apps/bilateral_grid_app.py
@@ -9,7 +9,7 @@ from bilateral_grid_Mullapudi2016 import bilateral_grid_Mullapudi2016
 import halide.imageio
 import numpy as np
 import sys
-from timeit import Timer
+import timeit
 
 
 def main():
@@ -46,7 +46,7 @@ def main():
 
     for name, fn in tests.items():
         print("Running %s... " % name, end="")
-        t = Timer(lambda: fn(input_buf, r_sigma, output_buf))
+        t = timeit.Timer(lambda: fn(input_buf, r_sigma, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 

--- a/python_bindings/apps/blur_app.py
+++ b/python_bindings/apps/blur_app.py
@@ -6,7 +6,7 @@ from blur import blur
 import halide.imageio
 import numpy as np
 import sys
-from timeit import Timer
+import timeit
 
 
 def main():
@@ -35,7 +35,7 @@ def main():
 
     for name, fn in tests.items():
         print("Running %s... " % name, end="")
-        t = Timer(lambda: fn(input_buf, output_buf))
+        t = timeit.Timer(lambda: fn(input_buf, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 

--- a/python_bindings/apps/blur_generator.py
+++ b/python_bindings/apps/blur_generator.py
@@ -3,10 +3,10 @@ Simple blur.
 """
 
 import halide as hl
-from enum import Enum
+import enum
 
 
-class BlurGPUSchedule(Enum):
+class BlurGPUSchedule(enum.Enum):
     # Fully inlining schedule.
     Inline = 0
     # Schedule caching intermedia result of blur_x.

--- a/python_bindings/apps/interpolate_app.py
+++ b/python_bindings/apps/interpolate_app.py
@@ -7,7 +7,7 @@ from interpolate_Mullapudi2016 import interpolate_Mullapudi2016
 import halide.imageio
 import numpy as np
 import sys
-from timeit import Timer
+import timeit
 
 
 def main():
@@ -36,7 +36,7 @@ def main():
 
     for name, fn in tests.items():
         print("Running %s... " % name, end="")
-        t = Timer(lambda: fn(input_buf, output_buf))
+        t = timeit.Timer(lambda: fn(input_buf, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 

--- a/python_bindings/apps/local_laplacian_app.py
+++ b/python_bindings/apps/local_laplacian_app.py
@@ -7,7 +7,7 @@ from local_laplacian_Mullapudi2016 import local_laplacian_Mullapudi2016
 import halide.imageio
 import numpy as np
 import sys
-from timeit import Timer
+import timeit
 
 
 def main():
@@ -41,7 +41,7 @@ def main():
 
     for name, fn in tests.items():
         print("Running %s... " % name, end="")
-        t = Timer(lambda: fn(input_buf, levels, alpha / (levels - 1), beta, output_buf))
+        t = timeit.Timer(lambda: fn(input_buf, levels, alpha / (levels - 1), beta, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 

--- a/python_bindings/test/correctness/addconstant_test.py
+++ b/python_bindings/test/correctness/addconstant_test.py
@@ -1,15 +1,18 @@
-import addconstantcpp, addconstantpy
-import addconstantcpp_with_offset_42, addconstantpy_with_offset_42
-import addconstantcpp_with_negative_offset, addconstantpy_with_negative_offset
+from addconstantcpp import addconstantcpp
+from addconstantpy import addconstantpy
+from addconstantcpp_with_offset_42 import addconstantcpp_with_offset_42
+from addconstantpy_with_offset_42 import addconstantpy_with_offset_42
+from addconstantcpp_with_negative_offset import addconstantcpp_with_negative_offset
+from addconstantpy_with_negative_offset import addconstantpy_with_negative_offset
 import numpy
 
 TESTS_AND_OFFSETS = [
-    (addconstantcpp.addconstantcpp, 0),
-    (addconstantpy.addconstantpy, 0),
-    (addconstantcpp_with_offset_42.addconstantcpp_with_offset_42, 42),
-    (addconstantpy_with_offset_42.addconstantpy_with_offset_42, 42),
-    (addconstantcpp_with_negative_offset.addconstantcpp_with_negative_offset, -1),
-    (addconstantpy_with_negative_offset.addconstantpy_with_negative_offset, -1),
+    (addconstantcpp, 0),
+    (addconstantpy, 0),
+    (addconstantcpp_with_offset_42, 42),
+    (addconstantpy_with_offset_42, 42),
+    (addconstantcpp_with_negative_offset, -1),
+    (addconstantpy_with_negative_offset, -1),
 ]
 
 ERROR_THRESHOLD = 0.0001

--- a/python_bindings/test/correctness/bit_test.py
+++ b/python_bindings/test/correctness/bit_test.py
@@ -1,4 +1,5 @@
-import bitcpp, bitpy
+from bitcpp import bitcpp
+from bitpy import bitpy
 import numpy as np
 
 
@@ -26,5 +27,5 @@ def test(fn):
 
 
 if __name__ == "__main__":
-    test(bitcpp.bitcpp)
-    test(bitpy.bitpy)
+    test(bitcpp)
+    test(bitpy)

--- a/python_bindings/test/correctness/iroperator.py
+++ b/python_bindings/test/correctness/iroperator.py
@@ -1,10 +1,10 @@
-from contextlib import contextmanager
+import contextlib
 import halide as hl
 import sys
-from io import StringIO
+import io
 
 # redirect_stdout() requires Python3, alas
-@contextmanager
+@contextlib.contextmanager
 def _redirect_stdout(out):
     old_out = sys.stdout
     sys.stdout = out
@@ -21,7 +21,7 @@ def test_print_expr():
         hl.cast(hl.UInt(8), x), "is what", "the", 1, "and", hl.f32(3.1415), "saw"
     )
     buf = hl.Buffer(hl.UInt(8), [1])
-    output = StringIO()
+    output = io.StringIO()
     with _redirect_stdout(output):
         f.realize(buf)
         expected = "0 is what the 1 and 3.141500 saw\n"
@@ -34,7 +34,7 @@ def test_print_when():
     f = hl.Func("f")
     f[x] = hl.print_when(x == 3, hl.cast(hl.UInt(8), x * x), "is result at", x)
     buf = hl.Buffer(hl.UInt(8), [10])
-    output = StringIO()
+    output = io.StringIO()
     with _redirect_stdout(output):
         f.realize(buf)
         expected = "9 is result at 3\n"

--- a/python_bindings/test/correctness/multi_method_module_test.py
+++ b/python_bindings/test/correctness/multi_method_module_test.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import multi_method_module
+from multi_method_module import simplecpp, user_context
 
 
 def test_simplecpp():
@@ -14,7 +14,7 @@ def test_simplecpp():
 
     simple_output = np.ndarray([2, 2], dtype=np.float32)
 
-    multi_method_module.simplecpp(buffer_input, float_arg, simple_output)
+    simplecpp(buffer_input, float_arg, simple_output)
 
     assert simple_output[0, 0] == 3.5 + 123
     assert simple_output[0, 1] == 3.5 + 123
@@ -24,7 +24,7 @@ def test_simplecpp():
 
 def test_user_context():
     output = bytearray("\0\0\0\0", "ascii")
-    multi_method_module.user_context(None, ord("q"), output)
+    user_context(None, ord("q"), output)
     assert output == bytearray("qqqq", "ascii")
 
 
@@ -34,7 +34,7 @@ def test_aot_call_failure_throws_exception():
     simple_output = np.zeros([2, 2], dtype=np.float32)
 
     try:
-        multi_method_module.simplecpp(buffer_input, float_arg, simple_output)
+        simplecpp(buffer_input, float_arg, simple_output)
     except RuntimeError as e:
         assert "Halide Runtime Error: -3" in str(e), str(e)
     else:

--- a/python_bindings/test/correctness/realize_warnings.py
+++ b/python_bindings/test/correctness/realize_warnings.py
@@ -1,6 +1,6 @@
 import halide as hl
-from io import StringIO
-from contextlib import redirect_stdout
+import io
+import contextlib
 
 
 def test_warnings():
@@ -17,8 +17,8 @@ def test_warnings():
         "the function is scheduled inline.\n"
     )
 
-    buffer = StringIO()
-    with redirect_stdout(buffer):
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
         g.realize([16])
 
     buffer.seek(0)

--- a/python_bindings/test/correctness/user_context_test.py
+++ b/python_bindings/test/correctness/user_context_test.py
@@ -1,10 +1,10 @@
 import array
-import user_context
+from user_context import user_context
 
 
 def test():
     output = bytearray("\0\0\0\0", "ascii")
-    user_context.user_context(None, ord("q"), output)
+    user_context(None, ord("q"), output)
     assert output == bytearray("qqqq", "ascii")
 
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1,3 +1,4 @@
+
 #include <atomic>
 #include <cmath>
 #include <condition_variable>

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1,4 +1,3 @@
-
 #include <atomic>
 #include <cmath>
 #include <condition_variable>


### PR DESCRIPTION
This change makes it a bit easier for me to transform the import paths when merging into Google: we can't set PYTHONPATH, and calling `sys.path.append()` is frowned upon. This should have no effect on the GitHub repo but will make my life easier downstream.