### PR TITLE
(Backport #7352  to release/15.x) Fix Python error handling 

### DIFF
--- a/python_bindings/src/halide/halide_/PyError.cpp
+++ b/python_bindings/src/halide/halide_/PyError.cpp
@@ -5,10 +5,6 @@ namespace PythonBindings {
 
 namespace {
 
-void halide_python_error(JITUserContext *, const char *msg) {
-    throw Error(msg);
-}
-
 void halide_python_print(JITUserContext *, const char *msg) {
     py::gil_scoped_acquire acquire;
     py::print(msg, py::arg("end") = "");
@@ -21,21 +17,35 @@ public:
     }
 
     void error(const char *msg) override {
+        // This method is called *only* from the Compiler -- never from jitted
+        // code -- so throwing an Error here is the right thing to do.
+
         throw Error(msg);
+
         // This method must not return!
     }
 };
 
 }  // namespace
 
+PyJITUserContext::PyJITUserContext()
+    : JITUserContext() {
+    handlers.custom_print = halide_python_print;
+    // No: we don't want a custom error function.
+    // If we leave it as the default, realize() and infer_input_bounds()
+    // will correctly propagate the final error message to halide_runtime_error,
+    // which will throw an exception at the end of the relevant call.
+    //
+    // (It's tempting to override custom_error to just do 'throw Error',
+    // but when called from jitted code, it likely won't be able to find
+    // an enclosing C++ try block, meaning it could call std::terminate.)
+    //
+    // handlers.custom_error = halide_python_error;
+}
+
 void define_error(py::module &m) {
     static HalidePythonCompileTimeErrorReporter reporter;
     set_custom_compile_time_error_reporter(&reporter);
-
-    Halide::JITHandlers handlers;
-    handlers.custom_error = halide_python_error;
-    handlers.custom_print = halide_python_print;
-    Halide::Internal::JITSharedRuntime::set_default_handlers(handlers);
 
     static py::exception<Error> halide_error(m, "HalideError");
     py::register_exception_translator([](std::exception_ptr p) {  // NOLINT

--- a/python_bindings/src/halide/halide_/PyError.h
+++ b/python_bindings/src/halide/halide_/PyError.h
@@ -8,6 +8,10 @@ namespace PythonBindings {
 
 void define_error(py::module &m);
 
+struct PyJITUserContext : public JITUserContext {
+    PyJITUserContext();
+};
+
 }  // namespace PythonBindings
 }  // namespace Halide
 

--- a/python_bindings/src/halide/halide_/PyFunc.cpp
+++ b/python_bindings/src/halide/halide_/PyFunc.cpp
@@ -3,6 +3,7 @@
 #include <utility>
 
 #include "PyBuffer.h"
+#include "PyError.h"
 #include "PyExpr.h"
 #include "PyFuncRef.h"
 #include "PyLoopLevel.h"
@@ -92,7 +93,8 @@ py::object evaluate_impl(const py::object &expr, bool may_gpu) {
     {
         py::gil_scoped_release release;
 
-        r = f.realize();
+        PyJITUserContext juc;
+        r = f.realize(&juc);
     }
     if (r->size() == 1) {
         return buffer_getitem_operator((*r)[0], {});
@@ -144,7 +146,9 @@ void define_func(py::module &m) {
                 "realize",
                 [](Func &f, Buffer<> buffer, const Target &target) -> void {
                     py::gil_scoped_release release;
-                    f.realize(buffer, target);
+
+                    PyJITUserContext juc;
+                    f.realize(&juc, buffer, target);
                 },
                 py::arg("dst"), py::arg("target") = Target())
 
@@ -160,7 +164,9 @@ void define_func(py::module &m) {
                     std::optional<Realization> r;
                     {
                         py::gil_scoped_release release;
-                        r = f.realize(sizes, target);
+
+                        PyJITUserContext juc;
+                        r = f.realize(&juc, sizes, target);
                     }
                     return realization_to_object(*r);
                 },
@@ -171,7 +177,9 @@ void define_func(py::module &m) {
                 "realize",
                 [](Func &f, std::vector<Buffer<>> buffers, const Target &t) -> void {
                     py::gil_scoped_release release;
-                    f.realize(Realization(std::move(buffers)), t);
+
+                    PyJITUserContext juc;
+                    f.realize(&juc, Realization(std::move(buffers)), t);
                 },
                 py::arg("dst"), py::arg("target") = Target())
 
@@ -361,10 +369,12 @@ void define_func(py::module &m) {
             .def(
                 "infer_input_bounds", [](Func &f, const py::object &dst, const Target &target) -> void {
                     const Target t = to_jit_target(target);
+                    PyJITUserContext juc;
+
                     // dst could be Buffer<>, vector<Buffer>, or vector<int>
                     try {
                         Buffer<> b = dst.cast<Buffer<>>();
-                        f.infer_input_bounds(b, t);
+                        f.infer_input_bounds(&juc, b, t);
                         return;
                     } catch (...) {
                         // fall thru
@@ -372,7 +382,7 @@ void define_func(py::module &m) {
 
                     try {
                         std::vector<Buffer<>> v = dst.cast<std::vector<Buffer<>>>();
-                        f.infer_input_bounds(Realization(std::move(v)), t);
+                        f.infer_input_bounds(&juc, Realization(std::move(v)), t);
                         return;
                     } catch (...) {
                         // fall thru
@@ -380,7 +390,7 @@ void define_func(py::module &m) {
 
                     try {
                         std::vector<int32_t> v = dst.cast<std::vector<int32_t>>();
-                        f.infer_input_bounds(v, t);
+                        f.infer_input_bounds(&juc, v, t);
                         return;
                     } catch (...) {
                         // fall thru

--- a/python_bindings/src/halide/halide_/PyPipeline.cpp
+++ b/python_bindings/src/halide/halide_/PyPipeline.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "PyError.h"
 #include "PyTuple.h"
 
 namespace Halide {
@@ -187,7 +188,9 @@ void define_pipeline(py::module &m) {
             .def(
                 "realize", [](Pipeline &p, Buffer<> buffer, const Target &target) -> void {
                     py::gil_scoped_release release;
-                    p.realize(Realization(std::move(buffer)), target);
+
+                    PyJITUserContext juc;
+                    p.realize(&juc, Realization(std::move(buffer)), target);
                 },
                 py::arg("dst"), py::arg("target") = Target())
 
@@ -202,7 +205,9 @@ void define_pipeline(py::module &m) {
                     std::optional<Realization> r;
                     {
                         py::gil_scoped_release release;
-                        r = p.realize(std::move(sizes), target);
+
+                        PyJITUserContext juc;
+                        r = p.realize(&juc, std::move(sizes), target);
                     }
                     return realization_to_object(*r);
                 },
@@ -212,17 +217,21 @@ void define_pipeline(py::module &m) {
             .def(
                 "realize", [](Pipeline &p, std::vector<Buffer<>> buffers, const Target &t) -> void {
                     py::gil_scoped_release release;
-                    p.realize(Realization(std::move(buffers)), t);
+
+                    PyJITUserContext juc;
+                    p.realize(&juc, Realization(std::move(buffers)), t);
                 },
                 py::arg("dst"), py::arg("target") = Target())
 
             .def(
                 "infer_input_bounds", [](Pipeline &p, const py::object &dst, const Target &target) -> void {
                     const Target t = to_jit_target(target);
+                    PyJITUserContext juc;
+
                     // dst could be Buffer<>, vector<Buffer>, or vector<int>
                     try {
                         Buffer<> b = dst.cast<Buffer<>>();
-                        p.infer_input_bounds(b, t);
+                        p.infer_input_bounds(&juc, b, t);
                         return;
                     } catch (...) {
                         // fall thru
@@ -230,7 +239,7 @@ void define_pipeline(py::module &m) {
 
                     try {
                         std::vector<Buffer<>> v = dst.cast<std::vector<Buffer<>>>();
-                        p.infer_input_bounds(Realization(std::move(v)), t);
+                        p.infer_input_bounds(&juc, Realization(std::move(v)), t);
                         return;
                     } catch (...) {
                         // fall thru
@@ -238,7 +247,7 @@ void define_pipeline(py::module &m) {
 
                     try {
                         std::vector<int32_t> v = dst.cast<std::vector<int32_t>>();
-                        p.infer_input_bounds(v, t);
+                        p.infer_input_bounds(&juc, v, t);
                         return;
                     } catch (...) {
                         // fall thru

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -28,18 +28,6 @@ using StubInputBuffer = Internal::StubInputBuffer<void>;
 
 namespace {
 
-// This seems redundant to the code in PyError.cpp, but is necessary
-// in case the Stub builder links in a separate copy of libHalide, rather
-// sharing the same halide.so that is built by default.
-void halide_python_error(JITUserContext *, const char *msg) {
-    throw Halide::Error(msg);
-}
-
-void halide_python_print(JITUserContext *, const char *msg) {
-    py::gil_scoped_acquire acquire;
-    py::print(msg, py::arg("end") = "");
-}
-
 class HalidePythonCompileTimeErrorReporter : public CompileTimeErrorReporter {
 public:
     void warning(const char *msg) override {
@@ -56,11 +44,6 @@ public:
 void install_error_handlers(py::module &m) {
     static HalidePythonCompileTimeErrorReporter reporter;
     set_custom_compile_time_error_reporter(&reporter);
-
-    Halide::JITHandlers handlers;
-    handlers.custom_error = halide_python_error;
-    handlers.custom_print = halide_python_print;
-    Halide::Internal::JITSharedRuntime::set_default_handlers(handlers);
 
     static py::object halide_error = py::module_::import("halide").attr("HalideError");
     if (halide_error.is(py::none())) {

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -1084,7 +1084,8 @@ std::string JITErrorBuffer::str() const {
 
 JITFuncCallContext::JITFuncCallContext(JITUserContext *context, const JITHandlers &pipeline_handlers)
     : context(context) {
-    custom_error_handler = (context->handlers.custom_error != nullptr ||
+    custom_error_handler = ((context->handlers.custom_error != nullptr &&
+                             context->handlers.custom_error != JITErrorBuffer::handler) ||
                             pipeline_handlers.custom_error != nullptr);
     // Hook the error handler if not set
     if (!custom_error_handler) {


### PR DESCRIPTION
* Fix Python error handling

Error handling in the Python bindings wasn't quite right for JIT:

We previously replaced halide_error() to throw a C++ exception. Sounds good, but unfortunately, doesn't work reliably: if called from jitted code (which doesn't know about C++ exceptions), the throw statement may be unable to find the enclosing try block (which is outside jitted code), meaning it will call std::terminate. Now, instead, we just leave the JIT error handler unset, and call with an explicit JITUserContext with a custom print handler; in theory, this meant that the code in JITFuncCallContext::finalize() would check for an error after the call into jitted code, and call `halide_runtime_error` if so (which would then trigger an all-in-C++-exception). Unfortunately...

(2) JITFuncCallContext is broken by design; it mutates the input JITUserContext, so that trying to use the same JITUserContext for two calls in a row leaves you with a JITUserContext with (at least) the error_handler set. Since at least one of the realize() calls does this twice (once for bounds query, once for execution), this means that an error in the second call would never be seen, since finalize() only reported errors if there wasn't a custom error handler on input. Per @abadams suggestion, we work around this by treating 'JITErrorBuffer::handler' as 'no custom error handler', which is mostly true. (But really, JITFuncCallContext and JITUserContext are a hard-to-reason-about mess and arguably need to rethought entirely.)

(3) Removed entirely-unnecessary overrides of runtime print and error handlers from PyStubImpl; despite the comments, this code is unnecessary.

* format