### PR TITLE
Add a -v flag to generator_main()

### DIFF
--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3934,6 +3934,9 @@ struct ExecuteGeneratorArgs {
 
     // Compiler Logger to use, for diagnostic work. If null, don't do any logging.
     CompilerLoggerFactory compiler_logger_factory = nullptr;
+
+    // If true, log the path of all output files to stdout.
+    bool log_outputs = false;
 };
 
 /**


### PR DESCRIPTION
This is a simple thing that just logs the path to all generated file(s) to stdout if `-v=1` is specified. It's intended for people running Generators directly from the commandline, and is intended as a more user-friendly alternative to HL_DEBUG_CODEGEN=1. No makefiles, etc specify it at present, but I anticipate using it in some tooling in the future.

Example usage:
```
$ resize_image_bilinear.generator_binary -v 1 -o /tmp -g resize_image_bilinear -n resize_image_bilinear_uint16 -f resize_image_bilinear_uint16 -e assembly,c_header,llvm_assembly,registration,static_library,stmt 'target=arm-64-android' 'input.type=uint16' 'output.type=uint16'
Generated file: /tmp/resize_image_bilinear_uint16.s
Generated file: /tmp/resize_image_bilinear_uint16.h
Generated file: /tmp/resize_image_bilinear_uint16.ll
Generated file: /tmp/resize_image_bilinear_uint16.registration.cpp
Generated file: /tmp/resize_image_bilinear_uint16.a
Generated file: /tmp/resize_image_bilinear_uint16.stmt
```