### PR TITLE
[xtensa] Clean up HalideFreeHelper code

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1884,7 +1884,7 @@ void CodeGen_C::emit_constexpr_function_info(const std::string &function_name,
 
 void CodeGen_C::emit_halide_free_helper(const std::string &alloc_name, const std::string &free_function) {
     stream << get_indent() << "HalideFreeHelper<" << free_function << "> "
-            << alloc_name << "_free(_ucon, " << alloc_name << ");\n";
+           << alloc_name << "_free(_ucon, " << alloc_name << ");\n";
 }
 
 void CodeGen_C::compile(const Module &input) {

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -300,6 +300,7 @@ protected:
     void emit_constexpr_function_info(const std::string &function_name,
                                       const std::vector<LoweredArgument> &args,
                                       const MetadataNameMap &metadata_name_map);
+    void emit_halide_free_helper(const std::string &alloc_name, const std::string &free_function);
 };
 
 }  // namespace Internal

--- a/src/CodeGen_Xtensa.cpp
+++ b/src/CodeGen_Xtensa.cpp
@@ -4322,9 +4322,7 @@ void CodeGen_Xtensa::visit(const Allocate *op) {
                                    (op->memory_type != MemoryType::VTCM ? "halide_free" : "halide_tcm_free") :
                                    op->free_function;
 
-        stream << get_indent();
-        stream << "HalideFreeHelper " << op_name << "_free(_ucon, "
-               << op_name << ", " << free_function << ");\n";
+        emit_halide_free_helper(op_name, free_function);
     }
 
     op->body.accept(this);


### PR DESCRIPTION
- Revise HalideFreeHelper to be a templated struct, to save the unnecessary stack storage for the function
- Add emit_halide_free_helper() method to consolidate usage
- Add a nullptr check to the `stack_is_core_private`, per comment
- Fix some minor whitespace issues

(If this PR is accepted here, I will of course backport the non-xtensa portions to main)