### PR TITLE
Use aligned_alloc() as default allocator for halide_malloc() on most platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -751,10 +751,11 @@ HEADERS = $(HEADER_FILES:%.h=$(SRC_DIR)/%.h)
 
 RUNTIME_CPP_COMPONENTS = \
   aarch64_cpu_features \
+  aligned_alloc_allocator \
   alignment_128 \
   alignment_32 \
-  allocation_cache \
   alignment_64 \
+  allocation_cache \
   android_clock \
   android_host_cpu_count \
   android_io \
@@ -778,8 +779,8 @@ RUNTIME_CPP_COMPONENTS = \
   halide_buffer_t \
   hexagon_cache_allocator \
   hexagon_cpu_features \
-  hexagon_dma_pool \
   hexagon_dma \
+  hexagon_dma_pool \
   hexagon_host \
   ios_io \
   linux_clock \
@@ -794,9 +795,9 @@ RUNTIME_CPP_COMPONENTS = \
   msan \
   msan_stubs \
   opencl \
-  openglcompute \
   opengl_egl_context \
   opengl_glx_context \
+  openglcompute \
   osx_clock \
   osx_get_symbol \
   osx_host_cpu_count \

--- a/apps/hannk/interpreter/interpreter.cpp
+++ b/apps/hannk/interpreter/interpreter.cpp
@@ -9,7 +9,6 @@
 #include <set>
 #include <unordered_set>
 
-// TODO: apparently not part of the public Halide API. Should it be?
 extern "C" int halide_malloc_alignment();
 
 namespace hannk {

--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -184,7 +184,7 @@ void define_enums(py::module &m) {
         .value("SanitizerCoverage", Target::Feature::SanitizerCoverage)
         .value("ProfileByTimer", Target::Feature::ProfileByTimer)
         .value("SPIRV", Target::Feature::SPIRV)
-        .value("AlignedAlloc", Target::Feature::AlignedAlloc)
+        .value("NoAlignedAlloc", Target::Feature::NoAlignedAlloc)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -184,6 +184,7 @@ void define_enums(py::module &m) {
         .value("SanitizerCoverage", Target::Feature::SanitizerCoverage)
         .value("ProfileByTimer", Target::Feature::ProfileByTimer)
         .value("SPIRV", Target::Feature::SPIRV)
+        .value("AlignedAlloc", Target::Feature::AlignedAlloc)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -77,6 +77,7 @@ std::unique_ptr<llvm::Module> parse_bitcode_file(llvm::StringRef buf, llvm::LLVM
 DECLARE_CPP_INITMOD(alignment_128)
 DECLARE_CPP_INITMOD(alignment_32)
 DECLARE_CPP_INITMOD(alignment_64)
+DECLARE_CPP_INITMOD(aligned_alloc_allocator)
 DECLARE_CPP_INITMOD(allocation_cache)
 DECLARE_CPP_INITMOD(android_clock)
 DECLARE_CPP_INITMOD(android_host_cpu_count)
@@ -817,6 +818,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
     bool bits_64 = (t.bits == 64);
     bool debug = t.has_feature(Target::Debug);
     bool tsan = t.has_feature(Target::TSAN);
+    bool aligned_alloc = t.has_feature(Target::AlignedAlloc);
 
     vector<std::unique_ptr<llvm::Module>> modules;
 
@@ -824,7 +826,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
         if (module_type != ModuleJITInlined && module_type != ModuleAOTNoRuntime) {
             // OS-dependent modules
             if (t.os == Target::Linux) {
-                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                if (aligned_alloc) {
+                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                }
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 if (t.arch == Target::X86) {
@@ -842,7 +848,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::WebAssemblyRuntime) {
-                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                if (aligned_alloc) {
+                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                }
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -857,7 +867,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_fake_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::OSX) {
-                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                if (aligned_alloc) {
+                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                }
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_osx_clock(c, bits_64, debug));
@@ -872,7 +886,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_osx_get_symbol(c, bits_64, debug));
                 modules.push_back(get_initmod_osx_host_cpu_count(c, bits_64, debug));
             } else if (t.os == Target::Android) {
-                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                if (aligned_alloc) {
+                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                }
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 if (t.arch == Target::ARM) {
@@ -890,7 +908,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::Windows) {
-                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                if (aligned_alloc) {
+                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                }
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_windows_clock(c, bits_64, debug));
@@ -903,7 +925,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_windows_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::IOS) {
-                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                if (aligned_alloc) {
+                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                }
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -916,6 +942,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                     modules.push_back(get_initmod_posix_threads(c, bits_64, debug));
                 }
             } else if (t.os == Target::QuRT) {
+                // QuRT ignores aligned_alloc and always uses its own allocator
                 modules.push_back(get_initmod_qurt_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_qurt_yield(c, bits_64, debug));
                 if (tsan) {
@@ -934,7 +961,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));
             } else if (t.os == Target::Fuchsia) {
-                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                if (aligned_alloc) {
+                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
+                }
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_fuchsia_clock(c, bits_64, debug));

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -818,7 +818,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
     bool bits_64 = (t.bits == 64);
     bool debug = t.has_feature(Target::Debug);
     bool tsan = t.has_feature(Target::TSAN);
-    bool aligned_alloc = t.has_feature(Target::AlignedAlloc);
+    bool aligned_alloc = !t.has_feature(Target::NoAlignedAlloc);
 
     vector<std::unique_ptr<llvm::Module>> modules;
 

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -908,11 +908,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::Windows) {
-                if (aligned_alloc) {
-                    modules.push_back(get_initmod_aligned_alloc_allocator(c, bits_64, debug));
-                } else {
-                    modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
-                }
+                // Never try to use aligned_alloc on Windows: it's not supported,
+                // and Microsoft has indicated that they likely never will.
+                // They do provide _aligned_alloc()/_aligned_free(), but that is essentially
+                // identical to our posix_allocator, so we won't bother specializing.
+                modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_windows_clock(c, bits_64, debug));

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -529,7 +529,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sanitizer_coverage", Target::SanitizerCoverage},
     {"profile_by_timer", Target::ProfileByTimer},
     {"spirv", Target::SPIRV},
-    {"aligned_alloc", Target::AlignedAlloc},
+    {"no_aligned_alloc", Target::NoAlignedAlloc},
     // NOTE: When adding features to this map, be sure to update PyEnums.cpp as well.
 };
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -529,6 +529,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sanitizer_coverage", Target::SanitizerCoverage},
     {"profile_by_timer", Target::ProfileByTimer},
     {"spirv", Target::SPIRV},
