### PR TITLE
Make auto scheduler libs available in HalideHelpers package

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -33,7 +33,7 @@ install(TARGETS Halide Halide_Generator Halide_LanguageOptions
 
 if (TARGET Halide_Adams2019)
     install(TARGETS Halide_Adams2019 Halide_Li2018 Halide_Mullapudi2016
-            EXPORT Halide_Targets
+            EXPORT Halide_Interfaces
             LIBRARY DESTINATION ${Halide_INSTALL_PLUGINDIR} COMPONENT Halide_Runtime
             NAMELINK_COMPONENT Halide_Development)
 endif ()


### PR DESCRIPTION
find_package(HalideHelpers) allows us to use add_halide_library(). But auto scheduler libs are not available unless they are in Halide-Interfaces.cmake.
Note:
Those libraries are not actually linked to the target application, but need to be available for add_custom_command call.