### PR TITLE
Fixes for top-of-tree LLVM

### DIFF
--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -28,7 +28,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringRef.h>
-#if LLVM_VERSION < 17
+#if LLVM_VERSION < 170
 #include <llvm/ADT/Triple.h>
 #endif
 #include <llvm/ADT/Twine.h>
@@ -83,7 +83,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
-#if LLVM_VERSION >= 17
+#if LLVM_VERSION >= 170
 #include <llvm/TargetParser/Triple.h>
 #endif
 #include <llvm/Transforms/IPO.h>

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -28,7 +28,9 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringRef.h>
+#if LLVM_VERSION < 17
 #include <llvm/ADT/Triple.h>
+#endif
 #include <llvm/ADT/Twine.h>
 #include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
@@ -81,6 +83,9 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
+#if LLVM_VERSION >= 17
+#include <llvm/TargetParser/Triple.h>
+#endif
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/IPO/Inliner.h>

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -378,8 +378,10 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
     // Make sure things marked as always-inline get inlined
     pass_manager.add(llvm::createAlwaysInlinerLegacyPass());
 
+#if LLVM_VERSION < 17
     // Remove any stale debug info
     pass_manager.add(llvm::createStripDeadDebugInfoPass());
+#endif
 
     // Enable symbol rewriting. This allows code outside libHalide to
     // use symbol rewriting when compiling Halide code (for example, by

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -380,6 +380,14 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
 
 #if LLVM_VERSION < 170
     // Remove any stale debug info
+    //
+    // Note: this pass was added in https://github.com/halide/Halide/pull/2060;
+    // based on the comments, it looks like it was an attempt to fix an error,
+    // but didn't actually fix it, and (apparently) just got left in?
+    //
+    // There is a 'new' equivalent that we could add in the optimization pass
+    // in Codegen_LLVM.cpp, but since this seems to be have added in error,
+    // we're just going to elide it for LLVM >= 17.0
     pass_manager.add(llvm::createStripDeadDebugInfoPass());
 #endif
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -378,7 +378,7 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
     // Make sure things marked as always-inline get inlined
     pass_manager.add(llvm::createAlwaysInlinerLegacyPass());
 
-#if LLVM_VERSION < 17
+#if LLVM_VERSION < 170
     // Remove any stale debug info
     pass_manager.add(llvm::createStripDeadDebugInfoPass());
 #endif


### PR DESCRIPTION
Note that there will likely be subsequent changes/fixes to LLVM_Output.cpp; this is a quick fix to get buildbots unbroken.