### PR TITLE
Devirtualize the protected compile() methods in Codegen_C

### DIFF
--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -66,8 +66,8 @@ protected:
 
     /** Emit a declaration. */
     // @{
-    virtual void compile(const LoweredFunc &func, const MetadataNameMap &metadata_name_map);
-    virtual void compile(const Buffer<> &buffer);
+    void compile(const LoweredFunc &func, const MetadataNameMap &metadata_name_map);
+    void compile(const Buffer<> &buffer);
     // @}
 
     /** This is a hook that subclasses can use to transform a function body


### PR DESCRIPTION
With the addition of `preprocess_function_body()`, neither of these need to be virtual, and devirtualizing them avoid `hidden overloaded virtual function` warnings in subclasses that don't override them.

(I'll follow this up with a PR to make appropriate changes in Codegen_Xtensa)