### PR TITLE
Add CMake support for C++ backend in test/generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1196,37 +1196,23 @@ GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_multitarget,$(GENERATOR_
 # remove AOT-CPP tests that don't (yet) work for C++ backend
 # (each tagged with the *known* blocking issue(s))
 
-# https://github.com/halide/Halide/issues/2084 (only if opencl enabled)
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_gpu_texture,$(GENERATOR_AOTCPP_TESTS))
-
-# https://github.com/halide/Halide/issues/2084 (only if opencl enabled)
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_acquire_release,$(GENERATOR_AOTCPP_TESTS))
-
-# https://github.com/halide/Halide/issues/2084 (only if opencl enabled)
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_define_extern_opencl,$(GENERATOR_AOTCPP_TESTS))
-
-# https://github.com/halide/Halide/issues/2084 (only if opencl enabled)
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_gpu_object_lifetime,$(GENERATOR_AOTCPP_TESTS))
-
-# https://github.com/halide/Halide/issues/2084 (only if opencl enabled)
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_gpu_only,$(GENERATOR_AOTCPP_TESTS))
+# sanitizercoverage relies on LLVM-specific hooks, so it will never work with the C backend
+GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_sanitizercoverage,$(GENERATOR_AOTCPP_TESTS))
 
 # https://github.com/halide/Halide/issues/2084 (only if opencl enabled))
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_cleanup_on_error,$(GENERATOR_AOTCPP_TESTS))
+#GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_cleanup_on_error,$(GENERATOR_AOTCPP_TESTS))
 
-# https://github.com/halide/Halide/issues/2084 (only if opencl enabled)
-GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_buffer_copy,$(GENERATOR_AOTCPP_TESTS))
-
-# https://github.com/halide/Halide/issues/2075
+# https://github.com/halide/Halide/issues/7273
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_msan,$(GENERATOR_AOTCPP_TESTS))
 
-# https://github.com/halide/Halide/issues/2075
+# https://github.com/halide/Halide/issues/7272
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_memory_profiler_mandelbrot,$(GENERATOR_AOTCPP_TESTS))
 
 # https://github.com/halide/Halide/issues/4916
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_stubtest,$(GENERATOR_AOTCPP_TESTS))
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_stubuser,$(GENERATOR_AOTCPP_TESTS))
 
+# Build requirements are finicky, testing non-C++ backend is good enough here
 GENERATOR_AOTCPP_TESTS := $(filter-out generator_aotcpp_gpu_multi_context_threaded,$(GENERATOR_AOTCPP_TESTS))
 
 test_aotcpp_generator: $(GENERATOR_AOTCPP_TESTS)
@@ -1669,6 +1655,11 @@ $(BIN_DIR)/$(TARGET)/generator_aot_sanitizercoverage: $(ROOT_DIR)/test/generator
 	@mkdir -p $(@D)
 	$(CXX) $(GEN_AOT_CXX_FLAGS) $(filter-out %.h,$^) $(GEN_AOT_INCLUDES) $(GEN_AOT_LD_FLAGS) -o $@
 
+# SanitizerCoverage test will never work with C++ backend
+$(BIN_DIR)/$(TARGET)/generator_aotcpp_sanitizercoverage: $(ROOT_DIR)/test/generator/sanitizercoverage_aottest.cpp
+	@mkdir -p $(@D)
+	echo "SanitizerCoverage test will never work with C++ backend"
+	exit 1
 
 # alias has additional deps to link in
 $(BIN_DIR)/$(TARGET)/generator_aot_alias: $(ROOT_DIR)/test/generator/alias_aottest.cpp $(FILTERS_DIR)/alias.a $(FILTERS_DIR)/alias_with_offset_42.a $(FILTERS_DIR)/alias_Adams2019.a $(FILTERS_DIR)/alias_Li2018.a $(FILTERS_DIR)/alias_Mullapudi2016.a  $(RUNTIME_EXPORTED_INCLUDES) $(BIN_DIR)/$(TARGET)/runtime.a

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2050,11 +2050,11 @@ void CodeGen_C::compile(const Buffer<> &buffer) {
         stream.write((char *)b.host, num_elems);
         stream << ")BUFCHARSOURCE\";\n";
 
-        stream << "static const uint8_t *" << name << "_data HALIDE_ATTRIBUTE_ALIGN(32) = (const uint8_t *) "
+        stream << "static const HALIDE_ATTRIBUTE_ALIGN(32) uint8_t *" << name << "_data = (const uint8_t *) "
                << name << "_string;\n";
     } else {
         // Emit the data
-        stream << "static " << (is_constant ? "const" : "") << " uint8_t " << name << "_data[] HALIDE_ATTRIBUTE_ALIGN(32) = {\n";
+        stream << "static " << (is_constant ? "const" : "") << " HALIDE_ATTRIBUTE_ALIGN(32) uint8_t " << name << "_data[] = {\n";
         stream << get_indent();
         for (size_t i = 0; i < num_elems * b.type.bytes(); i++) {
             if (i > 0) {

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -323,7 +323,7 @@ if (NOT ${USING_WASM})
                            FUNCTION_NAME HalideTest::cxx_mangling_gpu
                            FEATURES c_plus_plus_name_mangling cuda)
         target_link_libraries(generator_aot_cxx_mangling PRIVATE cxx_mangling_gpu)
-        target_link_libraries(generator_aot_cxx_mangling_cpp PRIVATE cxx_mangling_gpu)
+        target_link_libraries(generator_aotcpp_cxx_mangling PRIVATE cxx_mangling_gpu)
     endif ()
 
     # cxx_mangling_define_extern_externs.cpp

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -14,13 +14,12 @@ set(_USING_WASM (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm"))
 
 # Arguments are (mostly) identical to add_halide_library(), except:
 # - OMIT_C_BACKEND option to skip the CPP backend
-# - DEPS_OUT and DEPS_CPP_OUT as optional out-params, to receive the deps needed for using the standard / cpp outputs
 # - We always generate FUNCTION_INFO_HEADER
 #
 function(_add_halide_libraries TARGET)
     set(options GRADIENT_DESCENT OMIT_C_BACKEND)
-    set(oneValueArgs FROM GENERATOR_NAME FUNCTION_NAME NAMESPACE USE_RUNTIME AUTOSCHEDULER DEPS_OUT DEPS_CPP_OUT)
-    set(multiValueArgs ENABLE_IF TARGETS FEATURES PARAMS PLUGINS)
+    set(oneValueArgs FROM GENERATOR_NAME FUNCTION_NAME NAMESPACE USE_RUNTIME AUTOSCHEDULER)
+    set(multiValueArgs ENABLE_IF TARGETS FEATURES PARAMS PLUGINS EXTERNS)
     cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (args_ENABLE_IF AND NOT (${args_ENABLE_IF}))
@@ -48,8 +47,6 @@ function(_add_halide_libraries TARGET)
     endif()
 
     set(TARGET_CPP "${TARGET}_cpp")
-    set(_DEPS_CPP )
-    set(_DEPS )
 
     add_halide_library(${TARGET}
                        ${GRADIENT_DESCENT_OPT}
@@ -64,7 +61,10 @@ function(_add_halide_libraries TARGET)
                        PARAMS "${args_PARAMS}"
                        PLUGINS "${args_PLUGINS}"
                        FUNCTION_INFO_HEADER function_info_header_out)
-    list(APPEND _DEPS ${TARGET} ${TARGET}.runtime)
+    if (args_EXTERNS)
+        target_link_libraries(${TARGET} INTERFACE ${args_EXTERNS})
+    endif()
+
 
     if (NOT args_OMIT_C_BACKEND)
         # The C backend basically ignores TARGETS (it emits a warning that the sources
@@ -87,7 +87,9 @@ function(_add_halide_libraries TARGET)
                            PARAMS "${args_PARAMS}"
                            PLUGINS "${args_PLUGINS}"
                            FUNCTION_INFO_HEADER function_info_header_cpp_out)
-        list(APPEND _DEPS_CPP ${TARGET_CPP} ${TARGET}.runtime)
+        if (args_EXTERNS)
+            target_link_libraries(${TARGET_CPP} INTERFACE ${args_EXTERNS})
+        endif()
         # This is a bit subtle: we end up emitting NAME.h and NAME_cpp.h header files;
         # these are *identical* in content (aside from the guard macro and the filename).
         # For convenience, we use the NAME.h variant in all cases downstream (even when linking
@@ -96,13 +98,6 @@ function(_add_halide_libraries TARGET)
         # on NAME.h already being generated.) This is a bit suboptimal, but it is arguably better
         # that having conditionalized #includes in all the downstream test targets.
         add_dependencies(${TARGET_CPP} ${TARGET})
-    endif()
-
-    if (args_DEPS_OUT)
-        set(${args_DEPS_OUT} ${_DEPS} PARENT_SCOPE)
-    endif()
-    if (args_DEPS_CPP_OUT)
-        set(${args_DEPS_CPP_OUT} ${_DEPS_CPP} PARENT_SCOPE)
     endif()
 endfunction()
 
@@ -301,32 +296,33 @@ if (NOT ${_USING_WASM})
     # cxx_mangling_generator.cpp
     _add_halide_libraries(cxx_mangling
                           FUNCTION_NAME HalideTest::AnotherNamespace::cxx_mangling
-                          FEATURES c_plus_plus_name_mangling)
-    _add_halide_aot_tests(cxx_mangling
-                          DEPS cxx_mangling_externs)
-
+                          FEATURES c_plus_plus_name_mangling
+                          EXTERNS cxx_mangling_externs)
+    set(_CXX_MANGLING_HALIDE_LIBRARIES cxx_mangling)
     if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
         add_halide_library(cxx_mangling_gpu
                            FROM cxx_mangling.generator
-                           GENERATOR_NAME cxx_mangling
+                           GENERATOR cxx_mangling
                            FUNCTION_NAME HalideTest::cxx_mangling_gpu
                            FEATURES c_plus_plus_name_mangling cuda)
-        target_link_libraries(generator_aot_cxx_mangling PRIVATE cxx_mangling_gpu)
-        target_link_libraries(generator_aotcpp_cxx_mangling PRIVATE cxx_mangling_gpu)
+        list(APPEND _CXX_MANGLING_HALIDE_LIBRARIES cxx_mangling_gpu)
     endif ()
+    _add_halide_aot_tests(cxx_mangling HALIDE_LIBRARIES ${_CXX_MANGLING_HALIDE_LIBRARIES})
 
     # cxx_mangling_define_extern_externs.cpp
     add_library(cxx_mangling_define_extern_externs STATIC cxx_mangling_define_extern_externs.cpp)
+    # Ensure that cxx_mangling.h is availabe for cxx_mangling_define_extern_externs
     target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling)
+    add_dependencies(cxx_mangling_define_extern_externs cxx_mangling)
 
     # cxx_mangling_define_extern_aottest.cpp
     # cxx_mangling_define_extern_generator.cpp
     _add_halide_libraries(cxx_mangling_define_extern
                           FUNCTION_NAME "HalideTest::cxx_mangling_define_extern"
-                          FEATURES c_plus_plus_name_mangling user_context)
+                          FEATURES c_plus_plus_name_mangling user_context
+                          EXTERNS cxx_mangling_define_extern_externs cxx_mangling)
     _add_halide_aot_tests(cxx_mangling_define_extern
-                          HALIDE_LIBRARIES cxx_mangling_define_extern cxx_mangling
-                          DEPS cxx_mangling_externs cxx_mangling_define_extern_externs)
+                          HALIDE_LIBRARIES cxx_mangling_define_extern cxx_mangling)
 endif ()  # (NOT ${_USING_WASM})
 
 # define_extern_opencl_aottest.cpp

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -2,75 +2,205 @@
 # Convenience method for defining test cases in this directory.
 ##
 
