### PR TITLE
Permit vectorization of non-recursive atomic operations

### DIFF
--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -247,6 +247,7 @@ tests(GROUPS correctness
       realize_condition_depends_on_tuple.cpp
       realize_larger_than_two_gigs.cpp
       realize_over_shifted_domain.cpp
+      recursive_box_filters.cpp
       reduction_chain.cpp
       reduction_predicate_racing.cpp
       reduction_non_rectangular.cpp

--- a/test/correctness/recursive_box_filters.cpp
+++ b/test/correctness/recursive_box_filters.cpp
@@ -1,0 +1,50 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // Compute a two-tap and a four-tap box filter at the same time,
+    // recursively.
+
+    Var x;
+    Func f;
+    f(x) = x;
+    f.compute_root();
+
+    const int size = 1024;
+
+    Func h;
+    h(x) = {undef<int>(), undef<int>()};
+    h(0) = {f(0), f(0)};
+    h(1) = {f(1) + f(0), f(1) + f(0)};
+
+    RDom r(2, size - 2);
+    Expr blur2 = f(r) + f(r - 1);
+    h(r) = {blur2, blur2 + h(r - 2)[0]};
+
+    Var xo, xi;
+    // This is safe to vectorize, but it's not associative/commutative, so we
+    // have to pass 'true' to the atomic call to tell it to skip the check.
+    h.update(2).atomic(true).vectorize(r, 16);
+
+    Buffer<int> r0(size);
+    Buffer<int> r1(size);
+    h.realize({r0, r1});
+
+    for (int i = 3; i < size; i++) {
+        int correct2 = i + (i - 1);
+        int correct4 = i + (i - 1) + (i - 2) + (i - 3);
+        if (r0(i) != correct2) {
+            printf("r0[%d] = %d instead of %d\n", i, r0(i), correct2);
+            return -1;
+        }
+        if (r1(i) != correct4) {
+            printf("r1[%d] = %d instead of %d\n", i, r1(i), correct4);
+            return -1;
+        }
+    }
+
+    printf("Success!\n");
+
+    return 0;
+}

--- a/test/correctness/recursive_box_filters.cpp
+++ b/test/correctness/recursive_box_filters.cpp
@@ -22,7 +22,6 @@ int main(int argc, char **argv) {
     Expr blur2 = f(r) + f(r - 1);
     h(r) = {blur2, blur2 + h(r - 2)[0]};
 
-    Var xo, xi;
     // This is safe to vectorize, but it's not associative/commutative, so we
     // have to pass 'true' to the atomic call to tell it to skip the check.
     h.update(2).atomic(true).vectorize(r, 16);


### PR DESCRIPTION
Pre-vectorization, the code in the included test lowers to:

```
      let t16 = f0[((f1.s3.r6$x.r6$x*16) + f1.s3.r6$x.r7) + 2] + f0[((f1.s3.r6$x.r6$x*16) + f1.s3.r6$x.r7) + 1]
      let t17 = (((f1.s3.r6$x.r6$x*16) + f1.s3.r6$x.r7) - f1.0.min.0) + 2
      atomic {
        f1.0[t17] = t16
      }
      let t18 = ((f1.s3.r6$x.r6$x*16) + f1.s3.r6$x.r7) - f1.0.min.0
      let t19 = f0[((f1.s3.r6$x.r6$x*16) + f1.s3.r6$x.r7) + 2] + f0[((f1.s3.r6$x.r6$x*16) + f1.s3.r6$x.r7) + 1]
      let t20 = (((f1.s3.r6$x.r6$x*16) + f1.s3.r6$x.r7) - f1.0.min.0) + 2
      atomic {
        f1.1[t20] = f1.0[t18] + t19
      }

```

which then scalarizes, even though those atomic nodes could be vectorized just fine, because each atomic operation is non-recursive. This PR enables vectorization of such atomic nodes.

Note that the code in the test uses an unsafe override of the associativity/commutativity check, and while it's safe to vectorize as written, if you change it a little bit, e.g. by flipping the order of the tuple components, it's not.
