### PR TITLE
[xtensa] Generate PACKVRNR for i16(i32(i48x) >> wild_i32)

### DIFF
--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -1163,6 +1163,7 @@ private:
             {"halide_xtensa_rounding_shift_right_i32", rounding_shift_right(wild_i32x, bc(wild_u32))},
             // {"halide_xtensa_rounding_shift_right_u32", rounding_shift_right(wild_u32x, bc(wild_u32))},
 
+            {"halide_xtensa_narrow_i48_with_shift_i16", call("halide_xtensa_narrow_with_shift_i16", wild_i16x, {i32(wild_i48x), wild_i32})},
             {"halide_xtensa_narrow_i48_with_rounding_shift_i16", call("halide_xtensa_narrow_with_rounding_shift_i16", wild_i16x, {i32(wild_i48x), wild_u32})},
 
             {"halide_xtensa_widen_pair_mul_add_u24",

--- a/test/correctness/simd_op_check_xtensa.cpp
+++ b/test/correctness/simd_op_check_xtensa.cpp
@@ -147,6 +147,9 @@ public:
         check("IVP_NSAUN_2X32", vector_width / 4, count_leading_zeros(u32_1));
         check("IVP_NSAUN_2X32", vector_width / 4, count_leading_zeros(i32_1));
 
+        //  Shifts
+        check("IVP_PACKVRNRNX48", vector_width / 2, i16(widening_mul(i16_1, i16_2) >> 4));
+
         // These are not generated right now, because vectors are split now, so comment out for now.
         // Narrowing with shifting.
         // check("halide_xtensa_narrow_with_shift_i16", vector_width / 2, i16(i32_1 >> i32_2));


### PR DESCRIPTION
Fix for the issue mentioned in https://github.com/halide/Halide/pull/7294