### PR TITLE
Tighten alignment promises for halide_malloc() + use aligned_alloc()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -751,10 +751,11 @@ HEADERS = $(HEADER_FILES:%.h=$(SRC_DIR)/%.h)
 
 RUNTIME_CPP_COMPONENTS = \
   aarch64_cpu_features \
+  aligned_alloc_aligned_alloc \
   alignment_128 \
   alignment_32 \
-  allocation_cache \
   alignment_64 \
+  allocation_cache \
   android_clock \
   android_host_cpu_count \
   android_io \
@@ -778,8 +779,8 @@ RUNTIME_CPP_COMPONENTS = \
   halide_buffer_t \
   hexagon_cache_allocator \
   hexagon_cpu_features \
-  hexagon_dma_pool \
   hexagon_dma \
+  hexagon_dma_pool \
   hexagon_host \
   ios_io \
   linux_clock \
@@ -794,14 +795,15 @@ RUNTIME_CPP_COMPONENTS = \
   msan \
   msan_stubs \
   opencl \
-  openglcompute \
   opengl_egl_context \
   opengl_glx_context \
+  openglcompute \
   osx_clock \
   osx_get_symbol \
   osx_host_cpu_count \
   osx_opengl_context \
   osx_yield \
+  posix_aligned_alloc \
   posix_allocator \
   posix_clock \
   posix_error_handler \
@@ -829,6 +831,7 @@ RUNTIME_CPP_COMPONENTS = \
   trace_helper \
   tracing \
   wasm_cpu_features \
+  windows_aligned_alloc \
   windows_clock \
   windows_cuda \
   windows_d3d12compute_arm \

--- a/apps/hannk/interpreter/interpreter.cpp
+++ b/apps/hannk/interpreter/interpreter.cpp
@@ -3,14 +3,17 @@
 #include "interpreter/transforms.h"
 #include "util/error_util.h"
 
+#include "HalideBuffer.h"  // for HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT
 #include "HalideRuntime.h"
 
 #include <map>
 #include <set>
 #include <unordered_set>
 