-function(halide_define_aot_test NAME)
-    set(options OMIT_DEFAULT_GENERATOR)
-    set(oneValueArgs FUNCTION_NAME)
-    set(multiValueArgs GEN_DEPS EXTRA_LIBS ENABLE_IF FEATURES PARAMS GEN_TARGET GROUPS EXTRA_OUTPUTS)
+# TODO(#4938): remove need for these definitions
+function(_add_gpu_deps TARGET)
+    if ("${Halide_TARGET}" MATCHES "opencl")
+        target_compile_definitions("${TARGET}" PRIVATE TEST_OPENCL)
+    endif ()
+    if ("${Halide_TARGET}" MATCHES "metal")
+        target_compile_definitions("${TARGET}" PRIVATE TEST_METAL)
+    endif ()
+    if ("${Halide_TARGET}" MATCHES "cuda")
+        target_compile_definitions("${TARGET}" PRIVATE TEST_CUDA)
+    endif ()
+endfunction()
+
+function(_add_aot_test TARGET)
+    set(options "")
+    set(oneValueArgs "")
+    set(multiValueArgs SRCS DEPS GROUPS DEFINES)
     cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if (args_ENABLE_IF AND NOT (${args_ENABLE_IF}))
-        return()
-    endif ()
+    add_executable("${TARGET}" ${args_SRCS})
+    target_compile_definitions("${TARGET}" PRIVATE ${args_DEFINES})
+    target_include_directories("${TARGET}" PRIVATE "${Halide_SOURCE_DIR}/test/common" "${Halide_SOURCE_DIR}/tools")
+    target_link_libraries("${TARGET}" PRIVATE ${args_DEPS})
+    _add_gpu_deps("${TARGET}")
+    add_halide_test("${TARGET}" GROUPS generator ${args_GROUPS})
+endfunction()
+
+# Emit two halide_library targets, one with the default backend with the given name,
+# and (optionally) one with the C++ backend with the name NAME_cpp. (The CPP one defaults to being
+# emitted, but can be skipped if OMIT_C_BACKEND is specified.)
+
+# Arguments are (mostly) identical to add_halide_library(), except:
+# - OMIT_C_BACKEND option to skip the CPP backend
+# - DEPS_OUT and DEPS_CPP_OUT as optional out-params, to receive the deps needed for using the standard / cpp outputs
+# - LINK_TO_AOTTEST (if specified) will link the outputs to the relevant generator_aot_NAME/generator_aotcpp_NAME test
+#   (which must be defined prior to this rule).
+#
+function(_add_halide_libraries TARGET)
+    set(options GRADIENT_DESCENT OMIT_C_BACKEND)
+    set(oneValueArgs FROM GENERATOR FUNCTION_NAME NAMESPACE USE_RUNTIME AUTOSCHEDULER HEADER EXTRA_OUTPUTS DEPS_OUT DEPS_CPP_OUT LINK_TO_AOTTEST)
+    set(multiValueArgs GENERATOR_LINK_LIBRARIES TARGETS FEATURES PARAMS PLUGINS)
+    cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(EXTRA_OUTPUTS "")
     foreach (EO IN LISTS args_EXTRA_OUTPUTS)
         list(APPEND EXTRA_OUTPUTS ${EO} ${EO}_PATH_OUT)
     endforeach()
 
-    add_halide_generator("${NAME}.generator"
-                         SOURCES "${NAME}_generator.cpp"
-                         LINK_LIBRARIES ${args_GEN_DEPS})
+    # Passing on a no-value arg in CMake is unpleasant
+    if (args_GRADIENT_DESCENT)
+        set(GRADIENT_DESCENT_OPT "GRADIENT_DESCENT")
+    else()
+        set(GRADIENT_DESCENT_OPT "")
+    endif()
 
