### PR TITLE
Clean Up HalideFreeHelper code (main) 

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -228,20 +228,17 @@ const B &return_second(const A &a, const B &b) {
 }
 
 namespace {
+template<void(*FreeFn)(void *, void *)>
 class HalideFreeHelper {
-    typedef void (*FreeFunction)(void *user_context, void *p);
-    void * user_context;
-    void *p;
-    FreeFunction free_function;
+    void * const user_context;
+    void * ptr;
 public:
-    HalideFreeHelper(void *user_context, void *p, FreeFunction free_function)
-        : user_context(user_context), p(p), free_function(free_function) {}
+    HalideFreeHelper(void *user_context, void *ptr) : user_context(user_context), ptr(ptr) {}
     ~HalideFreeHelper() { free(); }
     void free() {
-        if (p) {
-            // TODO: do all free_functions guarantee to ignore a nullptr?
-            free_function(user_context, p);
-            p = nullptr;
+        if (ptr) {
+            FreeFn(user_context, ptr);
+            ptr = nullptr;
         }
     }
 };
@@ -1881,6 +1878,11 @@ void CodeGen_C::emit_constexpr_function_info(const std::string &function_name,
     stream << "}\n";
 }
 
+void CodeGen_C::emit_halide_free_helper(const std::string &alloc_name, const std::string &free_function) {
+    stream << get_indent() << "HalideFreeHelper<" << free_function << "> "
+            << alloc_name << "_free(_ucon, " << alloc_name << ");\n";
+}
+
 void CodeGen_C::compile(const Module &input) {
     TypeInfoGatherer type_info;
     for (const auto &f : input.functions()) {
@@ -3350,10 +3352,8 @@ void CodeGen_C::visit(const Allocate *op) {
         }
         create_assertion("(" + check.str() + ")", Call::make(Int(32), "halide_error_out_of_memory", {}, Call::Extern));
 
-        stream << get_indent();
         string free_function = op->free_function.empty() ? "halide_free" : op->free_function;
-        stream << "HalideFreeHelper " << op_name << "_free(_ucon, "
-               << op_name << ", " << free_function << ");\n";
+        emit_halide_free_helper(op_name, free_function);
     }
 
     op->body.accept(this);
@@ -3535,7 +3535,7 @@ int test1(struct halide_buffer_t *_buf_buffer, float _alpha, int32_t _beta, void
    int32_t _4 = halide_error_out_of_memory(_ucon);
    return _4;
   }
-  HalideFreeHelper _tmp_heap_free(_ucon, _tmp_heap, halide_free);
+  HalideFreeHelper<halide_free> _tmp_heap_free(_ucon, _tmp_heap);
   {
    int32_t _tmp_stack[127];
    int32_t _5 = _beta + 1;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1880,7 +1880,7 @@ void CodeGen_C::emit_constexpr_function_info(const std::string &function_name,
 
 void CodeGen_C::emit_halide_free_helper(const std::string &alloc_name, const std::string &free_function) {
     stream << get_indent() << "HalideFreeHelper<" << free_function << "> "
-            << alloc_name << "_free(_ucon, " << alloc_name << ");\n";
+           << alloc_name << "_free(_ucon, " << alloc_name << ");\n";
 }
 
 void CodeGen_C::compile(const Module &input) {

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -290,6 +290,7 @@ protected:
     void emit_constexpr_function_info(const std::string &function_name,
                                       const std::vector<LoweredArgument> &args,
                                       const MetadataNameMap &metadata_name_map);
+    void emit_halide_free_helper(const std::string &alloc_name, const std::string &free_function);
 };
 
 }  // namespace Internal


### PR DESCRIPTION
- Revise HalideFreeHelper to be a templated struct, to save the unnecessary stack storage for the function
- Add emit_halide_free_helper() method to consolidate usage