### PR TITLE
Fix issue in find_package in cross-compilation for no OS

### DIFF
--- a/README_cmake.md
+++ b/README_cmake.md
@@ -750,6 +750,8 @@ Variables that control package loading:
 | Variable             | Description                                                                                                                                                                   |
 |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `Halide_SHARED_LIBS` | override `BUILD_SHARED_LIBS` when loading the Halide package via `find_package`. Has no effect when using Halide via `add_subdirectory` as a Git or `FetchContent` submodule. |
+| `Halide_RUNTIME_NO_THREADS` | skip linking of Threads libraray to runtime. Should be set if your toolchain does not support it (e.g. baremetal). |
+| `Halide_RUNTIME_NO_DL_LIBS` | skip linking of DL libraray to runtime. Should be set if your toolchain does not support it (e.g. baremetal). |
 
 Variables set by the package:
 

--- a/apps/HelloBaremetal/cmake-external_project/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-external_project/CMakeLists.txt
@@ -29,10 +29,6 @@ ExternalProject_Add(gen_project
 # Step 2
 # Build application with cross compiler,
 # where the generator executable built in Step 1 is imported and called
-if (BAREMETAL)
-    # Avoid handling Threads library as mandatory dependency in find_package()
-    set(Halide_NO_THREADS ON)
-endif()
 
 # Import Halide. Instead of the package Halide, HalideHelpers is enough as we don't use JIT mode.
 find_package(HalideHelpers REQUIRED)

--- a/apps/HelloBaremetal/cmake-super_build/app/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-super_build/app/CMakeLists.txt
@@ -12,11 +12,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-if (BAREMETAL)
-    # Avoid handling Threads library as mandatory dependency in find_package()
-    set(Halide_NO_THREADS ON)
-endif()
-
 # Import Halide. Instead of the package Halide, HalideHelpers is enough as we don't use JIT mode.
 find_package(HalideHelpers REQUIRED)
 

--- a/apps/HelloBaremetal/cmake-twice/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-twice/CMakeLists.txt
@@ -8,11 +8,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
 
-if (BAREMETAL)
-    # Avoid handling Threads library as mandatory dependency in find_package()
-    set(Halide_NO_THREADS ON)
-endif()
-
 if (NOT DEFINED GEN_PACKAGE)
     set(GEN_PACKAGE "HelloBaremetal-add_generator")
 endif()

--- a/apps/HelloBaremetal/cmake/toolchain.noos-arm32-sample.cmake
+++ b/apps/HelloBaremetal/cmake/toolchain.noos-arm32-sample.cmake
@@ -29,8 +29,8 @@ set(CMAKE_EXE_LINKER_FLAGS "-z noexecstack")
 set(Halide_TARGET "arm-32-noos-semihosting")
 
 # To prevent Threads and DL libs from being linked to runtime, as this toolchain doesn't have them
-set(HALIDE_RUNTIME_NO_THREADS ON)
-set(HALIDE_RUNTIME_NO_DL_LIBS ON)
+set(Halide_RUNTIME_NO_THREADS ON)
+set(Halide_RUNTIME_NO_DL_LIBS ON)
 
 # Switch for baremetal specific build steps
 set(BAREMETAL ON)

--- a/apps/HelloBaremetal/cmake/toolchain.noos-arm32-sample.cmake
+++ b/apps/HelloBaremetal/cmake/toolchain.noos-arm32-sample.cmake
@@ -22,11 +22,15 @@ set(CMAKE_CXX_FLAGS "${C_COMMON_FLAGS}")
 set(CMAKE_C_FLAGS "${C_COMMON_FLAGS}")
 set(CMAKE_ASM_FLAGS "${C_COMMON_FLAGS}")
 
-# To surpress linker warning "missing .note.GNU-stack section" by GCC 12
+# To suppress linker warning "missing .note.GNU-stack section" by GCC 12
 set(CMAKE_EXE_LINKER_FLAGS "-z noexecstack")
 
 # Halide target for Halide Generator
 set(Halide_TARGET "arm-32-noos-semihosting")
+
+# To prevent Threads and DL libs from being linked to runtime, as this toolchain doesn't have them
+set(HALIDE_RUNTIME_NO_THREADS ON)
+set(HALIDE_RUNTIME_NO_DL_LIBS ON)
 
 # Switch for baremetal specific build steps
 set(BAREMETAL ON)

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -216,7 +216,7 @@ function(add_halide_library TARGET)
     ##
 
     set(options C_BACKEND GRADIENT_DESCENT)
-    set(oneValueArgs FROM GENERATOR FUNCTION_NAME NAMESPACE USE_RUNTIME AUTOSCHEDULER HEADER ${extra_output_names})
+    set(oneValueArgs FROM GENERATOR FUNCTION_NAME NAMESPACE USE_RUNTIME AUTOSCHEDULER HEADER ${extra_output_names} NO_THREADS NO_DL_LIBS)
     set(multiValueArgs TARGETS FEATURES PARAMS PLUGINS)
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -314,7 +314,16 @@ function(add_halide_library TARGET)
         set(ARG_USE_RUNTIME Halide::Runtime)
     elseif (NOT ARG_USE_RUNTIME)
         # If we're not using an existing runtime, create one.
-        add_halide_runtime("${TARGET}.runtime" TARGETS ${ARG_TARGETS} FROM ${ARG_FROM})
+
+        # To forward NO_THREADS/NO_DL_LIBS args to add_halide_runtime()
+        if (DEFINED ARG_NO_THREADS)
+            set(CALL_ARG_NO_THREADS NO_THREADS ${ARG_NO_THREADS})
+        endif ()
+        if (DEFINED ARG_NO_DL_LIBS)
+            set(CALL_ARG_NO_DL_LIBS NO_DL_LIBS ${ARG_NO_DL_LIBS})
+        endif ()
+
+        add_halide_runtime("${TARGET}.runtime" TARGETS ${ARG_TARGETS} FROM ${ARG_FROM} ${CALL_ARG_NO_THREADS} ${CALL_ARG_NO_DL_LIBS})
         set(ARG_USE_RUNTIME "${TARGET}.runtime")
     elseif (NOT TARGET ${ARG_USE_RUNTIME})
         message(FATAL_ERROR "Invalid runtime target ${ARG_USE_RUNTIME}")
@@ -556,7 +565,7 @@ endfunction()
 
 function(add_halide_runtime RT)
     set(options "")
-    set(oneValueArgs FROM)
+    set(oneValueArgs FROM NO_THREADS NO_DL_LIBS)
     set(multiValueArgs TARGETS)
     cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -581,6 +590,15 @@ function(add_halide_runtime RT)
             add_executable(_Halide_gengen ALIAS ${ARG_FROM})
         endif()
     endif()
+
+    # The default of NO_THREADS/NO_DL_LIBS is OFF unless HALIDE_RUNTIME_NO_THREADS/NO_DL_LIBS is defined globally
+    if (NOT DEFINED ARG_NO_THREADS)
+        set(ARG_NO_THREADS ${HALIDE_RUNTIME_NO_THREADS})
+    endif ()
+    if (NOT DEFINED ARG_NO_DL_LIBS)
+        set(ARG_NO_DL_LIBS ${HALIDE_RUNTIME_NO_DL_LIBS})
+    endif ()
+
     # Ensure _Halide_gengen is defined
     _Halide_gengen_ensure()
 
@@ -620,7 +638,14 @@ function(add_halide_runtime RT)
         _Halide_fix_xcode("${RT}")
     endif ()
 
-    target_link_libraries("${RT}" INTERFACE Halide::Runtime Threads::Threads ${CMAKE_DL_LIBS})
+    # Take care of the runtime/toolchain which doesn't have Threads or DL libs
+    if (NOT ARG_NO_THREADS AND NOT TARGET Threads::Threads)
+        find_package(Threads REQUIRED)
+    endif ()
+    target_link_libraries("${RT}" INTERFACE
+                          Halide::Runtime
+                          $<$<NOT:$<BOOL:${ARG_NO_THREADS}>>:Threads::Threads>
+                          $<$<NOT:$<BOOL:${ARG_NO_DL_LIBS}>>:${CMAKE_DL_LIBS}>)
     _Halide_add_targets_to_runtime("${RT}" TARGETS ${ARG_TARGETS})
 endfunction()
 

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -591,12 +591,12 @@ function(add_halide_runtime RT)
         endif()
     endif()
 
-    # The default of NO_THREADS/NO_DL_LIBS is OFF unless HALIDE_RUNTIME_NO_THREADS/NO_DL_LIBS is defined globally
+    # The default of NO_THREADS/NO_DL_LIBS is OFF unless Halide_RUNTIME_NO_THREADS/NO_DL_LIBS is defined globally
     if (NOT DEFINED ARG_NO_THREADS)
-        set(ARG_NO_THREADS ${HALIDE_RUNTIME_NO_THREADS})
+        set(ARG_NO_THREADS ${Halide_RUNTIME_NO_THREADS})
     endif ()
     if (NOT DEFINED ARG_NO_DL_LIBS)
-        set(ARG_NO_DL_LIBS ${HALIDE_RUNTIME_NO_DL_LIBS})
+        set(ARG_NO_DL_LIBS ${Halide_RUNTIME_NO_DL_LIBS})
     endif ()
 
     # Ensure _Halide_gengen is defined

--- a/packaging/common/HalideHelpersConfig.cmake
+++ b/packaging/common/HalideHelpersConfig.cmake
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.22)
 
 set(Halide_HOST_TARGET @Halide_HOST_TARGET@)
 
-include(CMakeFindDependencyMacro)
-
-set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-find_dependency(Threads)
-
 include(${CMAKE_CURRENT_LIST_DIR}/Halide-Interfaces.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/HalideTargetHelpers.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/HalideGeneratorHelpers.cmake)


### PR DESCRIPTION
When using toolchain where Threads libs are not available, which is the case in baremetal target cross-compilation, we were not able to load even HalideHelpers pacakge.