-    set(TARGET "generator_aot_${NAME}")
-    set(DEPS ${args_EXTRA_LIBS})
-    if (NOT args_OMIT_DEFAULT_GENERATOR)
-        add_halide_library(${NAME}
-                           FROM "${NAME}.generator"
-                           PARAMS "${args_PARAMS}"
-                           TARGETS "${args_GEN_TARGET}"
+    # Fill in default values for some arguments, as needed
+    if (NOT args_FROM)
+        add_halide_generator("${TARGET}.generator"
+                             SOURCES "${TARGET}_generator.cpp"
+                             LINK_LIBRARIES ${args_GENERATOR_LINK_LIBRARIES})
+        set(args_FROM "${TARGET}.generator")
+    endif()
+    if (NOT args_GENERATOR)
+        set(args_GENERATOR "${TARGET}")
+    endif()
+    if (NOT args_FUNCTION_NAME)
+        set(args_FUNCTION_NAME "${TARGET}")
+    endif()
+
+    set(TARGET_CPP "${TARGET}_cpp")
+    set(_DEPS_CPP )
+    set(_DEPS )
+
+    add_halide_library(${TARGET}
+                       ${GRADIENT_DESCENT_OPT}
+                       FROM "${args_FROM}"
+                       GENERATOR "${args_GENERATOR}"
+                       FUNCTION_NAME "${args_FUNCTION_NAME}"
+                       NAMESPACE "${args_NAMESPACE}"
+                       USE_RUNTIME "${args_USE_RUNTIME}"
+                       AUTOSCHEDULER "${args_AUTOSCHEDULER}"
+                       USE_RUNTIME "${args_USE_RUNTIME}"
+                       TARGETS "${args_TARGETS}"
+                       FEATURES "${args_FEATURES}"
+                       PARAMS "${args_PARAMS}"
+                       PLUGINS "${args_PLUGINS}"
+                       ${EXTRA_OUTPUTS})
+    list(APPEND _DEPS ${TARGET} ${TARGET}.runtime)
+    if (args_LINK_TO_AOTTEST)
+            target_link_libraries("generator_aot_${args_LINK_TO_AOTTEST}" PRIVATE ${_DEPS})
+    endif()
+
+    if (NOT args_OMIT_C_BACKEND)
+        # The C backend basically ignores TARGETS (it emits a warning that the sources
+        # will be compiled with the current CMake toolchain)... but making matters worse,
+        # if you specify multiple targets here, you'll fail in compile_multitarget() because
+        # it wants object file to be generated. We'll just dodge all that by deliberately
+        # omitting the TARGETS argument here entirely.
+        add_halide_library(${TARGET_CPP}
+                           C_BACKEND
+                           ${GRADIENT_DESCENT_OPT}
+                           FROM "${args_FROM}"
+                           GENERATOR "${args_GENERATOR}"
                            FUNCTION_NAME "${args_FUNCTION_NAME}"
+                           NAMESPACE "${args_NAMESPACE}"
+                           USE_RUNTIME "${args_USE_RUNTIME}"
+                           AUTOSCHEDULER "${args_AUTOSCHEDULER}"
+                           USE_RUNTIME "${args_USE_RUNTIME}"
+                           # No: see comment above
+                           # TARGETS "${args_TARGETS}"
                            FEATURES "${args_FEATURES}"
+                           PARAMS "${args_PARAMS}"
+                           PLUGINS "${args_PLUGINS}"
                            ${EXTRA_OUTPUTS})
-        list(APPEND DEPS ${NAME} ${NAME}.runtime)
+        list(APPEND _DEPS_CPP ${TARGET_CPP} ${TARGET}.runtime)
+        if (args_LINK_TO_AOTTEST)
+            target_link_libraries("generator_aotcpp_${args_LINK_TO_AOTTEST}" PRIVATE ${_DEPS_CPP})
+        endif()
+        # This is a bit subtle: we end up emitting NAME.h and NAME_cpp.h header files;
+        # these are *identical* in content (aside from the guard macro and the filename).
+        # For convenience, we use the NAME.h variant in all cases downstream (even when linking
+        # with the NAME_cpp.a output), but to make that reliable, we must ensure that TARGET
+        # is always generated before TARGET_CPP (so that anything depending on TARGET_CPP can rely
+        # on NAME.h already being generated.) This is a bit suboptimal, but it is arguably better
+        # that having conditionalized #includes in all the downstream test targets.
+        add_dependencies(${TARGET_CPP} ${TARGET})
+    endif()
+
+    if (args_DEPS_OUT)
+        set(${args_DEPS_OUT} ${_DEPS} PARENT_SCOPE)
+    endif()
+    if (args_DEPS_CPP_OUT)
+        set(${args_DEPS_CPP_OUT} ${_DEPS_CPP} PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(halide_define_aot_test NAME)
+    set(options OMIT_DEFAULT_HALIDE_LIBRARY OMIT_C_BACKEND)
+    set(oneValueArgs FUNCTION_NAME)
+    set(multiValueArgs GENERATOR_LINK_LIBRARIES EXTRA_LIBS ENABLE_IF FEATURES PARAMS TARGETS GROUPS EXTRA_OUTPUTS)
+    cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (args_ENABLE_IF AND NOT (${args_ENABLE_IF}))
+        return()
     endif ()
 
+    # Apparently CMake has no one-liner for 'assign bool value to var'?
+    set(TARGETING_WASM FALSE)
     if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
+        set(TARGETING_WASM FALSE)
+    endif()
+
+    # Always omit C++ backend testing when we are targeting wasm
+    if (TARGETING_WASM)
+        set(args_OMIT_C_BACKEND TRUE)
+    endif()
+
+    set(TARGET "generator_aot_${NAME}")
+    set(TARGET_CPP "generator_aotcpp_${NAME}")
+
+    if (TARGETING_WASM)
         add_wasm_executable("${TARGET}"
-                            SRCS "${NAME}_aottest.cpp"
-                            DEPS "${DEPS}"
+                            SRCS "${HALIDE_LIBRARY}_aottest.cpp"
                             INCLUDES
                             "${Halide_BINARY_DIR}/include"
                             "${Halide_SOURCE_DIR}/test/common"
                             "${Halide_SOURCE_DIR}/tools"
                             "${CMAKE_CURRENT_BINARY_DIR}")
-
         add_wasm_halide_test("${TARGET}" GROUPS generator "${args_GROUPS}")
-    else ()
-        add_executable("${TARGET}" "${NAME}_aottest.cpp")
-        target_include_directories(
-            "${TARGET}" PRIVATE
-            "${Halide_SOURCE_DIR}/test/common"
-            "${Halide_SOURCE_DIR}/tools"
-        )
-        if (NOT args_OMIT_DEFAULT_GENERATOR)
-            target_link_libraries(${TARGET} PRIVATE ${NAME})
-        endif ()
-        if (args_EXTRA_LIBS)
-            target_link_libraries(${TARGET} PRIVATE ${args_EXTRA_LIBS})
-        endif ()
+        return()
+    endif()
 
-        # TODO(#4938): remove need for these definitions
-        if ("${Halide_TARGET}" MATCHES "opencl")
-            target_compile_definitions("${TARGET}" PRIVATE TEST_OPENCL)
-        endif ()
-        if ("${Halide_TARGET}" MATCHES "metal")
-            target_compile_definitions("${TARGET}" PRIVATE TEST_METAL)
-        endif ()
-        if ("${Halide_TARGET}" MATCHES "cuda")
-            target_compile_definitions("${TARGET}" PRIVATE TEST_CUDA)
-        endif ()
-        add_halide_test("${TARGET}" GROUPS generator "${args_GROUPS}")
-    endif ()
+    _add_aot_test("${TARGET}"
+                  SRCS "${NAME}_aottest.cpp"
+                  DEPS ${args_EXTRA_LIBS}
+                  GROUPS ${args_GROUPS})
+    if (NOT args_OMIT_C_BACKEND)
+        _add_aot_test("${TARGET_CPP}"
+                      SRCS "${NAME}_aottest.cpp"
+                      DEPS ${args_EXTRA_LIBS}
+                      GROUPS ${args_GROUPS})
+    endif()
+
+    if (NOT args_OMIT_DEFAULT_HALIDE_LIBRARY)
+        if (args_OMIT_C_BACKEND)
+            set(OMIT_C_BACKEND_OPT "OMIT_C_BACKEND")
+        else()
+            set(OMIT_C_BACKEND_OPT "")
+        endif()
+        _add_halide_libraries("${NAME}"
+                ${OMIT_C_BACKEND_OPT}
+                LINK_TO_AOTTEST "${NAME}"
+                EXTRA_OUTPUTS ${args_EXTRA_OUTPUTS}
+                FEATURES ${args_FEATURES}
+                FUNCTION_NAME ${args_FUNCTION_NAME}
+                GENERATOR_LINK_LIBRARIES ${args_GENERATOR_LINK_LIBRARIES}
+                TARGETS ${args_TARGETS}
+                PARAMS ${args_PARAMS})
+    endif()
 endfunction()
 
 ##
@@ -78,15 +208,6 @@ endfunction()
 ##
 
 set(USING_WASM (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm"))
-
-if (NOT ${USING_WASM})
-    # cxx_mangling_externs.cpp
-    add_library(cxx_mangling_externs STATIC cxx_mangling_externs.cpp)
-
-    # cxx_mangling_define_extern_externs.cpp
-    add_library(cxx_mangling_define_extern_externs STATIC cxx_mangling_define_extern_externs.cpp)
-    target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling)
-endif ()
 
 if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
     find_package(CUDAToolkit REQUIRED)
@@ -105,9 +226,11 @@ endif ()
 halide_define_aot_test(acquire_release)
 if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
     target_link_libraries(generator_aot_acquire_release PRIVATE CUDA::cuda_driver CUDA::cudart)
+    target_link_libraries(generator_aotcpp_acquire_release PRIVATE CUDA::cuda_driver CUDA::cudart)
 endif ()
 if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
     target_link_libraries(generator_aot_acquire_release PRIVATE OpenCL::OpenCL)
+    target_link_libraries(generator_aotcpp_acquire_release PRIVATE OpenCL::OpenCL)
 endif ()
 
 # TODO: what are these?
@@ -121,13 +244,11 @@ endif ()
 set(ALIAS_LIBS alias_with_offset_42 alias_Adams2019 alias_Li2018 alias_Mullapudi2016)
 halide_define_aot_test(alias EXTRA_LIBS ${ALIAS_LIBS})
 foreach (LIB IN LISTS ALIAS_LIBS)
-    # We don't really need all the plugins at once here --
-    # It's just easier to specify them all (and adds a test that loading
-    # multiple plugins works)
-    add_halide_library(${LIB}
-                       FROM alias.generator
-                       GENERATOR ${LIB}
-                       PLUGINS Halide::Adams2019 Halide::Li2018 Halide::Mullapudi2016)
+    _add_halide_libraries(${LIB}
+                          LINK_TO_AOTTEST alias
+                          FROM alias.generator
+                          GENERATOR ${LIB}
+                          PLUGINS Halide::Adams2019 Halide::Li2018 Halide::Mullapudi2016)
 endforeach ()
 
 # argvcall_aottest.cpp
@@ -146,14 +267,14 @@ halide_define_aot_test(async_parallel
 # autograd_generator.cpp
 halide_define_aot_test(autograd ENABLE_IF TARGET Halide::Mullapudi2016 AND NOT ${USING_WASM}
                        GROUPS multithreaded)
-if (TARGET generator_aot_autograd)
-    add_halide_library(autograd_grad
-                       GRADIENT_DESCENT
-                       FROM autograd.generator
-                       GENERATOR autograd
-                       AUTOSCHEDULER Halide::Mullapudi2016)
-    target_link_libraries(generator_aot_autograd PRIVATE autograd_grad)
-endif ()
+_add_halide_libraries(autograd_grad
+                      LINK_TO_AOTTEST autograd
+                      GRADIENT_DESCENT
+                      FROM autograd.generator
+                      GENERATOR autograd
+                      FUNCTION_NAME autograd_grad
+                      AUTOSCHEDULER Halide::Mullapudi2016
+                      PLUGINS Halide::Mullapudi2016)
 
 # abstractgeneratortest_aottest.cpp
 # abstractgeneratortest_generator.cpp
@@ -177,35 +298,28 @@ halide_define_aot_test(can_use_target)
 
 # cleanup_on_error_aottest.cpp
 # cleanup_on_error_generator.cpp
-# TODO: requires access to internal header runtime/device_interface.h
-# halide_define_aot_test(cleanup_on_error)
+halide_define_aot_test(cleanup_on_error)
+# Alas, this test requires direct access to internal header runtime/device_interface.h
+target_include_directories(generator_aot_cleanup_on_error PRIVATE "${Halide_SOURCE_DIR}/src/runtime")
+target_include_directories(generator_aotcpp_cleanup_on_error PRIVATE "${Halide_SOURCE_DIR}/src/runtime")
 
 # configure_aottest.cpp
 # configure_generator.cpp
 halide_define_aot_test(configure)
 
-# cxx_mangling_define_extern_aottest.cpp
-# cxx_mangling_define_extern_generator.cpp
-halide_define_aot_test(cxx_mangling_define_extern
-                       # Needs extra deps / build rules
-                       ENABLE_IF NOT ${USING_WASM}
-                       FUNCTION_NAME "HalideTest::cxx_mangling_define_extern"
-                       FEATURES c_plus_plus_name_mangling user_context)
-if (TARGET cxx_mangling_define_extern)
-    target_link_libraries(cxx_mangling_define_extern INTERFACE cxx_mangling_externs cxx_mangling_define_extern_externs)
-    target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling_externs cxx_mangling)
-endif ()
+if (NOT ${USING_WASM})
 
-# cxx_mangling_aottest.cpp
-# cxx_mangling_generator.cpp
-halide_define_aot_test(cxx_mangling
-                       # Needs extra deps / build rules
-                       ENABLE_IF NOT ${USING_WASM}
-                       FUNCTION_NAME HalideTest::AnotherNamespace::cxx_mangling
-                       FEATURES c_plus_plus_name_mangling
-                       EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
-if (TARGET cxx_mangling)
+    # cxx_mangling_externs.cpp
+    add_library(cxx_mangling_externs STATIC cxx_mangling_externs.cpp)
+
+    # cxx_mangling_aottest.cpp
+    # cxx_mangling_generator.cpp
+    halide_define_aot_test(cxx_mangling
+                           FUNCTION_NAME HalideTest::AnotherNamespace::cxx_mangling
+                           FEATURES c_plus_plus_name_mangling
+                           EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
     target_link_libraries(cxx_mangling INTERFACE cxx_mangling_externs)
+    target_link_libraries(cxx_mangling_cpp INTERFACE cxx_mangling_externs)
     if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
         add_halide_library(cxx_mangling_gpu
                            FROM cxx_mangling.generator
@@ -213,8 +327,25 @@ if (TARGET cxx_mangling)
                            FUNCTION_NAME HalideTest::cxx_mangling_gpu
                            FEATURES c_plus_plus_name_mangling cuda)
         target_link_libraries(generator_aot_cxx_mangling PRIVATE cxx_mangling_gpu)
+        target_link_libraries(generator_aot_cxx_mangling_cpp PRIVATE cxx_mangling_gpu)
     endif ()
-endif ()
+
+    # cxx_mangling_define_extern_externs.cpp
+    add_library(cxx_mangling_define_extern_externs STATIC cxx_mangling_define_extern_externs.cpp)
+    target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling)
+    add_dependencies(cxx_mangling_define_extern_externs cxx_mangling)
+
+    # cxx_mangling_define_extern_aottest.cpp
+    # cxx_mangling_define_extern_generator.cpp
+    halide_define_aot_test(cxx_mangling_define_extern
+                           FUNCTION_NAME "HalideTest::cxx_mangling_define_extern"
+                           FEATURES c_plus_plus_name_mangling user_context)
+    target_link_libraries(cxx_mangling_define_extern INTERFACE cxx_mangling_define_extern_externs)
+    target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling)
+    target_link_libraries(cxx_mangling_define_extern_cpp INTERFACE cxx_mangling_define_extern_externs)
+    target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling_cpp)
+
+endif ()  # (NOT ${USING_WASM})
 
 # define_extern_opencl_aottest.cpp
 # define_extern_opencl_generator.cpp
@@ -222,6 +353,7 @@ halide_define_aot_test(define_extern_opencl)
 if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
     find_package(OpenCL REQUIRED)
     target_link_libraries(generator_aot_define_extern_opencl PRIVATE OpenCL::OpenCL)
+    target_link_libraries(generator_aotcpp_define_extern_opencl PRIVATE OpenCL::OpenCL)
 endif ()
 
 # embed_image_aottest.cpp
@@ -251,21 +383,30 @@ halide_define_aot_test(float16_t)
 # (Doesn't build/link properly under wasm, and isn't useful there anyway)
 if (NOT Halide_TARGET MATCHES "wasm")
     halide_define_aot_test(gpu_multi_context_threaded
-                           OMIT_DEFAULT_GENERATOR
-                           EXTRA_LIBS
-                           gpu_multi_context_threaded_add
-                           gpu_multi_context_threaded_mul)
+                           OMIT_DEFAULT_HALIDE_LIBRARY)
 
-    add_halide_library(gpu_multi_context_threaded_add FROM gpu_multi_context_threaded.generator
-                       FEATURES user_context)
-    add_halide_library(gpu_multi_context_threaded_mul FROM gpu_multi_context_threaded.generator
-                       FEATURES user_context)
+    # Explicitly define our Generator here since OMIT_DEFAULT_HALIDE_LIBRARY
+    # was specified
+    add_halide_generator(gpu_multi_context_threaded.generator
+                         SOURCES gpu_multi_context_threaded_generator.cpp)
+
+    _add_halide_libraries(gpu_multi_context_threaded_add
+                          LINK_TO_AOTTEST gpu_multi_context_threaded
+                          FROM gpu_multi_context_threaded.generator
+                          FEATURES user_context)
+
+    _add_halide_libraries(gpu_multi_context_threaded_mul
+                          LINK_TO_AOTTEST gpu_multi_context_threaded
+                          FROM gpu_multi_context_threaded.generator
+                          FEATURES user_context)
 
     if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
         target_link_libraries(generator_aot_gpu_multi_context_threaded PRIVATE CUDA::cuda_driver CUDA::cudart)
+        target_link_libraries(generator_aotcpp_gpu_multi_context_threaded PRIVATE CUDA::cuda_driver CUDA::cudart)
     endif ()
     if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
         target_link_libraries(generator_aot_gpu_multi_context_threaded PRIVATE OpenCL::OpenCL)
+        target_link_libraries(generator_aotcpp_gpu_multi_context_threaded PRIVATE OpenCL::OpenCL)
     endif ()
 endif ()
 
@@ -293,8 +434,10 @@ halide_define_aot_test(mandelbrot
 # memory_profiler_mandelbrot_aottest.cpp
 # memory_profiler_mandelbrot_generator.cpp
 halide_define_aot_test(memory_profiler_mandelbrot
-                       # Requires profiler support (which requires threading), not yet available for wasm tests
+                       # Requires profiler support (which requires threading), not yet available for wasm tests...
                        ENABLE_IF NOT ${USING_WASM}
+                       # ... or the C backend (https://github.com/halide/Halide/issues/7272)
+                       OMIT_C_BACKEND
                        FEATURES profile
                        GROUPS multithreaded)
 
@@ -334,7 +477,7 @@ set(metadata_tester_params
 
 # Note that metadata_tester (but not metadata_tester_ucon) is built as "multitarget" to verify that
 # the metadata names are correctly emitted.
-if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
+if (${USING_WASM})
     # wasm doesn't support multitargets
     # TODO: currently, Halide_CMAKE_TARGET == Halide_HOST_TARGET when building for Emscripten; we should fix this
     set(MDT_TARGETS ${Halide_TARGET})
@@ -345,40 +488,48 @@ endif()
 halide_define_aot_test(metadata_tester
                        EXTRA_LIBS metadata_tester_ucon
                        PARAMS ${metadata_tester_params}
-                       GEN_TARGET ${MDT_TARGETS}
+                       TARGETS ${MDT_TARGETS}
                        EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
-add_halide_library(metadata_tester_ucon
-                   FROM metadata_tester.generator
-                   GENERATOR metadata_tester
-                   FEATURES user_context
-                   PARAMS ${metadata_tester_params}
-                   FUNCTION_INFO_HEADER metadata_tester_ucon_path)
+_add_halide_libraries(metadata_tester_ucon
+                      LINK_TO_AOTTEST metadata_tester
+                      FROM metadata_tester.generator
+                      GENERATOR metadata_tester
+                      FEATURES user_context
+                      PARAMS ${metadata_tester_params}
+                      FUNCTION_INFO_HEADER metadata_tester_ucon_path)
 
 # msan_aottest.cpp
 # msan_generator.cpp
 halide_define_aot_test(msan FEATURES msan
+                       # Broken for C++ backend (https://github.com/halide/Halide/issues/7273)
+                       OMIT_C_BACKEND
                        GROUPS multithreaded)
 
 # (Doesn't build/link properly on windows / under wasm)
 if (NOT Halide_TARGET MATCHES "windows" AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT Halide_TARGET MATCHES "wasm")
     # sanitizercoverage_aottest.cpp
     # sanitizercoverage_generator.cpp
-    halide_define_aot_test(sanitizercoverage FEATURES sanitizer_coverage)
+    halide_define_aot_test(sanitizercoverage
+                           # sanitizercoverage relies on LLVM-specific hooks, so it will never work with the C backend
+                           OMIT_C_BACKEND
+                           FEATURES sanitizer_coverage)
 endif ()
 
 # multitarget_aottest.cpp
 # multitarget_generator.cpp
 halide_define_aot_test(multitarget
-                       # Multitarget doesn't apply to WASM
+                       # Multitarget doesn't apply to WASM...
                        ENABLE_IF NOT ${USING_WASM}
-                       GEN_TARGET cmake-no_bounds_query cmake
+                       # ... or to the C backend
+                       OMIT_C_BACKEND
+                       TARGETS cmake-no_bounds_query cmake
                        FEATURES c_plus_plus_name_mangling
                        FUNCTION_NAME HalideTest::multitarget)
 
 # nested_externs_aottest.cpp
 # nested_externs_generator.cpp
 halide_define_aot_test(nested_externs
-                       OMIT_DEFAULT_GENERATOR
+                       OMIT_DEFAULT_HALIDE_LIBRARY
                        EXTRA_LIBS
                        nested_externs_root
                        nested_externs_inner
@@ -386,10 +537,13 @@ halide_define_aot_test(nested_externs
                        nested_externs_leaf
                        nested_externs_root.runtime)
 
-add_halide_library(nested_externs_root FROM nested_externs.generator)
-add_halide_library(nested_externs_inner FROM nested_externs.generator)
-add_halide_library(nested_externs_combine FROM nested_externs.generator)
-add_halide_library(nested_externs_leaf FROM nested_externs.generator)
+# Explicitly define our Generator here since OMIT_DEFAULT_HALIDE_LIBRARY
+# was specified
+add_halide_generator(nested_externs.generator SOURCES nested_externs_generator.cpp)
+_add_halide_libraries(nested_externs_root FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
+_add_halide_libraries(nested_externs_inner FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
+_add_halide_libraries(nested_externs_combine FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
+_add_halide_libraries(nested_externs_leaf FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
 
 # opencl_runtime_aottest.cpp
 # opencl_runtime_generator.cpp
@@ -415,11 +569,11 @@ halide_define_aot_test(string_param PARAMS "rpn_expr=5 y * x +")
 # stubtest_aottest.cpp
 # stubtest_generator.cpp
 # stubtest_jittest.cpp
-# stubs not supported in CMake
+# TODO: stubs not supported in CMake
 
 # stubuser_aottest.cpp
 # stubuser_generator.cpp
-# stubs not supported in CMake
+# TODO: stubs not supported in CMake
 
 # shuffler_aottest.cpp
 # shuffler_generator.cpp

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -18,13 +18,12 @@ endfunction()
 function(_add_aot_test TARGET)
     set(options "")
     set(oneValueArgs "")
-    set(multiValueArgs SRCS DEPS GROUPS DEFINES)
+    set(multiValueArgs SRCS GROUPS DEFINES)
     cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     add_executable("${TARGET}" ${args_SRCS})
     target_compile_definitions("${TARGET}" PRIVATE ${args_DEFINES})
     target_include_directories("${TARGET}" PRIVATE "${Halide_SOURCE_DIR}/test/common" "${Halide_SOURCE_DIR}/tools")
-    target_link_libraries("${TARGET}" PRIVATE ${args_DEPS})
     _add_gpu_deps("${TARGET}")
     add_halide_test("${TARGET}" GROUPS generator ${args_GROUPS})
 endfunction()
@@ -141,7 +140,7 @@ endfunction()
 function(halide_define_aot_test NAME)
     set(options OMIT_DEFAULT_HALIDE_LIBRARY OMIT_C_BACKEND)
     set(oneValueArgs FUNCTION_NAME)
-    set(multiValueArgs GENERATOR_LINK_LIBRARIES EXTRA_LIBS ENABLE_IF FEATURES PARAMS TARGETS GROUPS EXTRA_OUTPUTS)
+    set(multiValueArgs GENERATOR_LINK_LIBRARIES ENABLE_IF FEATURES PARAMS TARGETS GROUPS EXTRA_OUTPUTS)
     cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (args_ENABLE_IF AND NOT (${args_ENABLE_IF}))
@@ -176,12 +175,10 @@ function(halide_define_aot_test NAME)
 
     _add_aot_test("${TARGET}"
                   SRCS "${NAME}_aottest.cpp"
-                  DEPS ${args_EXTRA_LIBS}
                   GROUPS ${args_GROUPS})
     if (NOT args_OMIT_C_BACKEND)
         _add_aot_test("${TARGET_CPP}"
                       SRCS "${NAME}_aottest.cpp"
-                      DEPS ${args_EXTRA_LIBS}
                       GROUPS ${args_GROUPS})
     endif()
 
@@ -576,7 +573,9 @@ halide_define_aot_test(templated)
 
 # tiled_blur_aottest.cpp
 # tiled_blur_generator.cpp
-halide_define_aot_test(tiled_blur EXTRA_LIBS blur2x2)
+halide_define_aot_test(tiled_blur)
+target_link_libraries(generator_aot_tiled_blur PRIVATE blur2x2)
+target_link_libraries(generator_aotcpp_tiled_blur PRIVATE blur2x2_cpp)
 
 # user_context_aottest.cpp
 # user_context_generator.cpp

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -242,7 +242,7 @@ endif ()
 # alias_aottest.cpp
 # alias_generator.cpp
 set(ALIAS_LIBS alias_with_offset_42 alias_Adams2019 alias_Li2018 alias_Mullapudi2016)
-halide_define_aot_test(alias EXTRA_LIBS ${ALIAS_LIBS})
+halide_define_aot_test(alias)
 foreach (LIB IN LISTS ALIAS_LIBS)
     _add_halide_libraries(${LIB}
                           LINK_TO_AOTTEST alias
@@ -308,7 +308,6 @@ target_include_directories(generator_aotcpp_cleanup_on_error PRIVATE "${Halide_S
 halide_define_aot_test(configure)
 
 if (NOT ${USING_WASM})
-
     # cxx_mangling_externs.cpp
     add_library(cxx_mangling_externs STATIC cxx_mangling_externs.cpp)
 
@@ -344,7 +343,6 @@ if (NOT ${USING_WASM})
     target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling)
     target_link_libraries(cxx_mangling_define_extern_cpp INTERFACE cxx_mangling_define_extern_externs)
     target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling_cpp)
-
 endif ()  # (NOT ${USING_WASM})
 
 # define_extern_opencl_aottest.cpp
@@ -486,7 +484,6 @@ else()
 endif()
 
 halide_define_aot_test(metadata_tester
-                       EXTRA_LIBS metadata_tester_ucon
                        PARAMS ${metadata_tester_params}
                        TARGETS ${MDT_TARGETS}
                        EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
@@ -529,13 +526,7 @@ halide_define_aot_test(multitarget
 # nested_externs_aottest.cpp
 # nested_externs_generator.cpp
 halide_define_aot_test(nested_externs
-                       OMIT_DEFAULT_HALIDE_LIBRARY
-                       EXTRA_LIBS
-                       nested_externs_root
-                       nested_externs_inner
-                       nested_externs_combine
-                       nested_externs_leaf
-                       nested_externs_root.runtime)
+                       OMIT_DEFAULT_HALIDE_LIBRARY)
 
 # Explicitly define our Generator here since OMIT_DEFAULT_HALIDE_LIBRARY
 # was specified

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -298,16 +298,16 @@ if (NOT ${_USING_WASM})
                           FUNCTION_NAME HalideTest::AnotherNamespace::cxx_mangling
                           FEATURES c_plus_plus_name_mangling
                           EXTERNS cxx_mangling_externs)
-    set(_CXX_MANGLING_HALIDE_LIBRARIES cxx_mangling)
+    _add_halide_aot_tests(cxx_mangling)
     if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
         add_halide_library(cxx_mangling_gpu
                            FROM cxx_mangling.generator
                            GENERATOR cxx_mangling
                            FUNCTION_NAME HalideTest::cxx_mangling_gpu
                            FEATURES c_plus_plus_name_mangling cuda)
-        list(APPEND _CXX_MANGLING_HALIDE_LIBRARIES cxx_mangling_gpu)
+        target_link_libraries(generator_aot_cxx_mangling PRIVATE cxx_mangling_gpu)
+        target_link_libraries(generator_aotcpp_cxx_mangling PRIVATE cxx_mangling_gpu)
     endif ()
-    _add_halide_aot_tests(cxx_mangling HALIDE_LIBRARIES ${_CXX_MANGLING_HALIDE_LIBRARIES})
 
     # cxx_mangling_define_extern_externs.cpp
     add_library(cxx_mangling_define_extern_externs STATIC cxx_mangling_define_extern_externs.cpp)

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -150,7 +150,7 @@ function(halide_define_aot_test NAME)
     # Apparently CMake has no one-liner for 'assign bool value to var'?
     set(TARGETING_WASM FALSE)
     if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
-        set(TARGETING_WASM FALSE)
+        set(TARGETING_WASM TRUE)
     endif()
 
     # Always omit C++ backend testing when we are targeting wasm

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -6,7 +6,11 @@
 # Some tests are not available when compiling for WASM.
 ##
 
-set(_USING_WASM (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm"))
+if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
+    set(_USING_WASM 1)
+else()
+    set(_USING_WASM 0)
+endif()
 
 # Emit two halide_library targets, one with the default backend with the given name,
 # and (optionally) one with the C++ backend with the name NAME_cpp. (The CPP one defaults to being

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -1,32 +1,12 @@
 ##
-# Convenience method for defining test cases in this directory.
+# Convenience methods for defining test cases in this directory.
 ##
 
-# TODO(#4938): remove need for these definitions
-function(_add_gpu_deps TARGET)
-    if ("${Halide_TARGET}" MATCHES "opencl")
-        target_compile_definitions("${TARGET}" PRIVATE TEST_OPENCL)
-    endif ()
-    if ("${Halide_TARGET}" MATCHES "metal")
-        target_compile_definitions("${TARGET}" PRIVATE TEST_METAL)
-    endif ()
-    if ("${Halide_TARGET}" MATCHES "cuda")
-        target_compile_definitions("${TARGET}" PRIVATE TEST_CUDA)
-    endif ()
-endfunction()
+##
+# Some tests are not available when compiling for WASM.
+##
 
-function(_add_aot_test TARGET)
-    set(options "")
-    set(oneValueArgs "")
-    set(multiValueArgs SRCS GROUPS DEFINES)
-    cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-    add_executable("${TARGET}" ${args_SRCS})
-    target_compile_definitions("${TARGET}" PRIVATE ${args_DEFINES})
-    target_include_directories("${TARGET}" PRIVATE "${Halide_SOURCE_DIR}/test/common" "${Halide_SOURCE_DIR}/tools")
-    _add_gpu_deps("${TARGET}")
-    add_halide_test("${TARGET}" GROUPS generator ${args_GROUPS})
-endfunction()
+set(_USING_WASM (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm"))
 
 # Emit two halide_library targets, one with the default backend with the given name,
 # and (optionally) one with the C++ backend with the name NAME_cpp. (The CPP one defaults to being
@@ -35,19 +15,17 @@ endfunction()
 # Arguments are (mostly) identical to add_halide_library(), except:
 # - OMIT_C_BACKEND option to skip the CPP backend
 # - DEPS_OUT and DEPS_CPP_OUT as optional out-params, to receive the deps needed for using the standard / cpp outputs
-# - LINK_TO_AOTTEST (if specified) will link the outputs to the relevant generator_aot_NAME/generator_aotcpp_NAME test
-#   (which must be defined prior to this rule).
+# - We always generate FUNCTION_INFO_HEADER
 #
 function(_add_halide_libraries TARGET)
     set(options GRADIENT_DESCENT OMIT_C_BACKEND)
-    set(oneValueArgs FROM GENERATOR FUNCTION_NAME NAMESPACE USE_RUNTIME AUTOSCHEDULER HEADER EXTRA_OUTPUTS DEPS_OUT DEPS_CPP_OUT LINK_TO_AOTTEST)
-    set(multiValueArgs GENERATOR_LINK_LIBRARIES TARGETS FEATURES PARAMS PLUGINS)
+    set(oneValueArgs FROM GENERATOR_NAME FUNCTION_NAME NAMESPACE USE_RUNTIME AUTOSCHEDULER DEPS_OUT DEPS_CPP_OUT)
+    set(multiValueArgs ENABLE_IF TARGETS FEATURES PARAMS PLUGINS)
     cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(EXTRA_OUTPUTS "")
-    foreach (EO IN LISTS args_EXTRA_OUTPUTS)
-        list(APPEND EXTRA_OUTPUTS ${EO} ${EO}_PATH_OUT)
-    endforeach()
+    if (args_ENABLE_IF AND NOT (${args_ENABLE_IF}))
+        return()
+    endif ()
 
     # Passing on a no-value arg in CMake is unpleasant
     if (args_GRADIENT_DESCENT)
@@ -59,12 +37,11 @@ function(_add_halide_libraries TARGET)
     # Fill in default values for some arguments, as needed
     if (NOT args_FROM)
         add_halide_generator("${TARGET}.generator"
-                             SOURCES "${TARGET}_generator.cpp"
-                             LINK_LIBRARIES ${args_GENERATOR_LINK_LIBRARIES})
+                             SOURCES "${TARGET}_generator.cpp")
         set(args_FROM "${TARGET}.generator")
     endif()
-    if (NOT args_GENERATOR)
-        set(args_GENERATOR "${TARGET}")
+    if (NOT args_GENERATOR_NAME)
+        set(args_GENERATOR_NAME "${TARGET}")
     endif()
     if (NOT args_FUNCTION_NAME)
         set(args_FUNCTION_NAME "${TARGET}")
@@ -77,21 +54,17 @@ function(_add_halide_libraries TARGET)
     add_halide_library(${TARGET}
                        ${GRADIENT_DESCENT_OPT}
                        FROM "${args_FROM}"
-                       GENERATOR "${args_GENERATOR}"
+                       GENERATOR "${args_GENERATOR_NAME}"
                        FUNCTION_NAME "${args_FUNCTION_NAME}"
                        NAMESPACE "${args_NAMESPACE}"
                        USE_RUNTIME "${args_USE_RUNTIME}"
                        AUTOSCHEDULER "${args_AUTOSCHEDULER}"
-                       USE_RUNTIME "${args_USE_RUNTIME}"
                        TARGETS "${args_TARGETS}"
                        FEATURES "${args_FEATURES}"
                        PARAMS "${args_PARAMS}"
                        PLUGINS "${args_PLUGINS}"
-                       ${EXTRA_OUTPUTS})
+                       FUNCTION_INFO_HEADER function_info_header_out)
     list(APPEND _DEPS ${TARGET} ${TARGET}.runtime)
-    if (args_LINK_TO_AOTTEST)
-            target_link_libraries("generator_aot_${args_LINK_TO_AOTTEST}" PRIVATE ${_DEPS})
-    endif()
 
     if (NOT args_OMIT_C_BACKEND)
         # The C backend basically ignores TARGETS (it emits a warning that the sources
@@ -103,10 +76,9 @@ function(_add_halide_libraries TARGET)
                            C_BACKEND
                            ${GRADIENT_DESCENT_OPT}
                            FROM "${args_FROM}"
-                           GENERATOR "${args_GENERATOR}"
+                           GENERATOR "${args_GENERATOR_NAME}"
                            FUNCTION_NAME "${args_FUNCTION_NAME}"
                            NAMESPACE "${args_NAMESPACE}"
-                           USE_RUNTIME "${args_USE_RUNTIME}"
                            AUTOSCHEDULER "${args_AUTOSCHEDULER}"
                            USE_RUNTIME "${args_USE_RUNTIME}"
                            # No: see comment above
@@ -114,11 +86,8 @@ function(_add_halide_libraries TARGET)
                            FEATURES "${args_FEATURES}"
                            PARAMS "${args_PARAMS}"
                            PLUGINS "${args_PLUGINS}"
-                           ${EXTRA_OUTPUTS})
+                           FUNCTION_INFO_HEADER function_info_header_cpp_out)
         list(APPEND _DEPS_CPP ${TARGET_CPP} ${TARGET}.runtime)
-        if (args_LINK_TO_AOTTEST)
-            target_link_libraries("generator_aotcpp_${args_LINK_TO_AOTTEST}" PRIVATE ${_DEPS_CPP})
-        endif()
         # This is a bit subtle: we end up emitting NAME.h and NAME_cpp.h header files;
         # these are *identical* in content (aside from the guard macro and the filename).
         # For convenience, we use the NAME.h variant in all cases downstream (even when linking
@@ -137,74 +106,90 @@ function(_add_halide_libraries TARGET)
     endif()
 endfunction()
 
-function(halide_define_aot_test NAME)
-    set(options OMIT_DEFAULT_HALIDE_LIBRARY OMIT_C_BACKEND)
-    set(oneValueArgs FUNCTION_NAME)
-    set(multiValueArgs GENERATOR_LINK_LIBRARIES ENABLE_IF FEATURES PARAMS TARGETS GROUPS EXTRA_OUTPUTS)
+function(_add_one_aot_test TARGET)
+    set(options "")
+    set(oneValueArgs "")
+    set(multiValueArgs SRCS DEPS GROUPS INCLUDES DEFINES)
+    cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    add_executable("${TARGET}" ${args_SRCS})
+    target_compile_definitions("${TARGET}" PRIVATE ${args_DEFINES})
+    target_include_directories("${TARGET}" PRIVATE ${args_INCLUDES} "${Halide_SOURCE_DIR}/test/common" "${Halide_SOURCE_DIR}/tools")
+    target_link_libraries("${TARGET}" PRIVATE ${args_DEPS})
+    # TODO(#4938): remove need for these definitions
+    if ("${Halide_TARGET}" MATCHES "opencl")
+        target_compile_definitions("${TARGET}" PRIVATE TEST_OPENCL)
+    endif ()
+    if ("${Halide_TARGET}" MATCHES "metal")
+        target_compile_definitions("${TARGET}" PRIVATE TEST_METAL)
+    endif ()
+    if ("${Halide_TARGET}" MATCHES "cuda")
+        target_compile_definitions("${TARGET}" PRIVATE TEST_CUDA)
+    endif ()
+    if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
+        target_link_libraries("${TARGET}" PRIVATE CUDA::cuda_driver CUDA::cudart)
+    endif ()
+    if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
+        target_link_libraries("${TARGET}" PRIVATE OpenCL::OpenCL)
+    endif ()
+    add_halide_test("${TARGET}" GROUPS generator ${args_GROUPS})
+endfunction()
+
+function(_add_halide_aot_tests NAME)
+    set(options OMIT_C_BACKEND)
+    set(oneValueArgs "")
+    set(multiValueArgs ENABLE_IF GROUPS INCLUDES HALIDE_LIBRARIES HALIDE_RUNTIME DEPS)
     cmake_parse_arguments(args "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if (args_ENABLE_IF AND NOT (${args_ENABLE_IF}))
         return()
     endif ()
 
-    # Apparently CMake has no one-liner for 'assign bool value to var'?
-    set(TARGETING_WASM FALSE)
-    if (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm")
-        set(TARGETING_WASM TRUE)
+    # If HALIDE_LIBRARIES is omitted, assume we want just a single halide_library target
+    # with a matching name
+    if (NOT args_HALIDE_LIBRARIES)
+        set(args_HALIDE_LIBRARIES "${NAME}")
     endif()
 
-    # Always omit C++ backend testing when we are targeting wasm
-    if (TARGETING_WASM)
-        set(args_OMIT_C_BACKEND TRUE)
+    # If no Halide runtime specified, use one from the first halide_library in the list
+    if (NOT args_HALIDE_RUNTIME)
+        list(GET args_HALIDE_LIBRARIES 0 HR)
+        set(args_HALIDE_RUNTIME "${HR}.runtime")
     endif()
 
     set(TARGET "generator_aot_${NAME}")
     set(TARGET_CPP "generator_aotcpp_${NAME}")
 
-    if (TARGETING_WASM)
+    if (${_USING_WASM})
         add_wasm_executable("${TARGET}"
-                            SRCS "${HALIDE_LIBRARY}_aottest.cpp"
+                            SRCS "${NAME}_aottest.cpp"
+                            DEPS ${args_HALIDE_LIBRARIES} ${args_HALIDE_RUNTIME} ${args_DEPS}
                             INCLUDES
+                            ${args_INCLUDES}
                             "${Halide_BINARY_DIR}/include"
                             "${Halide_SOURCE_DIR}/test/common"
                             "${Halide_SOURCE_DIR}/tools"
                             "${CMAKE_CURRENT_BINARY_DIR}")
         add_wasm_halide_test("${TARGET}" GROUPS generator "${args_GROUPS}")
-        return()
-    endif()
-
-    _add_aot_test("${TARGET}"
-                  SRCS "${NAME}_aottest.cpp"
-                  GROUPS ${args_GROUPS})
-    if (NOT args_OMIT_C_BACKEND)
-        _add_aot_test("${TARGET_CPP}"
-                      SRCS "${NAME}_aottest.cpp"
-                      GROUPS ${args_GROUPS})
-    endif()
-
-    if (NOT args_OMIT_DEFAULT_HALIDE_LIBRARY)
-        if (args_OMIT_C_BACKEND)
-            set(OMIT_C_BACKEND_OPT "OMIT_C_BACKEND")
-        else()
-            set(OMIT_C_BACKEND_OPT "")
+    else()
+        _add_one_aot_test("${TARGET}"
+                          SRCS "${NAME}_aottest.cpp"
+                          DEPS ${args_HALIDE_LIBRARIES} ${args_HALIDE_RUNTIME} ${args_DEPS}
+                          INCLUDES ${args_INCLUDES}
+                          GROUPS ${args_GROUPS})
+        if (NOT args_OMIT_C_BACKEND)
+            set(HALIDE_LIBRARIES_CPP "")
+            foreach (hl IN LISTS args_HALIDE_LIBRARIES)
+                list(APPEND HALIDE_LIBRARIES_CPP "${hl}_cpp")
+            endforeach()
+            _add_one_aot_test("${TARGET_CPP}"
+                              SRCS "${NAME}_aottest.cpp"
+                              DEPS ${HALIDE_LIBRARIES_CPP} ${args_HALIDE_RUNTIME} ${args_DEPS}
+                              INCLUDES ${args_INCLUDES}
+                              GROUPS ${args_GROUPS})
         endif()
-        _add_halide_libraries("${NAME}"
-                ${OMIT_C_BACKEND_OPT}
-                LINK_TO_AOTTEST "${NAME}"
-                EXTRA_OUTPUTS ${args_EXTRA_OUTPUTS}
-                FEATURES ${args_FEATURES}
-                FUNCTION_NAME ${args_FUNCTION_NAME}
-                GENERATOR_LINK_LIBRARIES ${args_GENERATOR_LINK_LIBRARIES}
-                TARGETS ${args_TARGETS}
-                PARAMS ${args_PARAMS})
     endif()
 endfunction()
-
-##
-# Some tests are not available when compiling for WASM.
-##
-
-set(USING_WASM (TARGET_WEBASSEMBLY AND Halide_TARGET MATCHES "wasm"))
 
 if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
     find_package(CUDAToolkit REQUIRED)
@@ -219,16 +204,8 @@ endif ()
 
 # acquire_release_aottest.cpp
 # acquire_release_generator.cpp
-# acquire_release_generator.cpp
-halide_define_aot_test(acquire_release)
-if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
-    target_link_libraries(generator_aot_acquire_release PRIVATE CUDA::cuda_driver CUDA::cudart)
-    target_link_libraries(generator_aotcpp_acquire_release PRIVATE CUDA::cuda_driver CUDA::cudart)
-endif ()
-if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
-    target_link_libraries(generator_aot_acquire_release PRIVATE OpenCL::OpenCL)
-    target_link_libraries(generator_aotcpp_acquire_release PRIVATE OpenCL::OpenCL)
-endif ()
+_add_halide_libraries(acquire_release)
+_add_halide_aot_tests(acquire_release)
 
 # TODO: what are these?
 # configure_jittest.cpp
@@ -238,88 +215,100 @@ endif ()
 
 # alias_aottest.cpp
 # alias_generator.cpp
-set(ALIAS_LIBS alias_with_offset_42 alias_Adams2019 alias_Li2018 alias_Mullapudi2016)
-halide_define_aot_test(alias)
-foreach (LIB IN LISTS ALIAS_LIBS)
+set(EXTRA_ALIAS_LIBS alias_with_offset_42 alias_Adams2019 alias_Li2018 alias_Mullapudi2016)
+_add_halide_libraries(alias)
+foreach (LIB IN LISTS EXTRA_ALIAS_LIBS)
     _add_halide_libraries(${LIB}
-                          LINK_TO_AOTTEST alias
                           FROM alias.generator
-                          GENERATOR ${LIB}
+                          GENERATOR_NAME ${LIB}
                           PLUGINS Halide::Adams2019 Halide::Li2018 Halide::Mullapudi2016)
 endforeach ()
+_add_halide_aot_tests(alias
+                      HALIDE_LIBRARIES alias ${EXTRA_ALIAS_LIBS})
 
 # argvcall_aottest.cpp
 # argvcall_generator.cpp
-halide_define_aot_test(argvcall)
+_add_halide_libraries(argvcall)
+_add_halide_aot_tests(argvcall)
 
 # async_parallel_aottest.cpp
 # async_parallel_generator.cpp
-halide_define_aot_test(async_parallel
-                       # Requires threading support, not yet available for wasm tests
-                       ENABLE_IF NOT ${USING_WASM}
-                       FEATURES user_context
-                       GROUPS multithreaded)
+_add_halide_libraries(async_parallel FEATURES user_context)
+_add_halide_aot_tests(async_parallel
+                      # Requires threading support, not yet available for wasm tests
+                      ENABLE_IF NOT ${_USING_WASM}
+                      GROUPS multithreaded)
 
 # autograd_aottest.cpp
 # autograd_generator.cpp
-halide_define_aot_test(autograd ENABLE_IF TARGET Halide::Mullapudi2016 AND NOT ${USING_WASM}
-                       GROUPS multithreaded)
+_add_halide_libraries(autograd)
 _add_halide_libraries(autograd_grad
-                      LINK_TO_AOTTEST autograd
                       GRADIENT_DESCENT
                       FROM autograd.generator
-                      GENERATOR autograd
+                      GENERATOR_NAME autograd
                       FUNCTION_NAME autograd_grad
                       AUTOSCHEDULER Halide::Mullapudi2016
                       PLUGINS Halide::Mullapudi2016)
+_add_halide_aot_tests(autograd
+                      ENABLE_IF TARGET Halide::Mullapudi2016 AND NOT ${_USING_WASM}
+                      HALIDE_LIBRARIES autograd autograd_grad
+                      GROUPS multithreaded)
 
 # abstractgeneratortest_aottest.cpp
 # abstractgeneratortest_generator.cpp
-halide_define_aot_test(abstractgeneratortest)
+_add_halide_libraries(abstractgeneratortest)
+_add_halide_aot_tests(abstractgeneratortest)
 
 # bit_operations_aottest.cpp
 # bit_operations_generator.cpp
-halide_define_aot_test(bit_operations)
+_add_halide_libraries(bit_operations)
+_add_halide_aot_tests(bit_operations)
 
 # blur2x2_aottest.cpp
 # blur2x2_generator.cpp
-halide_define_aot_test(blur2x2)
+_add_halide_libraries(blur2x2)
+_add_halide_aot_tests(blur2x2)
 
 # buffer_copy_aottest.cpp
 # buffer_copy_generator.cpp
-halide_define_aot_test(buffer_copy)
+_add_halide_libraries(buffer_copy)
+_add_halide_aot_tests(buffer_copy)
 
 # can_use_target_aottest.cpp
 # can_use_target_generator.cpp
-halide_define_aot_test(can_use_target)
+_add_halide_libraries(can_use_target)
+_add_halide_aot_tests(can_use_target)
 
 # cleanup_on_error_aottest.cpp
 # cleanup_on_error_generator.cpp
-halide_define_aot_test(cleanup_on_error)
-# Alas, this test requires direct access to internal header runtime/device_interface.h
-target_include_directories(generator_aot_cleanup_on_error PRIVATE "${Halide_SOURCE_DIR}/src/runtime")
-target_include_directories(generator_aotcpp_cleanup_on_error PRIVATE "${Halide_SOURCE_DIR}/src/runtime")
+_add_halide_libraries(cleanup_on_error)
+_add_halide_aot_tests(cleanup_on_error
+                      # Alas, this test requires direct access to
+                      # internal header runtime/device_interface.h
+                      INCLUDES "${Halide_SOURCE_DIR}/src/runtime")
 
 # configure_aottest.cpp
 # configure_generator.cpp
-halide_define_aot_test(configure)
+_add_halide_libraries(configure)
+_add_halide_aot_tests(configure)
 
-if (NOT ${USING_WASM})
+# TODO: this could be made to work under wasm with some tweaking, it's just build-rule complexity
+if (NOT ${_USING_WASM})
     # cxx_mangling_externs.cpp
     add_library(cxx_mangling_externs STATIC cxx_mangling_externs.cpp)
 
     # cxx_mangling_aottest.cpp
     # cxx_mangling_generator.cpp
-    halide_define_aot_test(cxx_mangling
-                           FUNCTION_NAME HalideTest::AnotherNamespace::cxx_mangling
-                           FEATURES c_plus_plus_name_mangling
-                           EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
-    target_link_libraries(cxx_mangling INTERFACE cxx_mangling_externs)
-    target_link_libraries(cxx_mangling_cpp INTERFACE cxx_mangling_externs)
+    _add_halide_libraries(cxx_mangling
+                          FUNCTION_NAME HalideTest::AnotherNamespace::cxx_mangling
+                          FEATURES c_plus_plus_name_mangling)
+    _add_halide_aot_tests(cxx_mangling
+                          DEPS cxx_mangling_externs)
+
     if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
         add_halide_library(cxx_mangling_gpu
                            FROM cxx_mangling.generator
-                           GENERATOR cxx_mangling
+                           GENERATOR_NAME cxx_mangling
                            FUNCTION_NAME HalideTest::cxx_mangling_gpu
                            FEATURES c_plus_plus_name_mangling cuda)
         target_link_libraries(generator_aot_cxx_mangling PRIVATE cxx_mangling_gpu)
@@ -329,112 +318,100 @@ if (NOT ${USING_WASM})
     # cxx_mangling_define_extern_externs.cpp
     add_library(cxx_mangling_define_extern_externs STATIC cxx_mangling_define_extern_externs.cpp)
     target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling)
-    add_dependencies(cxx_mangling_define_extern_externs cxx_mangling)
 
     # cxx_mangling_define_extern_aottest.cpp
     # cxx_mangling_define_extern_generator.cpp
-    halide_define_aot_test(cxx_mangling_define_extern
-                           FUNCTION_NAME "HalideTest::cxx_mangling_define_extern"
-                           FEATURES c_plus_plus_name_mangling user_context)
-    target_link_libraries(cxx_mangling_define_extern INTERFACE cxx_mangling_define_extern_externs)
-    target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling)
-    target_link_libraries(cxx_mangling_define_extern_cpp INTERFACE cxx_mangling_define_extern_externs)
-    target_link_libraries(cxx_mangling_define_extern_externs PRIVATE cxx_mangling_cpp)
-endif ()  # (NOT ${USING_WASM})
+    _add_halide_libraries(cxx_mangling_define_extern
+                          FUNCTION_NAME "HalideTest::cxx_mangling_define_extern"
+                          FEATURES c_plus_plus_name_mangling user_context)
+    _add_halide_aot_tests(cxx_mangling_define_extern
+                          HALIDE_LIBRARIES cxx_mangling_define_extern cxx_mangling
+                          DEPS cxx_mangling_externs cxx_mangling_define_extern_externs)
+endif ()  # (NOT ${_USING_WASM})
 
 # define_extern_opencl_aottest.cpp
 # define_extern_opencl_generator.cpp
-halide_define_aot_test(define_extern_opencl)
-if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
-    find_package(OpenCL REQUIRED)
-    target_link_libraries(generator_aot_define_extern_opencl PRIVATE OpenCL::OpenCL)
-    target_link_libraries(generator_aotcpp_define_extern_opencl PRIVATE OpenCL::OpenCL)
-endif ()
+_add_halide_libraries(define_extern_opencl)
+_add_halide_aot_tests(define_extern_opencl)
 
 # embed_image_aottest.cpp
 # embed_image_generator.cpp
-halide_define_aot_test(embed_image)
+_add_halide_libraries(embed_image)
+_add_halide_aot_tests(embed_image)
 
 # error_codes_aottest.cpp
 # error_codes_generator.cpp
-halide_define_aot_test(error_codes)
+_add_halide_libraries(error_codes)
+_add_halide_aot_tests(error_codes)
 
 # example_aottest.cpp
 # example_generator.cpp
-halide_define_aot_test(example
-                       GROUPS multithreaded)
+_add_halide_libraries(example)
+_add_halide_aot_tests(example GROUPS multithreaded)
 
 # extern_output_aottest.cpp
 # extern_output_generator.cpp
-halide_define_aot_test(extern_output
-                       GROUPS multithreaded)
+_add_halide_libraries(extern_output)
+_add_halide_aot_tests(extern_output GROUPS multithreaded)
 
 # float16_t_aottest.cpp
 # float16_t_generator.cpp
-halide_define_aot_test(float16_t)
+_add_halide_libraries(float16_t)
+_add_halide_aot_tests(float16_t)
 
 # gpu_multi_context_threaded_aottest.cpp
 # gpu_multi_context_threaded_generator.cpp
 # (Doesn't build/link properly under wasm, and isn't useful there anyway)
-if (NOT Halide_TARGET MATCHES "wasm")
-    halide_define_aot_test(gpu_multi_context_threaded
-                           OMIT_DEFAULT_HALIDE_LIBRARY)
-
-    # Explicitly define our Generator here since OMIT_DEFAULT_HALIDE_LIBRARY
-    # was specified
+if (NOT ${_USING_WASM})
     add_halide_generator(gpu_multi_context_threaded.generator
                          SOURCES gpu_multi_context_threaded_generator.cpp)
-
     _add_halide_libraries(gpu_multi_context_threaded_add
-                          LINK_TO_AOTTEST gpu_multi_context_threaded
                           FROM gpu_multi_context_threaded.generator
                           FEATURES user_context)
-
     _add_halide_libraries(gpu_multi_context_threaded_mul
-                          LINK_TO_AOTTEST gpu_multi_context_threaded
                           FROM gpu_multi_context_threaded.generator
                           FEATURES user_context)
-
-    if (TARGET_NVPTX AND Halide_TARGET MATCHES "cuda")
-        target_link_libraries(generator_aot_gpu_multi_context_threaded PRIVATE CUDA::cuda_driver CUDA::cudart)
-        target_link_libraries(generator_aotcpp_gpu_multi_context_threaded PRIVATE CUDA::cuda_driver CUDA::cudart)
-    endif ()
-    if (TARGET_NVPTX AND Halide_TARGET MATCHES "opencl")
-        target_link_libraries(generator_aot_gpu_multi_context_threaded PRIVATE OpenCL::OpenCL)
-        target_link_libraries(generator_aotcpp_gpu_multi_context_threaded PRIVATE OpenCL::OpenCL)
-    endif ()
+    _add_halide_aot_tests(gpu_multi_context_threaded
+                          HALIDE_LIBRARIES gpu_multi_context_threaded_add gpu_multi_context_threaded_mul)
 endif ()
 
 # gpu_object_lifetime_aottest.cpp
 # gpu_object_lifetime_generator.cpp
-halide_define_aot_test(gpu_object_lifetime FEATURES debug)
+_add_halide_libraries(gpu_object_lifetime FEATURES debug)
+_add_halide_aot_tests(gpu_object_lifetime)
 
 # gpu_only_aottest.cpp
 # gpu_only_generator.cpp
-halide_define_aot_test(gpu_only)
+_add_halide_libraries(gpu_only)
+_add_halide_aot_tests(gpu_only)
 
 # gpu_texture_aottest.cpp
 # gpu_texture_generator.cpp
-halide_define_aot_test(gpu_texture)
+_add_halide_libraries(gpu_texture)
+_add_halide_aot_tests(gpu_texture)
 
 # image_from_array_aottest.cpp
 # image_from_array_generator.cpp
-halide_define_aot_test(image_from_array)
+_add_halide_libraries(image_from_array)
+_add_halide_aot_tests(image_from_array)
 
 # mandelbrot_aottest.cpp
 # mandelbrot_generator.cpp
-halide_define_aot_test(mandelbrot
-                       GROUPS multithreaded)
+_add_halide_libraries(mandelbrot)
+_add_halide_aot_tests(mandelbrot GROUPS multithreaded)
 
 # memory_profiler_mandelbrot_aottest.cpp
 # memory_profiler_mandelbrot_generator.cpp
-halide_define_aot_test(memory_profiler_mandelbrot
-                       # Requires profiler support (which requires threading), not yet available for wasm tests...
-                       ENABLE_IF NOT ${USING_WASM}
-                       # ... or the C backend (https://github.com/halide/Halide/issues/7272)
-                       OMIT_C_BACKEND
-                       FEATURES profile
-                       GROUPS multithreaded)
+# Requires profiler support (which requires threading), not yet available for wasm tests or the C backend
+# (https://github.com/halide/Halide/issues/7272)
+_add_halide_libraries(memory_profiler_mandelbrot
+                      ENABLE_IF NOT ${_USING_WASM}
+                      OMIT_C_BACKEND
+                      FEATURES profile)
+_add_halide_aot_tests(memory_profiler_mandelbrot
+                      ENABLE_IF NOT ${_USING_WASM}
+                      OMIT_C_BACKEND
+                      GROUPS multithreaded)
 
 # metadata_tester_aottest.cpp
 # metadata_tester_generator.cpp
@@ -472,7 +449,7 @@ set(metadata_tester_params
 
 # Note that metadata_tester (but not metadata_tester_ucon) is built as "multitarget" to verify that
 # the metadata names are correctly emitted.
-if (${USING_WASM})
+if (${_USING_WASM})
     # wasm doesn't support multitargets
     # TODO: currently, Halide_CMAKE_TARGET == Halide_HOST_TARGET when building for Emscripten; we should fix this
     set(MDT_TARGETS ${Halide_TARGET})
@@ -480,79 +457,86 @@ else()
     set(MDT_TARGETS cmake-no_bounds_query cmake)
 endif()
 
-halide_define_aot_test(metadata_tester
-                       PARAMS ${metadata_tester_params}
-                       TARGETS ${MDT_TARGETS}
-                       EXTRA_OUTPUTS FUNCTION_INFO_HEADER)
-_add_halide_libraries(metadata_tester_ucon
-                      LINK_TO_AOTTEST metadata_tester
-                      FROM metadata_tester.generator
-                      GENERATOR metadata_tester
-                      FEATURES user_context
+_add_halide_libraries(metadata_tester
                       PARAMS ${metadata_tester_params}
-                      FUNCTION_INFO_HEADER metadata_tester_ucon_path)
+                      TARGETS ${MDT_TARGETS})
+_add_halide_libraries(metadata_tester_ucon
+                      FROM metadata_tester.generator
+                      GENERATOR_NAME metadata_tester
+                      FEATURES user_context
+                      PARAMS ${metadata_tester_params})
+_add_halide_aot_tests(metadata_tester
+                      HALIDE_LIBRARIES metadata_tester metadata_tester_ucon)
 
 # msan_aottest.cpp
 # msan_generator.cpp
-halide_define_aot_test(msan FEATURES msan
-                       # Broken for C++ backend (https://github.com/halide/Halide/issues/7273)
-                       OMIT_C_BACKEND
-                       GROUPS multithreaded)
+_add_halide_libraries(msan
+                      FEATURES msan
+                      # Broken for C++ backend (https://github.com/halide/Halide/issues/7273)
+                      OMIT_C_BACKEND)
+_add_halide_aot_tests(msan
+                      OMIT_C_BACKEND
+                      GROUPS multithreaded)
 
 # (Doesn't build/link properly on windows / under wasm)
-if (NOT Halide_TARGET MATCHES "windows" AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT Halide_TARGET MATCHES "wasm")
+if (NOT Halide_TARGET MATCHES "windows" AND NOT CMAKE_SYSTEM_NAME MATCHES "Windows" AND NOT ${_USING_WASM})
     # sanitizercoverage_aottest.cpp
     # sanitizercoverage_generator.cpp
-    halide_define_aot_test(sanitizercoverage
-                           # sanitizercoverage relies on LLVM-specific hooks, so it will never work with the C backend
-                           OMIT_C_BACKEND
-                           FEATURES sanitizer_coverage)
+    _add_halide_libraries(sanitizercoverage
+                          # sanitizercoverage relies on LLVM-specific hooks, so it will never work with the C backend
+                          OMIT_C_BACKEND
+                          FEATURES sanitizer_coverage)
+    _add_halide_aot_tests(sanitizercoverage OMIT_C_BACKEND)
 endif ()
 
 # multitarget_aottest.cpp
 # multitarget_generator.cpp
-halide_define_aot_test(multitarget
+_add_halide_libraries(multitarget
                        # Multitarget doesn't apply to WASM...
-                       ENABLE_IF NOT ${USING_WASM}
+                       ENABLE_IF NOT ${_USING_WASM}
                        # ... or to the C backend
                        OMIT_C_BACKEND
                        TARGETS cmake-no_bounds_query cmake
                        FEATURES c_plus_plus_name_mangling
                        FUNCTION_NAME HalideTest::multitarget)
+_add_halide_aot_tests(multitarget
+                      ENABLE_IF NOT ${_USING_WASM}
+                      OMIT_C_BACKEND)
 
 # nested_externs_aottest.cpp
 # nested_externs_generator.cpp
-halide_define_aot_test(nested_externs
-                       OMIT_DEFAULT_HALIDE_LIBRARY)
-
-# Explicitly define our Generator here since OMIT_DEFAULT_HALIDE_LIBRARY
-# was specified
 add_halide_generator(nested_externs.generator SOURCES nested_externs_generator.cpp)
-_add_halide_libraries(nested_externs_root FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
-_add_halide_libraries(nested_externs_inner FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
-_add_halide_libraries(nested_externs_combine FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
-_add_halide_libraries(nested_externs_leaf FROM nested_externs.generator LINK_TO_AOTTEST nested_externs)
+set(NESTED_EXTERNS_LIBS nested_externs_root nested_externs_inner nested_externs_combine nested_externs_leaf)
+foreach (LIB IN LISTS NESTED_EXTERNS_LIBS)
+    _add_halide_libraries(${LIB} FROM nested_externs.generator GENERATOR_NAME ${LIB})
+endforeach ()
+_add_halide_aot_tests(nested_externs
+                      HALIDE_LIBRARIES ${NESTED_EXTERNS_LIBS})
 
 # opencl_runtime_aottest.cpp
 # opencl_runtime_generator.cpp
-halide_define_aot_test(opencl_runtime)
+_add_halide_libraries(opencl_runtime)
+_add_halide_aot_tests(opencl_runtime)
 
 # output_assign_aottest.cpp
 # output_assign_generator.cpp
-halide_define_aot_test(output_assign)
+_add_halide_libraries(output_assign)
+_add_halide_aot_tests(output_assign)
 
 # pyramid_aottest.cpp
 # pyramid_generator.cpp
-halide_define_aot_test(pyramid PARAMS levels=10
-                       GROUPS multithreaded)
+_add_halide_libraries(pyramid PARAMS levels=10 )
+_add_halide_aot_tests(pyramid GROUPS multithreaded)
 
 # rdom_input_aottest.cpp
 # rdom_input_generator.cpp
-halide_define_aot_test(rdom_input)
+_add_halide_libraries(rdom_input)
+_add_halide_aot_tests(rdom_input)
 
 # string_param_aottest.cpp
 # string_param_generator.cpp
-halide_define_aot_test(string_param PARAMS "rpn_expr=5 y * x +")
+_add_halide_libraries(string_param PARAMS "rpn_expr=5 y * x +")
+_add_halide_aot_tests(string_param)
 
 # stubtest_aottest.cpp
 # stubtest_generator.cpp
@@ -565,31 +549,36 @@ halide_define_aot_test(string_param PARAMS "rpn_expr=5 y * x +")
 
 # shuffler_aottest.cpp
 # shuffler_generator.cpp
-halide_define_aot_test(shuffler)
+_add_halide_libraries(shuffler)
+_add_halide_aot_tests(shuffler)
 
 # templated_aottest.cpp
 # templated_generator.cpp
-halide_define_aot_test(templated)
+_add_halide_libraries(templated)
+_add_halide_aot_tests(templated)
 
 # tiled_blur_aottest.cpp
 # tiled_blur_generator.cpp
-halide_define_aot_test(tiled_blur)
-target_link_libraries(generator_aot_tiled_blur PRIVATE blur2x2)
-target_link_libraries(generator_aotcpp_tiled_blur PRIVATE blur2x2_cpp)
+_add_halide_libraries(tiled_blur)
+_add_halide_aot_tests(tiled_blur
+                      HALIDE_LIBRARIES tiled_blur blur2x2)
 
 # user_context_aottest.cpp
 # user_context_generator.cpp
-halide_define_aot_test(user_context FEATURES user_context
-                       GROUPS multithreaded)
+_add_halide_libraries(user_context FEATURES user_context)
+_add_halide_aot_tests(user_context GROUPS multithreaded)
 
 # user_context_insanity_aottest.cpp
 # user_context_insanity_generator.cpp
-halide_define_aot_test(user_context_insanity FEATURES user_context
-                       GROUPS multithreaded)
+_add_halide_libraries(user_context_insanity FEATURES user_context)
+_add_halide_aot_tests(user_context_insanity GROUPS multithreaded)
 
 # variable_num_threads_aottest.cpp
 # variable_num_threads_generator.cpp
-halide_define_aot_test(variable_num_threads
-                       # Requires threading support, not yet available for wasm tests
-                       ENABLE_IF NOT ${USING_WASM}
-                       GROUPS multithreaded)
+_add_halide_libraries(variable_num_threads
+                      # Requires threading support, not yet available for wasm tests
+                      ENABLE_IF NOT ${_USING_WASM})
+_add_halide_aot_tests(variable_num_threads
+                      # Requires threading support, not yet available for wasm tests
+                      ENABLE_IF NOT ${_USING_WASM}
+                      GROUPS multithreaded)


### PR DESCRIPTION
When the CMake rules were rewritten a while back, the support for building/testing generators with the C++ backend (instead of the standard LLVM, etc) got lost. This adds it back in.

Also made some drive-by fixes to the Makefile to enable some tests there that work correctly now.

Also made a drive-by fix in in Codegen_C to fix allocation nodes that were just wrappers around buffer_get_host -- this prevented the cleanup_on_error test from building with the C++ backend.