### PR TITLE
Minimal updates to allow Halide building with LLVM17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2178,6 +2178,10 @@ ifneq (,$(findstring clang version 16.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif
 
+ifneq (,$(findstring clang version 17.0,$(CLANG_VERSION)))
+CLANG_OK=yes
+endif
+
 ifneq (,$(findstring Apple LLVM version 5.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif
@@ -2198,7 +2202,7 @@ $(BUILD_DIR)/clang_ok:
 	@exit 1
 endif
 
-ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 140 150 160))
+ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 140 150 160 170))
 LLVM_OK=yes
 endif
 

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -24,8 +24,8 @@ if (LLVM_PACKAGE_VERSION VERSION_LESS 14.0)
     message(FATAL_ERROR "LLVM version must be 14.0 or newer")
 endif ()
 
-if (LLVM_PACKAGE_VERSION VERSION_GREATER 16.0)
-    message(WARNING "Halide is not tested on LLVM versions beyond 16.0")
+if (LLVM_PACKAGE_VERSION VERSION_GREATER 17.0)
+    message(WARNING "Halide is not tested on LLVM versions beyond 17.0")
 endif ()
 
 set(Halide_LLVM_DEFS ${LLVM_DEFINITIONS} $<BUILD_INTERFACE:LLVM_VERSION=${LLVM_VERSION_MAJOR}${LLVM_VERSION_MINOR}>)


### PR DESCRIPTION
(Opening as draft initially until Buildbots build the new LLVM versions)