### PR TITLE
Bounds visitors for min/max were missing single_point mutated case

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -3711,6 +3711,17 @@ void bounds_test() {
         check_constant_bound(e4, u16(0), u16(65535));
     }
 
+    // Test case from https://github.com/halide/Halide/pull/7377
+    {
+        Var x;
+        Expr e = Load::make(Int(32), "buf", max(x, -x), Buffer<>{}, Parameter{}, const_true(), ModulusRemainder{});
+        e = Let::make(x.name(), 37, e);
+        Scope<Interval> scope;
+        scope.push("y", {0, 100});
+        Interval in = bounds_of_expr_in_scope(e, scope);
+        internal_assert(in.is_single_point());
+    }
+
     std::cout << "Bounds test passed" << std::endl;
 }
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -747,6 +747,8 @@ private:
 
         if (a.is_single_point(op->a) && b.is_single_point(op->b)) {
             interval = Interval::single_point(op);
+        } else if (a.is_single_point() && b.is_single_point()) {
+            interval = Interval::single_point(Interval::make_min(a.min, b.min));
         } else {
             interval = Interval(Interval::make_min(a.min, b.min),
                                 Interval::make_min(a.max, b.max));
@@ -763,6 +765,8 @@ private:
 
         if (a.is_single_point(op->a) && b.is_single_point(op->b)) {
             interval = Interval::single_point(op);
+        } else if (a.is_single_point() && b.is_single_point()) {
+            interval = Interval::single_point(Interval::make_max(a.min, b.min));
         } else {
             interval = Interval(Interval::make_max(a.min, b.min),
                                 Interval::make_max(a.max, b.max));


### PR DESCRIPTION
Other visitors handle this case, but it was inexplicably missing from min/max. This causes later checks to is_single_point to suboptimally return false because we get two distinct but equal Exprs.

Partially fixes #7374