### PR TITLE
Update all use of actions/checkout to v3

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -46,7 +46,7 @@ jobs:
         arch: [ x86_64, aarch64 ]
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2.1.0
@@ -99,7 +99,7 @@ jobs:
             arch: x86_64;arm64
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
 
       - name: Cache LLVM build folder
         id: cache-llvm
@@ -111,7 +111,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: lukka/get-cmake@latest
 
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         with:
           path: llvm-src
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: pip-labels
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
       - run: pipx run build --sdist -C--global-option=egg_info -C--global-option=-b.dev${{ needs.pip-labels.outputs.halide_pypi_label }}
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check clang-format
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: DoozyX/clang-format-lint-action@v0.14
         with:
           source: '.'
@@ -27,7 +27,7 @@ jobs:
     name: Check clang-tidy
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install clang-tidy
         run: |
           # from apt.llvm.org
@@ -46,7 +46,7 @@ jobs:
     name: Check CMake file lists
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run test sources check
         run: |
           shopt -s nullglob


### PR DESCRIPTION
We need this because https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ and some our checks are warning us about it (e.g. see https://github.com/halide/Halide/actions/runs/4369855467)