+    {"aligned_alloc", Target::AlignedAlloc},
     // NOTE: When adding features to this map, be sure to update PyEnums.cpp as well.
 };
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -162,6 +162,7 @@ struct Target {
         SanitizerCoverage = halide_target_feature_sanitizer_coverage,
         ProfileByTimer = halide_target_feature_profile_by_timer,
         SPIRV = halide_target_feature_spirv,
+        AlignedAlloc = halide_target_feature_aligned_alloc,
         FeatureEnd = halide_target_feature_end
     };
     Target() = default;

--- a/src/Target.h
+++ b/src/Target.h
@@ -162,7 +162,7 @@ struct Target {
         SanitizerCoverage = halide_target_feature_sanitizer_coverage,
         ProfileByTimer = halide_target_feature_profile_by_timer,
         SPIRV = halide_target_feature_spirv,
-        AlignedAlloc = halide_target_feature_aligned_alloc,
+        NoAlignedAlloc = halide_target_feature_no_aligned_alloc,
         FeatureEnd = halide_target_feature_end
     };
     Target() = default;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Keep these lists in alphabetical order.
 set(RUNTIME_CPP
     aarch64_cpu_features
+    aligned_alloc_allocator
     alignment_128
     alignment_32
     alignment_64
@@ -81,8 +82,8 @@ set(RUNTIME_CPP
     wasm_cpu_features
     windows_clock
     windows_cuda
-    windows_d3d12compute_x86
     windows_d3d12compute_arm
+    windows_d3d12compute_x86
     windows_get_symbol
     windows_io
     windows_opencl

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1366,6 +1366,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_sanitizer_coverage,     ///< Enable hooks for SanitizerCoverage support.
     halide_target_feature_profile_by_timer,       ///< Alternative to halide_target_feature_profile using timer interrupt for systems without threads or applicartions that need to avoid them.
     halide_target_feature_spirv,                  ///< Enable SPIR-V code generation support.
+    halide_target_feature_aligned_alloc,          ///< Use aligned_alloc() instead of malloc().
     halide_target_feature_end                     ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1366,7 +1366,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_sanitizer_coverage,     ///< Enable hooks for SanitizerCoverage support.
     halide_target_feature_profile_by_timer,       ///< Alternative to halide_target_feature_profile using timer interrupt for systems without threads or applicartions that need to avoid them.
     halide_target_feature_spirv,                  ///< Enable SPIR-V code generation support.
-    halide_target_feature_aligned_alloc,          ///< Use aligned_alloc() instead of malloc().
+    halide_target_feature_no_aligned_alloc,       ///< Never attempt to use aligned_alloc() (use malloc() instead).
     halide_target_feature_end                     ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -364,13 +364,17 @@ extern int halide_set_num_threads(int n);
  * halide_default_malloc/free.
  *
  * Note that halide_malloc must return a pointer aligned to the
- * maximum meaningful alignment for the platform for the purpose of
- * vector loads and stores. The default implementation uses 32-byte
- * alignment, which is safe for arm and x86. Additionally, it must be
- * safe to read at least 8 bytes before the start and beyond the
- * end.
+ * the value returned by halide_malloc_alignment(), *and* with allocated size
+ * rounded up to an integral number of "alignments" (i.e., it must honor
+ * the same contract as std::aligned_alloc()).
+ *
+ * The default implementation of halide_malloc_alignment() will be chosen to be
+ * the maximum meaningful alignment for the platform for the purpose of
+ * vector loads and stores for a given architecture. You may override this
+ * function, but bear in mind that it must return the same value for every call.
  */
 //@{
+extern int halide_malloc_alignment();
 extern void *halide_malloc(void *user_context, size_t x);
 extern void halide_free(void *user_context, void *ptr);
 extern void *halide_default_malloc(void *user_context, size_t x);

--- a/src/runtime/aligned_alloc_allocator.cpp
+++ b/src/runtime/aligned_alloc_allocator.cpp
@@ -3,6 +3,19 @@
 
 #include "printer.h"
 
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+
+// Read into a global to avoid making a call to halide_malloc_alignment()
+// in every halide_malloc() call (halide_malloc_alignment() is required to
+// return the same value every time).
+WEAK size_t _alignment = (size_t) halide_malloc_alignment();
+
+}  // namespace Internal
+}  // namespace Runtime
+}  // namespace Halide
+
 extern "C" {
 
 // aligned_alloc() is part of C11, and thus part of C++17, at least in theory...
@@ -15,7 +28,7 @@ extern void *aligned_alloc(size_t alignment, size_t size);
 extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
-    const size_t alignment = halide_malloc_alignment();
+    const size_t alignment = Halide::Runtime::Internal::_alignment;
     // The size parameter for aligned_alloc() must be an integral multiple of alignment.
     const size_t aligned_size = align_up(x, alignment);
     return aligned_alloc(alignment, aligned_size);

--- a/src/runtime/aligned_alloc_allocator.cpp
+++ b/src/runtime/aligned_alloc_allocator.cpp
@@ -10,7 +10,7 @@ namespace Internal {
 // Read into a global to avoid making a call to halide_malloc_alignment()
 // in every halide_malloc() call (halide_malloc_alignment() is required to
 // return the same value every time).
-WEAK size_t _alignment = (size_t) halide_malloc_alignment();
+WEAK size_t _alignment = (size_t)halide_malloc_alignment();
 
 }  // namespace Internal
 }  // namespace Runtime

