### PR TITLE
Make README consistent on supported LLVM versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ issue.
 
 ### TL;DR
 
-Have llvm-13.0 (or greater) installed and run `make` in the root directory of
+Have llvm-14.0 (or greater) installed and run `make` in the root directory of
 the repository (where this README is).
 
 ### Acquiring LLVM
@@ -127,10 +127,10 @@ works well on OS X and Ubuntu.)
 If you want to build it yourself, first check it out from GitHub:
 
 ```
-% git clone --depth 1 --branch llvmorg-13.0.0 https://github.com/llvm/llvm-project.git
+% git clone --depth 1 --branch llvmorg-14.0.0 https://github.com/llvm/llvm-project.git
 ```
 
-(If you want to build LLVM 13.x, use branch `release/13.x`; for current trunk,
+(If you want to build LLVM 14.x, use branch `release/14.x`; for current trunk,
 use `main`)
 
 Then build it like so:
@@ -285,10 +285,10 @@ Subsets of the tests can be selected with `-L` and include `correctness`,
 #### Building LLVM (optional)
 
 Follow these steps if you want to build LLVM yourself. First, download LLVM's
-sources (these instructions use the latest 13.0 release)
+sources (these instructions use the latest 14.0 release)
 
 ```
-D:\> git clone --depth 1 --branch llvmorg-13.0.0 https://github.com/llvm/llvm-project.git
+D:\> git clone --depth 1 --branch llvmorg-14.0.0 https://github.com/llvm/llvm-project.git
 ```
 
 For a 64-bit build, run:


### PR DESCRIPTION
According to https://github.com/halide/Halide/pull/7093, Halide 16 no longer need to support LLVM 13, this PR makes the build instruction in README more consistent with the PR.

cc @abadams 