### PR TITLE
Cleanup of src/runtime/internal and test/runtime

### DIFF
--- a/src/runtime/internal/block_storage.h
+++ b/src/runtime/internal/block_storage.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_RUNTIME_BLOCK_STORAGE_H
 #define HALIDE_RUNTIME_BLOCK_STORAGE_H
 
+#include "HalideRuntime.h"
 #include "memory_resources.h"
 
 namespace Halide {
@@ -89,9 +90,9 @@ private:
 
 BlockStorage::BlockStorage(void *user_context, const Config &cfg, const SystemMemoryAllocatorFns &sma)
     : config(cfg), allocator(sma) {
-    halide_abort_if_false(user_context, config.entry_size != 0);
-    halide_abort_if_false(user_context, allocator.allocate != nullptr);
-    halide_abort_if_false(user_context, allocator.deallocate != nullptr);
+    halide_debug_assert(user_context, config.entry_size != 0);
+    halide_debug_assert(user_context, allocator.allocate != nullptr);
+    halide_debug_assert(user_context, allocator.deallocate != nullptr);
     if (config.minimum_capacity) {
         reserve(user_context, config.minimum_capacity);
     }
@@ -110,7 +111,7 @@ BlockStorage::~BlockStorage() {
 }
 
 void BlockStorage::destroy(void *user_context) {
-    halide_abort_if_false(user_context, allocator.deallocate != nullptr);
+    halide_debug_assert(user_context, allocator.deallocate != nullptr);
     if (ptr != nullptr) {
         allocator.deallocate(user_context, ptr);
     }
@@ -371,7 +372,7 @@ const void *BlockStorage::back() const {
 
 void BlockStorage::allocate(void *user_context, size_t new_capacity) {
     if (new_capacity != capacity) {
-        halide_abort_if_false(user_context, allocator.allocate != nullptr);
+        halide_debug_assert(user_context, allocator.allocate != nullptr);
         size_t requested_bytes = new_capacity * config.entry_size;
         size_t block_size = max(config.block_size, config.entry_size);
         size_t block_count = (requested_bytes / block_size);
@@ -389,7 +390,7 @@ void BlockStorage::allocate(void *user_context, size_t new_capacity) {
             memcpy(new_ptr, ptr, count * config.entry_size);
         }
         if (ptr != nullptr) {
-            halide_abort_if_false(user_context, allocator.deallocate != nullptr);
+            halide_debug_assert(user_context, allocator.deallocate != nullptr);
             allocator.deallocate(user_context, ptr);
         }
         capacity = new_capacity;

--- a/src/runtime/internal/linked_list.h
+++ b/src/runtime/internal/linked_list.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_RUNTIME_LINKED_LIST_H
 #define HALIDE_RUNTIME_LINKED_LIST_H
 
+#include "HalideRuntime.h"
 #include "memory_arena.h"
 
 namespace Halide {
@@ -176,7 +177,7 @@ LinkedList::append(void *user_context, const void *value) {
 }
 
 void LinkedList::pop_front(void *user_context) {
-    halide_abort_if_false(user_context, (entry_count > 0));
+    halide_debug_assert(user_context, (entry_count > 0));
     EntryType *remove_ptr = front_ptr;
     EntryType *next_ptr = remove_ptr->next_ptr;
     if (next_ptr != nullptr) {
@@ -188,7 +189,7 @@ void LinkedList::pop_front(void *user_context) {
 }
 
 void LinkedList::pop_back(void *user_context) {
-    halide_abort_if_false(user_context, (entry_count > 0));
+    halide_debug_assert(user_context, (entry_count > 0));
     EntryType *remove_ptr = back_ptr;
     EntryType *prev_ptr = remove_ptr->prev_ptr;
     if (prev_ptr != nullptr) {
@@ -214,20 +215,20 @@ void LinkedList::clear(void *user_context) {
 }
 
 void LinkedList::remove(void *user_context, EntryType *entry_ptr) {
-    halide_abort_if_false(user_context, (entry_ptr != nullptr));
-    halide_abort_if_false(user_context, (entry_count > 0));
+    halide_debug_assert(user_context, (entry_ptr != nullptr));
+    halide_debug_assert(user_context, (entry_count > 0));
 
     if (entry_ptr->prev_ptr != nullptr) {
         entry_ptr->prev_ptr->next_ptr = entry_ptr->next_ptr;
     } else {
-        halide_abort_if_false(user_context, (front_ptr == entry_ptr));
+        halide_debug_assert(user_context, (front_ptr == entry_ptr));
         front_ptr = entry_ptr->next_ptr;
     }
 
     if (entry_ptr->next_ptr != nullptr) {
         entry_ptr->next_ptr->prev_ptr = entry_ptr->prev_ptr;
     } else {
-        halide_abort_if_false(user_context, (back_ptr == entry_ptr));
+        halide_debug_assert(user_context, (back_ptr == entry_ptr));
         back_ptr = entry_ptr->prev_ptr;
     }
 
@@ -246,7 +247,7 @@ LinkedList::insert_before(void *user_context, EntryType *entry_ptr) {
         if (prev_ptr != nullptr) {
             prev_ptr->next_ptr = new_ptr;
         } else {
-            halide_abort_if_false(user_context, (front_ptr == entry_ptr));
+            halide_debug_assert(user_context, (front_ptr == entry_ptr));
             front_ptr = new_ptr;
         }
         ++entry_count;
@@ -267,7 +268,7 @@ LinkedList::insert_after(void *user_context, EntryType *entry_ptr) {
         if (next_ptr != nullptr) {
             next_ptr->prev_ptr = new_ptr;
         } else {
-            halide_abort_if_false(user_context, (back_ptr == entry_ptr));
+            halide_debug_assert(user_context, (back_ptr == entry_ptr));
             back_ptr = new_ptr;
         }
         ++entry_count;

--- a/src/runtime/internal/memory_resources.h
+++ b/src/runtime/internal/memory_resources.h
@@ -1,6 +1,8 @@
 #ifndef HALIDE_RUNTIME_MEMORY_RESOURCES_H
 #define HALIDE_RUNTIME_MEMORY_RESOURCES_H
 
+#include "HalideRuntime.h"
+
 namespace Halide {
 namespace Runtime {
 namespace Internal {

--- a/src/runtime/internal/pointer_table.h
+++ b/src/runtime/internal/pointer_table.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_RUNTIME_POINTER_TABLE_H
 #define HALIDE_RUNTIME_POINTER_TABLE_H
 
+#include "HalideRuntime.h"
 #include "memory_resources.h"
 
 namespace Halide {
@@ -72,8 +73,8 @@ private:
 
 PointerTable::PointerTable(void *user_context, size_t initial_capacity, const SystemMemoryAllocatorFns &sma)
     : allocator(sma) {
-    halide_abort_if_false(user_context, allocator.allocate != nullptr);
-    halide_abort_if_false(user_context, allocator.deallocate != nullptr);
+    halide_debug_assert(user_context, allocator.allocate != nullptr);
+    halide_debug_assert(user_context, allocator.deallocate != nullptr);
     if (initial_capacity) {
         reserve(user_context, initial_capacity);
     }
@@ -96,7 +97,7 @@ PointerTable::~PointerTable() {
 }
 
 void PointerTable::destroy(void *user_context) {
-    halide_abort_if_false(user_context, allocator.deallocate != nullptr);
+    halide_debug_assert(user_context, allocator.deallocate != nullptr);
     if (ptr != nullptr) {
         allocator.deallocate(user_context, ptr);
     }
@@ -329,7 +330,7 @@ const void **PointerTable::data() const {
 
 void PointerTable::allocate(void *user_context, size_t new_capacity) {
     if (new_capacity != capacity) {
-        halide_abort_if_false(user_context, allocator.allocate != nullptr);
+        halide_debug_assert(user_context, allocator.allocate != nullptr);
         size_t bytes = new_capacity * sizeof(void *);
 
 #ifdef DEBUG_RUNTIME
@@ -341,7 +342,7 @@ void PointerTable::allocate(void *user_context, size_t new_capacity) {
             memcpy(new_ptr, ptr, count * sizeof(void *));
         }
         if (ptr != nullptr) {
-            halide_abort_if_false(user_context, allocator.deallocate != nullptr);
+            halide_debug_assert(user_context, allocator.deallocate != nullptr);
             allocator.deallocate(user_context, ptr);
         }
         capacity = new_capacity;

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_RUNTIME_STRING_STORAGE_H
 #define HALIDE_RUNTIME_STRING_STORAGE_H
 
+#include "HalideRuntime.h"
 #include "block_storage.h"
 
 namespace Halide {
@@ -125,7 +126,7 @@ StringStorage::~StringStorage() {
 }
 
 StringStorage *StringStorage::create(void *user_context, const SystemMemoryAllocatorFns &system_allocator) {
-    halide_abort_if_false(user_context, system_allocator.allocate != nullptr);
+    halide_debug_assert(user_context, system_allocator.allocate != nullptr);
     StringStorage *result = reinterpret_cast<StringStorage *>(
         system_allocator.allocate(user_context, sizeof(StringStorage)));
 
@@ -139,10 +140,10 @@ StringStorage *StringStorage::create(void *user_context, const SystemMemoryAlloc
 }
 
 void StringStorage::destroy(void *user_context, StringStorage *instance) {
-    halide_abort_if_false(user_context, instance != nullptr);
+    halide_debug_assert(user_context, instance != nullptr);
     const SystemMemoryAllocatorFns &system_allocator = instance->current_allocator();
     instance->destroy(user_context);
-    halide_abort_if_false(user_context, system_allocator.deallocate != nullptr);
+    halide_debug_assert(user_context, system_allocator.deallocate != nullptr);
     system_allocator.deallocate(user_context, instance);
 }
 

--- a/src/runtime/internal/string_table.h
+++ b/src/runtime/internal/string_table.h
@@ -1,6 +1,7 @@
 #ifndef HALIDE_RUNTIME_STRING_TABLE_H
 #define HALIDE_RUNTIME_STRING_TABLE_H
 
+#include "HalideRuntime.h"
 #include "block_storage.h"
 #include "pointer_table.h"
 #include "string_storage.h"

--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -205,11 +205,11 @@ public:
 // does nothing and should compile to a no-op.
 class SinkPrinter {
 public:
-    explicit SinkPrinter(void *user_context) {
+    ALWAYS_INLINE explicit SinkPrinter(void *user_context) {
     }
 };
 template<typename T>
-SinkPrinter operator<<(const SinkPrinter &s, T) {
+ALWAYS_INLINE SinkPrinter operator<<(const SinkPrinter &s, T) {
     return s;
 }
 

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -60,17 +60,20 @@ typedef ptrdiff_t ssize_t;
 // --------------
 
 #ifdef BITS_64
-#define INT64_C(c) c##L
-#define UINT64_C(c) c##UL
 typedef uint64_t uintptr_t;
 typedef int64_t intptr_t;
 #endif
 
 #ifdef BITS_32
-#define INT64_C(c) c##LL
-#define UINT64_C(c) c##ULL
 typedef uint32_t uintptr_t;
 typedef int32_t intptr_t;
+#endif
+
+#if !defined(BITS_32) && !defined(BITS_64)
+typedef __UINTPTR_TYPE__ uintptr_t;
+typedef __INTPTR_TYPE__ intptr_t;
+static_assert(sizeof(uintptr_t) == sizeof(void *));
+static_assert(sizeof(intptr_t) == sizeof(void *));
 #endif
 
 #define STDOUT_FILENO 1

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -1,28 +1,38 @@
-function(halide_define_runtime_internal_test NAME)
-    add_executable(runtime_internal_${NAME} ${NAME}.cpp)
-    target_link_libraries(runtime_internal_${NAME} PRIVATE Halide::Test)
-    target_include_directories(runtime_internal_${NAME} PRIVATE "${Halide_SOURCE_DIR}/src")
-    target_include_directories(runtime_internal_${NAME} PRIVATE "${Halide_SOURCE_DIR}/src/runtime")
-    target_link_libraries(runtime_internal_${NAME} PRIVATE Halide::Runtime)
+function(_set_target_options NAME)
+    target_include_directories(${NAME} PRIVATE "${Halide_SOURCE_DIR}/src" "${Halide_SOURCE_DIR}/src/runtime")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         # Halide runtime lib has declarations for memcmp etc that conflict with GNU stdlib
-        target_compile_options(runtime_internal_${NAME} PRIVATE -Wno-builtin-declaration-mismatch )
+        target_compile_options(${NAME} PRIVATE -Wno-builtin-declaration-mismatch )
     endif()
+    math(EXPR bits "8 * ${CMAKE_SIZEOF_VOID_P}")
     target_compile_definitions(
-        runtime_internal_${NAME}
+        ${NAME}
         PRIVATE
         HALIDE_VERSION=${Halide_VERSION}
         HALIDE_VERSION_MAJOR=${Halide_VERSION_MAJOR}
         HALIDE_VERSION_MINOR=${Halide_VERSION_MINOR}
         HALIDE_VERSION_PATCH=${Halide_VERSION_PATCH}
+        BITS_${bits}
         COMPILING_HALIDE_RUNTIME
         COMPILING_HALIDE_RUNTIME_TESTS
-    )    
+    )
+endfunction()
+
+function(halide_define_runtime_internal_test NAME)
+    add_executable(runtime_internal_${NAME} ${NAME}.cpp)
+    _set_target_options(runtime_internal_${NAME})
+    target_link_libraries(runtime_internal_${NAME} PRIVATE Halide::Test Halide::Runtime runtime_internal_common)
     add_halide_test(runtime_internal_${NAME} GROUPS runtime_internal)
 endfunction()
 
 # NOTE: These tests directly include runtime_internal.h which isn't compatible with MSVC
 if(NOT MSVC)
+    add_library(runtime_internal_common STATIC
+                common.cpp
+                "${Halide_SOURCE_DIR}/src/runtime/msan_stubs.cpp"
+                "${Halide_SOURCE_DIR}/src/runtime/to_string.cpp")
+    _set_target_options(runtime_internal_common)
+
     halide_define_runtime_internal_test(block_allocator)
     halide_define_runtime_internal_test(block_storage)
     halide_define_runtime_internal_test(linked_list)

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -19,15 +19,16 @@ function(_set_target_options NAME)
 endfunction()
 
 function(halide_define_runtime_internal_test NAME)
-    add_executable(runtime_internal_${NAME} ${NAME}.cpp)
+    add_executable(runtime_internal_${NAME} ${NAME}.cpp $<TARGET_OBJECTS:runtime_internal_common>)
     _set_target_options(runtime_internal_${NAME})
-    target_link_libraries(runtime_internal_${NAME} PRIVATE Halide::Test Halide::Runtime runtime_internal_common)
+    target_link_libraries(runtime_internal_${NAME} PRIVATE Halide::Test)
     add_halide_test(runtime_internal_${NAME} GROUPS runtime_internal)
 endfunction()
 
 # NOTE: These tests directly include runtime_internal.h which isn't compatible with MSVC
 if(NOT MSVC)
-    add_library(runtime_internal_common STATIC
+    # Weak linkages are easier to get right with OBJECT libraries
+    add_library(runtime_internal_common OBJECT
                 common.cpp
                 "${Halide_SOURCE_DIR}/src/runtime/msan_stubs.cpp"
                 "${Halide_SOURCE_DIR}/src/runtime/to_string.cpp")

--- a/test/runtime/block_allocator.cpp
+++ b/test/runtime/block_allocator.cpp
@@ -1,4 +1,7 @@
+#include "HalideRuntime.h"
+
 #include "common.h"
+#include "printer.h"
 
 #include "internal/block_allocator.h"
 #include "internal/pointer_table.h"
@@ -79,17 +82,17 @@ int main(int argc, char **argv) {
         request.properties.usage = MemoryUsage::DefaultUsage;
 
         MemoryRegion *r1 = instance->reserve(user_context, request);
-        halide_abort_if_false(user_context, r1 != nullptr);
-        halide_abort_if_false(user_context, allocated_block_memory == config.minimum_block_size);
-        halide_abort_if_false(user_context, allocated_region_memory == request.size);
+        HALIDE_CHECK(user_context, r1 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == config.minimum_block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == request.size);
 
         MemoryRegion *r2 = instance->reserve(user_context, request);
-        halide_abort_if_false(user_context, r2 != nullptr);
-        halide_abort_if_false(user_context, allocated_block_memory == config.minimum_block_size);
-        halide_abort_if_false(user_context, allocated_region_memory == (2 * request.size));
+        HALIDE_CHECK(user_context, r2 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == config.minimum_block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
 
         instance->reclaim(user_context, r1);
-        halide_abort_if_false(user_context, allocated_region_memory == (1 * request.size));
+        HALIDE_CHECK(user_context, allocated_region_memory == (1 * request.size));
 
         instance->destroy(user_context);
         debug(user_context) << "Test : block_allocator::destroy ("
@@ -97,16 +100,16 @@ int main(int argc, char **argv) {
                             << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
                             << ") !\n";
 
-        halide_abort_if_false(user_context, allocated_block_memory == 0);
-        halide_abort_if_false(user_context, allocated_region_memory == 0);
+        HALIDE_CHECK(user_context, allocated_block_memory == 0);
+        HALIDE_CHECK(user_context, allocated_region_memory == 0);
 
         BlockAllocator::destroy(user_context, instance);
 
         debug(user_context) << "Test : block_allocator::destroy ("
-                            << "allocated_system_memory=" << int32_t(allocated_system_memory) << " "
+                            << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
                             << ") !\n";
 
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     // stress test
@@ -138,14 +141,14 @@ int main(int argc, char **argv) {
             MemoryRegion *region = static_cast<MemoryRegion *>(pointers[n]);
             instance->reclaim(user_context, region);
         }
-        halide_abort_if_false(user_context, allocated_region_memory == 0);
+        HALIDE_CHECK(user_context, allocated_region_memory == 0);
 
         pointers.destroy(user_context);
         instance->destroy(user_context);
-        halide_abort_if_false(user_context, allocated_block_memory == 0);
+        HALIDE_CHECK(user_context, allocated_block_memory == 0);
 
         BlockAllocator::destroy(user_context, instance);
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     print(user_context) << "Success!\n";

--- a/test/runtime/block_storage.cpp
+++ b/test/runtime/block_storage.cpp
@@ -1,4 +1,7 @@
+#include "HalideRuntime.h"
+
 #include "common.h"
+#include "printer.h"
 
 #include "internal/block_storage.h"
 
@@ -26,49 +29,49 @@ int main(int argc, char **argv) {
 
         BlockStorage bs(user_context, config);
         bs.reserve(user_context, 256);
-        halide_abort_if_false(user_context, bs.size() == 0);
+        HALIDE_CHECK(user_context, bs.size() == 0);
 
         int a1[4] = {12, 34, 56, 78};
         bs.append(user_context, &a1[0]);
-        halide_abort_if_false(user_context, bs.size() == 1);
-        halide_abort_if_false(user_context, read_as<int>(bs, 0) == a1[0]);
+        HALIDE_CHECK(user_context, bs.size() == 1);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 0) == a1[0]);
 
         bs.append(user_context, &a1[1]);
-        halide_abort_if_false(user_context, bs.size() == 2);
-        halide_abort_if_false(user_context, read_as<int>(bs, 1) == a1[1]);
+        HALIDE_CHECK(user_context, bs.size() == 2);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 1) == a1[1]);
 
         bs.insert(user_context, 1, &a1[2]);
-        halide_abort_if_false(user_context, bs.size() == 3);
-        halide_abort_if_false(user_context, read_as<int>(bs, 0) == a1[0]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 1) == a1[2]);  // inserted here
-        halide_abort_if_false(user_context, read_as<int>(bs, 2) == a1[1]);
+        HALIDE_CHECK(user_context, bs.size() == 3);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 0) == a1[0]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 1) == a1[2]);  // inserted here
+        HALIDE_CHECK(user_context, read_as<int>(bs, 2) == a1[1]);
 
         bs.prepend(user_context, &a1[3]);
-        halide_abort_if_false(user_context, bs.size() == 4);
-        halide_abort_if_false(user_context, read_as<int>(bs, 0) == a1[3]);
+        HALIDE_CHECK(user_context, bs.size() == 4);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 0) == a1[3]);
 
         int a2[] = {98, 76, 54, 32, 10};
         size_t a2_size = 5;
         bs.fill(user_context, a2, a2_size);
-        halide_abort_if_false(user_context, bs.size() == a2_size);
-        halide_abort_if_false(user_context, read_as<int>(bs, 0) == a2[0]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 1) == a2[1]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 2) == a2[2]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 3) == a2[3]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 4) == a2[4]);
+        HALIDE_CHECK(user_context, bs.size() == a2_size);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 0) == a2[0]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 1) == a2[1]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 2) == a2[2]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 3) == a2[3]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 4) == a2[4]);
 
         int a3[] = {77, 66, 55};
         size_t a3_size = 3;
         bs.insert(user_context, 2, a3, a3_size);
-        halide_abort_if_false(user_context, bs.size() == (a2_size + a3_size));
-        halide_abort_if_false(user_context, read_as<int>(bs, 0) == a2[0]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 1) == a2[1]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 2) == a3[0]);  // a3 inserted here
-        halide_abort_if_false(user_context, read_as<int>(bs, 3) == a3[1]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 4) == a3[2]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 5) == a2[2]);  // a2 resumes here
-        halide_abort_if_false(user_context, read_as<int>(bs, 6) == a2[3]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 7) == a2[4]);
+        HALIDE_CHECK(user_context, bs.size() == (a2_size + a3_size));
+        HALIDE_CHECK(user_context, read_as<int>(bs, 0) == a2[0]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 1) == a2[1]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 2) == a3[0]);  // a3 inserted here
+        HALIDE_CHECK(user_context, read_as<int>(bs, 3) == a3[1]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 4) == a3[2]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 5) == a2[2]);  // a2 resumes here
+        HALIDE_CHECK(user_context, read_as<int>(bs, 6) == a2[3]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 7) == a2[4]);
 
         bs.pop_front(user_context);
         bs.pop_front(user_context);
@@ -76,14 +79,14 @@ int main(int argc, char **argv) {
         bs.pop_back(user_context);
         bs.pop_back(user_context);
 
-        halide_abort_if_false(user_context, bs.size() == (a2_size + a3_size - 4));
-        halide_abort_if_false(user_context, read_as<int>(bs, 0) == a3[0]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 1) == a3[1]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 2) == a3[2]);
-        halide_abort_if_false(user_context, read_as<int>(bs, 3) == a2[2]);
+        HALIDE_CHECK(user_context, bs.size() == (a2_size + a3_size - 4));
+        HALIDE_CHECK(user_context, read_as<int>(bs, 0) == a3[0]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 1) == a3[1]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 2) == a3[2]);
+        HALIDE_CHECK(user_context, read_as<int>(bs, 3) == a2[2]);
 
         bs.clear(user_context);
