### PR TITLE
Add a hook to Codegen_C::compile()

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1928,6 +1928,10 @@ void CodeGen_C::compile(const Module &input) {
     }
 }
 
+Stmt CodeGen_C::preprocess_function_body(const Stmt &stmt) {
+    return stmt;
+}
+
 void CodeGen_C::compile(const LoweredFunc &f, const MetadataNameMap &metadata_name_map) {
     // Don't put non-external function declarations in headers.
     if (is_header_or_extern_decl() && f.linkage == LinkageType::Internal) {
@@ -2014,7 +2018,8 @@ void CodeGen_C::compile(const LoweredFunc &f, const MetadataNameMap &metadata_na
                 stream << get_indent() << "halide_maybe_unused(_ucon);\n";
 
                 // Emit the body
-                print(f.body);
+                Stmt body_to_print = preprocess_function_body(f.body);
+                print(body_to_print);
 
                 // Return success.
                 stream << get_indent() << "return 0;\n";

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -70,6 +70,18 @@ protected:
     virtual void compile(const Buffer<> &buffer);
     // @}
 
+    /** This is a hook that subclasses can use to transform a function body
+     * just before it is emitted -- e.g., to transform the IR to code that
+     * is easier to recognize and emit. The default implementation simply
+     * returns the input unchanged.
+     *
+     * This hook will always be called after the function declaration and
+     * opening brace is emitted, so in addition to (possibly) returning
+     * a modified Stmt, this function may also emit C++ code to the default
+     * stream if it wishes to add some prologue at the start of the function.
+     */
+    virtual Stmt preprocess_function_body(const Stmt &stmt);
+
     /** An ID for the most recently generated ssa variable */
     std::string id;
 


### PR DESCRIPTION
At least one subclass of Codegen_C currently has to replicate ~all of the compile(LoweredFunc) method, with the result that it has often gone stale (and still is stale) wrt changes in the base; this adds an optional method to allow some modifications to the function body just before it is printed, to avoid redundant code.