### PR TITLE
Fix metadata generation for multitarget Generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1523,7 +1523,7 @@ METADATA_TESTER_GENERATOR_ARGS=\
 # the metadata names are correctly emitted.
 $(FILTERS_DIR)/metadata_tester.a: $(BIN_DIR)/metadata_tester.generator
 	@mkdir -p $(@D)
-	$(CURDIR)/$< -g metadata_tester -f metadata_tester -e static_library,c_header,function_info_header -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime,$(TARGET)-no_runtime-no_bounds_query $(METADATA_TESTER_GENERATOR_ARGS)
+	$(CURDIR)/$< -g metadata_tester -f metadata_tester -e static_library,c_header,registration,function_info_header -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime,$(TARGET)-no_runtime-no_bounds_query $(METADATA_TESTER_GENERATOR_ARGS)
 
 # c_source output doesn't work properly with multitarget output
 $(FILTERS_DIR)/metadata_tester.halide_generated.cpp: $(BIN_DIR)/metadata_tester.generator

--- a/Makefile
+++ b/Makefile
@@ -1518,10 +1518,12 @@ METADATA_TESTER_GENERATOR_ARGS=\
 	array_outputs8.size=2 \
 	array_outputs9.size=2
 
-# metadata_tester is built with and without user-context
+# metadata_tester is built with and without user-context.
+# Also note that metadata_tester (but not metadata_tester_ucon) is built as "multitarget" to verify that
+# the metadata names are correctly emitted.
 $(FILTERS_DIR)/metadata_tester.a: $(BIN_DIR)/metadata_tester.generator
 	@mkdir -p $(@D)
-	$(CURDIR)/$< -g metadata_tester -f metadata_tester $(GEN_AOT_OUTPUTS),function_info_header -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime $(METADATA_TESTER_GENERATOR_ARGS)
+	$(CURDIR)/$< -g metadata_tester -f metadata_tester $(GEN_AOT_OUTPUTS),function_info_header -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime,$(TARGET)-no_runtime-no_bounds_query $(METADATA_TESTER_GENERATOR_ARGS)
 
 $(FILTERS_DIR)/metadata_tester_ucon.a: $(BIN_DIR)/metadata_tester.generator
 	@mkdir -p $(@D)

--- a/Makefile
+++ b/Makefile
@@ -1523,7 +1523,12 @@ METADATA_TESTER_GENERATOR_ARGS=\
 # the metadata names are correctly emitted.
 $(FILTERS_DIR)/metadata_tester.a: $(BIN_DIR)/metadata_tester.generator
 	@mkdir -p $(@D)
-	$(CURDIR)/$< -g metadata_tester -f metadata_tester $(GEN_AOT_OUTPUTS),function_info_header -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime,$(TARGET)-no_runtime-no_bounds_query $(METADATA_TESTER_GENERATOR_ARGS)
+	$(CURDIR)/$< -g metadata_tester -f metadata_tester -e static_library,c_header,function_info_header -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime,$(TARGET)-no_runtime-no_bounds_query $(METADATA_TESTER_GENERATOR_ARGS)
+
+# c_source output doesn't work properly with multitarget output
+$(FILTERS_DIR)/metadata_tester.halide_generated.cpp: $(BIN_DIR)/metadata_tester.generator
+	@mkdir -p $(@D)
+	$(CURDIR)/$< -g metadata_tester -f metadata_tester -e c_source -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime $(METADATA_TESTER_GENERATOR_ARGS)
 
 $(FILTERS_DIR)/metadata_tester_ucon.a: $(BIN_DIR)/metadata_tester.generator
 	@mkdir -p $(@D)

--- a/src/Module.h
+++ b/src/Module.h
@@ -139,7 +139,7 @@ class Module {
     Internal::IntrusivePtr<Internal::ModuleContents> contents;
 
 public:
-    Module(const std::string &name, const Target &target);
+    Module(const std::string &name, const Target &target, const MetadataNameMap &metadata_name_map = {});
 
     /** Get the target this module has been lowered for. */
     const Target &target() const;

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -332,9 +332,12 @@ set(metadata_tester_params
     array_outputs8.size=2
     array_outputs9.size=2)
 
+# Note that metadata_tester (but not metadata_tester_ucon) is built as "multitarget" to verify that
+# the metadata names are correctly emitted.
 halide_define_aot_test(metadata_tester
                        EXTRA_LIBS metadata_tester_ucon
                        PARAMS ${metadata_tester_params}
+                       GEN_TARGET cmake-no_bounds_query cmake
                        EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
 add_halide_library(metadata_tester_ucon
                    FROM metadata_tester.generator

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -334,10 +334,18 @@ set(metadata_tester_params
 
 # Note that metadata_tester (but not metadata_tester_ucon) is built as "multitarget" to verify that
 # the metadata names are correctly emitted.
+if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
+    # wasm doesn't support multitargets
+    # TODO: currently, Halide_CMAKE_TARGET == Halide_HOST_TARGET when building for Emscripten; we should fix this
+    set(MDT_TARGETS ${Halide_TARGET})
+else()
+    set(MDT_TARGETS cmake-no_bounds_query cmake)
+endif()
+
 halide_define_aot_test(metadata_tester
                        EXTRA_LIBS metadata_tester_ucon
                        PARAMS ${metadata_tester_params}
-                       GEN_TARGET cmake-no_bounds_query cmake
+                       GEN_TARGET ${MDT_TARGETS}
                        EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
 add_halide_library(metadata_tester_ucon
                    FROM metadata_tester.generator


### PR DESCRIPTION
We had a mechanism in place to ensure that Outputs that got renamed during lowering still emitted the proper names in the metadata... but this didn't work reliably for Multitarget generation. Now it does.