### PR TITLE
Attempt to give proper labels to pip 'nightly' builds

### DIFF
--- a/.github/workflows/pip-label.yml
+++ b/.github/workflows/pip-label.yml
@@ -1,0 +1,27 @@
+# When creating 'dev' (e.g. nightly) PyPI packages, we need to create a unique
+# label for each upload. For simplicity, we choose the Unix time-since-epoch in
+# UTC form (aka `date +%s`); however, since we have multiple jobs that want to
+# use the same label, we split this into two GitHub Actions: this one (which
+# chooses and uploads the label), and pip.yml (which uses the label).
+name: Create PyPI Label
+
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [ created ]
+
+jobs:
+  create-pypi-label:
+    name: Create label for PyPI packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create label for nightly PyPI packages
+        run: |
+          mkdir -p ./halide_uploads
+          echo $(date +%s) > ./halide_uploads/halide_pypi_label
+      - uses: actions/upload-artifact@v3
+        with:
+          name: halide_pypi_label
+          path: halide_uploads/halide_pypi_label

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -5,23 +5,38 @@
 name: Build PyPI package
 
 on:
-  push:
-    branches: [ main ]
-  release:
-    types: [ created ]
+  workflow_run:
+    workflows: [Create PyPI Label]
+    types: [completed]
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 env:
-  LLVM_VER: 15.0.1
+  LLVM_VER: 15.0.7
 
 permissions:
   contents: read  #  to fetch code (actions/checkout)
   packages: read  #  to fetch packages (docker)
 
 jobs:
+  get-pypi-label:
+    runs-on: ubuntu-latest
+    permissions:
+      # required when deleting artifact
+      actions: write
+    steps:
+      - id: HalidePyPILabel
+        name: Download Label for PyPI
+        uses: redhat-plumbers-in-action/download-artifact@1
+        with:
+          name: halide_pypi_label
+
+      - name: Log Label
+        run: |
+          echo "Using label: ${{ steps.HalidePyPILabel.outputs.halide_pypi_label }}"
+
   pip-linux:
     name: Package Halide Python bindings
 
@@ -52,6 +67,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "${{ matrix.arch }}"
           CIBW_BUILD: "cp38-manylinux* cp39-manylinux* cp310-manylinux*"
+          CIBW_CONFIG_SETTINGS: "--global-option=egg_info --global-option=-b.dev${{ steps.HalidePyPILabel.outputs.halide_pypi_label }}"
           CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/halide/manylinux2014_x86_64-llvm:${{ env.LLVM_VER }}
           # CIBW_MANYLINUX_I686_IMAGE: ghcr.io/halide/manylinux2014_i686-llvm:${{ env.LLVM_VER }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/halide/manylinux2014_aarch64-llvm:${{ env.LLVM_VER }}
@@ -175,6 +191,7 @@ jobs:
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/local-halide
           CIBW_BUILD: "cp38-${{ matrix.pytag }} cp39-${{ matrix.pytag }} cp310-${{ matrix.pytag }}"
           CIBW_ARCHS_MACOS: "universal2"
+          CIBW_CONFIG_SETTINGS: "--global-option=egg_info --global-option=-b.dev${{ steps.HalidePyPILabel.outputs.halide_pypi_label }}"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -186,7 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
-      - run: pipx run build --sdist
+      - run: pipx run build --sdist -C--global-option=egg_info -C--global-option=-b.dev${{ steps.HalidePyPILabel.outputs.halide_pypi_label }}
       - uses: actions/upload-artifact@v3
         with:
           name: wheels


### PR DESCRIPTION
Uploading to the test server requires unique names. This attempts to use versions of the form `devTIME`, where TIME is unix-time-UTC. This PR is arguably incomplete right now (I suspect it would be better to switch to 'true' nightlies that trigger at, say, 9pm PST, and also to add rotation so we only keep a handful of uploads); this is meant to test the basic mechanism to see if the GitHub Action setup will work.