### PR TITLE
Tighten alignment promises for halide_malloc()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -753,8 +753,8 @@ RUNTIME_CPP_COMPONENTS = \
   aarch64_cpu_features \
   alignment_128 \
   alignment_32 \
-  allocation_cache \
   alignment_64 \
+  allocation_cache \
   android_clock \
   android_host_cpu_count \
   android_io \
@@ -778,8 +778,8 @@ RUNTIME_CPP_COMPONENTS = \
   halide_buffer_t \
   hexagon_cache_allocator \
   hexagon_cpu_features \
-  hexagon_dma_pool \
   hexagon_dma \
+  hexagon_dma_pool \
   hexagon_host \
   ios_io \
   linux_clock \
@@ -794,14 +794,15 @@ RUNTIME_CPP_COMPONENTS = \
   msan \
   msan_stubs \
   opencl \
-  openglcompute \
   opengl_egl_context \
   opengl_glx_context \
+  openglcompute \
   osx_clock \
   osx_get_symbol \
   osx_host_cpu_count \
   osx_opengl_context \
   osx_yield \
+  posix_aligned_alloc \
   posix_allocator \
   posix_clock \
   posix_error_handler \

--- a/apps/hannk/interpreter/interpreter.cpp
+++ b/apps/hannk/interpreter/interpreter.cpp
@@ -3,14 +3,12 @@
 #include "interpreter/transforms.h"
 #include "util/error_util.h"
 
+#include "HalideBuffer.h"  // for HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT
 #include "HalideRuntime.h"
 
 #include <map>
 #include <set>
 #include <unordered_set>
