### PR TITLE
Docs/update readme python

### DIFF
--- a/README_python.md
+++ b/README_python.md
@@ -193,7 +193,8 @@ f.vectorize(x, 8).parallel(y)
 buf = f.realize([edge, edge, 3])
 
 # Do something with the image. We'll just save it to a PNG.
-hl.imageio.imwrite("/tmp/example.png", buf)
+from halide import imageio
+imageio.imwrite("/tmp/example.png", buf)
 ```
 
 It's worth noting in the example above that the Halide `Buffer` object supports

--- a/README_python.md
+++ b/README_python.md
@@ -193,8 +193,7 @@ f.vectorize(x, 8).parallel(y)
 buf = f.realize([edge, edge, 3])
 
 # Do something with the image. We'll just save it to a PNG.
-import imageio
-imageio.imsave("/tmp/example.png", buf)
+hl.imageio.imwrite("/tmp/example.png", buf)
 ```
 
 It's worth noting in the example above that the Halide `Buffer` object supports


### PR DESCRIPTION
- There is no `imsave` function in `halide/imageio.py`. Use `imwrite`
- If you assume pip installed `imageio`, the following error will occur:
   ```
   ValueError: Image must be 2D (grayscale, RGB, or RGBA).
   ```