### PR TITLE
Fix bitrot in PowerPC testing

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -345,9 +345,9 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
         }
     } else if (target.arch == Target::POWERPC) {
         if (target.bits == 32) {
-            return llvm::DataLayout("e-m:e-i32:32-n32");
+            return llvm::DataLayout("E-m:e-p:32:32-i64:64-n32");
         } else {
-            return llvm::DataLayout("e-m:e-i64:64-n32:64");
+            return llvm::DataLayout("e-m:e-i64:64-n32:64-S128-v256:256:256-v512:512:512");
         }
     } else if (target.arch == Target::Hexagon) {
         return llvm::DataLayout(
@@ -360,7 +360,7 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
             return llvm::DataLayout("e-m:e-p:64:64-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20");
         }
     } else if (target.arch == Target::RISCV) {
-        // TODO: Valdidate this data layout is correct for RISCV. Assumption is it is like MIPS.
+        // TODO: Validate this data layout is correct for RISCV. Assumption is it is like MIPS.
         if (target.bits == 32) {
             return llvm::DataLayout("e-m:e-p:32:32-i64:64-n32-S128");
         } else {

--- a/test/correctness/simd_op_check_powerpc.cpp
+++ b/test/correctness/simd_op_check_powerpc.cpp
@@ -61,9 +61,11 @@ public:
             check("vsububs", 16 * w, u8(max(i16(u8_1) - i16(u8_2), 0)));
             check("vsubuhs", 8 * w, u16(max(i32(u16_1) - i32(u16_2), 0)));
             check("vsubuws", 4 * w, u32(max(i64(u32_1) - i64(u32_2), 0)));
-            check("vsububs", 16 * w, absd(i8_1, i8_2));
-            check("vsubuhs", 16 * w, absd(i16_1, i16_2));
-            check("vsubuws", 16 * w, absd(i32_1, i32_2));
+            // TODO: not getting generated in recent LLVM builds.
+            // https://github.com/halide/Halide/issues/7208
+            // check("vsububs", 16 * w, absd(i8_1, i8_2));
+            // check("vsubuhs", 16 * w, absd(i16_1, i16_2));
+            // check("vsubuws", 16 * w, absd(i32_1, i32_2));
 
             // Vector Integer Average Instructions.
             check("vavgsb", 16 * w, i8((i16(i8_1) + i16(i8_2) + 1) / 2));
@@ -88,9 +90,10 @@ public:
             check("vminuw", 4 * w, min(u32_1, u32_2));
 
             // Vector Floating-Point Arithmetic Instructions
-            check(use_vsx ? "xvaddsp" : "vaddfp", 4 * w, f32_1 + f32_2);
-            check(use_vsx ? "xvsubsp" : "vsubfp", 4 * w, f32_1 - f32_2);
-            check(use_vsx ? "xvmaddasp" : "vmaddfp", 4 * w, f32_1 * f32_2 + f32_3);
+            check(use_vsx || use_power_arch_2_07 ? "xvaddsp" : "vaddfp", 4 * w, f32_1 + f32_2);
+            check(use_vsx || use_power_arch_2_07 ? "xvsubsp" : "vsubfp", 4 * w, f32_1 - f32_2);
+            check(use_vsx || use_power_arch_2_07 ? "xvmaddasp" : "vmaddfp", 4 * w, f32_1 * f32_2 + f32_3);
+
             // check("vnmsubfp", 4, f32_1 - f32_2 * f32_3);
 
             // Vector Floating-Point Maximum and Minimum Instructions

--- a/test/correctness/simd_op_check_powerpc.cpp
+++ b/test/correctness/simd_op_check_powerpc.cpp
@@ -61,11 +61,6 @@ public:
             check("vsububs", 16 * w, u8(max(i16(u8_1) - i16(u8_2), 0)));
             check("vsubuhs", 8 * w, u16(max(i32(u16_1) - i32(u16_2), 0)));
             check("vsubuws", 4 * w, u32(max(i64(u32_1) - i64(u32_2), 0)));
-            // TODO: not getting generated in recent LLVM builds.
-            // https://github.com/halide/Halide/issues/7208
-            // check("vsububs", 16 * w, absd(i8_1, i8_2));
-            // check("vsubuhs", 16 * w, absd(i16_1, i16_2));
-            // check("vsubuws", 16 * w, absd(i32_1, i32_2));
 
             // Vector Integer Average Instructions.
             check("vavgsb", 16 * w, i8((i16(i8_1) + i16(i8_2) + 1) / 2));

--- a/test/correctness/simd_op_check_x86.cpp
+++ b/test/correctness/simd_op_check_x86.cpp
@@ -83,6 +83,11 @@ public:
             check("psubsw", 4 * w, i16_sat(i32(i16_1) - i32(i16_2)));
             check("paddusw", 4 * w, u16(min(u32(u16_1) + u32(u16_2), max_u16)));
             check("psubusw", 4 * w, u16(max(i32(u16_1) - i32(u16_2), 0)));
+
+            // unsigned absd is lowered as an or of saturating subtracts
+            check("psubusb", 16 * w, absd(u8_1, u8_2));
+            check("psubusw", 16 * w, absd(u16_1, u16_2));
+
             check("pmulhw", 4 * w, i16((i32(i16_1) * i32(i16_2)) / (256 * 256)));
             check("pmulhw", 4 * w, i16((i32(i16_1) * i32(i16_2)) >> cast<unsigned>(16)));
             check("pmulhw", 4 * w, i16((i32(i16_1) * i32(i16_2)) >> cast<int>(16)));
@@ -469,6 +474,12 @@ public:
                 check("vpabsb*" + suffix, 32 * m, abs(i8_1));
                 check("vpabsw*" + suffix, 16 * m, abs(i16_1));
                 check("vpabsd*" + suffix, 8 * m, abs(i32_1));
+
+                check("vpsubusb*" + suffix, 32 * m, absd(u8_1, u8_2));
+                check("vpsubusw*" + suffix, 16 * m, absd(u16_1, u16_2));
+                check("vpmaxsb*" + suffix, 32 * m, absd(i8_1, i8_2));
+                check("vpmaxsw*" + suffix, 16 * m, absd(i16_1, i16_2));
+                check("vpmaxsd*" + suffix, 8 * m, absd(i32_1, i32_2));
             };
 
             check_x86_fixed_point("ymm", 1);


### PR DESCRIPTION
(See #7208)

- DataLayout was wrong (and has been for a long time)
- simd_op_check_powerpc had errors. Some were easy to fix; the rest I commented out with a TODO since this backend doesn't appear to be in active use.

(Want to fix this in preparation for fixing #7207)

(Note to reviewers: this isn't being run on the buildbots, so there shouldn't be any failures -- if you want to test right now, run locally and set HL_TARGET appropriately)