### PR TITLE
Overflow on casts is fine for ints < 32 bits

### DIFF
--- a/src/Simplify_Cast.cpp
+++ b/src/Simplify_Cast.cpp
@@ -81,7 +81,7 @@ Expr Simplify::visit(const Cast *op, ExprInfo *bounds) {
                    const_uint(value, &u) &&
                    op->type.bits() >= value.type().bits()) {
             // uint -> int with less than or equal to the number of bits
-            if (op->type.can_represent(u)) {
+            if (op->type.can_represent(u) || op->type.bits() < 32) {
                 // Recursively call mutate just to set the bounds
                 return mutate(make_const(op->type, safe_numeric_cast<int64_t>(u)), bounds);
             } else {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -145,6 +145,9 @@ void check_casts() {
     check(cast(UInt(8), x + 1) - cast(UInt(8), x),
           cast(UInt(8), x + 1) - cast(UInt(8), x));
 
+    // Overflow is well-defined for ints < 32 bits
+    check(cast(Int(8), make_const(UInt(8), 128)), make_const(Int(8), -128));
+
     // Check that chains of widening casts don't lose the distinction
     // between zero-extending and sign-extending.
     check(cast(UInt(64), cast(UInt(32), cast(Int(8), -1))),


### PR DESCRIPTION
Fixes #7365 