### PR TITLE
Use single-char form of `unique_name` for semaphores

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2608,7 +2608,7 @@ void CodeGen_C::visit(const Call *op) {
         } else if (op->type == type_of<struct halide_semaphore_t *>() &&
                    sz && *sz == 16) {
             stream << get_indent();
-            string semaphore_name = unique_name("sema");
+            string semaphore_name = unique_name('m');
             stream << "halide_semaphore_t " << semaphore_name << ";\n";
             rhs << "&" << semaphore_name;
         } else {


### PR DESCRIPTION
The multi-char form of `unique_name` will append a `$` to the identifier, e.g. `sema$4`. This isn't really legal for a C/C++ identifier.