### PR TITLE
Use `aligned_alloc()` when possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -751,6 +751,7 @@ HEADERS = $(HEADER_FILES:%.h=$(SRC_DIR)/%.h)
 
 RUNTIME_CPP_COMPONENTS = \
   aarch64_cpu_features \
+  aligned_alloc_aligned_alloc \
   alignment_128 \
   alignment_32 \
   alignment_64 \
@@ -830,6 +831,7 @@ RUNTIME_CPP_COMPONENTS = \
   trace_helper \
   tracing \
   wasm_cpu_features \
+  windows_aligned_alloc \
   windows_clock \
   windows_cuda \
   windows_d3d12compute_arm \

--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -184,6 +184,7 @@ void define_enums(py::module &m) {
         .value("SanitizerCoverage", Target::Feature::SanitizerCoverage)
         .value("ProfileByTimer", Target::Feature::ProfileByTimer)
         .value("SPIRV", Target::Feature::SPIRV)
+        .value("NoAlignedAlloc", Target::Feature::NoAlignedAlloc)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -77,6 +77,7 @@ std::unique_ptr<llvm::Module> parse_bitcode_file(llvm::StringRef buf, llvm::LLVM
 DECLARE_CPP_INITMOD(alignment_128)
 DECLARE_CPP_INITMOD(alignment_32)
 DECLARE_CPP_INITMOD(alignment_64)
+DECLARE_CPP_INITMOD(aligned_alloc_aligned_alloc)
 DECLARE_CPP_INITMOD(allocation_cache)
 DECLARE_CPP_INITMOD(android_clock)
 DECLARE_CPP_INITMOD(android_host_cpu_count)
@@ -144,6 +145,7 @@ DECLARE_CPP_INITMOD(timer_profiler)
 DECLARE_CPP_INITMOD(to_string)
 DECLARE_CPP_INITMOD(trace_helper)
 DECLARE_CPP_INITMOD(tracing)
+DECLARE_CPP_INITMOD(windows_aligned_alloc)
 DECLARE_CPP_INITMOD(windows_clock)
 DECLARE_CPP_INITMOD(windows_cuda)
 DECLARE_CPP_INITMOD(windows_get_symbol)
@@ -819,11 +821,15 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
     bool bits_64 = (t.bits == 64);
     bool debug = t.has_feature(Target::Debug);
     bool tsan = t.has_feature(Target::TSAN);
+    bool aligned_alloc = !t.has_feature(Target::NoAlignedAlloc);
 
     vector<std::unique_ptr<llvm::Module>> modules;
 
     const auto add_allocator = [&]() {
-        modules.push_back(get_initmod_posix_aligned_alloc(c, bits_64, debug));
+        const auto aligned_alloc_initmod_fn = aligned_alloc ?
+                                                  get_initmod_aligned_alloc_aligned_alloc :
+                                                  get_initmod_posix_aligned_alloc;
+        modules.push_back(aligned_alloc_initmod_fn(c, bits_64, debug));
         modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
     };
 
@@ -898,7 +904,8 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 }
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::Windows) {
-                modules.push_back(get_initmod_posix_aligned_alloc(c, bits_64, debug));
+                // Windows has its own special halide_internal_aligned_alloc() implementation
+                modules.push_back(get_initmod_windows_aligned_alloc(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -529,6 +529,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sanitizer_coverage", Target::SanitizerCoverage},
     {"profile_by_timer", Target::ProfileByTimer},
     {"spirv", Target::SPIRV},
+    {"no_aligned_alloc", Target::NoAlignedAlloc},
     // NOTE: When adding features to this map, be sure to update PyEnums.cpp as well.
 };
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -162,6 +162,7 @@ struct Target {
         SanitizerCoverage = halide_target_feature_sanitizer_coverage,
         ProfileByTimer = halide_target_feature_profile_by_timer,
         SPIRV = halide_target_feature_spirv,
+        NoAlignedAlloc = halide_target_feature_no_aligned_alloc,
         FeatureEnd = halide_target_feature_end
     };
     Target() = default;

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Keep these lists in alphabetical order.
 set(RUNTIME_CPP
     aarch64_cpu_features
+    aligned_alloc_aligned_alloc
     alignment_128
     alignment_32
     alignment_64
@@ -80,6 +81,7 @@ set(RUNTIME_CPP
     trace_helper
     tracing
     wasm_cpu_features
+    windows_aligned_alloc
     windows_clock
     windows_cuda
     windows_d3d12compute_arm

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -367,8 +367,9 @@ extern int halide_set_num_threads(int n);
  * maximum meaningful alignment for the platform for the purpose of
  * vector loads and stores, *and* with an allocated size that is (at least)
  * an integral multiple of that same alignment. The default implementation
- * uses 32-byte alignment on arm and 64-byte alignment on x86. Additionally,
- * it must be safe to read at least 8 bytes before the start and beyond the end.
+ * uses 32-byte alignment on arm and 64-byte alignment on x86.
+ *
+ * Additionally, it must be safe to read at least 8 bytes beyond the end.
  */
 //@{
 extern void *halide_malloc(void *user_context, size_t x);
@@ -1366,6 +1367,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_sanitizer_coverage,     ///< Enable hooks for SanitizerCoverage support.
     halide_target_feature_profile_by_timer,       ///< Alternative to halide_target_feature_profile using timer interrupt for systems without threads or applicartions that need to avoid them.
     halide_target_feature_spirv,                  ///< Enable SPIR-V code generation support.
+    halide_target_feature_no_aligned_alloc,       ///< Never attempt to use aligned_alloc() (use malloc() instead).
     halide_target_feature_end                     ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 

--- a/src/runtime/aligned_alloc_aligned_alloc.cpp
+++ b/src/runtime/aligned_alloc_aligned_alloc.cpp
@@ -1,0 +1,22 @@
+#include "HalideRuntime.h"
+#include "runtime_internal.h"
+
+extern "C" {
+
+extern void *aligned_alloc(size_t alignment, size_t size);
+extern void free(void *);
+
+// An implementation of aligned_alloc() that is layered on top of aligned_alloc().
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
+    // Alignment must be a power of two and >= sizeof(void*)
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
+
+    const size_t aligned_size = align_up(size, alignment);
+    return ::aligned_alloc(alignment, aligned_size);
+}
+
+WEAK_INLINE void halide_internal_aligned_free(void *ptr) {
+    ::free(ptr);
+}
+
+}  // extern "C"

--- a/src/runtime/windows_aligned_alloc.cpp
+++ b/src/runtime/windows_aligned_alloc.cpp
@@ -1,0 +1,24 @@
+#include "HalideRuntime.h"
+#include "runtime_internal.h"
+
+extern "C" {
+
+extern void *_aligned_malloc(size_t size, size_t alignment);
+extern void _aligned_free(void *);
+
+// An implementation of aligned_alloc() that is layered on top of MSVC's _aligned_malloc/_aligned_free().
+WEAK_INLINE void *halide_internal_aligned_alloc(size_t alignment, size_t size) {
+    // Alignment must be a power of two and >= sizeof(void*)
+    halide_debug_assert(nullptr, is_power_of_two(alignment) && alignment >= sizeof(void *));
+
+    const size_t aligned_size = align_up(size, alignment);
+
+    // Note: argument order is reversed from C11's aligned_alloc()
+    return ::_aligned_malloc(aligned_size, alignment);
+}
+
+WEAK_INLINE void halide_internal_aligned_free(void *ptr) {
+    ::_aligned_free(ptr);
+}
+
+}  // extern "C"

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -6,6 +6,7 @@ tests(GROUPS correctness_multi_gpu
 tests(GROUPS correctness
       SOURCES
       align_bounds.cpp
+      allocator_alignment.cpp
       argmax.cpp
       async_device_copy.cpp
       autodiff.cpp

--- a/test/correctness/allocator_alignment.cpp
+++ b/test/correctness/allocator_alignment.cpp
@@ -1,0 +1,108 @@
+#include "Halide.h"
+#include "halide_benchmark.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::ConciseCasts;
+
+namespace {
+
+void check(int r) {
+    assert(r == 0);
+}
+
+void run_test(Target t) {
+    // Must call this so that the changes in cached runtime are noticed
+    Halide::Internal::JITSharedRuntime::release_all();
+
+    class TestGen1 : public Generator<TestGen1> {
+    public:
+        Input<Buffer<uint32_t, 2>> img_{"img"};
+        Input<uint32_t> offset_{"offset"};
+        Output<Buffer<uint32_t, 2>> out_{"out"};
+
+        void generate() {
+            Var x("x"), y("y");
+
+            // Make a copy so that halide_malloc() is called by the generated
+            // code (since Halide::Runtime::Buffer doesn't use halid_malloc(),
+            // see https://github.com/halide/Halide/issues/7188).
+            Func copy("copy");
+            copy(x, y) = img_(x, y);
+
+            out_(x, y) = u32_sat(copy(x, y) + offset_);
+
+            copy.compute_root().store_in(MemoryType::Heap).vectorize(x, natural_vector_size<uint32_t>());
+            out_.vectorize(x, natural_vector_size<uint32_t>());
+        }
+    };
+
+    // Make it large enough so that we won't attempt to use stack instead of heap
+    const int W = t.natural_vector_size<uint32_t>() * 256;
+    const int H = 2048;
+
+    Buffer<uint32_t> in1(W, H);
+    Buffer<uint32_t> in2(W, H);
+
+    for (int i = 0; i < W; i++) {
+        for (int j = 0; j < H; j++) {
+            in1(i, j) = i + j * 10;
+            in2(i, j) = i * 10 + j;
+        }
+    }
+
+    const GeneratorContext context(t);
+
+    auto gen = TestGen1::create(context);
+    Callable c = gen->compile_to_callable();
+
+    const uint32_t offset1 = 42;
+    Buffer<uint32_t> out1(W, H);
+    check(c(in1, offset1, out1));
+
+    const uint32_t offset2 = 22;
+    Buffer<uint32_t> out2(W, H);
+    check(c(in2, offset2, out2));
+
+    const uint32_t offset3 = 12;
+    Buffer<uint32_t> out3(W, H);
+    check(c(in1, offset3, out3));
+
+    const uint32_t offset4 = 16;
+    Buffer<uint32_t> out4(W, H);
+    check(c(in2, offset4, out4));
+
+    for (int i = 0; i < W; i++) {
+        for (int j = 0; j < H; j++) {
+            assert(out1(i, j) == i + j * 10 + offset1);
+            assert(out2(i, j) == i * 10 + j + offset2);
+            assert(out3(i, j) == i + j * 10 + offset3);
+            assert(out4(i, j) == i * 10 + j + offset4);
+        }
+    }
+
+    // Now run a benchmark, but don't check it
+    double time = Halide::Tools::benchmark(10, 100, [&]() {
+        check(c(in2, offset4, out4));
+    });
+    const float megapixels = (W * H) / (1024.f * 1024.f);
+    printf("Benchmark: %dx%d -> %f mpix/s for %s\n", W, H, megapixels / time, t.to_string().c_str());
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    const Target t = get_jit_target_from_environment();
+    if (t.arch == Target::WebAssembly) {
+        printf("[SKIP] This test is too slow for Wasm.\n");
+        return 0;
+    }
+
+    printf("Testing with malloc()... ");
+    run_test(t.with_feature(Target::NoAlignedAlloc));
+
+    printf("Testing with aligned_alloc()... ");
+    run_test(t.without_feature(Target::NoAlignedAlloc));
+
+    printf("Success!\n");
+}


### PR DESCRIPTION
Currently, all our `halide_malloc()` implementations just use `malloc()`/`free()`, user overallocation tricks to ensure the right alignment. This PR adds a new implementation, which uses the C11/C++17 `aligned_alloc()` call instead. By default, we use this implementation on all Unixy platforms, with a new Feature, `no_aligned_alloc`, to allow forcing the use of `malloc()` instead. This is necessary because while ~all modern Linux versions support this, Android doesn't support it till API >= 28, and OSX doesn't support it till >= 10.15. (The QuRT allocator will continue to use `malloc()` for now, pending some post-holiday investigation by QC.)

We also add a Windows-specific variant that uses their `_aligned_malloc()`/`_aligned_free()` calls; IIRC, the MSVC team has stated that they are unlikely to ever support the standard `aligned_alloc()` calls, for reasons that aren't important here, but do support these as a partial workaround.

This will likely need some torture testing, since it's possible that some platforms offer `aligned_alloc()` implementations that have inferior performance to `malloc()`.