### PR TITLE
Float16: Remove unused header dependency

### DIFF
--- a/src/Float16.cpp
+++ b/src/Float16.cpp
@@ -1,6 +1,5 @@
 #include "Float16.h"
 #include "Error.h"
-#include "IRMutator.h"
 #include "Util.h"
 
 #include <cmath>


### PR DESCRIPTION
IRMutator.h is not needed for the Float16.h.