-        halide_abort_if_false(user_context, bs.size() == 0);
+        HALIDE_CHECK(user_context, bs.size() == 0);
     }
 
     // test copy and equality
@@ -105,15 +108,15 @@ int main(int argc, char **argv) {
 
         BlockStorage bs3(bs1);
 
-        halide_abort_if_false(user_context, bs1.size() == (a1_size));
-        halide_abort_if_false(user_context, bs2.size() == (a2_size));
-        halide_abort_if_false(user_context, bs3.size() == bs1.size());
+        HALIDE_CHECK(user_context, bs1.size() == (a1_size));
+        HALIDE_CHECK(user_context, bs2.size() == (a2_size));
+        HALIDE_CHECK(user_context, bs3.size() == bs1.size());
 
-        halide_abort_if_false(user_context, bs1 != bs2);
-        halide_abort_if_false(user_context, bs1 == bs3);
+        HALIDE_CHECK(user_context, bs1 != bs2);
+        HALIDE_CHECK(user_context, bs1 == bs3);
 
         bs2 = bs1;
-        halide_abort_if_false(user_context, bs1 == bs2);
+        HALIDE_CHECK(user_context, bs1 == bs2);
     }
 
     // test struct storage
@@ -122,25 +125,25 @@ int main(int argc, char **argv) {
         config.entry_size = sizeof(TestStruct);
 
         BlockStorage bs(user_context, config);
-        halide_abort_if_false(user_context, bs.size() == 0);
+        HALIDE_CHECK(user_context, bs.size() == 0);
 
         TestStruct s1 = {8, 16, 32.0f};
         bs.append(user_context, &s1);
-        halide_abort_if_false(user_context, bs.size() == 1);
+        HALIDE_CHECK(user_context, bs.size() == 1);
 
         const TestStruct e1 = read_as<TestStruct>(bs, 0);
-        halide_abort_if_false(user_context, e1.i8 == s1.i8);
-        halide_abort_if_false(user_context, e1.ui16 == s1.ui16);
-        halide_abort_if_false(user_context, e1.f32 == s1.f32);
+        HALIDE_CHECK(user_context, e1.i8 == s1.i8);
+        HALIDE_CHECK(user_context, e1.ui16 == s1.ui16);
+        HALIDE_CHECK(user_context, e1.f32 == s1.f32);
 
         TestStruct s2 = {1, 2, 3.0f};
         bs.prepend(user_context, &s2);
-        halide_abort_if_false(user_context, bs.size() == 2);
+        HALIDE_CHECK(user_context, bs.size() == 2);
 
         const TestStruct e2 = read_as<TestStruct>(bs, 0);
-        halide_abort_if_false(user_context, e2.i8 == s2.i8);
-        halide_abort_if_false(user_context, e2.ui16 == s2.ui16);
-        halide_abort_if_false(user_context, e2.f32 == s2.f32);
+        HALIDE_CHECK(user_context, e2.i8 == s2.i8);
+        HALIDE_CHECK(user_context, e2.ui16 == s2.ui16);
+        HALIDE_CHECK(user_context, e2.f32 == s2.f32);
     }
 
     print(user_context) << "Success!\n";

