### PR TITLE
Minor cleanup of GPUCompilationCache

### DIFF
--- a/src/runtime/gpu_context_common.h
+++ b/src/runtime/gpu_context_common.h
@@ -9,14 +9,8 @@ class GPUCompilationCache {
     struct CachedCompilation {
         ContextT context{};
         ModuleStateT module_state{};
-        uint32_t kernel_id{};
-        uint32_t use_count{0};
-
-        CachedCompilation(ContextT context, ModuleStateT module_state,
-                          uint32_t kernel_id, uint32_t use_count)
-            : context(context), module_state(module_state),
-              kernel_id(kernel_id), use_count(use_count) {
-        }
+        uintptr_t kernel_id{0};
+        uintptr_t use_count{0};
     };
 
     halide_mutex mutex;
@@ -27,17 +21,16 @@ class GPUCompilationCache {
     CachedCompilation *compilations{nullptr};
     int count{0};
 
-    static constexpr uint32_t kInvalidId{0};
-    static constexpr uint32_t kDeletedId{1};
+    static constexpr uintptr_t kInvalidId{0};
+    static constexpr uintptr_t kDeletedId{1};
 
-    uint32_t unique_id{2};  // zero is an invalid id
+    uintptr_t unique_id{2};  // zero is an invalid id
 
-public:
-    static ALWAYS_INLINE uintptr_t kernel_hash(ContextT context, uint32_t id, uint32_t bits) {
+    static ALWAYS_INLINE uintptr_t kernel_hash(ContextT context, uintptr_t id, int bits) {
         uintptr_t addr = (uintptr_t)context + id;
         // Fibonacci hashing. The golden ratio is 1.9E3779B97F4A7C15F39...
         // in hexadecimal.
-        if (sizeof(uintptr_t) >= 8) {
+        if constexpr (sizeof(uintptr_t) >= 8) {
             return (addr * (uintptr_t)0x9E3779B97F4A7C15) >> (64 - bits);
         } else {
             return (addr * (uintptr_t)0x9E3779B9) >> (32 - bits);
@@ -70,7 +63,7 @@ public:
         return false;
     }
 
-    HALIDE_MUST_USE_RESULT bool find_internal(ContextT context, uint32_t id,
+    HALIDE_MUST_USE_RESULT bool find_internal(ContextT context, uintptr_t id,
                                               ModuleStateT *&module_state, int increment) {
         if (log2_compilations_size == 0) {
             return false;
@@ -90,17 +83,6 @@ public:
                 }
                 return true;
             }
-        }
-        return false;
-    }
-
-    HALIDE_MUST_USE_RESULT bool lookup(ContextT context, void *state_ptr, ModuleStateT &module_state) {
-        ScopedMutexLock lock_guard(&mutex);
-        uint32_t id = (uint32_t)(uintptr_t)state_ptr;
-        ModuleStateT *mod_ptr;
-        if (find_internal(context, id, mod_ptr, 0)) {
-            module_state = *mod_ptr;
-            return true;
         }
         return false;
     }
@@ -134,8 +116,23 @@ public:
         return true;
     }
 
+public:
+    HALIDE_MUST_USE_RESULT bool lookup(ContextT context, void *state_ptr, ModuleStateT &module_state) {
+        ScopedMutexLock lock_guard(&mutex);
+
+        uintptr_t id = (uintptr_t)state_ptr;
+        ModuleStateT *mod_ptr;
+        if (find_internal(context, id, mod_ptr, 0)) {
+            module_state = *mod_ptr;
+            return true;
+        }
+        return false;
+    }
+
     template<typename FreeModuleT>
     void release_context(void *user_context, bool all, ContextT context, FreeModuleT &f) {
+        ScopedMutexLock lock_guard(&mutex);
+
         if (count == 0) {
             return;
         }
@@ -157,7 +154,8 @@ public:
 
     template<typename FreeModuleT>
     void delete_context(void *user_context, ContextT context, FreeModuleT &f) {
-        ScopedMutexLock lock_guard(&mutex);
+        // No: release_context() will acquire the mutex.
+        // ScopedMutexLock lock_guard(&mutex);
 
         release_context(user_context, false, context, f);
     }
@@ -176,15 +174,19 @@ public:
     }
 
     template<typename CompileModuleT, typename... Args>
-    HALIDE_MUST_USE_RESULT bool kernel_state_setup(void *user_context, void **state_ptr,
+    HALIDE_MUST_USE_RESULT bool kernel_state_setup(void *user_context, void **state_ptr_ptr,
                                                    ContextT context, ModuleStateT &result,
                                                    CompileModuleT f,
                                                    Args... args) {
         ScopedMutexLock lock_guard(&mutex);
 
-        uint32_t *id_ptr = (uint32_t *)state_ptr;
+        uintptr_t *id_ptr = (uintptr_t *)state_ptr_ptr;
         if (*id_ptr == 0) {
             *id_ptr = unique_id++;
+            if (unique_id == (uintptr_t)-1) {
+                // Sorry, out of ids
+                return false;
+            }
         }
 
         ModuleStateT *mod;
@@ -210,8 +212,10 @@ public:
     }
 
     void release_hold(void *user_context, ContextT context, void *state_ptr) {
+        ScopedMutexLock lock_guard(&mutex);
+
         ModuleStateT *mod;
-        uint32_t id = (uint32_t)(uintptr_t)state_ptr;
+        uintptr_t id = (uintptr_t)state_ptr;
         bool result = find_internal(context, id, mod, -1);
         halide_debug_assert(user_context, result);  // Value must be in cache to be released
         (void)result;

--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -1,5 +1,17 @@
 #ifndef HALIDE_RUNTIME_PRINTER_H
 #define HALIDE_RUNTIME_PRINTER_H
+
+// This is useful for debugging threading issues in the Halide runtime:
+// prefix all `debug()` statements with the thread id that did the logging.
+// Left here (but disabled) for future reference.
+#ifndef HALIDE_RUNTIME_PRINTER_LOG_THREADID
+#define HALIDE_RUNTIME_PRINTER_LOG_THREADID 0
+#endif
+
+#if HALIDE_RUNTIME_PRINTER_LOG_THREADID
+extern "C" int pthread_threadid_np(long thread, uint64_t *thread_id);
+#endif
+
 namespace Halide {
 namespace Runtime {
 namespace Internal {
@@ -51,6 +63,12 @@ public:
             // Pointers equal ensures no writes to buffer via formatting code
             end = dst;
         }
+
+#if HALIDE_RUNTIME_PRINTER_LOG_THREADID
+        uint64_t tid;
+        pthread_threadid_np(0, &tid);
+        *this << "(TID:" << tid << ")";
+#endif
     }
 
     // Not movable, not copyable


### PR DESCRIPTION
While tracking down an apparently-unrelated threading bug in the webgpu backend, I made some tweaks to this code that I think are worth keeping. The main one of importance is that `release_hold()` and `release_context()` really should acquire the mutex -- they weren't before -- so now all public methods are properly mutexed.

The other changes are mostly cosmetic:
- Moved helper methods to be private rather than public
- Changed the id value size to be `uintptr_t` rather than `uint32_t`; the space allocated for them is sizeof(void*). (Not sure this moves the needle but it felt right.)
- Removed unused ctor for CachedCompilation

Also, drive-by change in printer.h to capture some logging improvements.