### PR TITLE
Unify user_context name-and-type everywhere

### DIFF
--- a/src/Callable.cpp
+++ b/src/Callable.cpp
@@ -62,7 +62,7 @@ Callable::Callable(const std::string &name,
 
     contents->quick_call_check_info.reserve(contents->jit_cache.arguments.size());
     for (const Argument &a : contents->jit_cache.arguments) {
-        const auto qcci = (a.name == "__user_context") ?
+        const auto qcci = (a.name == user_context_name()) ?
                               Callable::make_ucon_qcci() :
                               (a.is_scalar() ? Callable::make_scalar_qcci(a.type) : Callable::make_buffer_qcci());
         contents->quick_call_check_info.push_back(qcci);
@@ -179,7 +179,7 @@ Callable::FailureFn Callable::check_fcci(size_t argc, const FullCallCheckInfo *a
     // this is effectively just documentation that these invariants are expected to have
     // been enforced prior to this call.
     assert(contents->jit_cache.jit_target.has_feature(Target::UserContext));
-    assert(contents->jit_cache.arguments[0].name == "__user_context");
+    assert(contents->jit_cache.arguments[0].name == user_context_name());
 
     JITUserContext *context = *(JITUserContext **)const_cast<void *>(argv[0]);
     assert(context != nullptr);

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -3411,7 +3411,7 @@ extern "C" {
 #endif
 
 HALIDE_FUNCTION_ATTRS
-int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta, void const *__user_context) {
+int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta, void *__user_context) {
  void *_ucon = __user_context;
  halide_maybe_unused(_ucon);
  auto *_0 = _halide_buffer_get_host(_buf_buffer);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4416,7 +4416,7 @@ Value *CodeGen_LLVM::create_alloca_at_entry(llvm::Type *t, int n, bool zero_init
 }
 
 Value *CodeGen_LLVM::get_user_context() const {
-    Value *ctx = sym_get("__user_context", false);
+    Value *ctx = sym_get(user_context_name(), false);
     if (!ctx) {
         ctx = ConstantPointerNull::get(i8_t->getPointerTo());  // void*
     }

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -68,7 +68,7 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
     stream << "HALIDE_FUNCTION_ATTRS\n";
     stream << "inline int " << simple_name << "_th_(";
     for (size_t i = 0; i < args.size(); i++) {
-        if (args[i].name == "__user_context") {
+        if (args[i].name == user_context_name()) {
             continue;
         } else if (args[i].is_buffer()) {
             buffer_args.push_back(args[i]);

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -486,7 +486,7 @@ void lower_impl(const vector<Function> &output_funcs,
     }
 
     for (const InferredArgument &arg : inferred_args) {
-        if (arg.param.defined() && arg.param.name() == "__user_context") {
+        if (arg.param.defined() && arg.param.name() == user_context_name()) {
             // The user context is always in the inferred args, but is
             // not required to be in the args list.
             continue;
@@ -519,7 +519,7 @@ void lower_impl(const vector<Function> &output_funcs,
             }
             err << "\n\nParameters referenced in generated code: ";
             for (const InferredArgument &ia : inferred_args) {
-                if (ia.arg.name != "__user_context") {
+                if (ia.arg.name != user_context_name()) {
                     err << ia.arg.name << " ";
                 }
             }

--- a/src/LowerParallelTasks.cpp
+++ b/src/LowerParallelTasks.cpp
@@ -243,7 +243,7 @@ struct LowerParallelTasks : public IRMutator {
             Type closure_function_type;
 
             std::vector<LoweredArgument> closure_args(use_parallel_for ? 3 : 5);
-            closure_args[0] = make_scalar_arg<void *>("__user_context");
+            closure_args[0] = make_scalar_arg(user_context_name(), user_context_type());
             if (use_parallel_for) {
                 // The closure will be a halide_task_t, with arguments like:
                 //

--- a/src/Param.h
+++ b/src/Param.h
@@ -32,7 +32,7 @@ class Param {
     using not_void_T = typename std::conditional<std::is_void<T>::value, DynamicParamType *, T>::type;
 
     void check_name() const {
-        user_assert(param.name() != "__user_context")
+        user_assert(param.name() != Internal::user_context_name())
             << "Param<void*>(\"__user_context\") "
             << "is no longer used to control whether Halide functions take explicit "
             << "user_context arguments. Use set_custom_user_context() when jitting, "
@@ -327,8 +327,7 @@ public:
  * the function (if any). It is rare that this function is necessary
  * (e.g. to pass the user context to an extern function written in C). */
 inline Expr user_context_value() {
-    return Internal::Variable::make(Handle(), "__user_context",
-                                    Internal::Parameter(Handle(), false, 0, "__user_context"));
+    return Internal::Variable::make(Internal::user_context_type(), Internal::user_context_name(), Internal::user_context_parameter());
 }
 
 }  // namespace Halide

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -174,6 +174,18 @@ public:
 /** Validate arguments to a call to a func, image or imageparam. */
 void check_call_arg_types(const std::string &name, std::vector<Expr> *args, int dims);
 
+inline const char *user_context_name() {
+    return "__user_context";
+}
+
+inline Type user_context_type() {
+    return Handle();
+}
+
+inline Parameter user_context_parameter() {
+    return Parameter(user_context_type(), false, 0, user_context_name());
+}
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -153,8 +153,8 @@ struct PipelineContents {
 
     PipelineContents()
         : module("", Target()) {
-        user_context_arg.arg = Argument("__user_context", Argument::InputScalar, type_of<const void *>(), 0, ArgumentEstimates{});
-        user_context_arg.param = Parameter(Handle(), false, 0, "__user_context");
+        user_context_arg.arg = Argument(user_context_name(), Argument::InputScalar, user_context_type(), 0, ArgumentEstimates{});
+        user_context_arg.param = user_context_parameter();
     }
 
     ~PipelineContents() {

--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -40,7 +40,7 @@ string remove_namespaces(const string &name) {
 
 bool can_convert(const LoweredArgument *arg) {
     if (arg->type.is_handle()) {
-        if (arg->name == "__user_context") {
+        if (arg->name == user_context_name()) {
             /* __user_context is a void* pointer to a user supplied memory region.
              * We allow the Python callee to pass PyObject* pointers to that. */
             return true;

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -2522,7 +2522,7 @@ int WasmModuleContents::run(const void *const *args) {
     for (size_t i = 0; i < arguments.size(); i++) {
         const Argument &arg = arguments[i];
         const void *arg_ptr = args[i];
-        if (arg.name == "__user_context") {
+        if (arg.name == user_context_name()) {
             jit_user_context = *(JITUserContext **)const_cast<void *>(arg_ptr);
         }
     }
@@ -2547,7 +2547,7 @@ int WasmModuleContents::run(const void *const *args) {
             wbufs[i] = wbuf;
             wabt_args.push_back(load_value(wbuf));
         } else {
-            if (arg.name == "__user_context") {
+            if (arg.name == user_context_name()) {
                 wabt_args.push_back(wabt::interp::Value::Make(kMagicJitUserContextValue));
             } else {
                 wabt_args.push_back(load_value(arg.type, arg_ptr));
@@ -2622,7 +2622,7 @@ int WasmModuleContents::run(const void *const *args) {
             wbufs[i] = wbuf;
             js_args.push_back(load_scalar(context, wbuf));
         } else {
-            if (arg.name == "__user_context") {
+            if (arg.name == user_context_name()) {
                 js_args.push_back(load_scalar(context, kMagicJitUserContextValue));
                 JITUserContext *jit_user_context = *(JITUserContext **)const_cast<void *>(arg_ptr);
                 context->SetAlignedPointerInEmbedderData(kJitUserContext, jit_user_context);

--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -200,7 +200,7 @@ extern "C" {
 #endif
 
 HALIDE_FUNCTION_ATTRS
-int test2(void const *__user_context, float _alpha, int32_t _beta, struct halide_buffer_t *_buf_buffer);
+int test2(void *__user_context, float _alpha, int32_t _beta, struct halide_buffer_t *_buf_buffer);
 
 HALIDE_FUNCTION_ATTRS
 int test2_argv(void **args);

--- a/test/generator/cxx_mangling_define_extern_aottest.cpp
+++ b/test/generator/cxx_mangling_define_extern_aottest.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
 
     Buffer<double, 1> result_1(10), result_2(10), result_3(10);
 
-    const void *user_context = nullptr;
+    void *user_context = nullptr;
     int ptr_arg = 42;
     int *int_ptr = &ptr_arg;
     const int *const_int_ptr = &ptr_arg;


### PR DESCRIPTION
For reasons that aren't clear, we sometimes emitted user_context as `void*` or `Handle()` (most places), but sometimes as `const void *` (Codegen_C). This attempts to unify it to be plain `void *` everywhere, to avoid the need for const-cast and also void possibilities of c++ name-mangling linker mismatches in some obscure cases.

This is technically a breaking change, since existing code may be passing in `const void *` pointers; I think this is arguably acceptable, since the breakage will be very obvious and very straightforward to fix.

Alternately, I considered unifying on `const void *`, but that seems more restrictive at the call site, and makes for a weird mismatch with our runtime functions (which are all uniformly `void *`).

I'm not entirely happy with the breakage, but the status quo is clearly wrong, and really, has always been.