--- a/src/runtime/aligned_alloc_allocator.cpp
+++ b/src/runtime/aligned_alloc_allocator.cpp
@@ -5,26 +5,24 @@
 
 extern "C" {
 
-extern void *malloc(size_t);
+// aligned_alloc() is part of C11, and thus part of C++17, at least in theory...
+// Frustratingly, it still isn't available everywhere (e.g. on Android,
+// even when compiling with C++17, you must specify a certain SDK level),
+// so we can't use it unconditionally, which is why it's not used in the
+// standard posix_allocator.
+
+extern void *aligned_alloc(size_t alignment, size_t size);
 extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
-    // Allocate enough space for aligning the pointer we return.
     const size_t alignment = halide_malloc_alignment();
-    void *orig = malloc(x + alignment);
-    if (orig == nullptr) {
-        // Will result in a failed assertion and a call to halide_error
-        return nullptr;
-    }
-
-    // We want to store the original pointer prior to the pointer we return.
-    void *ptr = (void *)align_up((uintptr_t)orig + sizeof(void *), alignment);
-    ((void **)ptr)[-1] = orig;
-    return ptr;
+    // The size parameter for aligned_alloc() must be an integral multiple of alignment.
+    const size_t aligned_size = align_up(x, alignment);
+    return aligned_alloc(alignment, aligned_size);
 }
 
 WEAK void halide_default_free(void *user_context, void *ptr) {
-    free(((void **)ptr)[-1]);
+    free(ptr);
 }
 }
 

