### PR TITLE
Backport changes to CodegenC from the xtensa branch

### DIFF
--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -127,6 +127,9 @@ protected:
     /** Emit a version of a string that is a valid identifier in C (. is replaced with _) */
     virtual std::string print_name(const std::string &);
 
+    /** Add platform specific prologue */
+    virtual void add_platform_prologue();
+
     /** Add typedefs for vector types. Not needed for OpenCL, might
      * use different syntax for other C-like languages. */
     virtual void add_vector_typedefs(const std::set<Type> &vector_types);
@@ -281,6 +284,13 @@ protected:
 
     /** true if add_vector_typedefs() has been called. */
     bool using_vector_typedefs;
+
+    /** Some architectures have private memory for the call stack; this
+     * means a thread cannot hand pointers to stack memory to another
+     * thread. Returning true here flag forces heap allocation of
+     * things that might be shared, such as closures and any buffer
+     * that may be used in a parallel context. */
+    virtual bool is_stack_private_to_thread() const;
 
     void emit_argv_wrapper(const std::string &function_name,
                            const std::vector<LoweredArgument> &args);


### PR DESCRIPTION
Backported with some trivial style changes (virtual method instead of flag, since this should never changes for a given instance)