--- a/test/runtime/common.cpp
+++ b/test/runtime/common.cpp
@@ -7,7 +7,7 @@ extern "C" {
 extern int printf(const char *format, ...);
 
 void halide_print(void *user_context, const char *str) {
-    printf("%s", str);
+    printf("%s\n", str);
 }
 
 void halide_error(void *user_context, const char *msg) {

--- a/test/runtime/common.cpp
+++ b/test/runtime/common.cpp
@@ -1,0 +1,86 @@
+#include "HalideRuntime.h"
+
+#include "printer.h"
+
+extern "C" {
+
+extern int printf(const char *format, ...);
+
+void halide_print(void *user_context, const char *str) {
+    printf("%s", str);
+}
+
+void halide_error(void *user_context, const char *msg) {
+    halide_print(user_context, msg);
+    abort();
+}
+
+void halide_profiler_report(void *user_context) {
+}
+
+void halide_profiler_reset() {
+}
+
+}  // extern "C"
+
+namespace {
+
+size_t allocated_system_memory = 0;
+
+void *align_up(void *ptr, size_t offset, size_t alignment) {
+    return (void *)(((((size_t)ptr + offset)) + (alignment - 1)) & ~(alignment - 1));
+}
+
+}  // namespace
+
+namespace Halide::Runtime::Internal {
+
+size_t get_allocated_system_memory() {
+    return allocated_system_memory;
+}
+
+void *allocate_system(void *user_context, size_t bytes) {
+    constexpr size_t alignment = 128;
+    constexpr size_t header_size = 2 * sizeof(size_t);
+    size_t alloc_size = bytes + header_size + (alignment - 1);
+    void *raw_ptr = malloc(alloc_size);
+    if (raw_ptr == nullptr) {
+        return nullptr;
+    }
+    void *aligned_ptr = align_up(raw_ptr, header_size, alignment);
+    size_t aligned_offset = (size_t)((size_t)aligned_ptr - (size_t)raw_ptr);
+    *((size_t *)aligned_ptr - 1) = aligned_offset;
+    *((size_t *)aligned_ptr - 2) = alloc_size;
+    allocated_system_memory += alloc_size;
+
+    debug(user_context) << "Test : allocate_system ("
+                        << "ptr=" << (void *)(raw_ptr) << " "
+                        << "aligned_ptr=" << (void *)(aligned_ptr) << " "
+                        << "aligned_offset=" << int32_t(aligned_offset) << " "
+                        << "alloc_size=" << int32_t(alloc_size) << " "
+                        << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
+                        << ") !\n";
+
+    return aligned_ptr;
+}
+
+void deallocate_system(void *user_context, void *aligned_ptr) {
+    size_t aligned_offset = *((size_t *)aligned_ptr - 1);
+    size_t alloc_size = *((size_t *)aligned_ptr - 2);
+    void *raw_ptr = (void *)((uint8_t *)aligned_ptr - aligned_offset);
+    // The compiler may see printing the pointer value after the free as a use.
+    // This protects against a use after free warning.
+    intptr_t raw_ptr_save = (intptr_t)raw_ptr;
+    free(raw_ptr);
+    allocated_system_memory -= alloc_size;
+
+    debug(user_context) << "Test : deallocate_system ("
+                        << "ptr=" << (void *)(raw_ptr_save) << " "
+                        << "aligned_ptr=" << (void *)(aligned_ptr) << " "
+                        << "aligned_offset=" << int32_t(aligned_offset) << " "
+                        << "alloc_size=" << int32_t(alloc_size) << " "
+                        << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
+                        << ") !\n";
+}
+
+}  // namespace Halide::Runtime::Internal

--- a/test/runtime/common.h
+++ b/test/runtime/common.h
@@ -1,83 +1,22 @@
-#include <cstddef>
-#include <cstdint>
+#ifndef HALIDE_TEST_RUNTIME_COMMON_H_
+#define HALIDE_TEST_RUNTIME_COMMON_H_
 
 #include "HalideRuntime.h"
-#include "msan_stubs.cpp"
-#include "runtime_internal.h"
-#include "to_string.cpp"
 
-extern "C" {
+namespace Halide::Runtime::Internal {
 
-extern int printf(const char *format, ...);
+size_t get_allocated_system_memory();
+void *allocate_system(void *user_context, size_t bytes);
+void deallocate_system(void *user_context, void *aligned_ptr);
 
-void halide_print(void *user_context, const char *str) {
-    printf("%s", str);
-}
+}  // namespace Halide::Runtime::Internal
 
-void halide_error(void *user_context, const char *msg) {
-    halide_print(user_context, msg);
-}
+#define HALIDE_CHECK(user_context, cond)                                                                                           \
+    do {                                                                                                                           \
+        if (!(cond)) {                                                                                                             \
+            halide_print(user_context, __FILE__ ":" _halide_expand_and_stringify(__LINE__) " HALIDE_CHECK() failed: " #cond "\n"); \
+            abort();                                                                                                               \
+        }                                                                                                                          \
+    } while (0)
 
-void halide_profiler_report(void *user_context) {
-}
-
-void halide_profiler_reset() {
-}
-
-}  // extern "C"
-
-#include "printer.h"
-
-namespace {
-
-size_t allocated_system_memory = 0;
-
-void *align_up(void *ptr, size_t offset, size_t alignment) {
-    return (void *)(((((size_t)ptr + offset)) + (alignment - 1)) & ~(alignment - 1));
-}
-
-void *allocate_system(void *user_context, size_t bytes) {
-    constexpr size_t alignment = 128;
-    constexpr size_t header_size = 2 * sizeof(size_t);
-    size_t alloc_size = bytes + header_size + (alignment - 1);
-    void *raw_ptr = malloc(alloc_size);
-    if (raw_ptr == nullptr) {
-        return nullptr;
-    }
-    void *aligned_ptr = align_up(raw_ptr, header_size, alignment);
-    size_t aligned_offset = (size_t)((size_t)aligned_ptr - (size_t)raw_ptr);
-    *((size_t *)aligned_ptr - 1) = aligned_offset;
-    *((size_t *)aligned_ptr - 2) = alloc_size;
-    allocated_system_memory += alloc_size;
-
-    debug(user_context) << "Test : allocate_system ("
-                        << "ptr=" << (void *)(raw_ptr) << " "
-                        << "aligned_ptr=" << (void *)(aligned_ptr) << " "
-                        << "aligned_offset=" << int32_t(aligned_offset) << " "
-                        << "alloc_size=" << int32_t(alloc_size) << " "
-                        << "allocated_system_memory=" << int32_t(allocated_system_memory) << " "
-                        << ") !\n";
-
-    return aligned_ptr;
-}
-
-void deallocate_system(void *user_context, void *aligned_ptr) {
-    size_t aligned_offset = *((size_t *)aligned_ptr - 1);
-    size_t alloc_size = *((size_t *)aligned_ptr - 2);
-    void *raw_ptr = (void *)((uint8_t *)aligned_ptr - aligned_offset);
-    // The compiler may see printing the pointer value after the free as a use.
-    // This protects against a use after free warning.
-    intptr_t raw_ptr_save = (intptr_t)raw_ptr;
-    free(raw_ptr);
-    allocated_system_memory -= alloc_size;
-
-    debug(user_context) << "Test : deallocate_system ("
-                        << "ptr=" << (void *)(raw_ptr_save) << " "
-                        << "aligned_ptr=" << (void *)(aligned_ptr) << " "
-                        << "aligned_offset=" << int32_t(aligned_offset) << " "
-                        << "alloc_size=" << int32_t(alloc_size) << " "
-                        << "allocated_system_memory=" << int32_t(allocated_system_memory) << " "
-                        << ") !\n";
-}
-
-}  // anonymous namespace
+#endif  // HALIDE_TEST_RUNTIME_COMMON_H_

--- a/test/runtime/linked_list.cpp
+++ b/test/runtime/linked_list.cpp
@@ -1,4 +1,7 @@
+#include "HalideRuntime.h"
+
 #include "common.h"
+#include "printer.h"
 
 #include "internal/linked_list.h"
 
@@ -23,80 +26,80 @@ int main(int argc, char **argv) {
     // test class interface
     {
         LinkedList list(user_context, sizeof(int), 64, test_allocator);
-        halide_abort_if_false(user_context, list.size() == 0);
+        HALIDE_CHECK(user_context, list.size() == 0);
 
         const int i0 = 12;
         list.append(user_context, &i0);  // contents: 12
-        halide_abort_if_false(user_context, list.size() == 1);
-        halide_abort_if_false(user_context, (list.front() != nullptr));
-        halide_abort_if_false(user_context, (list.back() != nullptr));
-        halide_abort_if_false(user_context, read_as<int>(list.front()) == i0);
-        halide_abort_if_false(user_context, read_as<int>(list.back()) == i0);
+        HALIDE_CHECK(user_context, list.size() == 1);
+        HALIDE_CHECK(user_context, (list.front() != nullptr));
+        HALIDE_CHECK(user_context, (list.back() != nullptr));
+        HALIDE_CHECK(user_context, read_as<int>(list.front()) == i0);
+        HALIDE_CHECK(user_context, read_as<int>(list.back()) == i0);
 
         const int i1 = 34;
         list.append(user_context, &i1);  // contents: 12, 34
-        halide_abort_if_false(user_context, list.size() == 2);
-        halide_abort_if_false(user_context, read_as<int>(list.back()) == i1);
+        HALIDE_CHECK(user_context, list.size() == 2);
+        HALIDE_CHECK(user_context, read_as<int>(list.back()) == i1);
 
         const int i2 = 56;
         list.insert_before(user_context, list.back(), &i2);  // contents: 12, 56, 34
-        halide_abort_if_false(user_context, list.size() == 3);
-        halide_abort_if_false(user_context, read_as<int>(list.back()) == i1);
+        HALIDE_CHECK(user_context, list.size() == 3);
+        HALIDE_CHECK(user_context, read_as<int>(list.back()) == i1);
 
         const int i3 = 78;
         list.prepend(user_context, &i3);  // contents: 78, 12, 56, 34
-        halide_abort_if_false(user_context, list.size() == 4);
-        halide_abort_if_false(user_context, read_as<int>(list.front()) == i3);
-        halide_abort_if_false(user_context, read_as<int>(list.back()) == i1);
+        HALIDE_CHECK(user_context, list.size() == 4);
+        HALIDE_CHECK(user_context, read_as<int>(list.front()) == i3);
+        HALIDE_CHECK(user_context, read_as<int>(list.back()) == i1);
 
         list.pop_front(user_context);  // contents: 12, 56, 34
-        halide_abort_if_false(user_context, list.size() == 3);
-        halide_abort_if_false(user_context, read_as<int>(list.front()) == i0);
-        halide_abort_if_false(user_context, read_as<int>(list.back()) == i1);
+        HALIDE_CHECK(user_context, list.size() == 3);
+        HALIDE_CHECK(user_context, read_as<int>(list.front()) == i0);
+        HALIDE_CHECK(user_context, read_as<int>(list.back()) == i1);
 
         list.pop_back(user_context);  // contents: 12, 56
-        halide_abort_if_false(user_context, list.size() == 2);
-        halide_abort_if_false(user_context, read_as<int>(list.front()) == i0);
-        halide_abort_if_false(user_context, read_as<int>(list.back()) == i2);
+        HALIDE_CHECK(user_context, list.size() == 2);
+        HALIDE_CHECK(user_context, read_as<int>(list.front()) == i0);
+        HALIDE_CHECK(user_context, read_as<int>(list.back()) == i2);
 
         list.clear(user_context);
-        halide_abort_if_false(user_context, list.size() == 0);
+        HALIDE_CHECK(user_context, list.size() == 0);
 
         size_t count = 4 * 1024;
         for (size_t n = 0; n < count; ++n) {
             list.append(user_context, &n);
         }
-        halide_abort_if_false(user_context, list.size() == count);
+        HALIDE_CHECK(user_context, list.size() == count);
 
         list.destroy(user_context);
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     // test struct storage
     {
         LinkedList list(user_context, sizeof(TestStruct), 32, test_allocator);
-        halide_abort_if_false(user_context, list.size() == 0);
+        HALIDE_CHECK(user_context, list.size() == 0);
 
         TestStruct s1 = {8, 16, 32.0f};
         list.append(user_context, &s1);
-        halide_abort_if_false(user_context, list.size() == 1);
+        HALIDE_CHECK(user_context, list.size() == 1);
 
         const TestStruct e1 = read_as<TestStruct>(list.front());
-        halide_abort_if_false(user_context, e1.i8 == s1.i8);
-        halide_abort_if_false(user_context, e1.ui16 == s1.ui16);
-        halide_abort_if_false(user_context, e1.f32 == s1.f32);
+        HALIDE_CHECK(user_context, e1.i8 == s1.i8);
+        HALIDE_CHECK(user_context, e1.ui16 == s1.ui16);
+        HALIDE_CHECK(user_context, e1.f32 == s1.f32);
 
         TestStruct s2 = {1, 2, 3.0f};
         list.prepend(user_context, &s2);
-        halide_abort_if_false(user_context, list.size() == 2);
+        HALIDE_CHECK(user_context, list.size() == 2);
 
         TestStruct e2 = read_as<TestStruct>(list.front());
-        halide_abort_if_false(user_context, e2.i8 == s2.i8);
-        halide_abort_if_false(user_context, e2.ui16 == s2.ui16);
-        halide_abort_if_false(user_context, e2.f32 == s2.f32);
+        HALIDE_CHECK(user_context, e2.i8 == s2.i8);
+        HALIDE_CHECK(user_context, e2.ui16 == s2.ui16);
+        HALIDE_CHECK(user_context, e2.f32 == s2.f32);
 
         list.destroy(user_context);
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     print(user_context) << "Success!\n";

--- a/test/runtime/memory_arena.cpp
+++ b/test/runtime/memory_arena.cpp
@@ -1,4 +1,7 @@
+#include "HalideRuntime.h"
+
 #include "common.h"
+#include "printer.h"
 
 #include "internal/memory_arena.h"
 
@@ -20,18 +23,18 @@ int main(int argc, char **argv) {
         MemoryArena::Config config = {sizeof(int), 32, 0};
         MemoryArena arena(user_context, config, test_allocator);
         void *p1 = arena.reserve(user_context);
-        halide_abort_if_false(user_context, allocated_system_memory >= (1 * sizeof(int)));
-        halide_abort_if_false(user_context, p1 != nullptr);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() >= (1 * sizeof(int)));
+        HALIDE_CHECK(user_context, p1 != nullptr);
 
         void *p2 = arena.reserve(user_context, true);
-        halide_abort_if_false(user_context, allocated_system_memory >= (2 * sizeof(int)));
-        halide_abort_if_false(user_context, p2 != nullptr);
-        halide_abort_if_false(user_context, (*static_cast<int *>(p2)) == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() >= (2 * sizeof(int)));
+        HALIDE_CHECK(user_context, p2 != nullptr);
+        HALIDE_CHECK(user_context, (*static_cast<int *>(p2)) == 0);
 
         arena.reclaim(user_context, p1);
         arena.destroy(user_context);
 
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     // test dyanmic construction
@@ -46,16 +49,16 @@ int main(int argc, char **argv) {
         for (size_t n = 0; n < count; ++n) {
             pointers[n] = arena->reserve(user_context, true);
         }
-        halide_abort_if_false(user_context, allocated_system_memory >= (count * sizeof(int)));
+        HALIDE_CHECK(user_context, get_allocated_system_memory() >= (count * sizeof(int)));
         for (size_t n = 0; n < count; ++n) {
             void *ptr = pointers[n];
-            halide_abort_if_false(user_context, ptr != nullptr);
-            halide_abort_if_false(user_context, (*static_cast<double *>(ptr)) == 0.0);
+            HALIDE_CHECK(user_context, ptr != nullptr);
+            HALIDE_CHECK(user_context, (*static_cast<double *>(ptr)) == 0.0);
         }
         arena->destroy(user_context);
 
         MemoryArena::destroy(user_context, arena);
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     // test struct allocations
@@ -64,11 +67,11 @@ int main(int argc, char **argv) {
         MemoryArena::Config config = {sizeof(TestStruct), 32, 0};
         MemoryArena arena(user_context, config, test_allocator);
         void *s1 = arena.reserve(user_context, true);
-        halide_abort_if_false(user_context, s1 != nullptr);
-        halide_abort_if_false(user_context, allocated_system_memory >= (1 * sizeof(int)));
-        halide_abort_if_false(user_context, ((TestStruct *)s1)->i8 == int8_t(0));
-        halide_abort_if_false(user_context, ((TestStruct *)s1)->ui16 == uint16_t(0));
-        halide_abort_if_false(user_context, ((TestStruct *)s1)->f32 == float(0));
+        HALIDE_CHECK(user_context, s1 != nullptr);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() >= (1 * sizeof(int)));
+        HALIDE_CHECK(user_context, ((TestStruct *)s1)->i8 == int8_t(0));
+        HALIDE_CHECK(user_context, ((TestStruct *)s1)->ui16 == uint16_t(0));
+        HALIDE_CHECK(user_context, ((TestStruct *)s1)->f32 == float(0));
 
         arena.destroy(user_context);
 
@@ -80,15 +83,15 @@ int main(int argc, char **argv) {
 
         for (size_t n = 0; n < count; ++n) {
             void *s1 = pointers[n];
-            halide_abort_if_false(user_context, s1 != nullptr);
-            halide_abort_if_false(user_context, ((TestStruct *)s1)->i8 == int8_t(0));
-            halide_abort_if_false(user_context, ((TestStruct *)s1)->ui16 == uint16_t(0));
-            halide_abort_if_false(user_context, ((TestStruct *)s1)->f32 == float(0));
+            HALIDE_CHECK(user_context, s1 != nullptr);
+            HALIDE_CHECK(user_context, ((TestStruct *)s1)->i8 == int8_t(0));
+            HALIDE_CHECK(user_context, ((TestStruct *)s1)->ui16 == uint16_t(0));
+            HALIDE_CHECK(user_context, ((TestStruct *)s1)->f32 == float(0));
         }
 
         arena.destroy(user_context);
 
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     print(user_context) << "Success!\n";

--- a/test/runtime/string_storage.cpp
+++ b/test/runtime/string_storage.cpp
@@ -1,4 +1,7 @@
+#include "HalideRuntime.h"
+
 #include "common.h"
+#include "printer.h"
 
 #include "internal/string_storage.h"
 
@@ -11,29 +14,29 @@ int main(int argc, char **argv) {
     // test class interface
     {
         StringStorage ss(user_context, 0, test_allocator);
-        halide_abort_if_false(user_context, ss.length() == 0);
+        HALIDE_CHECK(user_context, ss.length() == 0);
 
         const char *ts1 = "Testing!";
         const size_t ts1_length = strlen(ts1);
         ss.assign(user_context, ts1);
-        halide_abort_if_false(user_context, ss.length() == ts1_length);
-        halide_abort_if_false(user_context, ss.contains(ts1));
+        HALIDE_CHECK(user_context, ss.length() == ts1_length);
+        HALIDE_CHECK(user_context, ss.contains(ts1));
 
         const char *ts2 = "More ";
         const size_t ts2_length = strlen(ts2);
         ss.prepend(user_context, ts2);
-        halide_abort_if_false(user_context, ss.length() == (ts1_length + ts2_length));
-        halide_abort_if_false(user_context, ss.contains(ts2));
-        halide_abort_if_false(user_context, ss.contains(ts1));
+        HALIDE_CHECK(user_context, ss.length() == (ts1_length + ts2_length));
+        HALIDE_CHECK(user_context, ss.contains(ts2));
+        HALIDE_CHECK(user_context, ss.contains(ts1));
 
         ss.append(user_context, '!');
-        halide_abort_if_false(user_context, ss.length() == (ts1_length + ts2_length + 1));
+        HALIDE_CHECK(user_context, ss.length() == (ts1_length + ts2_length + 1));
 
         ss.clear(user_context);
-        halide_abort_if_false(user_context, ss.length() == 0);
+        HALIDE_CHECK(user_context, ss.length() == 0);
 
         ss.destroy(user_context);
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
     // test copy and equality
@@ -52,20 +55,20 @@ int main(int argc, char **argv) {
 
         StringStorage ss3(ss1);
 
-        halide_abort_if_false(user_context, ss1.length() == (ts1_length));
-        halide_abort_if_false(user_context, ss2.length() == (ts2_length));
-        halide_abort_if_false(user_context, ss3.length() == ss1.length());
+        HALIDE_CHECK(user_context, ss1.length() == (ts1_length));
+        HALIDE_CHECK(user_context, ss2.length() == (ts2_length));
+        HALIDE_CHECK(user_context, ss3.length() == ss1.length());
 
-        halide_abort_if_false(user_context, ss1 != ss2);
-        halide_abort_if_false(user_context, ss1 == ss3);
+        HALIDE_CHECK(user_context, ss1 != ss2);
+        HALIDE_CHECK(user_context, ss1 == ss3);
 
         ss2 = ss1;
-        halide_abort_if_false(user_context, ss1 == ss2);
+        HALIDE_CHECK(user_context, ss1 == ss2);
 
         ss1.destroy(user_context);
         ss2.destroy(user_context);
         ss3.destroy(user_context);
-        halide_abort_if_false(user_context, allocated_system_memory == 0);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
     print(user_context) << "Success!\n";
     return 0;

--- a/test/runtime/string_table.cpp
+++ b/test/runtime/string_table.cpp
@@ -1,4 +1,7 @@
+#include "HalideRuntime.h"
+
 #include "common.h"
+#include "printer.h"
 
 #include "internal/string_table.h"
 
@@ -15,29 +18,29 @@ int main(int argc, char **argv) {
             "one", "two", "three", "four"};
 
         StringTable st1(user_context, 0, test_allocator);
-        halide_abort_if_false(user_context, st1.size() == 0);
+        HALIDE_CHECK(user_context, st1.size() == 0);
 
         st1.fill(user_context, data, data_size);
-        halide_abort_if_false(user_context, st1.size() == data_size);
-        halide_abort_if_false(user_context, strncmp(st1[0], data[0], strlen(data[0])) == 0);
-        halide_abort_if_false(user_context, strncmp(st1[1], data[1], strlen(data[1])) == 0);
-        halide_abort_if_false(user_context, strncmp(st1[2], data[2], strlen(data[2])) == 0);
-        halide_abort_if_false(user_context, strncmp(st1[3], data[3], strlen(data[3])) == 0);
-        halide_abort_if_false(user_context, st1.contains(data[0]));
-        halide_abort_if_false(user_context, st1.contains(data[1]));
-        halide_abort_if_false(user_context, st1.contains(data[2]));
-        halide_abort_if_false(user_context, st1.contains(data[3]));
+        HALIDE_CHECK(user_context, st1.size() == data_size);
+        HALIDE_CHECK(user_context, strncmp(st1[0], data[0], strlen(data[0])) == 0);
+        HALIDE_CHECK(user_context, strncmp(st1[1], data[1], strlen(data[1])) == 0);
+        HALIDE_CHECK(user_context, strncmp(st1[2], data[2], strlen(data[2])) == 0);
+        HALIDE_CHECK(user_context, strncmp(st1[3], data[3], strlen(data[3])) == 0);
+        HALIDE_CHECK(user_context, st1.contains(data[0]));
+        HALIDE_CHECK(user_context, st1.contains(data[1]));
+        HALIDE_CHECK(user_context, st1.contains(data[2]));
+        HALIDE_CHECK(user_context, st1.contains(data[3]));
 
         st1.clear(user_context);
-        halide_abort_if_false(user_context, st1.size() == 0);
+        HALIDE_CHECK(user_context, st1.size() == 0);
 
         size_t entry_count = st1.parse(user_context, "one:two:three:four", ":");
-        halide_abort_if_false(user_context, entry_count == data_size);
-        halide_abort_if_false(user_context, st1.size() == data_size);
-        halide_abort_if_false(user_context, st1.contains(data[0]));
-        halide_abort_if_false(user_context, st1.contains(data[1]));
-        halide_abort_if_false(user_context, st1.contains(data[2]));
-        halide_abort_if_false(user_context, st1.contains(data[3]));
+        HALIDE_CHECK(user_context, entry_count == data_size);
+        HALIDE_CHECK(user_context, st1.size() == data_size);
+        HALIDE_CHECK(user_context, st1.contains(data[0]));
+        HALIDE_CHECK(user_context, st1.contains(data[1]));
+        HALIDE_CHECK(user_context, st1.contains(data[2]));
+        HALIDE_CHECK(user_context, st1.contains(data[3]));
     }
 
     print(user_context) << "Success!\n";


### PR DESCRIPTION
- Don't include .cpp files.
- Don't use header-only "libraries" that rely on include order or being included only once (to wit: test/runtime/common.h -> common.cpp)
- All files should explicitly #include what they need, even if they think it's already included (ie, order of include files should not matter)
- In src/runtime/internal, change all `halide_abort_if_false` -> `halide_debug_assert`
- in test/runtime, add HALIDE_CHECK to common.h and use it for tests instead of `halide_abort_if_false`