### PR TITLE
Remove check_jit_user_context() from V8 bindings

### DIFF
--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -1712,21 +1712,6 @@ void copy_hostbuf_to_existing_wasmbuf(const Local<Context> &context, const halid
     dump_wasmbuf(context, dst_ptr, "dst_post");
 }
 
-JITUserContext *check_jit_user_context(JITUserContext *jit_user_context) {
-    user_assert(!jit_user_context->handlers.custom_malloc &&
-                !jit_user_context->handlers.custom_free)
-        << "The WebAssembly JIT cannot support set_custom_allocator()";
-    user_assert(!jit_user_context->handlers.custom_do_task)
-        << "The WebAssembly JIT cannot support set_custom_do_task()";
-    user_assert(!jit_user_context->handlers.custom_do_par_for)
-        << "The WebAssembly JIT cannot support set_custom_do_par_for()";
-    user_assert(!jit_user_context->handlers.custom_get_symbol &&
-                !jit_user_context->handlers.custom_load_library &&
-                !jit_user_context->handlers.custom_get_library_symbol)
-        << "The WebAssembly JIT cannot support custom_get_symbol, custom_load_library, or custom_get_library_symbol.";
-    return jit_user_context;
-}
-
 // Some internal code can call halide_error(null, ...), so this needs to be resilient to that.
 // Callers must expect null and not crash.
 JITUserContext *get_jit_user_context(const Local<Context> &context, const Local<Value> &arg) {
@@ -2639,7 +2624,7 @@ int WasmModuleContents::run(const void *const *args) {
         } else {
             if (arg.name == "__user_context") {
                 js_args.push_back(load_scalar(context, kMagicJitUserContextValue));
-                JITUserContext *jit_user_context = check_jit_user_context(*(JITUserContext **)const_cast<void *>(arg_ptr));
+                JITUserContext *jit_user_context = *(JITUserContext **)const_cast<void *>(arg_ptr);
                 context->SetAlignedPointerInEmbedderData(kJitUserContext, jit_user_context);
             } else {
                 js_args.push_back(load_scalar(context, arg.type, arg_ptr));


### PR DESCRIPTION
Obsolete code from early V8 work, it can trigger inappropriately in some corner-case scenarios. Remove it entirely to avoid false errors.