--- a/src/runtime/alignment_128.cpp
+++ b/src/runtime/alignment_128.cpp
@@ -1,5 +1,5 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+extern "C" WEAK int halide_malloc_alignment() {
     return 128;
 }

--- a/src/runtime/alignment_32.cpp
+++ b/src/runtime/alignment_32.cpp
@@ -1,5 +1,5 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+extern "C" WEAK int halide_malloc_alignment() {
     return 32;
 }

--- a/src/runtime/alignment_64.cpp
+++ b/src/runtime/alignment_64.cpp
@@ -1,5 +1,5 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+extern "C" WEAK int halide_malloc_alignment() {
     return 64;
 }

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -24,7 +24,7 @@ WEAK void *halide_default_malloc(void *user_context, size_t user_size) {
     // in size, which we can always fit entirely into 2*alignment.
     const size_t requested_size = (aligned_size <= alignment) ?
                                       (alignment * 2) :
-                                      (aligned_size + alignment - 1);
+                                      (aligned_size + alignment);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -19,12 +19,7 @@ WEAK void *halide_default_malloc(void *user_context, size_t user_size) {
     // so that all allocators follow the behavior of aligned_alloc() and
     // return aligned pointer *and* aligned length.
     const size_t aligned_size = align_up(user_size, alignment);
-
-    // We can save a bit of space by special-casing allocations < alignment
-    // in size, which we can always fit entirely into 2*alignment.
-    const size_t requested_size = (aligned_size <= alignment) ?
-                                      (alignment * 2) :
-                                      (aligned_size + alignment);
+    const size_t requested_size = (aligned_size + alignment);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -3,6 +3,19 @@
 
 #include "printer.h"
 
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+
+// Read into a global to avoid making a call to halide_malloc_alignment()
+// in every halide_malloc() call (halide_malloc_alignment() is required to
+// return the same value every time).
+WEAK size_t _alignment = (size_t) halide_malloc_alignment();
+
+}  // namespace Internal
+}  // namespace Runtime
+}  // namespace Halide
+
 extern "C" {
 
 extern void *malloc(size_t);
@@ -10,7 +23,7 @@ extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t user_size) {
     // Allocate enough space for aligning the pointer we return.
-    const size_t alignment = halide_malloc_alignment();
+    const size_t alignment = Halide::Runtime::Internal::_alignment;
 
     // All bets are off if alignment is smaller than a pointer.
     halide_debug_assert(user_context, alignment >= sizeof(void *));

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -10,7 +10,7 @@ namespace Internal {
 // Read into a global to avoid making a call to halide_malloc_alignment()
 // in every halide_malloc() call (halide_malloc_alignment() is required to
 // return the same value every time).
-WEAK size_t _alignment = (size_t) halide_malloc_alignment();
+WEAK size_t _alignment = (size_t)halide_malloc_alignment();
 
 }  // namespace Internal
 }  // namespace Runtime

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -8,7 +8,7 @@ extern "C" {
 extern void *malloc(size_t);
 extern void free(void *);
 
-WEAK void *halide_default_malloc(void *user_context, size_t x) {
+WEAK void *halide_default_malloc(void *user_context, size_t user_size) {
     // Allocate enough space for aligning the pointer we return.
     const size_t alignment = halide_malloc_alignment();
 

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -24,7 +24,7 @@ WEAK void *halide_default_malloc(void *user_context, size_t user_size) {
     // in size, which we can always fit entirely into 2*alignment.
     const size_t requested_size = (aligned_size <= alignment) ?
                                       (alignment * 2) :
-                                      (aligned_size + sizeof(void *) + alignment - 1);
+                                      (aligned_size + alignment - 1);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -23,8 +23,8 @@ WEAK void *halide_default_malloc(void *user_context, size_t user_size) {
     // We can save a bit of space by special-casing allocations < alignment
     // in size, which we can always fit entirely into 2*alignment.
     const size_t requested_size = (aligned_size <= alignment) ?
-                                  (alignment * 2) :
-                                  (aligned_size + sizeof(void *) + alignment - 1);
+                                      (alignment * 2) :
+                                      (aligned_size + sizeof(void *) + alignment - 1);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -19,8 +19,8 @@ WEAK void *aligned_malloc(size_t alignment, size_t user_size) {
     // We can save a bit of space by special-casing allocations < alignment
     // in size, which we can always fit entirely into 2*alignment.
     const size_t requested_size = (aligned_size <= alignment) ?
-                                  (alignment * 2) :
-                                  (aligned_size + sizeof(void *) + alignment - 1);
+                                      (alignment * 2) :
+                                      (aligned_size + sizeof(void *) + alignment - 1);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -63,7 +63,7 @@ WEAK __attribute__((destructor)) void halide_allocator_cleanup() {
 // Read into a global to avoid making a call to halide_malloc_alignment()
 // in every halide_malloc() call (halide_malloc_alignment() is required to
 // return the same value every time).
-WEAK size_t _alignment = (size_t) halide_malloc_alignment();
+WEAK size_t _alignment = (size_t)halide_malloc_alignment();
 
 }  // namespace Internal
 }  // namespace Runtime

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -15,7 +15,7 @@ WEAK void *aligned_malloc(size_t alignment, size_t size) {
     size = align_up(size, alignment);
 
     // Allocate enough space for aligning the pointer we return.
-    void *orig = malloc(size + alignment * 2);
+    void *orig = malloc(size + alignment);
     if (orig == nullptr) {
         // Will result in a failed assertion and a call to halide_error
         return nullptr;

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -20,7 +20,7 @@ WEAK void *aligned_malloc(size_t alignment, size_t user_size) {
     // in size, which we can always fit entirely into 2*alignment.
     const size_t requested_size = (aligned_size <= alignment) ?
                                       (alignment * 2) :
-                                      (aligned_size + alignment - 1);
+                                      (aligned_size + alignment);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -20,7 +20,7 @@ WEAK void *aligned_malloc(size_t alignment, size_t user_size) {
     // in size, which we can always fit entirely into 2*alignment.
     const size_t requested_size = (aligned_size <= alignment) ?
                                       (alignment * 2) :
-                                      (aligned_size + sizeof(void *) + alignment - 1);
+                                      (aligned_size + alignment - 1);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -1,7 +1,6 @@
 #include "HalideRuntime.h"
 
 extern "C" {
-
 extern void *malloc(size_t);
 extern void free(void *);
 }
@@ -61,13 +60,18 @@ WEAK __attribute__((destructor)) void halide_allocator_cleanup() {
     }
 }
 
+// Read into a global to avoid making a call to halide_malloc_alignment()
+// in every halide_malloc() call (halide_malloc_alignment() is required to
+// return the same value every time).
+WEAK size_t _alignment = (size_t) halide_malloc_alignment();
+
 }  // namespace Internal
 }  // namespace Runtime
 }  // namespace Halide
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
     // Hexagon needs up to 128 byte alignment.
-    const size_t alignment = 128;
+    const size_t alignment = Halide::Runtime::Internal::_alignment;
 
     if (x <= buffer_size) {
         for (int i = 0; i < num_buffers; ++i) {

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -12,10 +12,10 @@ namespace Internal {
 
 WEAK void *aligned_malloc(size_t alignment, size_t size) {
     // We also need to align the size of the buffer.
-    size = (size + alignment - 1) & ~(alignment - 1);
+    size = align_up(size, alignment);
 
     // Allocate enough space for aligning the pointer we return.
-    void *orig = malloc(size + alignment);
+    void *orig = malloc(size + alignment * 2);
     if (orig == nullptr) {
         // Will result in a failed assertion and a call to halide_error
         return nullptr;

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -15,12 +15,7 @@ WEAK void *aligned_malloc(size_t alignment, size_t user_size) {
     // so that all allocators follow the behavior of aligned_alloc() and
     // return aligned pointer *and* aligned length.
     const size_t aligned_size = align_up(user_size, alignment);
-
-    // We can save a bit of space by special-casing allocations < alignment
-    // in size, which we can always fit entirely into 2*alignment.
-    const size_t requested_size = (aligned_size <= alignment) ?
-                                      (alignment * 2) :
-                                      (aligned_size + alignment);
+    const size_t requested_size = (aligned_size + alignment);
 
     // malloc() and friends must return a pointer aligned to at least
     // alignof(std::max_align_t); we can't reasonably check that in

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -114,6 +114,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_join_thread,
     (void *)&halide_load_library,
     (void *)&halide_malloc,
+    (void *)&halide_malloc_alignment,
     (void *)&halide_memoization_cache_cleanup,
     (void *)&halide_memoization_cache_evict,
     (void *)&halide_memoization_cache_lookup,

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -201,6 +201,11 @@ void halide_thread_yield();
 
 }  // extern "C"
 
+template<typename T>
+ALWAYS_INLINE T align_up(T p, size_t alignment) {
+    return (p + alignment - 1) & ~(alignment - 1);
+}
+
 namespace {
 template<typename T>
 ALWAYS_INLINE void swap(T &a, T &b) {

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -195,7 +195,7 @@ struct halide_pseudostack_slot_t {
 WEAK void halide_use_jit_module();
 WEAK void halide_release_jit_module();
 
-WEAK_INLINE int halide_malloc_alignment();
+WEAK int halide_malloc_alignment();
 
 void halide_thread_yield();
 

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -6,6 +6,7 @@ tests(GROUPS correctness_multi_gpu
 tests(GROUPS correctness
       SOURCES
       align_bounds.cpp
+      allocator_alignment.cpp
       argmax.cpp
       async_device_copy.cpp
       autodiff.cpp

--- a/test/correctness/allocator_alignment.cpp
+++ b/test/correctness/allocator_alignment.cpp
@@ -32,7 +32,7 @@ void run_test(Target t) {
 
             out_(x, y) = u32_sat(copy(x, y) + offset_);
 
-            copy.compute_root().vectorize(x, natural_vector_size<uint32_t>());
+            copy.compute_root().store_in(MemoryType::Heap).vectorize(x, natural_vector_size<uint32_t>());
             out_.vectorize(x, natural_vector_size<uint32_t>());
         }
     };

--- a/test/correctness/allocator_alignment.cpp
+++ b/test/correctness/allocator_alignment.cpp
@@ -93,6 +93,10 @@ void run_test(Target t) {
 
 int main(int argc, char **argv) {
     const Target t = get_jit_target_from_environment();
+    if (t.arch == Target::WebAssembly) {
+        printf("[SKIP] This test is too slow for Wasm.\n");
+        return 0;
+    }
 
     printf("Testing with malloc()... ");
     run_test(t.with_feature(Target::NoAlignedAlloc));

--- a/test/correctness/allocator_alignment.cpp
+++ b/test/correctness/allocator_alignment.cpp
@@ -1,0 +1,104 @@
+#include "Halide.h"
+#include "halide_benchmark.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::ConciseCasts;
+
+namespace {
+
+void check(int r) {
+    assert(r == 0);
+}
+
+void run_test(Target t) {
+    // Must call this so that the changes in cached runtime are noticed
+    Halide::Internal::JITSharedRuntime::release_all();
+
+    class TestGen1 : public Generator<TestGen1> {
+    public:
+        Input<Buffer<uint32_t, 2>> img_{"img"};
+        Input<uint32_t> offset_{"offset"};
+        Output<Buffer<uint32_t, 2>> out_{"out"};
+
+        void generate() {
+            Var x("x"), y("y");
+
+            // Make a copy so that halide_malloc() is called by the generated
+            // code (since Halide::Runtime::Buffer doesn't use halid_malloc(),
+            // see https://github.com/halide/Halide/issues/7188).
+            Func copy("copy");
+            copy(x, y) = img_(x, y);
+
+            out_(x, y) = u32_sat(copy(x, y) + offset_);
+
+            copy.compute_root().vectorize(x, natural_vector_size<uint32_t>());
+            out_.vectorize(x, natural_vector_size<uint32_t>());
+        }
+    };
+
+    // Make it large enough so that we won't attempt to use stack instead of heap
+    const int W = t.natural_vector_size<uint32_t>() * 256;
+    const int H = 2048;
+
+    Buffer<uint32_t> in1(W, H);
+    Buffer<uint32_t> in2(W, H);
+
+    for (int i = 0; i < W; i++) {
+        for (int j = 0; j < H; j++) {
+            in1(i, j) = i + j * 10;
+            in2(i, j) = i * 10 + j;
+        }
+    }
+
+    const GeneratorContext context(t);
+
+    auto gen = TestGen1::create(context);
+    Callable c = gen->compile_to_callable();
+
+    const uint32_t offset1 = 42;
+    Buffer<uint32_t> out1(W, H);
+    check(c(in1, offset1, out1));
+
+    const uint32_t offset2 = 22;
+    Buffer<uint32_t> out2(W, H);
+    check(c(in2, offset2, out2));
+
+    const uint32_t offset3 = 12;
+    Buffer<uint32_t> out3(W, H);
+    check(c(in1, offset3, out3));
+
+    const uint32_t offset4 = 16;
+    Buffer<uint32_t> out4(W, H);
+    check(c(in2, offset4, out4));
+
+    for (int i = 0; i < W; i++) {
+        for (int j = 0; j < H; j++) {
+            assert(out1(i, j) == i + j * 10 + offset1);
+            assert(out2(i, j) == i * 10 + j + offset2);
+            assert(out3(i, j) == i + j * 10 + offset3);
+            assert(out4(i, j) == i * 10 + j + offset4);
+        }
+    }
+
+    // Now run a benchmark, but don't check it
+    double time = Halide::Tools::benchmark(10, 100, [&]() {
+        check(c(in2, offset4, out4));
+    });
+    const float megapixels = (W * H) / (1024.f * 1024.f);
+    printf("Benchmark: %dx%d -> %f mpix/s for %s\n", W, H, megapixels / time, t.to_string().c_str());
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    const Target t = get_jit_target_from_environment();
+
+    printf("Testing default allocator... ");
+    run_test(t.without_feature(Target::AlignedAlloc));
+
+    printf("Testing aligned allocator... ");
+    run_test(t.with_feature(Target::AlignedAlloc));
+
+    printf("Success!\n");
+}

--- a/test/correctness/allocator_alignment.cpp
+++ b/test/correctness/allocator_alignment.cpp
@@ -94,11 +94,11 @@ void run_test(Target t) {
 int main(int argc, char **argv) {
     const Target t = get_jit_target_from_environment();
 
-    printf("Testing default allocator... ");
-    run_test(t.without_feature(Target::AlignedAlloc));
+    printf("Testing with malloc()... ");
+    run_test(t.with_feature(Target::NoAlignedAlloc));
 
-    printf("Testing aligned allocator... ");
-    run_test(t.with_feature(Target::AlignedAlloc));
+    printf("Testing with aligned_alloc()... ");
+    run_test(t.without_feature(Target::NoAlignedAlloc));
 
     printf("Success!\n");
 }


### PR DESCRIPTION
C++17 includes C11, which includes `aligned_alloc` as part of the standard library. We should move to prefer using it over `malloc()` in `halide_malloc()`, since we currently have to do an overallocate-and-adjust trick with malloc() to get what we want.

We can't move to it everywhere, alas, because:
- Older versions of Android (before Android 9) and OSX (before 10.15) don't support them regardless of your compiler version
- Microsoft has stated that they are unlikely to *ever* support it, as they map malloc() directly onto Win32 APIs and apparently those APIs don't offer any aligned-allocation options, oddly enough
- Hexagon/QuRT I left as-is, because I'm not sure about whether `aligned_alloc` is offered there and if so, what version. (Would welcome input from @pranavb-ca et al on this)

That said, on ~all modern Unixy platforms, it should be available and arguably preferable, so this PR makes it the default, with a `no_aligned_alloc` feature to allow dropping back to using plain malloc()-with-hackery. (This option is ignored for Windows and QuRT, of course.)

It's worth pointing out that this subtlely modifies the (implicit) contract of `halide_malloc`: in addition to guaranteeing that the returned pointer is aligned to `halide_malloc_alignment()`, the `aligned_alloc()` allocator also requires/guarantees that the memory returned is an integral number of align-sizes long (rounding up, obviously). In order to avoid subtle behavior differences between the two malloc-based allocators remaining (posix and qurt) I modified them to also make the same guarantee. (I guess I should document this and make sure that all the overrides of `halide_malloc()` I know of in Google and other places make this same guarantee...)

I considered adding a new `halide_aligned_alloc()` runtime function instead, and then migrating all the calls we make for buffer memory there (since that's the only place we really care about this alignment), leaving `halide_malloc()` to be used for whatever places we need to allocate memory that doesn't need special alignment... but (1) I'm not sure if there are enough of the latter to be worthwhile, and (2) we'd have to 'dumb down' `halide_malloc()` to make the exercise worthwhile, and that would leave us risk of hard-to-repro crashes if we got one of the allocations wrong.

This will likely need some torture testing, since it's possible that some platforms offer `aligned_alloc` but with inferior performance.