-// TODO: apparently not part of the public Halide API. Should it be?
-extern "C" int halide_malloc_alignment();
+// TODO: temporary, until https://github.com/halide/Halide/pull/7190 lands
+#ifndef HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT
+#define HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT 128
+#endif
 
 namespace hannk {
 
@@ -108,8 +111,10 @@ std::unique_ptr<char[]> allocate_tensors(const Op *root, const InterpreterOption
     // Feed this info to the allocation planner.
     // Let's assume that whatever alignment halide_malloc() needs is necessary here, too.
     // (Note that TFLite will complain if alignment is less than 64...)
+    // Let's assume that whatever alignment Halide::Runtime::Buffer needs is necessary here, too.
     constexpr int kTfLiteDefaultTensorAlignment = 64;
-    const size_t alignment = (size_t)std::max(halide_malloc_alignment(), kTfLiteDefaultTensorAlignment);
+    constexpr int kHalideBufferAlignment = HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT;
+    constexpr size_t alignment = (size_t)std::max(kHalideBufferAlignment, kTfLiteDefaultTensorAlignment);
     AllocationPlanner planner(alignment);
     for (auto &it : find_tensors.tensor_info) {
         auto &info = it.second;

--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -184,6 +184,7 @@ void define_enums(py::module &m) {
         .value("SanitizerCoverage", Target::Feature::SanitizerCoverage)
         .value("ProfileByTimer", Target::Feature::ProfileByTimer)
         .value("SPIRV", Target::Feature::SPIRV)
+        .value("NoAlignedAlloc", Target::Feature::NoAlignedAlloc)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -903,7 +903,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::Windows) {
-                // Windows has its own special _aligned_alloc() implementation
+                // Windows has its own special halide_internal_aligned_alloc() implementation
                 modules.push_back(get_initmod_windows_aligned_alloc(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -529,6 +529,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sanitizer_coverage", Target::SanitizerCoverage},
     {"profile_by_timer", Target::ProfileByTimer},
     {"spirv", Target::SPIRV},
+    {"no_aligned_alloc", Target::NoAlignedAlloc},
     // NOTE: When adding features to this map, be sure to update PyEnums.cpp as well.
 };
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -162,6 +162,7 @@ struct Target {
         SanitizerCoverage = halide_target_feature_sanitizer_coverage,
         ProfileByTimer = halide_target_feature_profile_by_timer,
         SPIRV = halide_target_feature_spirv,
+        NoAlignedAlloc = halide_target_feature_no_aligned_alloc,
         FeatureEnd = halide_target_feature_end
     };
     Target() = default;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Keep these lists in alphabetical order.
 set(RUNTIME_CPP
     aarch64_cpu_features
+    aligned_alloc_aligned_alloc
     alignment_128
     alignment_32
     alignment_64
@@ -52,6 +53,7 @@ set(RUNTIME_CPP
     osx_host_cpu_count
     osx_opengl_context
     osx_yield
+    posix_aligned_alloc
     posix_allocator
     posix_clock
     posix_error_handler
@@ -79,10 +81,11 @@ set(RUNTIME_CPP
     trace_helper
     tracing
     wasm_cpu_features
+    windows_aligned_alloc
     windows_clock
     windows_cuda
-    windows_d3d12compute_x86
     windows_d3d12compute_arm
+    windows_d3d12compute_x86
     windows_get_symbol
     windows_io
     windows_opencl

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -365,10 +365,9 @@ extern int halide_set_num_threads(int n);
  *
  * Note that halide_malloc must return a pointer aligned to the
  * maximum meaningful alignment for the platform for the purpose of
- * vector loads and stores. The default implementation uses 32-byte
- * alignment, which is safe for arm and x86. Additionally, it must be
- * safe to read at least 8 bytes before the start and beyond the
- * end.
+ * vector loads and stores, *and* with an allocated size that is (at least)
+ * an integral multiple of that same alignment. The default implementation
+ * uses 32-byte alignment on arm and 64-byte alignment on x86.
  */
 //@{
 extern void *halide_malloc(void *user_context, size_t x);
@@ -1366,6 +1365,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_sanitizer_coverage,     ///< Enable hooks for SanitizerCoverage support.
     halide_target_feature_profile_by_timer,       ///< Alternative to halide_target_feature_profile using timer interrupt for systems without threads or applicartions that need to avoid them.
     halide_target_feature_spirv,                  ///< Enable SPIR-V code generation support.
+    halide_target_feature_no_aligned_alloc,       ///< Never attempt to use aligned_alloc() (use malloc() instead).
     halide_target_feature_end                     ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 

--- a/src/runtime/aligned_alloc_aligned_alloc.cpp
+++ b/src/runtime/aligned_alloc_aligned_alloc.cpp
@@ -6,12 +6,8 @@ extern "C" {
 extern void *aligned_alloc(size_t alignment, size_t size);
 extern void free(void *);
 
-}  // extern "C"
-
-namespace Halide::Runtime::Internal {
-
 // An implementation of aligned_alloc() that is layered on top of aligned_alloc().
-WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
     // Alignment must be a power of two and >= sizeof(void*)
     halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
 
@@ -19,8 +15,8 @@ WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
     return ::aligned_alloc(alignment, aligned_size);
 }
 
-WEAK_INLINE void _aligned_free(void *ptr) {
+WEAK_INLINE void halide_internal_aligned_free(void *ptr) {
     ::free(ptr);
 }
 
-}  // namespace Halide::Runtime::Internal
+}  // extern "C"

--- a/src/runtime/aligned_alloc_aligned_alloc.cpp
+++ b/src/runtime/aligned_alloc_aligned_alloc.cpp
@@ -13,7 +13,7 @@ namespace Halide::Runtime::Internal {
 // An implementation of aligned_alloc() that is layered on top of aligned_alloc().
 WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
     // Alignment must be a power of two and >= sizeof(void*)
-    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void*));
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
 
     const size_t aligned_size = align_up(size, alignment);
     return ::aligned_alloc(alignment, aligned_size);

--- a/src/runtime/aligned_alloc_aligned_alloc.cpp
+++ b/src/runtime/aligned_alloc_aligned_alloc.cpp
@@ -1,0 +1,26 @@
+#include "HalideRuntime.h"
+#include "runtime_internal.h"
+
+extern "C" {
+
+extern void *aligned_alloc(size_t alignment, size_t size);
+extern void free(void *);
+
+}  // extern "C"
+
+namespace Halide::Runtime::Internal {
+
+// An implementation of aligned_alloc() that is layered on top of aligned_alloc().
+WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
+    // Alignment must be a power of two and >= sizeof(void*)
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void*));
+
+    const size_t aligned_size = align_up(size, alignment);
+    return ::aligned_alloc(alignment, aligned_size);
+}
+
+WEAK_INLINE void _aligned_free(void *ptr) {
+    ::free(ptr);
+}
+
+}  // namespace Halide::Runtime::Internal

--- a/src/runtime/alignment_128.cpp
+++ b/src/runtime/alignment_128.cpp
@@ -1,5 +1,8 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+namespace Halide::Runtime::Internal {
+
+WEAK_INLINE int _malloc_alignment() {
     return 128;
 }
+}  // namespace Halide::Runtime::Internal

--- a/src/runtime/alignment_128.cpp
+++ b/src/runtime/alignment_128.cpp
@@ -1,8 +1,8 @@
 #include "runtime_internal.h"
 
-namespace Halide::Runtime::Internal {
+extern "C" {
 
-WEAK_INLINE int _malloc_alignment() {
+WEAK_INLINE int halide_internal_malloc_alignment() {
     return 128;
 }
-}  // namespace Halide::Runtime::Internal
+}  // extern "C"

--- a/src/runtime/alignment_32.cpp
+++ b/src/runtime/alignment_32.cpp
@@ -1,8 +1,8 @@
 #include "runtime_internal.h"
 
-namespace Halide::Runtime::Internal {
+extern "C" {
 
-WEAK_INLINE int _malloc_alignment() {
+WEAK_INLINE int halide_internal_malloc_alignment() {
     return 32;
 }
-}  // namespace Halide::Runtime::Internal
+}  // extern "C"

--- a/src/runtime/alignment_32.cpp
+++ b/src/runtime/alignment_32.cpp
@@ -1,5 +1,8 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+namespace Halide::Runtime::Internal {
+
+WEAK_INLINE int _malloc_alignment() {
     return 32;
 }
+}  // namespace Halide::Runtime::Internal

--- a/src/runtime/alignment_64.cpp
+++ b/src/runtime/alignment_64.cpp
@@ -1,5 +1,8 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+namespace Halide::Runtime::Internal {
+
+WEAK_INLINE int _malloc_alignment() {
     return 64;
 }
+}  // namespace Halide::Runtime::Internal

--- a/src/runtime/alignment_64.cpp
+++ b/src/runtime/alignment_64.cpp
@@ -1,8 +1,8 @@
 #include "runtime_internal.h"
 
-namespace Halide::Runtime::Internal {
+extern "C" {
 
-WEAK_INLINE int _malloc_alignment() {
+WEAK_INLINE int halide_internal_malloc_alignment() {
     return 64;
 }
-}  // namespace Halide::Runtime::Internal
+}  // extern "C"

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -106,7 +106,7 @@ struct CacheBlockHeader {
 // the hash entry.
 WEAK __attribute((always_inline)) size_t header_bytes() {
     size_t s = sizeof(CacheBlockHeader);
-    size_t mask = ::Halide::Runtime::Internal::_malloc_alignment() - 1;
+    size_t mask = ::halide_internal_malloc_alignment() - 1;
     return (s + mask) & ~mask;
 }
 

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -106,7 +106,7 @@ struct CacheBlockHeader {
 // the hash entry.
 WEAK __attribute((always_inline)) size_t header_bytes() {
     size_t s = sizeof(CacheBlockHeader);
-    size_t mask = halide_malloc_alignment() - 1;
+    size_t mask = ::Halide::Runtime::Internal::_malloc_alignment() - 1;
     return (s + mask) & ~mask;
 }
 

--- a/src/runtime/posix_aligned_alloc.cpp
+++ b/src/runtime/posix_aligned_alloc.cpp
@@ -6,12 +6,8 @@ extern "C" {
 extern void *malloc(size_t);
 extern void free(void *);
 
-}  // extern "C"
-
-namespace Halide::Runtime::Internal {
-
 // An implementation of aligned_alloc() that is layered on top of malloc()/free().
-WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
     // Alignment must be a power of two and >= sizeof(void*)
     halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
 
@@ -40,8 +36,8 @@ WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
     return ptr;
 }
 
-WEAK_INLINE void _aligned_free(void *ptr) {
+WEAK_INLINE void halide_internal_aligned_free(void *ptr) {
     ::free(((void **)ptr)[-1]);
 }
 
-}  // namespace Halide::Runtime::Internal
+}  // extern "C"

--- a/src/runtime/posix_aligned_alloc.cpp
+++ b/src/runtime/posix_aligned_alloc.cpp
@@ -13,7 +13,7 @@ namespace Halide::Runtime::Internal {
 // An implementation of aligned_alloc() that is layered on top of malloc()/free().
 WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
     // Alignment must be a power of two and >= sizeof(void*)
-    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void*));
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
 
     // Allocate enough space for aligning the pointer we return.
     //

--- a/src/runtime/posix_aligned_alloc.cpp
+++ b/src/runtime/posix_aligned_alloc.cpp
@@ -1,0 +1,47 @@
+#include "HalideRuntime.h"
+#include "runtime_internal.h"
+
+extern "C" {
+
+extern void *malloc(size_t);
+extern void free(void *);
+
+}  // extern "C"
+
+namespace Halide::Runtime::Internal {
+
+// An implementation of aligned_alloc() that is layered on top of malloc()/free().
+WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
+    // Alignment must be a power of two and >= sizeof(void*)
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void*));
+
+    // Allocate enough space for aligning the pointer we return.
+    //
+    // Always round allocations up to alignment size,
+    // so that all allocators follow the behavior of aligned_alloc() and
+    // return aligned pointer *and* aligned length.
+    const size_t aligned_size = align_up(size + alignment, alignment);
+
+    void *orig = ::malloc(aligned_size);
+    if (orig == nullptr) {
+        // Will result in a failed assertion and a call to halide_error
+        return nullptr;
+    }
+
+    // malloc() and friends must return a pointer aligned to at least
+    // alignof(std::max_align_t); we can't reasonably check that in
+    // the runtime, but we can realistically assume it's at least
+    // 8-aligned.
+    halide_debug_assert(nullptr, (((uintptr_t)orig) % 8) == 0);
+
+    // We want to store the original pointer prior to the pointer we return.
+    void *ptr = (void *)align_up((uintptr_t)orig + sizeof(void *), alignment);
+    ((void **)ptr)[-1] = orig;
+    return ptr;
+}
+
+WEAK_INLINE void _aligned_free(void *ptr) {
+    ::free(((void **)ptr)[-1]);
+}
+
+}  // namespace Halide::Runtime::Internal

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -7,12 +7,12 @@ extern void *malloc(size_t);
 extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
-    const size_t alignment = Halide::Runtime::Internal::_malloc_alignment();
-    return ::Halide::Runtime::Internal::_aligned_alloc(alignment, x);
+    const size_t alignment = ::halide_internal_malloc_alignment();
+    return ::halide_internal_aligned_alloc(alignment, x);
 }
 
 WEAK void halide_default_free(void *user_context, void *ptr) {
-    ::Halide::Runtime::Internal::_aligned_free(ptr);
+    ::halide_internal_aligned_free(ptr);
 }
 }
 

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -1,29 +1,18 @@
 #include "HalideRuntime.h"
 #include "runtime_internal.h"
 
-#include "printer.h"
-
 extern "C" {
 
 extern void *malloc(size_t);
 extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
-    // Allocate enough space for aligning the pointer we return.
-    const size_t alignment = halide_malloc_alignment();
-    void *orig = malloc(x + alignment);
-    if (orig == nullptr) {
-        // Will result in a failed assertion and a call to halide_error
-        return nullptr;
-    }
-    // We want to store the original pointer prior to the pointer we return.
-    void *ptr = (void *)(((size_t)orig + alignment + sizeof(void *) - 1) & ~(alignment - 1));
-    ((void **)ptr)[-1] = orig;
-    return ptr;
+    const size_t alignment = Halide::Runtime::Internal::_malloc_alignment();
+    return ::Halide::Runtime::Internal::_aligned_alloc(alignment, x);
 }
 
 WEAK void halide_default_free(void *user_context, void *ptr) {
-    free(((void **)ptr)[-1]);
+    ::Halide::Runtime::Internal::_aligned_free(ptr);
 }
 }
 

