### PR TITLE
correctness_round should use Target::supports_type()

### DIFF
--- a/test/correctness/round.cpp
+++ b/test/correctness/round.cpp
@@ -11,10 +11,8 @@ bool test(Expr e, const char *funcname, int vector_width, int N, Buffer<T> &inpu
     f(x) = e;
     Target t = get_jit_target_from_environment();
     if (t.has_gpu_feature()) {
-        if (e.type() == Float(64) &&
-            ((t.has_feature(Target::OpenCL) && !t.has_feature(Target::CLDoubles)) ||
-             t.has_feature(Target::Metal) ||
-             t.has_feature(Target::D3D12Compute))) {
+        if (!t.supports_type(e.type())) {
+            printf("(Target does not support (%s x %d), skipping...)\n", type_of<T>() == Float(32) ? "float" : "double", vector_width);
             return true;
         }
         f.gpu_single_thread();


### PR DESCRIPTION
This gives it proper support for new GPU backends