### PR TITLE
Tiny improvements in codegen in C backend

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1387,7 +1387,7 @@ string CodeGen_C::print_reinterpret(Type type, const Expr &e) {
     // If we are generating a typed nullptr, just emit that as a literal, with no intermediate,
     // to avoid ugly code like
     //
-    //      uint64_t _32 = static_cast<uint64_t>(0ull);
+    //      uint64_t _32 = (uint64_t)(0ull);
     //      auto *_33 = (void *)(_32);
     //
     // and instead just do
@@ -2429,7 +2429,7 @@ void CodeGen_C::visit(const UIntImm *op) {
             "ul",   // OpenCL
             "",     // HLSL
         };
-        print_assignment(op->type, "static_cast<" + print_type(op->type) + ">(" + std::to_string(op->value) + suffixes[(int)integer_suffix_style] + ")");
+        print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + suffixes[(int)integer_suffix_style] + ")");
     }
 }
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2439,24 +2439,10 @@ void CodeGen_C::visit(const StringImm *op) {
     id = oss.str();
 }
 
-// NaN is the only float/double for which this is true... and
-// surprisingly, there doesn't seem to be a portable isnan function
-// (dsharlet).
-template<typename T>
-static bool isnan(T x) {
-    return x != x;
-}
-
-template<typename T>
-static bool isinf(T x) {
-    return std::numeric_limits<T>::has_infinity && (x == std::numeric_limits<T>::infinity() ||
-                                                    x == -std::numeric_limits<T>::infinity());
-}
-
 void CodeGen_C::visit(const FloatImm *op) {
-    if (isnan(op->value)) {
+    if (std::isnan(op->value)) {
         id = "nan_f32()";
-    } else if (isinf(op->value)) {
+    } else if (std::isinf(op->value)) {
         if (op->value > 0) {
             id = "inf_f32()";
         } else {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1384,7 +1384,19 @@ string CodeGen_C::print_reinterpret(Type type, const Expr &e) {
     } else {
         oss << "reinterpret<" << print_type(type) << ">";
     }
-    oss << "(" << print_expr(e) << ")";
+    // If we are generating a typed nullptr, just emit that as a literal, with no intermediate,
+    // to avoid ugly code like
+    //
+    //      uint64_t _32 = static_cast<uint64_t>(0ull);
+    //      auto *_33 = (void *)(_32);
+    //
+    // and instead just do
+    //      auto *_33 = (void *)(nullptr);
+    if (type.is_handle() && is_const_zero(e)) {
+        oss << "(nullptr)";
+    } else {
+        oss << "(" << print_expr(e) << ")";
+    }
     return oss.str();
 }
 


### PR DESCRIPTION
(1) Emit `true` or `false` instead of `(bool)(0ull)` etc for bool literals (2) Avoid redundant temporaries in print_cast_expr(), which occur in a small but nonzero number of cases

Basically this means that code currently like

```
  bool _523 = (bool)(0ull);
  bool _524 = (bool)(_523);
  ...
  foo(_524);
```

becomes

```
  foo(false);
```

...I'm sure this has no output on final object code, but it makes the generated C code less weird to read.

EDIT: (2), do something similar when emitting nullptr constants.

(3), it's 2023, we no longer need to roll our own `isnan()` and `isinf()`