--- a/src/runtime/qurt_allocator.cpp
+++ b/src/runtime/qurt_allocator.cpp
@@ -27,7 +27,7 @@ WEAK void *mem_buf[num_buffers] = {
 
 WEAK __attribute__((destructor)) void halide_allocator_cleanup() {
     for (void *buf : mem_buf) {
-        ::Halide::Runtime::Internal::_aligned_free(buf);
+        ::halide_internal_aligned_free(buf);
     }
 }
 
@@ -36,20 +36,20 @@ WEAK __attribute__((destructor)) void halide_allocator_cleanup() {
 }  // namespace Halide
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
-    const size_t alignment = Halide::Runtime::Internal::_malloc_alignment();
+    const size_t alignment = ::halide_internal_malloc_alignment();
 
     if (x <= buffer_size) {
         for (int i = 0; i < num_buffers; ++i) {
             if (__sync_val_compare_and_swap(buf_is_used + i, 0, 1) == 0) {
                 if (mem_buf[i] == nullptr) {
-                    mem_buf[i] = ::Halide::Runtime::Internal::_aligned_alloc(alignment, buffer_size);
+                    mem_buf[i] = ::halide_internal_aligned_alloc(alignment, buffer_size);
                 }
                 return mem_buf[i];
             }
         }
     }
 
-    return ::Halide::Runtime::Internal::_aligned_alloc(alignment, x);
+    return ::halide_internal_aligned_alloc(alignment, x);
 }
 
 WEAK void halide_default_free(void *user_context, void *ptr) {
@@ -60,7 +60,7 @@ WEAK void halide_default_free(void *user_context, void *ptr) {
         }
     }
 
