### PR TITLE
Emit prototypes for destructor functions in C Backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1609,7 +1609,7 @@ $(FILTERS_DIR)/autograd_grad.a: $(BIN_DIR)/autograd.generator $(BIN_MULLAPUDI201
 # all have the form nested_externs_*).
 $(FILTERS_DIR)/nested_externs_%.a: $(BIN_DIR)/nested_externs.generator
 	@mkdir -p $(@D)
-	$(CURDIR)/$< -g nested_externs_$* $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime
+	$(CURDIR)/$< -g nested_externs_$* $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) target=$(TARGET)-no_runtime-c_plus_plus_name_mangling
 
 # Similarly, gpu_multi needs two different kernels to test compilation caching.
 # Also requies user-context.

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1487,7 +1487,7 @@ public:
     }
 
     bool has_c_declarations() const {
-        return !c_externs.empty();
+        return !c_externs.empty() || !destructors.empty();
     }
 
     bool has_c_plus_plus_declarations() const {

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -508,7 +508,7 @@ _add_halide_aot_tests(multitarget
 add_halide_generator(nested_externs.generator SOURCES nested_externs_generator.cpp)
 set(NESTED_EXTERNS_LIBS nested_externs_root nested_externs_inner nested_externs_combine nested_externs_leaf)
 foreach (LIB IN LISTS NESTED_EXTERNS_LIBS)
-    _add_halide_libraries(${LIB} FROM nested_externs.generator GENERATOR_NAME ${LIB})
+    _add_halide_libraries(${LIB} FROM nested_externs.generator GENERATOR_NAME ${LIB} FEATURES c_plus_plus_name_mangling)
 endforeach ()
 _add_halide_aot_tests(nested_externs
                       HALIDE_LIBRARIES ${NESTED_EXTERNS_LIBS})


### PR DESCRIPTION
We gathered up the destructors, but only emitted the prototypes if there was at least one non-C++ function declaration needed -- so if you built with cpp_name_mangling enabled, you might omit the right prototype. Fixed and added the right flag to a Generator test to tickle this behavior.