### PR TITLE
Make Callable::call_argv_fast public

### DIFF
--- a/src/Callable.h
+++ b/src/Callable.h
@@ -385,7 +385,7 @@ public:
      * This function relies on the same calling convention as the argv-based
      * functions generated for ahead-of-time compiled Halide pilelines.
      *
-     * Very rough specifications ofthe calling convention (but check the source
+     * Very rough specifications of the calling convention (but check the source
      * code to be sure):
      *
      *   * Arguments are passed in the same order as they appear in the C

--- a/src/Callable.h
+++ b/src/Callable.h
@@ -281,7 +281,6 @@ private:
 
     // Note that the first entry in argv must always be a JITUserContext*.
     int call_argv_checked(size_t argc, const void *const *argv, const QuickCallCheckInfo *actual_cci) const;
-    int call_argv_fast(size_t argc, const void *const *argv) const;
 
     using FailureFn = std::function<int(JITUserContext *)>;
 
@@ -380,6 +379,15 @@ public:
             };
         }
     }
+
+    /** Unsafe low-overhead way of invoking the Callable.
+     *
+     * This function relies on the same calling convention as the argv-based
+     * functions generated for ahead-of-time compiled Halide pilelines.
+     *
+     * \note The first argument in the first entry in argv must always be a JITUserContext*.
+     */
+    int call_argv_fast(size_t argc, const void *const *argv) const;
 };
 
 }  // namespace Halide

--- a/src/Callable.h
+++ b/src/Callable.h
@@ -385,7 +385,16 @@ public:
      * This function relies on the same calling convention as the argv-based
      * functions generated for ahead-of-time compiled Halide pilelines.
      *
-     * \note The first argument in the first entry in argv must always be a JITUserContext*.
+     * Very rough specifications ofthe calling convention (but check the source
+     * code to be sure):
+     *
+     *   * Arguments are passed in the same order as they appear in the C
+     *     function argument list.
+     *   * The first entry in argv must always be a JITUserContext*. Please,
+     *     note that this means that argv[0] actually contains JITUserContext**.
+     *   * All scalar arguments are passed by pointer, not by value, regardless of size.
+     *   * All buffer arguments (input or output) are passed as halide_buffer_t*.
+     *
      */
     int call_argv_fast(size_t argc, const void *const *argv) const;
 };


### PR DESCRIPTION
Addresses #7314.

I'm wondering, is the argv-based calling convention is documented somewhere? If so, I can add a reference to the doc string.