### PR TITLE
[RISC-V] Do not add vector intrinsics with lanes=1

### DIFF
--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -228,6 +228,9 @@ void CodeGen_RISCV::init_module() {
                     if ((intrin.ret_type.relative_scale * bit_width_scale * intrin.ret_type.type.bits()) > 64) {
                         break;
                     }
+                    if (intrin.riscv_name[0] == 'v' && !ret_type.is_vector()) {
+                        break;
+                    }
 
                     for (const auto &arg_type : intrin.arg_types) {
                         if (arg_type.type_pattern == IntrinsicArgPattern::Undefined) {


### PR DESCRIPTION
Currently, LLVM throws the following error when `vector_bits=64`:
```
Intrinsic has incorrect return type!
ptr @llvm.riscv.vaadd.i64.i64.i64
Intrinsic has incorrect return type!
ptr @llvm.riscv.vaaddu.i64.i64.i64
```
corresponding intrinsic code:
```
; Function Attrs: alwaysinline nounwind
define internal i64 @"halving_add_wrapper$3"(i64 %0, i64 %1) #9 {
entry:
  call void asm sideeffect "csrw vxrm,${0:z}", "rJ,~{memory}"(i64 2)
  %2 = call i64 @llvm.riscv.vaadd.i64.i64.i64(i64 undef, i64 %0, i64 %1, i64 1)
  ret i64 %2
}
```

<details>
<summary>Printer</summary>

```patch
--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -381,6 +381,11 @@ llvm::Function *CodeGen_RISCV::define_riscv_intrinsic_wrapper(const RISCVIntrins
     function_does_not_access_memory(wrapper);
     wrapper->addFnAttr(llvm::Attribute::NoUnwind);
 
+    std::string str;
+    llvm::raw_string_ostream output(str);
+    wrapper->print(output);
+    std::cout << str << std::endl;
+
     llvm::verifyFunction(*wrapper);
     return wrapper;
 }
```
</details>

<details>
<summary>Reproducer</summary>

```cpp
#include <Halide.h>

using namespace Halide;

const int width = 640;
const int height = 480;

int main(int argc, char** argv) {
    Func f("f");
    Buffer<uint8_t> input(width, height);

    Var x("x"), y("y");
    f(x, y) = input(x, y);

    f.vectorize(x, 8);

    Target target = get_host_target();
    target.vector_bits = 8 * sizeof(uint8_t) * 8;

    std::vector<Target::Feature> features;
    features.push_back(Target::RVV);
    target.set_features(features);

    std::cout << target << std::endl;

    f.print_loop_nest();

    Buffer<uint8_t> output(width, height);
    f.realize(output, target);
}
```

</details>

Solution is to enable `vaadd` and others with `<vscale x 1 x i64>` or just skip as proposed in this PR.