### PR TITLE
Bounds visitor for div was missing single_point mutated case

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -3724,6 +3724,17 @@ void bounds_test() {
         internal_assert(in.is_single_point());
     }
 
+    // Test case from https://github.com/halide/Halide/pull/7379
+    {
+        Var x;
+        Expr e = Load::make(Int(32), "buf", -x / x, Buffer<>{}, Parameter{}, const_true(), ModulusRemainder{});
+        e = Let::make(x.name(), 37, e);
+        Scope<Interval> scope;
+        scope.push("y", {0, 100});
+        Interval in = bounds_of_expr_in_scope(e, scope);
+        internal_assert(in.is_single_point());
+    }
+
     std::cout << "Bounds test passed" << std::endl;
 }
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -612,6 +612,8 @@ private:
             }
         } else if (a.is_single_point(op->a) && b.is_single_point(op->b)) {
             interval = Interval::single_point(op);
+        } else if (a.is_single_point() && b.is_single_point()) {
+            interval = Interval::single_point(a.min / b.min);
         } else if (can_prove(b.min == b.max)) {
             Expr e1 = a.has_lower_bound() ? a.min / b.min : a.min;
             Expr e2 = a.has_upper_bound() ? a.max / b.max : a.max;


### PR DESCRIPTION
So further investigating issue I reported #7374 I found that also `Div` visit misses this case which results in not bounded loop being generated.