-
-// TODO: apparently not part of the public Halide API. Should it be?
-extern "C" int halide_malloc_alignment();
 
 namespace hannk {
 
@@ -108,8 +106,10 @@ std::unique_ptr<char[]> allocate_tensors(const Op *root, const InterpreterOption
     // Feed this info to the allocation planner.
     // Let's assume that whatever alignment halide_malloc() needs is necessary here, too.
     // (Note that TFLite will complain if alignment is less than 64...)
+    // Let's assume that whatever alignment Halide::Runtime::Buffer needs is necessary here, too.
     constexpr int kTfLiteDefaultTensorAlignment = 64;
-    const size_t alignment = (size_t)std::max(halide_malloc_alignment(), kTfLiteDefaultTensorAlignment);
+    constexpr int kHalideBufferAlignment = HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT;
+    constexpr size_t alignment = (size_t)std::max(kHalideBufferAlignment, kTfLiteDefaultTensorAlignment);
     AllocationPlanner planner(alignment);
     for (auto &it : find_tensors.tensor_info) {
         auto &info = it.second;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -52,6 +52,7 @@ set(RUNTIME_CPP
     osx_host_cpu_count
     osx_opengl_context
     osx_yield
+    posix_aligned_alloc
     posix_allocator
     posix_clock
     posix_error_handler
@@ -81,8 +82,8 @@ set(RUNTIME_CPP
     wasm_cpu_features
     windows_clock
     windows_cuda
-    windows_d3d12compute_x86
     windows_d3d12compute_arm
+    windows_d3d12compute_x86
     windows_get_symbol
     windows_io
     windows_opencl

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -52,6 +52,9 @@
 #define HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT 128
 #endif
 
+static_assert(((HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT & (HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT - 1)) == 0),
+              "HALIDE_RUNTIME_BUFFER_ALLOCATION_ALIGNMENT must be a power of 2.");
+
 // Unfortunately, not all C++17 runtimes support aligned_alloc
 // (it may depends on OS/SDK version); this is provided as an opt-out
 // if you are compiling on a platform that doesn't provide a (good)

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -365,10 +365,10 @@ extern int halide_set_num_threads(int n);
  *
  * Note that halide_malloc must return a pointer aligned to the
  * maximum meaningful alignment for the platform for the purpose of
- * vector loads and stores. The default implementation uses 32-byte
- * alignment, which is safe for arm and x86. Additionally, it must be
- * safe to read at least 8 bytes before the start and beyond the
- * end.
+ * vector loads and stores, *and* with an allocated size that is (at least)
+ * an integral multiple of that same alignment. The default implementation
+ * uses 32-byte alignment on arm and 64-byte alignment on x86. Additionally,
+ * it must be safe to read at least 8 bytes before the start and beyond the end.
  */
 //@{
 extern void *halide_malloc(void *user_context, size_t x);

--- a/src/runtime/alignment_128.cpp
+++ b/src/runtime/alignment_128.cpp
@@ -1,5 +1,8 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+extern "C" {
+
+WEAK_INLINE int halide_internal_malloc_alignment() {
     return 128;
 }
+}  // extern "C"

--- a/src/runtime/alignment_32.cpp
+++ b/src/runtime/alignment_32.cpp
@@ -1,5 +1,8 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+extern "C" {
+
+WEAK_INLINE int halide_internal_malloc_alignment() {
     return 32;
 }
+}  // extern "C"

--- a/src/runtime/alignment_64.cpp
+++ b/src/runtime/alignment_64.cpp
@@ -1,5 +1,8 @@
 #include "runtime_internal.h"
 
-extern "C" WEAK_INLINE int halide_malloc_alignment() {
+extern "C" {
+
+WEAK_INLINE int halide_internal_malloc_alignment() {
     return 64;
 }
+}  // extern "C"

--- a/src/runtime/cache.cpp
+++ b/src/runtime/cache.cpp
@@ -106,7 +106,7 @@ struct CacheBlockHeader {
 // the hash entry.
 WEAK __attribute((always_inline)) size_t header_bytes() {
     size_t s = sizeof(CacheBlockHeader);
-    size_t mask = halide_malloc_alignment() - 1;
+    size_t mask = ::halide_internal_malloc_alignment() - 1;
     return (s + mask) & ~mask;
 }
 

--- a/src/runtime/posix_aligned_alloc.cpp
+++ b/src/runtime/posix_aligned_alloc.cpp
@@ -1,0 +1,43 @@
+#include "HalideRuntime.h"
+#include "runtime_internal.h"
+
+extern "C" {
+
+extern void *malloc(size_t);
+extern void free(void *);
+
+// An implementation of aligned_alloc() that is layered on top of malloc()/free().
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
+    // Alignment must be a power of two and >= sizeof(void*)
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
+
+    // Allocate enough space for aligning the pointer we return.
+    //
+    // Always round allocations up to alignment size,
+    // so that all allocators follow the behavior of aligned_alloc() and
+    // return aligned pointer *and* aligned length.
+    const size_t aligned_size = align_up(size + alignment, alignment);
+
+    void *orig = ::malloc(aligned_size);
+    if (orig == nullptr) {
+        // Will result in a failed assertion and a call to halide_error
+        return nullptr;
+    }
+
+    // malloc() and friends must return a pointer aligned to at least
+    // alignof(std::max_align_t); we can't reasonably check that in
+    // the runtime, but we can realistically assume it's at least
+    // 8-aligned.
+    halide_debug_assert(nullptr, (((uintptr_t)orig) % 8) == 0);
+
+    // We want to store the original pointer prior to the pointer we return.
+    void *ptr = (void *)align_up((uintptr_t)orig + sizeof(void *), alignment);
+    ((void **)ptr)[-1] = orig;
+    return ptr;
+}
+
+WEAK_INLINE void halide_internal_aligned_free(void *ptr) {
+    ::free(((void **)ptr)[-1]);
+}
+
+}  // extern "C"

--- a/src/runtime/posix_allocator.cpp
+++ b/src/runtime/posix_allocator.cpp
@@ -1,29 +1,18 @@
 #include "HalideRuntime.h"
 #include "runtime_internal.h"
 
-#include "printer.h"
-
 extern "C" {
 
 extern void *malloc(size_t);
 extern void free(void *);
 
 WEAK void *halide_default_malloc(void *user_context, size_t x) {
-    // Allocate enough space for aligning the pointer we return.
-    const size_t alignment = halide_malloc_alignment();
-    void *orig = malloc(x + alignment);
-    if (orig == nullptr) {
-        // Will result in a failed assertion and a call to halide_error
-        return nullptr;
-    }
-    // We want to store the original pointer prior to the pointer we return.
-    void *ptr = (void *)(((size_t)orig + alignment + sizeof(void *) - 1) & ~(alignment - 1));
-    ((void **)ptr)[-1] = orig;
-    return ptr;
+    const size_t alignment = ::halide_internal_malloc_alignment();
+    return ::halide_internal_aligned_alloc(alignment, x);
 }
 
 WEAK void halide_default_free(void *user_context, void *ptr) {
-    free(((void **)ptr)[-1]);
+    ::halide_internal_aligned_free(ptr);
 }
 }
 

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -195,11 +195,25 @@ struct halide_pseudostack_slot_t {
 WEAK void halide_use_jit_module();
 WEAK void halide_release_jit_module();
 
-WEAK_INLINE int halide_malloc_alignment();
+// These are all intended to be inlined into other pieces of runtime code;
+// they are not intended to be called or replaced by user code.
+WEAK_INLINE int halide_internal_malloc_alignment();
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size);
+WEAK_INLINE void halide_internal_aligned_free(void *ptr);
 
 void halide_thread_yield();
 
 }  // extern "C"
+
+template<typename T>
+ALWAYS_INLINE T align_up(T p, size_t alignment) {
+    return (p + alignment - 1) & ~(alignment - 1);
+}
+
+template<typename T>
+ALWAYS_INLINE T is_power_of_two(T value) {
+    return (value != 0) && ((value & (value - 1)) == 0);
+}
 
 namespace {
 template<typename T>
@@ -224,7 +238,8 @@ ALWAYS_INLINE T min(const T &a, const T &b) {
 // A namespace for runtime modules to store their internal state
 // in. Should not be for things communicated between runtime modules,
 // because it's possible for them to be compiled with different c++
-// name mangling due to mixing and matching target triples.
+// name mangling due to mixing and matching target triples (this usually
+// only affects Windows builds).
 namespace Halide {
 namespace Runtime {
 namespace Internal {


### PR DESCRIPTION
This makes a couple of changes to the behavior/implementation of `halide_malloc()`:

* Currently, halide_malloc must return a pointer aligned to the maximum meaningful alignment for the platform for the purpose of vector loads and stores. This PR also adds the requirement that the memory returned must be legal to access in an integral multple of alignment >= the requested size (in other words: you should be able to do vector load/stores "off the end" without causing any faults).

* Currently, the `halide_malloc_alignment()` function is used to determine the default alignment; this cannot be overridden by user code (well, it can be, but the override will have no useful effect). It is intended to be "internal only" but is used in at least one place outside the runtime (apps/hannk). This change removes the call entirely, in favor of a call that is harder to access from outside the runtime and much less likely for end users to attempt to call. (It also changes apps/hannk to stop using it.)