### PR TITLE
Fix tuple output bounds checks

### DIFF
--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -94,6 +94,7 @@ tests(GROUPS error
       thread_id_outside_block_id.cpp
       too_many_args.cpp
       tuple_arg_select_undef.cpp
+      tuple_output_bounds_check.cpp
       tuple_val_select_undef.cpp
       unbounded_input.cpp
       unbounded_output.cpp

--- a/test/error/tuple_output_bounds_check.cpp
+++ b/test/error/tuple_output_bounds_check.cpp
@@ -1,0 +1,26 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // The code below used to not inject appropriate bounds checks.
+    // See https://github.com/halide/Halide/issues/7343
+
+    Var x;
+
+    const int size = 1024;
+
+    Func h;
+    h(x) = {0, 0};
+    RDom r(0, size);
+    h(r) = {h(r - 100)[0], 0};
+
+    Var xo, xi;
+    h.split(x, xo, xi, 16, TailStrategy::RoundUp);
+
+    Buffer<int> r0(size);
+    Buffer<int> r1(size);
+    h.realize({r0, r1});
+
+    return 0;
+}


### PR DESCRIPTION
Tuple outputs weren't getting appropriate bounds checks due to overzealous culling of uninteresting code in the add_image_checks pass.

Fixes #7343 