-    ::Halide::Runtime::Internal::_aligned_free(ptr);
+    ::halide_internal_aligned_free(ptr);
 }
 
 namespace Halide {

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -195,6 +195,12 @@ struct halide_pseudostack_slot_t {
 WEAK void halide_use_jit_module();
 WEAK void halide_release_jit_module();
 
+// These are all intended to be inlined into other pieces of runtime code;
+// they are not intended to be called or replaced by user code.
+WEAK_INLINE int halide_internal_malloc_alignment();
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size);
+WEAK_INLINE void halide_internal_aligned_free(void *ptr);
+
 void halide_thread_yield();
 
 }  // extern "C"
@@ -229,16 +235,18 @@ ALWAYS_INLINE T min(const T &a, const T &b) {
 
 }  // namespace
 
-// A namespace for runtime modules to store their internal state in.
-namespace Halide::Runtime::Internal {
-
-// These are all intended to be inlined into other pieces of runtime code;
-// they are not intended to be called or replaced by user code.
-WEAK_INLINE int _malloc_alignment();
-WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size);
-WEAK_INLINE void _aligned_free(void *ptr);
-
-}  // namespace Halide::Runtime::Internal
+// A namespace for runtime modules to store their internal state
+// in. Should not be for things communicated between runtime modules,
+// because it's possible for them to be compiled with different c++
+// name mangling due to mixing and matching target triples (this usually
+// only affects Windows builds).
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+// Empty
+}
+}  // namespace Runtime
+}  // namespace Halide
 using namespace Halide::Runtime::Internal;
 
 /** halide_abort_if_false() is a macro that calls halide_print if the supplied condition is

--- a/src/runtime/windows_aligned_alloc.cpp
+++ b/src/runtime/windows_aligned_alloc.cpp
@@ -18,7 +18,7 @@ namespace Halide::Runtime::Internal {
 // An implementation of aligned_alloc() that is layered on top of MSVC's _aligned_malloc/_aligned_free().
 WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
     // Alignment must be a power of two and >= sizeof(void*)
-    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void*));
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
 
     const size_t aligned_size = align_up(size, alignment);
 

--- a/src/runtime/windows_aligned_alloc.cpp
+++ b/src/runtime/windows_aligned_alloc.cpp
@@ -11,12 +11,8 @@ extern void *_aligned_malloc(size_t size, size_t alignment);
 extern void _aligned_free(void *);
 #endif
 
-}  // extern "C"
-
-namespace Halide::Runtime::Internal {
-
 // An implementation of aligned_alloc() that is layered on top of MSVC's _aligned_malloc/_aligned_free().
-WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
     // Alignment must be a power of two and >= sizeof(void*)
     halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
 
@@ -30,7 +26,7 @@ WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
 #endif
 }
 
-WEAK_INLINE void _aligned_free(void *ptr) {
+WEAK_INLINE void halide_internal_aligned_free(void *ptr) {
 #ifdef DEBUG_RUNTIME
     ::_aligned_free_dbg(ptr);
 #else
@@ -38,4 +34,4 @@ WEAK_INLINE void _aligned_free(void *ptr) {
 #endif
 }
 
-}  // namespace Halide::Runtime::Internal
+}  // extern "C"

--- a/src/runtime/windows_aligned_alloc.cpp
+++ b/src/runtime/windows_aligned_alloc.cpp
@@ -1,0 +1,41 @@
+#include "HalideRuntime.h"
+#include "runtime_internal.h"
+
+extern "C" {
+
+#ifdef DEBUG_RUNTIME
+extern void *_aligned_malloc_dbg(size_t size, size_t alignment, const char *filename, int linenumber);
+extern void _aligned_free_dbg(void *);
+#else
+extern void *_aligned_malloc(size_t size, size_t alignment);
+extern void _aligned_free(void *);
+#endif
+
+}  // extern "C"
+
+namespace Halide::Runtime::Internal {
+
+// An implementation of aligned_alloc() that is layered on top of MSVC's _aligned_malloc/_aligned_free().
+WEAK_INLINE void *_aligned_alloc(size_t alignment, size_t size) {
+    // Alignment must be a power of two and >= sizeof(void*)
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void*));
+
+    const size_t aligned_size = align_up(size, alignment);
+
+    // Note: argument order is reversed from C11's aligned_alloc()
+#ifdef DEBUG_RUNTIME
+    return ::_aligned_malloc_dbg(aligned_size, alignment, __FILE__, __LINE__);
+#else
+    return ::_aligned_malloc(aligned_size, alignment);
+#endif
+}
+
+WEAK_INLINE void _aligned_free(void *ptr) {
+#ifdef DEBUG_RUNTIME
+    ::_aligned_free_dbg(ptr);
+#else
+    ::_aligned_free(ptr);
+#endif
+}
+
+}  // namespace Halide::Runtime::Internal

--- a/src/runtime/windows_aligned_alloc.cpp
+++ b/src/runtime/windows_aligned_alloc.cpp
@@ -3,13 +3,8 @@
 
 extern "C" {
 
-#ifdef DEBUG_RUNTIME
-extern void *_aligned_malloc_dbg(size_t size, size_t alignment, const char *filename, int linenumber);
-extern void _aligned_free_dbg(void *);
-#else
 extern void *_aligned_malloc(size_t size, size_t alignment);
 extern void _aligned_free(void *);
-#endif
 
 // An implementation of aligned_alloc() that is layered on top of MSVC's _aligned_malloc/_aligned_free().
 WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
@@ -19,19 +14,11 @@ WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
     const size_t aligned_size = align_up(size, alignment);
 
     // Note: argument order is reversed from C11's aligned_alloc()
-#ifdef DEBUG_RUNTIME
-    return ::_aligned_malloc_dbg(aligned_size, alignment, __FILE__, __LINE__);
-#else
     return ::_aligned_malloc(aligned_size, alignment);
-#endif
 }
 
 WEAK_INLINE void halide_internal_aligned_free(void *ptr) {
-#ifdef DEBUG_RUNTIME
-    ::_aligned_free_dbg(ptr);
-#else
     ::_aligned_free(ptr);
-#endif
 }
 
 }  // extern "C"

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -6,6 +6,7 @@ tests(GROUPS correctness_multi_gpu
 tests(GROUPS correctness
       SOURCES
       align_bounds.cpp
+      allocator_alignment.cpp
       argmax.cpp
       async_device_copy.cpp
       autodiff.cpp

--- a/test/correctness/allocator_alignment.cpp
+++ b/test/correctness/allocator_alignment.cpp
@@ -1,0 +1,108 @@
+#include "Halide.h"
+#include "halide_benchmark.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::ConciseCasts;
+
+namespace {
+
+void check(int r) {
+    assert(r == 0);
+}
+
+void run_test(Target t) {
+    // Must call this so that the changes in cached runtime are noticed
+    Halide::Internal::JITSharedRuntime::release_all();
+
+    class TestGen1 : public Generator<TestGen1> {
+    public:
+        Input<Buffer<uint32_t, 2>> img_{"img"};
+        Input<uint32_t> offset_{"offset"};
+        Output<Buffer<uint32_t, 2>> out_{"out"};
+
+        void generate() {
+            Var x("x"), y("y");
+
+            // Make a copy so that halide_malloc() is called by the generated
+            // code (since Halide::Runtime::Buffer doesn't use halid_malloc(),
+            // see https://github.com/halide/Halide/issues/7188).
+            Func copy("copy");
+            copy(x, y) = img_(x, y);
+
+            out_(x, y) = u32_sat(copy(x, y) + offset_);
+
+            copy.compute_root().store_in(MemoryType::Heap).vectorize(x, natural_vector_size<uint32_t>());
+            out_.vectorize(x, natural_vector_size<uint32_t>());
+        }
+    };
+
+    // Make it large enough so that we won't attempt to use stack instead of heap
+    const int W = t.natural_vector_size<uint32_t>() * 256;
+    const int H = 2048;
+
+    Buffer<uint32_t> in1(W, H);
+    Buffer<uint32_t> in2(W, H);
+
+    for (int i = 0; i < W; i++) {
+        for (int j = 0; j < H; j++) {
+            in1(i, j) = i + j * 10;
+            in2(i, j) = i * 10 + j;
+        }
+    }
+
+    const GeneratorContext context(t);
+
+    auto gen = TestGen1::create(context);
+    Callable c = gen->compile_to_callable();
+
+    const uint32_t offset1 = 42;
+    Buffer<uint32_t> out1(W, H);
+    check(c(in1, offset1, out1));
+
+    const uint32_t offset2 = 22;
+    Buffer<uint32_t> out2(W, H);
+    check(c(in2, offset2, out2));
+
+    const uint32_t offset3 = 12;
+    Buffer<uint32_t> out3(W, H);
+    check(c(in1, offset3, out3));
+
+    const uint32_t offset4 = 16;
+    Buffer<uint32_t> out4(W, H);
+    check(c(in2, offset4, out4));
+
+    for (int i = 0; i < W; i++) {
+        for (int j = 0; j < H; j++) {
+            assert(out1(i, j) == i + j * 10 + offset1);
+            assert(out2(i, j) == i * 10 + j + offset2);
+            assert(out3(i, j) == i + j * 10 + offset3);
+            assert(out4(i, j) == i * 10 + j + offset4);
+        }
+    }
+
+    // Now run a benchmark, but don't check it
+    double time = Halide::Tools::benchmark(10, 100, [&]() {
+        check(c(in2, offset4, out4));
+    });
+    const float megapixels = (W * H) / (1024.f * 1024.f);
+    printf("Benchmark: %dx%d -> %f mpix/s for %s\n", W, H, megapixels / time, t.to_string().c_str());
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    const Target t = get_jit_target_from_environment();
+    if (t.arch == Target::WebAssembly) {
+        printf("[SKIP] This test is too slow for Wasm.\n");
+        return 0;
+    }
+
+    printf("Testing with malloc()... ");
+    run_test(t.with_feature(Target::NoAlignedAlloc));
+
+    printf("Testing with aligned_alloc()... ");
+    run_test(t.without_feature(Target::NoAlignedAlloc));
+
+    printf("Success!\n");
+}

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -290,18 +290,8 @@ public:
         check("vdelta(v*,v*)", hvx_width / 2, in_u32(3 * x / 2));
         check("vdelta(v*,v*)", hvx_width * 3, in_u16(x * 3));
         check("vdelta(v*,v*)", hvx_width * 3, in_u8(x * 3));
-
-        if (Halide::Internal::get_llvm_version() >= 160) {
-            // As of commit 073d5e5945c4, this pattern doesn't generate vdelta,
-            // but does emit vrdelta, which the author claims is superior codegen
-            // for this case.
-            check("vrdelta(v*,v*)", hvx_width * 4, in_u16(x * 4));
-            check("vrdelta(v*,v*)", hvx_width * 4, in_u8(x * 4));
-        } else {
-            abort();
-            check("vdelta(v*,v*)", hvx_width * 4, in_u16(x * 4));
-            check("vdelta(v*,v*)", hvx_width * 4, in_u8(x * 4));
-        }
+        check("vdelta(v*,v*)", hvx_width * 4, in_u16(x * 4));
+        check("vdelta(v*,v*)", hvx_width * 4, in_u8(x * 4));
 
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(u8_1));
         check("vlut32(v*.b,v*.b,r*)", hvx_width / 1, in_u8(clamp(u16_1, 0, 63)));


### PR DESCRIPTION
This makes several hand-in-hand changes to the behavior of `halide_malloc()`:

* Currently, halide_malloc must return a pointer aligned to the maximum meaningful alignment for the platform for the purpose of vector loads and stores. This PR also adds the requirement that the memory returned must be legal to access in an integral multple of alignment >= the requested size (in other words: you should be able to do vector load/stores "off the end" without causing any faults).

* Currently, the `halide_malloc_alignment()` function is used to determine the default alignment; this cannot be overridden by user code (well, it can be, but the override will have no useful effect). It is intended to be "internal only" but is used in at least one place outside the runtime (apps/hannk). This change removes the call entirely, in favor of a call that is harder to access from outside the runtime and much less likely for end users to attempt to call. (It also changes apps/hannk to stop using it.)

* Currently, all our `halide_malloc()` implementations just use `malloc()`/`free()`, user overallocation tricks to ensure the right alignment. This PR adds a new implementation, which uses the C11/C++17 `aligned_alloc()` call instead. By default, we use this implementation on all Unixy platforms, with a new Feature, `no_aligned_alloc`, to allow forcing the use of `malloc()` instead. This is necessary because while ~all modern Linux versions support this, Android doesn't support it till API >= 28, and OSX doesn't support it till >= 10.15. (The QuRT allocator will continue to use `malloc()` for now, pending some post-holiday investigation by QC.)

* We also add a Windows-specific variant that uses their `_aligned_malloc()`/`_aligned_free()` calls; IIRC, the MSVC team has stated that they are unlikely to ever support the standard `aligned_alloc()` calls, for reasons that aren't important here, but do support these as a partial workaround.

This will likely need some torture testing, since it's possible that some platforms offer `aligned_alloc()` implementations that have inferior performance to `malloc()`.