### PR TITLE
Add missing `cache.clear()` call at end of functions

### DIFF
--- a/src/CodeGen_Xtensa.cpp
+++ b/src/CodeGen_Xtensa.cpp
@@ -222,6 +222,7 @@ void CodeGen_Xtensa::compile(const LoweredFunc &f, const std::map<std::string, s
 
             // Return success.
             stream << get_indent() << "return 0;\n";
+            cache.clear();
         }
 
         indent -= 1;


### PR DESCRIPTION
Fix was made in Codegen_C.cpp a while back; the cache must be clear and end-of-func to avoid trying to share assignments between do-par-for lambdas.