### PR TITLE
Optimize Module::compile() for some edge cases

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -538,11 +538,10 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
     // ever rely on submodules (e.g.: toplevel declarations in C/C++), don't bother resolving
     // the submodules, which can call compile_to_buffer().
     const auto should_ignore_submodules = [](const std::map<OutputFileType, std::string> &output_files) {
-        auto output_files_copy = output_files;
-        output_files_copy.erase(OutputFileType::c_header);
-        output_files_copy.erase(OutputFileType::function_info_header);
-        output_files_copy.erase(OutputFileType::registration);
-        return output_files_copy.empty();
+        const size_t uninteresting_count = output_files.count(OutputFileType::c_header) +
+                                           output_files.count(OutputFileType::function_info_header) +
+                                           output_files.count(OutputFileType::registration);
+        return output_files.size() == uninteresting_count;
     };
 
     // If there are submodules, recursively lower submodules to


### PR DESCRIPTION
Avoid redundant `compile_to_buffer()` calls for output requests that can't possibly ever need them.