### PR TITLE
Conditional allocations shouldn't fail for size=0 in C++ backend (#7255)

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -3427,7 +3427,7 @@ int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta, void
   } // overflow test tmp.heap
   int64_t _3 = _2;
   int32_t *_tmp_heap = (int32_t  *)halide_malloc(_ucon, sizeof(int32_t )*_3);
-  if (!_tmp_heap)
+  if (!((_tmp_heap != nullptr) || (_3 == 0)))
   {
    int32_t _4 = halide_error_out_of_memory(_ucon);
    return _4;


### PR DESCRIPTION
Allocations can be conditional; if the condition evaluates to false, we end up calling `halide_malloc(0)` (or `halide_tcm_malloc(0)` in the xtensa branch). Since it's legal via spec for `malloc(0)` to return nullptr, we need to be cautious here: if we are compiling with assertions enabled, *and* have a malloc() (etc) implementation that returns nullptr for alloc(0), we need to skip the assertion check, since we know the result won't be used.

Note: a similar check will be inserted in the xtensa branch separately.
Note 2: LLVM backend already has this check via Codegen_Posix.cpp