### PR TITLE
Disable unreachable-code clang-tidy warnings

### DIFF
--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -1583,27 +1583,23 @@ int main(int argc, char **argv) {
 
     constexpr auto sig = compute_signature(metadata_tester_argument_info());
     if (strcmp(&sig[0], "@@@@i?bhiqBHIQfdP@@@@@@@bbbbhhhhiiiiPP@@@@@@@@@@@@@@@@@@B#############################")) {
+        // NOLINTNEXTLINE(clang-diagnostic-unreachable-code)
         std::cerr << "Incorrect signature for metadata_tester_ucon_argument_info(): " << &sig[0] << "\n";
         exit(-1);
     }
 
     constexpr auto usig = compute_signature(metadata_tester_ucon_argument_info());
     if (strcmp(&usig[0], "P@@@@i?bhiqBHIQfdP@@@@@@@bbbbhhhhiiiiPP@@@@@@@@@@@@@@@@@@B#############################")) {
+        // NOLINTNEXTLINE(clang-diagnostic-unreachable-code)
         std::cerr << "Incorrect signature for metadata_tester_ucon_argument_info(): " << &usig[0] << "\n";
         exit(-1);
     }
 
     constexpr size_t count = count_buffers(metadata_tester_argument_info());
-    if (count != 58) {
-        std::cerr << "Incorrect buffer count for metadata_tester_argument_info(): " << count << "\n";
-        exit(-1);
-    }
+    static_assert(count == 58, "Incorrect buffer count for metadata_tester_argument_info");
 
     constexpr size_t ucount = count_buffers(metadata_tester_ucon_argument_info());
-    if (ucount != 58) {
-        std::cerr << "Incorrect buffer count for metadata_tester_ucon_argument_info(): " << ucount << "\n";
-        exit(-1);
-    }
+    static_assert(ucount == 58, "Incorrect buffer count for metadata_tester_ucon_argument_info");
 
     std::cout << "Success!\n";
     return 0;


### PR DESCRIPTION
Some configurations of clang-tidy will (correctly) complain that the code inside the `if` clauses here will never be executed, since it ends up as something like `if (strcmp("foo", "foo"))`... but for testing purposes, we want to keep it, for obvious reasons. It's hard to construct a string-compare here as constexpr, so I'm just going to NOLINT it.

Also changed the `count_buffers()` check to a static_assert for simplicity.