### PR TITLE
Add Callable default ctor + `defined()` method

### DIFF
--- a/src/Callable.cpp
+++ b/src/Callable.cpp
@@ -47,7 +47,11 @@ void destroy<CallableContents>(const CallableContents *p) {
 }  // namespace Internal
 
 Callable::Callable()
-    : contents(new CallableContents) {
+    : contents(nullptr) {
+}
+
+bool Callable::defined() const {
+    return contents.defined();
 }
 
 Callable::Callable(const std::string &name,
@@ -136,6 +140,8 @@ Callable::FailureFn Callable::check_qcci(size_t argc, const QuickCallCheckInfo *
 }
 
 Callable::FailureFn Callable::check_fcci(size_t argc, const FullCallCheckInfo *actual_fcci) const {
+    internal_assert(defined());
+
     // Lazily create full_call_check_info upon the first call to make_std_function().
     if (contents->full_call_check_info.empty()) {
         contents->full_call_check_info.reserve(contents->jit_cache.arguments.size());
@@ -197,6 +203,8 @@ Callable::FailureFn Callable::check_fcci(size_t argc, const FullCallCheckInfo *a
 }
 
 int Callable::call_argv_checked(size_t argc, const void *const *argv, const QuickCallCheckInfo *actual_qcci) const {
+    internal_assert(defined());
+
     // It's *essential* we call this for safety.
     const auto failure_fn = check_qcci(argc, actual_qcci);
     if (failure_fn) {

--- a/src/Callable.cpp
+++ b/src/Callable.cpp
@@ -140,7 +140,7 @@ Callable::FailureFn Callable::check_qcci(size_t argc, const QuickCallCheckInfo *
 }
 
 Callable::FailureFn Callable::check_fcci(size_t argc, const FullCallCheckInfo *actual_fcci) const {
-    internal_assert(defined());
+    user_assert(defined()) << "Cannot call() a default-constructed Callable.";
 
     // Lazily create full_call_check_info upon the first call to make_std_function().
     if (contents->full_call_check_info.empty()) {
@@ -203,7 +203,7 @@ Callable::FailureFn Callable::check_fcci(size_t argc, const FullCallCheckInfo *a
 }
 
 int Callable::call_argv_checked(size_t argc, const void *const *argv, const QuickCallCheckInfo *actual_qcci) const {
-    internal_assert(defined());
+    user_assert(defined()) << "Cannot call() a default-constructed Callable.";
 
     // It's *essential* we call this for safety.
     const auto failure_fn = check_qcci(argc, actual_qcci);

--- a/src/Callable.h
+++ b/src/Callable.h
@@ -273,7 +273,6 @@ private:
         }
     };
 
-    Callable();
     Callable(const std::string &name,
              const JITHandlers &jit_handlers,
              const std::map<std::string, JITExtern> &jit_externs,
@@ -303,6 +302,13 @@ private:
     const std::vector<Argument> &arguments() const;
 
 public:
+    /** Construct a default Callable. This is not usable (trying to call it will fail).
+     * The defined() method will return false. */
+    Callable();
+
+    /** Return true if the Callable is well-defined and usable, false if it is a default-constructed empty Callable. */
+    bool defined() const;
+
     template<typename... Args>
     HALIDE_FUNCTION_ATTRS int
     operator()(JITUserContext *context, Args &&...args) const {

--- a/test/correctness/callable.cpp
+++ b/test/correctness/callable.cpp
@@ -45,6 +45,15 @@ int main(int argc, char **argv) {
     const Target t = get_jit_target_from_environment();
 
     {
+        // Check that we can default-construct a Callable.
+        Callable c;
+        assert(!c.defined());
+
+        // This will assert-fail.
+        // c(0,1,2);
+    }
+
+    {
         Param<int32_t> p_int(42);
         Param<float> p_float(1.0f);
         ImageParam p_img(UInt(8), 2);


### PR DESCRIPTION
This allows it to behave like other Halide IR pieces.