### PR TITLE
Fix some sources of signed integer overflow in the compiler

### DIFF
--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -376,65 +376,64 @@ int64_t lcm(int64_t a, int64_t b) {
     b /= gcd(a, b);
 
     // Then multiply
-    if (mul_would_overflow(64, a, b)) {
-        return 0;
-    } else {
-        return a * b;
-    }
+    int64_t result;
+    mul_with_overflow(64, a, b, &result);
+    return result;
 }
 
 ModulusRemainder operator+(const ModulusRemainder &a, const ModulusRemainder &b) {
-    if (add_would_overflow(64, a.remainder, b.remainder)) {
-        return {1, 0};
-    } else {
-        int64_t modulus = gcd(a.modulus, b.modulus);
-        int64_t remainder = mod(a.remainder + b.remainder, modulus);
-        return {modulus, remainder};
+    int64_t m = 1, r = 0;
+    if (add_with_overflow(64, a.remainder, b.remainder, &r)) {
+        m = gcd(a.modulus, b.modulus);
+        r = mod(r, m);
     }
+    return {m, r};
 }
 
 ModulusRemainder operator-(const ModulusRemainder &a, const ModulusRemainder &b) {
-    if (sub_would_overflow(64, a.remainder, b.remainder)) {
-        return {1, 0};
-    } else {
-        int64_t modulus = gcd(a.modulus, b.modulus);
-        int64_t remainder = mod(a.remainder - b.remainder, modulus);
-        return {modulus, remainder};
+    int64_t m = 1, r = 0;
+    if (sub_with_overflow(64, a.remainder, b.remainder, &r)) {
+        m = gcd(a.modulus, b.modulus);
+        r = mod(r, m);
     }
+    return {m, r};
 }
 
 ModulusRemainder operator*(const ModulusRemainder &a, const ModulusRemainder &b) {
+    int64_t m, r;
     if (a.modulus == 0) {
         // a is constant
-        if (!mul_would_overflow(64, a.remainder, b.modulus) && !mul_would_overflow(64, a.remainder, b.remainder)) {
-            return {a.remainder * b.modulus, a.remainder * b.remainder};
+        if (mul_with_overflow(64, a.remainder, b.modulus, &m) &&
+            mul_with_overflow(64, a.remainder, b.remainder, &r)) {
+            return {m, r};
         }
     } else if (b.modulus == 0) {
         // b is constant
-        if (!mul_would_overflow(64, b.remainder, a.modulus) && !mul_would_overflow(64, a.remainder, b.remainder)) {
-            return {b.remainder * a.modulus, a.remainder * b.remainder};
+        if (mul_with_overflow(64, a.modulus, b.remainder, &m) &&
+            mul_with_overflow(64, a.remainder, b.remainder, &r)) {
+            return {m, r};
         }
     } else if (a.remainder == 0 && b.remainder == 0) {
         // multiple times multiple
-        if (!mul_would_overflow(64, a.modulus, b.modulus)) {
-            return {a.modulus * b.modulus, 0};
+        if (mul_with_overflow(64, a.modulus, b.modulus, &m)) {
+            return {m, 0};
         }
     } else if (a.remainder == 0) {
         int64_t g = gcd(b.modulus, b.remainder);
-        if (!mul_would_overflow(64, a.modulus, g)) {
-            return {a.modulus * g, 0};
+        if (mul_with_overflow(64, a.modulus, g, &m)) {
+            return {m, 0};
         }
     } else if (b.remainder == 0) {
         int64_t g = gcd(a.modulus, a.remainder);
-        if (!mul_would_overflow(64, b.modulus, g)) {
-            return {b.modulus * g, 0};
+        if (mul_with_overflow(64, b.modulus, g, &m)) {
+            return {m, 0};
         }
     } else {
         // Convert them to the same modulus and multiply
-        if (!mul_would_overflow(64, a.remainder, b.remainder)) {
-            int64_t modulus = gcd(a.modulus, b.modulus);
-            int64_t remainder = mod(a.remainder * b.remainder, modulus);
-            return {modulus, remainder};
+        if (mul_with_overflow(64, a.remainder, b.remainder, &r)) {
+            m = gcd(a.modulus, b.modulus);
+            r = mod(r, m);
+            return {m, r};
         }
     }
 
@@ -477,7 +476,8 @@ ModulusRemainder ModulusRemainder::unify(const ModulusRemainder &a, const Modulu
     // Reduce them to the same modulus and the same remainder
     int64_t modulus = gcd(a.modulus, b.modulus);
 
-    if (sub_would_overflow(64, a.remainder, b.remainder)) {
+    int64_t r;
+    if (!sub_with_overflow(64, a.remainder, b.remainder, &r)) {
         // The modulus is not representable as an int64.
         return {0, 1};
     }

--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -375,9 +375,10 @@ int64_t lcm(int64_t a, int64_t b) {
     // Remove all of the common factors from one of the operands
     b /= gcd(a, b);
 
-    // Then multiply
+    // Then multiply. On overflow this will return zero, so ignore the overflow
+    // flag.
     int64_t result;
-    mul_with_overflow(64, a, b, &result);
+    (void)mul_with_overflow(64, a, b, &result);
     return result;
 }
 

--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -9,21 +9,12 @@ Expr Simplify::visit(const Add *op, ExprInfo *bounds) {
     Expr b = mutate(op->b, &b_bounds);
 
     if (bounds && no_overflow_int(op->type)) {
-        bounds->min_defined = a_bounds.min_defined && b_bounds.min_defined;
-        bounds->max_defined = a_bounds.max_defined && b_bounds.max_defined;
-        if (add_would_overflow(64, a_bounds.min, b_bounds.min)) {
-            bounds->min_defined = false;
-            bounds->min = 0;
-        } else {
-            bounds->min = a_bounds.min + b_bounds.min;
-        }
-        if (add_would_overflow(64, a_bounds.max, b_bounds.max)) {
-            bounds->max_defined = false;
-            bounds->max = 0;
-        } else {
-            bounds->max = a_bounds.max + b_bounds.max;
-        }
-
+        bounds->min_defined = a_bounds.min_defined &&
+                              b_bounds.min_defined &&
+                              add_with_overflow(64, a_bounds.min, b_bounds.min, &(bounds->min));
+        bounds->max_defined = a_bounds.max_defined &&
+                              b_bounds.max_defined &&
+                              add_with_overflow(64, a_bounds.max, b_bounds.max, &(bounds->max));
         bounds->alignment = a_bounds.alignment + b_bounds.alignment;
         bounds->trim_bounds_using_alignment();
     }

--- a/src/Simplify_Internal.h
+++ b/src/Simplify_Internal.h
@@ -29,14 +29,13 @@ namespace Halide {
 namespace Internal {
 
 inline int64_t saturating_mul(int64_t a, int64_t b) {
-    if (mul_would_overflow(64, a, b)) {
-        if ((a > 0) == (b > 0)) {
-            return INT64_MAX;
-        } else {
-            return INT64_MIN;
-        }
+    int64_t result;
+    if (mul_with_overflow(64, a, b, &result)) {
+        return result;
+    } else if ((a > 0) == (b > 0)) {
+        return INT64_MAX;
     } else {
-        return a * b;
+        return INT64_MIN;
     }
 }
 

--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -12,20 +12,12 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
         // Doesn't account for correlated a, b, so any
         // cancellation rule that exploits that should always
         // remutate to recalculate the bounds.
-        bounds->min_defined = a_bounds.min_defined && b_bounds.max_defined;
-        bounds->max_defined = a_bounds.max_defined && b_bounds.min_defined;
-        if (sub_would_overflow(64, a_bounds.min, b_bounds.max)) {
-            bounds->min_defined = false;
-            bounds->min = 0;
-        } else {
-            bounds->min = a_bounds.min - b_bounds.max;
-        }
-        if (sub_would_overflow(64, a_bounds.max, b_bounds.min)) {
-            bounds->max_defined = false;
-            bounds->max = 0;
-        } else {
-            bounds->max = a_bounds.max - b_bounds.min;
-        }
+        bounds->min_defined = a_bounds.min_defined &&
+                              b_bounds.max_defined &&
+                              sub_with_overflow(64, a_bounds.min, b_bounds.max, &(bounds->min));
+        bounds->max_defined = a_bounds.max_defined &&
+                              b_bounds.min_defined &&
+                              sub_with_overflow(64, a_bounds.max, b_bounds.min, &(bounds->max));
         bounds->alignment = a_bounds.alignment - b_bounds.alignment;
         bounds->trim_bounds_using_alignment();
     }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -523,7 +523,7 @@ bool add_would_overflow(int bits, int64_t a, int64_t b) {
 }
 
 bool add_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
-#ifndef __MSC_VER
+#ifndef _MSC_VER
     if (bits == 64) {
         static_assert(sizeof(long long) == sizeof(int64_t));
         bool flag = __builtin_saddll_overflow(a, b, (long long *)result);
@@ -551,7 +551,7 @@ bool sub_would_overflow(int bits, int64_t a, int64_t b) {
 }
 
 bool sub_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
-#ifndef __MSC_VER
+#ifndef _MSC_VER
     if (bits == 64) {
         static_assert(sizeof(long long) == sizeof(int64_t));
         bool flag = __builtin_ssubll_overflow(a, b, (long long *)result);
@@ -591,7 +591,7 @@ bool mul_would_overflow(int bits, int64_t a, int64_t b) {
 }
 
 bool mul_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
-#ifndef __MSC_VER
+#ifndef _MSC_VER
     if (bits == 64) {
         static_assert(sizeof(long long) == sizeof(int64_t));
         bool flag = __builtin_smulll_overflow(a, b, (long long *)result);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -566,7 +566,7 @@ bool sub_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
         *result = 0;
         return false;
     } else {
-        *result = a + b;
+        *result = a - b;
         return true;
     }
 }
@@ -602,11 +602,11 @@ bool mul_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
         return !flag;
     }
 #endif
-    if (sub_would_overflow(bits, a, b)) {
+    if (mul_would_overflow(bits, a, b)) {
         *result = 0;
         return false;
     } else {
-        *result = a + b;
+        *result = a * b;
         return true;
     }
 }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -522,11 +522,53 @@ bool add_would_overflow(int bits, int64_t a, int64_t b) {
             (b < 0 && a < min_val - b));   // (a + b) < min_val, rewritten to avoid overflow
 }
 
+bool add_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
+#ifndef __MSC_VER
+    if (bits == 64) {
+        static_assert(sizeof(long long) == sizeof(int64_t));
+        bool flag = __builtin_saddll_overflow(a, b, (long long *)result);
+        if (flag) {
+            // Overflowed 64 bits
+            *result = 0;
+        }
+        return !flag;
+    }
+#endif
+    if (add_would_overflow(bits, a, b)) {
+        *result = 0;
+        return false;
+    } else {
+        *result = a + b;
+        return true;
+    }
+}
+
 bool sub_would_overflow(int bits, int64_t a, int64_t b) {
     int64_t max_val = 0x7fffffffffffffffLL >> (64 - bits);
     int64_t min_val = -max_val - 1;
     return ((b < 0 && a > max_val + b) ||  // (a - b) > max_val, rewritten to avoid overflow
             (b > 0 && a < min_val + b));   // (a - b) < min_val, rewritten to avoid overflow
+}
+
+bool sub_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
+#ifndef __MSC_VER
+    if (bits == 64) {
+        static_assert(sizeof(long long) == sizeof(int64_t));
+        bool flag = __builtin_ssubll_overflow(a, b, (long long *)result);
+        if (flag) {
+            // Overflowed 64 bits
+            *result = 0;
+        }
+        return !flag;
+    }
+#endif
+    if (sub_would_overflow(bits, a, b)) {
+        *result = 0;
+        return false;
+    } else {
+        *result = a + b;
+        return true;
+    }
 }
 
 bool mul_would_overflow(int bits, int64_t a, int64_t b) {
@@ -545,6 +587,27 @@ bool mul_would_overflow(int bits, int64_t a, int64_t b) {
         // no 64-bit overflow occurs, and the third clause catches
         // 64-bit overflow.
         return ab < min_val || ab > max_val || (ab / a != b);
+    }
+}
+
+bool mul_with_overflow(int bits, int64_t a, int64_t b, int64_t *result) {
+#ifndef __MSC_VER
+    if (bits == 64) {
+        static_assert(sizeof(long long) == sizeof(int64_t));
+        bool flag = __builtin_smulll_overflow(a, b, (long long *)result);
+        if (flag) {
+            // Overflowed 64 bits
+            *result = 0;
+        }
+        return !flag;
+    }
+#endif
+    if (sub_would_overflow(bits, a, b)) {
+        *result = 0;
+        return false;
+    } else {
+        *result = a + b;
+        return true;
     }
 }
 

--- a/src/Util.h
+++ b/src/Util.h
@@ -348,6 +348,15 @@ bool sub_would_overflow(int bits, int64_t a, int64_t b);
 bool mul_would_overflow(int bits, int64_t a, int64_t b);
 // @}
 
+/** Routines to perform arithmetic on signed types without triggering signed
+ * overflow. If overflow would occur, sets result to zero, and returns
+ * false. Otherwise set result to the correct value, and returns true. */
+// @{
+bool add_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
+bool sub_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
+bool mul_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
+// @}
+
 /** Helper class for saving/restoring variable values on the stack, to allow
  * for early-exit that preserves correctness */
 template<typename T>

--- a/src/Util.h
+++ b/src/Util.h
@@ -352,9 +352,9 @@ bool mul_would_overflow(int bits, int64_t a, int64_t b);
  * overflow. If overflow would occur, sets result to zero, and returns
  * false. Otherwise set result to the correct value, and returns true. */
 // @{
-bool add_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
-bool sub_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
-bool mul_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
+HALIDE_MUST_USE_RESULT bool add_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
+HALIDE_MUST_USE_RESULT bool sub_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
+HALIDE_MUST_USE_RESULT bool mul_with_overflow(int bits, int64_t a, int64_t b, int64_t *result);
 // @}
 
 /** Helper class for saving/restoring variable values on the stack, to allow

--- a/test/correctness/intrinsics.cpp
+++ b/test/correctness/intrinsics.cpp
@@ -39,16 +39,18 @@ void check(Expr test, Expr expected) {
 
 template<typename T>
 int64_t mul_shift_right(int64_t a, int64_t b, int q) {
-    const int64_t min_t = std::numeric_limits<T>::min();
-    const int64_t max_t = std::numeric_limits<T>::max();
-    return std::min<int64_t>(std::max<int64_t>((a * b) >> q, min_t), max_t);
+    constexpr int64_t min_t = std::numeric_limits<T>::min();
+    constexpr int64_t max_t = std::numeric_limits<T>::max();
+    using W = std::conditional_t<min_t == 0, uint64_t, int64_t>;
+    return std::min<int64_t>(std::max<int64_t>((W(a) * W(b)) >> q, min_t), max_t);
 }
 
 template<typename T>
 int64_t rounding_mul_shift_right(int64_t a, int64_t b, int q) {
     const int64_t min_t = std::numeric_limits<T>::min();
     const int64_t max_t = std::numeric_limits<T>::max();
-    return std::min<int64_t>(std::max<int64_t>((a * b + (1ll << (q - 1))) >> q, min_t), max_t);
+    using W = std::conditional_t<min_t == 0, uint64_t, int64_t>;
+    return std::min<int64_t>(std::max<int64_t>((W(a) * W(b) + (W(1) << (q - 1))) >> q, min_t), max_t);
 }
 
 template<typename T>


### PR DESCRIPTION
Also, use compiler intrinsics when possible to handle overflow, as it generates faster code.

Fixes #7229 