### PR TITLE
Dont use negative values for exit()

### DIFF
--- a/apps/hannk/benchmark.cpp
+++ b/apps/hannk/benchmark.cpp
@@ -29,7 +29,7 @@ void run_benchmark(const std::string &filename, const InterpreterOptions &option
     if (!interpreter.prepare()) {
         std::cerr << "hannk::Interpreter::prepare() failed\n";
         // TODO: probably better form to return an error here, but for now, this is fine.
-        exit(-1);
+        exit(1);
     }
 
     if (!options.trace) {
@@ -63,13 +63,13 @@ __attribute__((visibility("default"))) int main(int argc, char **argv) {
         }
         if (argv[i][0] == '-') {
             HLOG(ERROR) << "Unknown flag: " << argv[i] << ".\n";
-            exit(-1);
+            exit(1);
         }
     }
 
     if (options.verbosity > 0 && options.trace) {
         HLOG(ERROR) << "You cannot specify --trace and --verbose at the same time.\n";
-        exit(-1);
+        exit(1);
     }
 
     for (int i = 1; i < argc; i++) {

--- a/apps/hannk/util/model_runner.cpp
+++ b/apps/hannk/util/model_runner.cpp
@@ -410,7 +410,7 @@ ModelRunner::RunResult ModelRunner::run_in_hannk(const std::vector<char> &buffer
     if (!interpreter.prepare()) {
         std::cerr << "hannk::Interpreter::prepare() failed\n";
         // TODO: probably better form to return an error here, but for now, this is fine.
-        exit(-1);
+        exit(1);
     }
 
     // Fill in the inputs with pseudorandom data (save the seeds for later).

--- a/apps/onnx/onnx_converter_test.cc
+++ b/apps/onnx/onnx_converter_test.cc
@@ -4,11 +4,11 @@
 
 #define EXPECT_EQ(a, b) \
     if ((a) != (b)) {   \
-        exit(-1);       \
+        exit(1);       \
     }
 #define EXPECT_NEAR(a, b, c)         \
     if (std::abs((a) - (b)) > (c)) { \
-        exit(-1);                    \
+        exit(1);                    \
     }
 
 static void test_abs() {

--- a/apps/simd_op_check/driver.cpp
+++ b/apps/simd_op_check/driver.cpp
@@ -39,12 +39,12 @@ halide_buffer_t make_buffer(int w, int h) {
     // memalign() isn't present on OSX, but posix_memalign is
     int result = posix_memalign((void **)&mem, 128, w * h * sizeof(T));
     if (result != 0 || mem == NULL) {
-        exit(-1);
+        exit(1);
     }
 #else
     mem = (T *)memalign(128, w * h * sizeof(T));
     if (mem == NULL) {
-        exit(-1);
+        exit(1);
     }
 #endif
 

--- a/apps/wavelet/wavelet.cpp
+++ b/apps/wavelet/wavelet.cpp
@@ -19,7 +19,7 @@ void _assert(bool condition, const char *fmt, ...) {
         va_start(args, fmt);
         vfprintf(stderr, fmt, args);
         va_end(args);
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -337,7 +337,7 @@ void check(const Expr &e, int64_t m, int64_t r) {
         std::cerr << "Computed modulus, remainder = "
                   << result.modulus << ", "
                   << result.remainder << "\n";
-        exit(-1);
+        exit(1);
     }
 }
 }  // namespace

--- a/src/autoschedulers/adams2019/PerfectHashMap.h
+++ b/src/autoschedulers/adams2019/PerfectHashMap.h
@@ -22,7 +22,7 @@ struct PerfectHashMapAsserter {
     }
     ~PerfectHashMapAsserter() {
         if (!c) {
-            exit(-1);
+            exit(1);
         }
     }
 };

--- a/test/common/test_sharding.h
+++ b/test/common/test_sharding.h
@@ -64,7 +64,7 @@ public:
         if (total_shards != 0) {
             if (total_shards < 0 || shard_index < 0 || shard_index >= total_shards) {
                 std::cerr << "Illegal values for sharding: total " << total_shards << " current " << shard_index << "\n";
-                exit(-1);
+                exit(1);
             }
         }
     }

--- a/test/correctness/async.cpp
+++ b/test/correctness/async.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
             if (out(x) != correct) {
                 printf("out(%d) = %d instead of %d\n",
                        x, out(x), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
             if (out(x) != correct) {
                 printf("out(%d) = %d instead of %d\n",
                        x, out(x), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -160,7 +160,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -214,7 +214,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -298,7 +298,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -321,7 +321,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -346,7 +346,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -369,7 +369,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -409,7 +409,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }
@@ -435,7 +435,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         });
     }

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -406,7 +406,7 @@ int main(int argc, char **argv) {
         if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn()) {
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/bounds_of_abs.cpp
+++ b/test/correctness/bounds_of_abs.cpp
@@ -14,7 +14,7 @@ void check(Func f, ImageParam in, int min, int extent) {
     if (im.extent(0) != extent || im.min(0) != min) {
         printf("Inferred size was [%d, %d] instead of [%d, %d]\n",
                im.min(0), im.extent(0), min, extent);
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/bounds_of_cast.cpp
+++ b/test/correctness/bounds_of_cast.cpp
@@ -14,7 +14,7 @@ void check(Func f, ImageParam in, int min, int extent) {
     if (im.extent(0) != extent || im.min(0) != min) {
         printf("Inferred size was [%d, %d] instead of [%d, %d]\n",
                im.min(0), im.extent(0), min, extent);
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/callable.cpp
+++ b/test/correctness/callable.cpp
@@ -174,14 +174,14 @@ int main(int argc, char **argv) {
                        x,
                        (long long unsigned)out1(x),
                        (long long unsigned)correct);
-                exit(-1);
+                exit(1);
             }
             if (out2(x) != correct) {
                 printf("out2(%d) = %llu instead of %llu\n",
                        x,
                        (long long unsigned)out2(x),
                        (long long unsigned)correct);
-                exit(-1);
+                exit(1);
             }
         }
     }
@@ -218,14 +218,14 @@ int main(int argc, char **argv) {
                 float delta = imf(i, j) - correct;
                 if (delta < -0.001 || delta > 0.001) {
                     printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }
 
         if (call_counter != 32 * 32) {
             printf("In pipeline_set_jit_externs_func, my_func was called %d times instead of %d\n", call_counter, 32 * 32);
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/callable_generator.cpp
+++ b/test/correctness/callable_generator.cpp
@@ -184,14 +184,14 @@ int main(int argc, char **argv) {
                        x,
                        (long long unsigned)out1(x),
                        (long long unsigned)correct);
-                exit(-1);
+                exit(1);
             }
             if (out2(x) != correct) {
                 printf("out2(%d) = %llu instead of %llu\n",
                        x,
                        (long long unsigned)out2(x),
                        (long long unsigned)correct);
-                exit(-1);
+                exit(1);
             }
         }
     }
@@ -232,14 +232,14 @@ int main(int argc, char **argv) {
                 float delta = imf(i, j) - correct;
                 if (delta < -0.001 || delta > 0.001) {
                     printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }
 
         if (call_counter != 32 * 32) {
             printf("In pipeline_set_jit_externs_func, my_func was called %d times instead of %d\n", call_counter, 32 * 32);
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/callable_typed.cpp
+++ b/test/correctness/callable_typed.cpp
@@ -173,14 +173,14 @@ int main(int argc, char **argv) {
                        x,
                        (long long unsigned)out1(x),
                        (long long unsigned)correct);
-                exit(-1);
+                exit(1);
             }
             if (out2(x) != correct) {
                 printf("out2(%d) = %llu instead of %llu\n",
                        x,
                        (long long unsigned)out2(x),
                        (long long unsigned)correct);
-                exit(-1);
+                exit(1);
             }
         }
     }
@@ -218,14 +218,14 @@ int main(int argc, char **argv) {
                 float delta = imf(i, j) - correct;
                 if (delta < -0.001 || delta > 0.001) {
                     printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }
 
         if (call_counter != 32 * 32) {
             printf("In pipeline_set_jit_externs_func, my_func was called %d times instead of %d\n", call_counter, 32 * 32);
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -71,7 +71,7 @@ int my_trace(JITUserContext *user_context, const halide_trace_event_t *e) {
         if (iter != stores.end()) {
             const Bound &b = iter->second;
             if (!check_coordinates(b, e->coordinates, e->dimensions, e->type.lanes, "store", fname)) {
-                exit(-1);
+                exit(1);
             }
         }
         stores_total++;
@@ -81,7 +81,7 @@ int my_trace(JITUserContext *user_context, const halide_trace_event_t *e) {
         if (iter != loads.end()) {
             const Bound &b = iter->second;
             if (!check_coordinates(b, e->coordinates, e->dimensions, e->type.lanes, "load", fname)) {
-                exit(-1);
+                exit(1);
             }
         }
         loads_total++;
@@ -2096,7 +2096,7 @@ int rvar_bounds_test() {
         Stmt visit(const Allocate *op) override {
             if ((op->name == "input_c") && (op->constant_allocation_size() != 64)) {
                 printf("Expected allocation size for input_c is 64, but is %d instead\n", op->constant_allocation_size());
-                exit(-1);
+                exit(1);
             }
             return IRMutator::visit(op);
         }

--- a/test/correctness/constant_expr.cpp
+++ b/test/correctness/constant_expr.cpp
@@ -45,16 +45,16 @@ void test_expr(T value) {
     Expr e = make_const(t, value);
     if (e.type() != t) {
         std::cerr << "constant of type " << t << " returned expr of type " << e.type() << "\n";
-        exit(-1);
+        exit(1);
     }
     T nvalue = T(0);
     if (!scalar_from_constant_expr<T>(e, &nvalue)) {
         std::cerr << "constant of type " << t << " failed scalar_from_constant_expr with value " << value << "\n";
-        exit(-1);
+        exit(1);
     }
     if (nvalue != value) {
         std::cerr << "Roundtrip failed for type " << t << ": input " << value << " output " << nvalue << "\n";
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/cuda_8_bit_dot_product.cpp
+++ b/test/correctness/cuda_8_bit_dot_product.cpp
@@ -47,7 +47,7 @@ void test(Target t) {
                     }
                     if (out(x, y) != correct) {
                         printf("out(%d, %d) = %d instead of %d\n", x, y, (int)(out(x, y)), (int)(correct));
-                        exit(-1);
+                        exit(1);
                     }
                 }
             }
@@ -58,7 +58,7 @@ void test(Target t) {
             std::basic_regex<char> regex("dp[24]a[.lo]*[us]32[.][us]32");
             if (!std::regex_search((const char *)buf.begin(), (const char *)buf.end(), regex)) {
                 printf("Did not find use of dp2a or dp4a in compiled code. Rerun test with HL_DEBUG_CODEGEN=1 to debug\n");
-                exit(-1);
+                exit(1);
             }
         }
     }

--- a/test/correctness/custom_error_reporter.cpp
+++ b/test/correctness/custom_error_reporter.cpp
@@ -14,7 +14,7 @@ int should_be_evaluated() {
 
 int should_never_be_evaluated() {
     printf("Should never be evaluated\n");
-    exit(-1);
+    exit(1);
     return 0;
 }
 
@@ -44,7 +44,7 @@ public:
 
         if (warnings_occurred != 1 || errors_occurred != 1 || evaluated != 1) {
             printf("There should have been 1 warning and 1 error and 1 evaluated assertion argument\n");
-            exit(-1);
+            exit(1);
         }
 
         // CompileTimeErrorReporter::error() must not return.

--- a/test/correctness/custom_lowering_pass.cpp
+++ b/test/correctness/custom_lowering_pass.cpp
@@ -16,7 +16,7 @@ class CheckForFloatDivision : public IRMutator {
     Expr visit(const Div *op) override {
         if (op->type.is_float() && is_const(op->b)) {
             std::cerr << "Found floating-point division by constant: " << Expr(op) << "\n";
-            exit(-1);
+            exit(1);
         }
         return op;
     }

--- a/test/correctness/div_round_to_zero.cpp
+++ b/test/correctness/div_round_to_zero.cpp
@@ -33,7 +33,7 @@ void test() {
                 int r = result(n + 128, d + 128);
                 if (r != correct) {
                     printf("result(%d, %d) = %d instead of %d\n", n, d, r, correct);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }
@@ -56,7 +56,7 @@ void test() {
                 int r = result_fast(n + 128, d - 1);
                 if (r != correct) {
                     printf("result_fast(%d, %d) = %d instead of %d\n", n, d, r, correct);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }
@@ -83,7 +83,7 @@ void test() {
                 int r = result_const(n + 128);
                 if (r != correct) {
                     printf("result_const(%d, %d) = %d instead of %d\n", n, d, r, correct);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }

--- a/test/correctness/exception.cpp
+++ b/test/correctness/exception.cpp
@@ -6,14 +6,14 @@ using namespace Halide;
 void check_pure(Func f) {
     if (f.has_update_definition()) {
         std::cout << "f's reduction definition was supposed to fail!\n";
-        exit(-1);
+        exit(1);
     }
 }
 
 void check_error(bool error) {
     if (!error) {
         std::cout << "There was supposed to be an error!\n";
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/extract_concat_bits.cpp
+++ b/test/correctness/extract_concat_bits.cpp
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
             for (int i = 0; i < out.width(); i++) {
                 if (out(i) == 0) {
                     std::cerr << "Mismatch between: " << a << " and " << b << " when x == " << i << "\n";
-                    exit(-1);
+                    exit(1);
                 }
             }
         };

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -27,7 +27,7 @@ public:
 
     void error(const char *msg) override {
         fprintf(stderr, "Error: %s\n", msg);
-        exit(-1);
+        exit(1);
     }
 };
 
@@ -43,7 +43,7 @@ int run_test() {
         float16_t correct = Halide::float16_t(-0.5f) + Halide::float16_t(i) / Halide::float16_t(128.0f);
         if (in1(i) != correct) {
             fprintf(stderr, "in1(%d) = %f instead of %f\n", i, float(in2(i)), float(correct));
-            exit(-1);
+            exit(1);
         }
     });
 
@@ -51,7 +51,7 @@ int run_test() {
         bfloat16_t correct = Halide::bfloat16_t(-0.5f) + Halide::bfloat16_t(i) / Halide::bfloat16_t(128.0f);
         if (in2(i) != correct) {
             fprintf(stderr, "in2(%d) = %f instead of %f\n", i, float(in2(i)), float(correct));
-            exit(-1);
+            exit(1);
         }
     });
 

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -3,7 +3,7 @@ using namespace Halide;
 
 void *my_malloc(JITUserContext *user_context, size_t x) {
     printf("There was not supposed to be a heap allocation\n");
-    exit(-1);
+    exit(1);
     return nullptr;
 }
 
@@ -16,7 +16,7 @@ void my_error(JITUserContext *user_context, const char *msg) {
     char expected[] = "Bounds given for f in x (from 0 to 7) do not cover required region (from 0 to 9)";
     if (strncmp(expected, msg, sizeof(expected) - 1)) {
         printf("Unexpected error: '%s'\n", msg);
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/fuse.cpp
+++ b/test/correctness/fuse.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
 
         Expr visit(const Internal::Mod *op) override {
             std::cerr << "Found mod: " << Expr(op) << "\n";
-            exit(-1);
+            exit(1);
             return op;
         }
     };

--- a/test/correctness/gpu_thread_barrier.cpp
+++ b/test/correctness/gpu_thread_barrier.cpp
@@ -38,7 +38,7 @@ public:
 
         if (c.count != correct) {
             printf("There were %d barriers. There were supposed to be %d\n", c.count, correct);
-            exit(-1);
+            exit(1);
         }
 
         return s;

--- a/test/correctness/interleave.cpp
+++ b/test/correctness/interleave.cpp
@@ -40,7 +40,7 @@ void check_interleave_count(Func f, int correct) {
     if (c < correct) {
         printf("Func %s should have interleaved >= %d times but interleaved %d times instead.\n",
                f.name().c_str(), correct, c);
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/interval.cpp
+++ b/test/correctness/interval.cpp
@@ -9,7 +9,7 @@ void check(Interval result, Interval expected, int line) {
         std::cerr << "Interval test on line " << line << " failed\n"
                   << "  Expected [" << expected.min << ", " << expected.max << "]\n"
                   << "  Got      [" << result.min << ", " << result.max << "]\n";
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/introspection.cpp
+++ b/test/correctness/introspection.cpp
@@ -29,13 +29,13 @@ void check(const void *var, const std::string &type,
     if (!paths_equal(correct_name, name)) {
         printf("Mispredicted name: %s vs %s\n",
                name.c_str(), correct_name.c_str());
-        exit(-1);
+        exit(1);
     }
 
     if (!paths_equal(loc, correct_loc)) {
         printf("Mispredicted source location: %s vs %s\n",
                loc.c_str(), correct_loc.c_str());
-        exit(-1);
+        exit(1);
     }
 }
 }  // namespace Halide

--- a/test/correctness/inverse.cpp
+++ b/test/correctness/inverse.cpp
@@ -24,7 +24,7 @@ void check(Buffer<float> a, Buffer<float> b) {
         int err = bits_diff(a(i), b(i));
         if (err > 13) {
             printf("Mismatch in mantissa at %d: %10.10f %10.10f. Differs by %d bits.\n", i, a(i), b(i), err);
-            // exit(-1);
+            // exit(1);
         }
     }
 }

--- a/test/correctness/likely.cpp
+++ b/test/correctness/likely.cpp
@@ -46,7 +46,7 @@ public:
         s.accept(&c);
         if (c.sin_count != correct) {
             printf("There were %d sin calls instead of %d\n", c.sin_count, correct);
-            exit(-1);
+            exit(1);
         }
         return s;
     }
@@ -69,7 +69,7 @@ public:
         s.accept(&c);
         if (c.store_count != correct) {
             printf("There were %d stores to %s instead of %d\n", c.store_count, func.c_str(), correct);
-            exit(-1);
+            exit(1);
         }
         return s;
     }

--- a/test/correctness/load_library.cpp
+++ b/test/correctness/load_library.cpp
@@ -21,12 +21,12 @@ void my_error_handler(JITUserContext *u, const char *msg) {
     // hence the abbreviation to "err".
     if (!strstr(msg, "OpenCL API not found")) {
         fprintf(stderr, "Saw unexpected err: %s\n", msg);
-        exit(-1);
+        exit(1);
     }
     printf("Saw expected err: %s\n", msg);
     if (load_library_calls == 0 || get_library_symbol_calls == 0) {
         fprintf(stderr, "Should have seen load_library and get_library_symbol calls!\n");
-        exit(-1);
+        exit(1);
     }
     printf("Success!\n");
     exit(0);
@@ -34,14 +34,14 @@ void my_error_handler(JITUserContext *u, const char *msg) {
 
 void *my_get_symbol_impl(const char *name) {
     fprintf(stderr, "Saw unexpected call: get_symbol(%s)\n", name);
-    exit(-1);
+    exit(1);
 }
 
 void *my_load_library_impl(const char *name) {
     load_library_calls++;
     if (!strstr(name, "OpenCL") && !strstr(name, "opencl")) {
         fprintf(stderr, "Saw unexpected call: load_library(%s)\n", name);
-        exit(-1);
+        exit(1);
     }
     printf("Saw load_library: %s\n", name);
     return nullptr;
@@ -51,7 +51,7 @@ void *my_get_library_symbol_impl(void *lib, const char *name) {
     get_library_symbol_calls++;
     if (lib != nullptr || strcmp(name, "clGetPlatformIDs") != 0) {
         fprintf(stderr, "Saw unexpected call: get_library_symbol(%p, %s)\n", lib, name);
-        exit(-1);
+        exit(1);
     }
     printf("Saw get_library_symbol: %s\n", name);
     return nullptr;

--- a/test/correctness/make_struct.cpp
+++ b/test/correctness/make_struct.cpp
@@ -17,7 +17,7 @@ extern "C" HALIDE_EXPORT_SYMBOL int check_struct(struct_t *s) {
         s->c != 1234 ||
         strcmp(s->d, "Test global string\n")) {
         printf("Unexpected struct values: %f %d %d %s\n", s->a, s->b, s->c, s->d);
-        exit(-1);
+        exit(1);
     }
     return 0;
 }

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -578,7 +578,7 @@ int main(int argc, char **argv) {
         if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn()) {
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/out_constraint.cpp
+++ b/test/correctness/out_constraint.cpp
@@ -12,7 +12,7 @@ void check_int(const Expr &expr, int expected) {
     if (!is_const(expr, expected)) {
         std::cerr << "Found expression " << expr << "; "
                   << "expected constant int " << expected << "\n";
-        exit(-1);
+        exit(1);
     }
 }
 
@@ -43,7 +43,7 @@ class Validator : public IRMutator {
 
         if (c.count != 1) {
             std::cerr << "expected one loop, found " << c.count << "\n";
-            exit(-1);
+            exit(1);
         }
 
         return s;
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
         Buffer<uint8_t> out = f.realize({size});
         if (!out.all_equal(42)) {
             std::cerr << "wrong output\n";
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         Buffer<uint8_t> out = f.realize({size});
         if (!out.all_equal(42)) {
             std::cerr << "wrong output\n";
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -57,12 +57,12 @@ public:
         if (expected_store_count != c.store_count) {
             printf("There were %d predicated stores; expect %d predicated stores\n",
                    c.store_count, expected_store_count);
-            exit(-1);
+            exit(1);
         }
         if (expected_load_count != c.load_count) {
             printf("There were %d predicated loads; expect %d predicated loads\n",
                    c.load_count, expected_load_count);
-            exit(-1);
+            exit(1);
         }
         return s;
     }

--- a/test/correctness/reduction_non_rectangular.cpp
+++ b/test/correctness/reduction_non_rectangular.cpp
@@ -25,7 +25,7 @@ int intermediate_bound_depend_on_output_trace(JITUserContext *user_context, cons
                 printf("Bounds on store of g were supposed to be x < y and x=[0, 99] and y=[0, 99]\n"
                        "Instead they are: %d %d\n",
                        e->coordinates[0], e->coordinates[1]);
-                exit(-1);
+                exit(1);
             }
             niters++;
         }
@@ -47,7 +47,7 @@ int func_call_bound_trace(JITUserContext *user_context, const halide_trace_event
                 printf("Bounds on store of g were supposed to be x=[10, 109]\n"
                        "Instead it is: %d\n",
                        e->coordinates[0]);
-                exit(-1);
+                exit(1);
             }
             niters++;
         }
@@ -70,7 +70,7 @@ int box_bound_trace(JITUserContext *user_context, const halide_trace_event_t *e)
                 printf("Bounds on store of g were supposed to be x < y and x=[0, 99] and y=[0, 99]\n"
                        "Instead they are: %d %d\n",
                        e->coordinates[0], e->coordinates[1]);
-                exit(-1);
+                exit(1);
             }
             niters++;
         }

--- a/test/correctness/reorder_storage.cpp
+++ b/test/correctness/reorder_storage.cpp
@@ -10,7 +10,7 @@ int expected_allocation = 0;
 void *my_malloc(JITUserContext *user_context, size_t x) {
     if (std::abs((int)x - expected_allocation) > tolerance) {
         printf("Error! Expected allocation of %d bytes, got %zu bytes (tolerance %d)\n", expected_allocation, x, tolerance);
-        exit(-1);
+        exit(1);
     }
     return malloc(x);
 }

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -832,7 +832,7 @@ int allocation_bound_test_trace(JITUserContext *user_context, const halide_trace
             printf("Bounds on realization of f were supposed to be [0, 2]\n"
                    "Instead they are: [%d, %d]\n",
                    e->coordinates[0], e->coordinates[1]);
-            exit(-1);
+            exit(1);
         }
     }
     return 0;

--- a/test/correctness/set_custom_trace.cpp
+++ b/test/correctness/set_custom_trace.cpp
@@ -17,7 +17,7 @@ protected:
             if (op->name == "f") {
                 if (producer != "g") {
                     printf("Produce \"f\" should be inside of produce \"g\"\n");
-                    exit(-1);
+                    exit(1);
                 }
             }
             std::string old_producer = producer;
@@ -28,7 +28,7 @@ protected:
             if (op->name == "f") {
                 if (producer != "g") {
                     printf("Consume \"f\" should be inside of produce \"g\"\n");
-                    exit(-1);
+                    exit(1);
                 }
             }
             std::string old_consumer = consumer;

--- a/test/correctness/skip_stages.cpp
+++ b/test/correctness/skip_stages.cpp
@@ -21,7 +21,7 @@ void check_counts(int a = 0, int b = 0, int c = 0, int d = 0) {
     for (int i = 0; i < 4; i++) {
         if (correct[i] != call_count[i]) {
             printf("call_count[%d] was supposed to be %d but instead is %d\n", i, correct[i], call_count[i]);
-            exit(-1);
+            exit(1);
         }
     }
 }

--- a/test/correctness/skip_stages_external_array_functions.cpp
+++ b/test/correctness/skip_stages_external_array_functions.cpp
@@ -31,7 +31,7 @@ void check_queries(int a = 0, int b = 0, int c = 0, int d = 0) {
     for (int i = 0; i < 4; i++) {
         if (correct[i] != bounds_query_count[i]) {
             printf("bounds_query_count[%d] was supposed to be %d but instead is %d\n", i, correct[i], bounds_query_count[i]);
-            exit(-1);
+            exit(1);
         }
     }
 }
@@ -41,7 +41,7 @@ void check_counts(int a = 0, int b = 0, int c = 0, int d = 0) {
     for (int i = 0; i < 4; i++) {
         if (correct[i] != call_count[i]) {
             printf("call_count[%d] was supposed to be %d but instead is %d\n", i, correct[i], call_count[i]);
-            exit(-1);
+            exit(1);
         }
     }
 }

--- a/test/correctness/skip_stages_memoize.cpp
+++ b/test/correctness/skip_stages_memoize.cpp
@@ -13,7 +13,7 @@ int single_toggle_trace(JITUserContext *user_context, const halide_trace_event_t
         if ((e->event == halide_trace_store) && (std::string(e->func) == buffer_name)) {
             printf("set_toggle1 is false; %s's producer should never have had been executed.\n",
                    buffer_name.c_str());
-            exit(-1);
+            exit(1);
         }
     }
     return 0;
@@ -25,14 +25,14 @@ int double_toggle_trace(JITUserContext *user_context, const halide_trace_event_t
         if ((e->event == halide_trace_store) && (std::string(e->func) == buffer_name)) {
             printf("set_toggle1 is false; %s's producer should never have had been executed.\n",
                    buffer_name.c_str());
-            exit(-1);
+            exit(1);
         }
     } else if (!set_toggle2) {
         std::string buffer_name = "f2_" + std::to_string(buffer_index);
         if ((e->event == halide_trace_store) && (std::string(e->func) == buffer_name)) {
             printf("set_toggle2 is false; %s's producer should never have had been executed.\n",
                    buffer_name.c_str());
-            exit(-1);
+            exit(1);
         }
     }
     return 0;

--- a/test/correctness/sliding_reduction.cpp
+++ b/test/correctness/sliding_reduction.cpp
@@ -18,7 +18,7 @@ void check(Buffer<int> im) {
             if (im(x, y) != correct) {
                 printf("Value at %d %d was %d instead of %d\n",
                        x, y, im(x, y), correct);
-                exit(-1);
+                exit(1);
             }
         }
     }

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -12,7 +12,7 @@ HalideExtern_2(int, call_counter, int, int);
 
 extern "C" void *my_malloc(JITUserContext *, size_t x) {
     printf("Malloc wasn't supposed to be called!\n");
-    exit(-1);
+    exit(1);
 }
 
 int main(int argc, char **argv) {

--- a/test/correctness/stack_allocations.cpp
+++ b/test/correctness/stack_allocations.cpp
@@ -6,13 +6,13 @@ using namespace Halide;
 extern "C" {
 void *my_malloc(JITUserContext *ctx, size_t sz) {
     printf("There weren't supposed to be heap allocations!\n");
-    exit(-1);
+    exit(1);
     return nullptr;
 }
 
 void my_free(JITUserContext *ctx, void *ptr) {
     printf("There weren't supposed to be heap allocations!\n");
-    exit(-1);
+    exit(1);
 }
 }
 

--- a/test/correctness/store_in.cpp
+++ b/test/correctness/store_in.cpp
@@ -45,7 +45,7 @@ void check(MemoryType t1, MemoryType t2, MemoryType t3) {
     if (mallocs != expected_mallocs) {
         std::cerr << "Wrong number of mallocs for " << t1 << ", " << t2 << ", " << t3 << "\n"
                   << "Expected " << expected_mallocs << " got " << mallocs << "\n";
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/correctness/tracing_broadcast.cpp
+++ b/test/correctness/tracing_broadcast.cpp
@@ -11,7 +11,7 @@ int my_trace(JITUserContext *user_context, const halide_trace_event_t *e) {
                 printf("All values stored should have been 1234567890\n"
                        "Instead they are: %d\n",
                        val);
-                exit(-1);
+                exit(1);
             }
         }
     }

--- a/test/correctness/tuple_undef.cpp
+++ b/test/correctness/tuple_undef.cpp
@@ -35,7 +35,7 @@ public:
 
         if (c.count != correct) {
             printf("There were %d stores. There were supposed to be %d\n", c.count, correct);
-            exit(-1);
+            exit(1);
         }
 
         return s;

--- a/test/correctness/uninitialized_read.cpp
+++ b/test/correctness/uninitialized_read.cpp
@@ -8,7 +8,7 @@ int my_trace(JITUserContext *user_context, const halide_trace_event_t *e) {
     if (e->event == 2) {  // begin realization
         if (e->coordinates[1] != 4) {
             printf("Realization of f was supposed to be 4-wide\n");
-            exit(-1);
+            exit(1);
         }
     }
     return 0;

--- a/test/correctness/vector_cast.cpp
+++ b/test/correctness/vector_cast.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
         if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn()) {
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/vector_math.cpp
+++ b/test/correctness/vector_math.cpp
@@ -746,7 +746,7 @@ int main(int argc, char **argv) {
         if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
         if (!task.fn(task.lanes, task.seed)) {
-            exit(-1);
+            exit(1);
         }
     }
 

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -139,7 +139,7 @@ void add_tasks(const Target &target, std::vector<Task> &tasks) {
                                     << "Reducing from " << src_type.with_lanes(src_lanes)
                                     << " to " << dst_type.with_lanes(dst_lanes) << "\n"
                                     << "RHS: " << f.update_value() << "\n";
-                                exit(-1);
+                                exit(1);
                             }
                         };
                         tasks.push_back({target, fn});

--- a/test/correctness/vector_tile.cpp
+++ b/test/correctness/vector_tile.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 void check_error(bool error) {
     if (!error) {
         std::cout << "There was supposed to be an error!\n";
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/generator/abstractgeneratortest_aottest.cpp
+++ b/test/generator/abstractgeneratortest_aottest.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
         int actual = output(x, y);
         if (expected != actual) {
             fprintf(stderr, "at %d %d, expected %d, actual %d\n", x, y, expected, actual);
-            exit(-1);
+            exit(1);
         }
     });
 

--- a/test/generator/argvcall_aottest.cpp
+++ b/test/generator/argvcall_aottest.cpp
@@ -17,7 +17,7 @@ void verify(const Buffer<int32_t, 3> &img, float f1, float f2) {
                 int expected = (int32_t)(c * (i > j ? i : j) * f1 / f2);
                 if (img(i, j, c) != expected) {
                     printf("img[%d, %d, %d] = %d (expected %d)\n", i, j, c, img(i, j, c), expected);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
     result = argvcall(1.2f, 3.4f, output);
     if (result != 0) {
         fprintf(stderr, "Result: %d\n", result);
-        exit(-1);
+        exit(1);
     }
     verify(output, 1.2f, 3.4f);
 
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     result = argvcall_argv(args);
     if (result != 0) {
         fprintf(stderr, "Result: %d\n", result);
-        exit(-1);
+        exit(1);
     }
     verify(output, arg0, arg1);
 

--- a/test/generator/autograd_aottest.cpp
+++ b/test/generator/autograd_aottest.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 
     result = autograd(a, b, c, lut, lut_indices, out, out_lut);
     if (result != 0) {
-        exit(-1);
+        exit(1);
     }
     out.for_each_element([&](int x) {
         float expected = f(a(x), b(x), c(x));
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
                            grad_loss_output_lut_wrt_lut,
                            grad_loss_output_lut_wrt_lut_indices);
     if (result != 0) {
-        exit(-1);
+        exit(1);
     }
 
     // Although the values are float, all should be exact results,

--- a/test/generator/buffer_copy_aottest.cpp
+++ b/test/generator/buffer_copy_aottest.cpp
@@ -24,14 +24,14 @@ int main(int argc, char **argv) {
         int result = halide_buffer_copy(nullptr, input, nullptr, out);
         if (result != 0) {
             printf("halide_buffer_copy() failed\n");
-            exit(-1);
+            exit(1);
         }
 
         Buffer<int, 2> in_crop = input.cropped(0, 32, 64).cropped(1, 32, 64);
         out.for_each_value([&](int a, int b) {
             if (a != b) {
                 printf("Copying a crop failed\n");
-                exit(-1);
+                exit(1);
             }
         },
                            in_crop);
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
         int result = halide_buffer_copy(nullptr, in_crop, dev, out);
         if (result != 0) {
             printf("halide_buffer_copy() failed\n");
-            exit(-1);
+            exit(1);
         }
 
         out.copy_to_host();
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
         out.for_each_value([&](int a, int b) {
             if (a != b) {
                 printf("Copying a crop failed\n");
-                exit(-1);
+                exit(1);
             }
         },
                            in_crop);
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         int result = halide_buffer_copy(nullptr, in_crop, nullptr, out);
         if (result != 0) {
             printf("halide_buffer_copy() failed\n");
-            exit(-1);
+            exit(1);
         }
 
         in_crop.copy_to_host();
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
         out.for_each_value([&](int a, int b) {
             if (a != b) {
                 printf("Copying a crop failed\n");
-                exit(-1);
+                exit(1);
             }
         },
                            in_crop);
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
             if (output(x, y) != input(x, y) + 4) {
                 printf("output(%d, %d) = %f intead of %f\n",
                        x, y, output(x, y), input(x, y) + 4);
-                exit(-1);
+                exit(1);
             }
         });
     }

--- a/test/generator/configure_aottest.cpp
+++ b/test/generator/configure_aottest.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
                            extra_buffer_output, extra_func_output);
     if (result != 0) {
         fprintf(stderr, "Result: %d\n", result);
-        exit(-1);
+        exit(1);
     }
 
     output.for_each_element([&](int x, int y, int c) {

--- a/test/generator/error_codes_aottest.cpp
+++ b/test/generator/error_codes_aottest.cpp
@@ -13,7 +13,7 @@ void my_halide_error(void *user_context, const char *msg) {
 void check(int result, int correct) {
     if (result != correct) {
         printf("The exit status was %d instead of %d\n", result, correct);
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/generator/extern_output_aottest.cpp
+++ b/test/generator/extern_output_aottest.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
         if (actual != correct) {
             printf("output(%d, %d) = %d instead of %d %d\n",
                    x, y, actual, correct, input(x, y));
-            exit(-1);
+            exit(1);
         }
     });
 

--- a/test/generator/image_from_array_aottest.cpp
+++ b/test/generator/image_from_array_aottest.cpp
@@ -61,7 +61,7 @@ void compare_vectors(vector<int> const &under_test, vector<int> const &reference
     cout << " instead of ";
     print_vector(reference);
     cout << "\n";
-    exit(-1);
+    exit(1);
 }
 
 void verify_dimension_sizes() {
@@ -94,7 +94,7 @@ void compare_extents(const Image &img, int reference, int dimension) {
         return;
     cout << "Extent of dimension " << dimension << " of " << img.dimensions()
          << " is " << img.dim(dimension).extent() << " instead of " << reference << "\n";
-    exit(-1);
+    exit(1);
 }
 
 template<typename Array, typename T = typename remove_all_extents<Array>::type>
@@ -110,7 +110,7 @@ void verify_image_construction_from_array(Array &vals) {
     if (reference != under_test) {
         cerr << "Start of array: " << reference
              << "Start of image: " << under_test << "\n";
-        exit(-1);
+        exit(1);
     }
 }
 

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -42,7 +42,7 @@ struct typed_scalar {
     bool operator==(const typed_scalar &that) const {
         if (this->type != that.type) {
             std::cerr << "Mismatched types\n";
-            exit(-1);
+            exit(1);
         }
         switch (type.element_of().as_u32()) {
         case halide_type_t(halide_type_float, 32).as_u32():
@@ -71,7 +71,7 @@ struct typed_scalar {
             return value.u.handle == that.value.u.handle;
         default:
             std::cerr << "Unsupported type\n";
-            exit(-1);
+            exit(1);
             break;
         }
     }
@@ -120,7 +120,7 @@ struct typed_scalar {
             break;
         default:
             std::cerr << "Unsupported type\n";
-            exit(-1);
+            exit(1);
             break;
         }
         return o;
@@ -131,7 +131,7 @@ struct typed_scalar {
     do {                                                                                               \
         if ((exp) != (act)) {                                                                          \
             std::cerr << #exp << " == " << #act << ": Expected " << exp << ", Actual " << act << "\n"; \
-            exit(-1);                                                                                  \
+            exit(1);                                                                                   \
         }                                                                                              \
     } while (0);
 
@@ -149,7 +149,7 @@ struct typed_scalar {
             EXPECT_EQ(etype, atype);                                             \
         } else {                                                                 \
             std::cerr << "One null, one non-null\n";                             \
-            exit(-1);                                                            \
+            exit(1);                                                             \
         }                                                                        \
     } while (0);
 
@@ -217,11 +217,11 @@ void verify(const Buffer<uint8_t, 3> &input,
             const Buffer<int32_t, 3> &tupled_output_buffer1) {
     if (output_scalar.dimensions() != 0) {
         std::cerr << "output_scalar should be zero-dimensional\n";
-        exit(-1);
+        exit(1);
     }
     if (output_scalar() != 1234.25f) {
         std::cerr << "output_scalar value is wrong (" << output_scalar() << "\n";
-        exit(-1);
+        exit(1);
     }
     for (int x = 0; x < kSize; x++) {
         for (int y = 0; y < kSize; y++) {
@@ -232,27 +232,27 @@ void verify(const Buffer<uint8_t, 3> &input,
                 const float actual1 = output1(x, y, c);
                 if (expected0 != actual0) {
                     std::cerr << "img0[" << x << "," << y << "," << c << "] = " << actual0 << ", expected " << expected0 << "\n";
-                    exit(-1);
+                    exit(1);
                 }
                 if (expected1 != actual1) {
                     std::cerr << "img1[" << x << "," << y << "," << c << "] = " << actual1 << ", expected " << expected1 << "\n";
-                    exit(-1);
+                    exit(1);
                 }
                 if (output_array0(x, y, c) != 1.5f) {
                     std::cerr << "output_array0[" << x << "," << y << "," << c << "] = " << output_array0(x, y, c) << ", expected " << 1.5f << "\n";
-                    exit(-1);
+                    exit(1);
                 }
                 if (output_array1(x, y, c) != 3.0f) {
                     std::cerr << "output_array1[" << x << "," << y << "," << c << "] = " << output_array1(x, y, c) << ", expected " << 2.0f << "\n";
-                    exit(-1);
+                    exit(1);
                 }
                 if (untyped_output_buffer(x, y, c) != expected1) {
                     std::cerr << "untyped_output_buffer[" << x << "," << y << "," << c << "] = " << untyped_output_buffer(x, y, c) << ", expected " << expected1 << "\n";
-                    exit(-1);
+                    exit(1);
                 }
                 if (tupled_output_buffer0(x, y, c) != expected1) {
                     std::cerr << "tupled_output_buffer0[" << x << "," << y << "," << c << "] = " << tupled_output_buffer0(x, y, c) << ", expected " << expected1 << "\n";
-                    exit(-1);
+                    exit(1);
                 }
             }
         }
@@ -367,7 +367,7 @@ void check_metadata(const halide_filter_metadata_t &md, bool expect_ucon_at_0) {
         !strstr(md.target, "wasm") &&
         !strstr(md.target, "arm")) {
         std::cerr << "Expected x86 or arm, Actual " << md.target << "\n";
-        exit(-1);
+        exit(1);
     }
 
     // Not static, since we free make_scalar() results each time
@@ -1572,27 +1572,27 @@ int main(int argc, char **argv) {
     check_metadata(*metadata_tester_metadata(), false);
     if (strcmp(metadata_tester_metadata()->name, "metadata_tester")) {
         std::cerr << "Expected name metadata_tester, got " << metadata_tester_metadata()->name << "\n";
-        exit(-1);
+        exit(1);
     }
 
     check_metadata(*metadata_tester_ucon_metadata(), true);
     if (strcmp(metadata_tester_ucon_metadata()->name, "metadata_tester_ucon")) {
         std::cerr << "Expected name metadata_tester_ucon, got " << metadata_tester_ucon_metadata()->name << "\n";
-        exit(-1);
+        exit(1);
     }
 
     constexpr auto sig = compute_signature(metadata_tester_argument_info());
     if (strcmp(&sig[0], "@@@@i?bhiqBHIQfdP@@@@@@@bbbbhhhhiiiiPP@@@@@@@@@@@@@@@@@@B#############################")) {
         // NOLINTNEXTLINE(clang-diagnostic-unreachable-code)
         std::cerr << "Incorrect signature for metadata_tester_ucon_argument_info(): " << &sig[0] << "\n";
-        exit(-1);
+        exit(1);
     }
 
     constexpr auto usig = compute_signature(metadata_tester_ucon_argument_info());
     if (strcmp(&usig[0], "P@@@@i?bhiqBHIQfdP@@@@@@@bbbbhhhhiiiiPP@@@@@@@@@@@@@@@@@@B#############################")) {
         // NOLINTNEXTLINE(clang-diagnostic-unreachable-code)
         std::cerr << "Incorrect signature for metadata_tester_ucon_argument_info(): " << &usig[0] << "\n";
-        exit(-1);
+        exit(1);
     }
 
     constexpr size_t count = count_buffers(metadata_tester_argument_info());

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -117,17 +117,17 @@ extern "C" void halide_error(void *user_context, const char *msg) {
 // enabled, and the default implementation of our msan-specific runtime needs them.
 extern "C" void __msan_check_mem_is_initialized(const void *mem, size_t size) {
     fprintf(stderr, "Impossible\n");
-    exit(-1);
+    exit(1);
 }
 
 extern "C" void __msan_unpoison(const void *mem, size_t size) {
     fprintf(stderr, "Impossible\n");
-    exit(-1);
+    exit(1);
 }
 
 extern "C" long __msan_test_shadow(const void *mem, size_t size) {
     fprintf(stderr, "Impossible\n");
-    exit(-1);
+    exit(1);
 }
 
 extern "C" int halide_msan_check_memory_is_initialized(void *user_context, const void *ptr, uint64_t len, const char *name) {
@@ -135,13 +135,13 @@ extern "C" int halide_msan_check_memory_is_initialized(void *user_context, const
     if (check_stage == CheckInputBuffer) {
         if (len != sizeof(halide_buffer_t)) {
             fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         check_stage = CheckInputShape;
     } else if (check_stage == CheckInputShape) {
         if (len != sizeof(halide_dimension_t) * 3) {
             fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         check_stage = CheckInputContents;
     } else if (check_stage == CheckInputContents) {
@@ -153,13 +153,13 @@ extern "C" int halide_msan_check_memory_is_initialized(void *user_context, const
     } else if (check_stage == CheckExternResultBuffer) {
         if (len != sizeof(halide_buffer_t)) {
             fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         check_stage = CheckExternResultShape;
     } else if (check_stage == CheckExternResultShape) {
         if (len != sizeof(halide_dimension_t) * 3) {
             fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         check_stage = CheckExternResultContents;
     } else if (check_stage == CheckExternResultContents) {
@@ -169,7 +169,7 @@ extern "C" int halide_msan_check_memory_is_initialized(void *user_context, const
         externresult_contents_checked += len;
     } else {
         fprintf(stderr, "Failure: bad enum\n");
-        exit(-1);
+        exit(1);
     }
     return 0;
 }
@@ -179,13 +179,13 @@ extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, co
     if (annotate_stage == AnnotateBoundsInferenceBuffer) {
         if (output_previous != nullptr || len != sizeof(halide_buffer_t)) {
             fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         annotate_stage = AnnotateBoundsInferenceShape;
     } else if (annotate_stage == AnnotateBoundsInferenceShape) {
         if (output_previous != nullptr || len != sizeof(halide_dimension_t) * 3) {
             fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         bounds_inference_count += 1;
         if (bounds_inference_count == 4) {
@@ -197,55 +197,55 @@ extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, co
         if (expect_intermediate_buffer_error) {
             if (len != 80) {
                 fprintf(stderr, "Failure: Expected error message of len=80, saw %d bytes\n", (unsigned int)len);
-                exit(-1);
+                exit(1);
             }
             return 0;  // stay in this state
         }
         if (output_previous != nullptr || len != sizeof(halide_buffer_t)) {
             fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         annotate_stage = AnnotateIntermediateShape;
     } else if (annotate_stage == AnnotateIntermediateShape) {
         if (output_previous != nullptr || len != sizeof(halide_dimension_t) * 3) {
             fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         annotate_stage = AnnotateOutputBuffer;
     } else if (annotate_stage == AnnotateOutputBuffer) {
         if (output_previous != nullptr || len != sizeof(halide_buffer_t)) {
             fprintf(stderr, "Failure: Expected sizeof(halide_buffer_t), saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         annotate_stage = AnnotateOutputShape;
     } else if (annotate_stage == AnnotateOutputShape) {
         if (output_previous != nullptr || len != sizeof(halide_dimension_t) * 3) {
             fprintf(stderr, "Failure: Expected sizeof(halide_dimension_t) * 3, saw %d\n", (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         annotate_stage = AnnotateIntermediateContents;
     } else if (annotate_stage == AnnotateIntermediateContents) {
         if (output_previous != nullptr || len != 4 * 4 * 3) {
             fprintf(stderr, "Failure: Expected %d, saw %d\n", 4 * 4 * 3, (unsigned int)len);
-            exit(-1);
+            exit(1);
         }
         annotate_stage = AnnotateOutputContents;
     } else if (annotate_stage == AnnotateOutputContents) {
         if (output_previous == nullptr) {
             if (ptr != output_base) {
                 fprintf(stderr, "Failure: Expected base p %p but saw %p\n", output_base, ptr);
-                exit(-1);
+                exit(1);
             }
             if (ptr <= output_previous) {
                 fprintf(stderr, "Failure: Expected monotonic increase but saw %p -> %p\n", output_previous, ptr);
-                exit(-1);
+                exit(1);
             }
             output_previous = ptr;
         }
         output_contents_annotated += len;
     } else {
         fprintf(stderr, "Failure: bad enum\n");
-        exit(-1);
+        exit(1);
     }
     return 0;
 }
@@ -260,7 +260,7 @@ void verify(const T &image) {
         int actual = image(x, y, c);
         if (actual != expected) {
             fprintf(stderr, "Failure @ %d %d %d: expected %d, got %d\n", x, y, c, expected, actual);
-            exit(-1);
+            exit(1);
         }
     });
 }
@@ -282,24 +282,24 @@ int main() {
         reset_state(in, out);
         if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
-            exit(-1);
+            exit(1);
         }
         verify(out);
         if (input_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (input_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (output_contents_annotated != 4 * 4 * 3) {
             fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
-            exit(-1);
+            exit(1);
         }
         if (output_previous == nullptr) {
             fprintf(stderr, "Failure: Expected to see annotations.\n");
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -317,31 +317,31 @@ int main() {
         reset_state(in, out);
         if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
-            exit(-1);
+            exit(1);
         }
         if (input_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (input_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (output_contents_annotated != 4 * 4 * 3) {
             fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
-            exit(-1);
+            exit(1);
         }
         if (output_previous == nullptr) {
             fprintf(stderr, "Failure: Expected to see annotations.\n");
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -352,31 +352,31 @@ int main() {
         reset_state(in, out);
         if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
-            exit(-1);
+            exit(1);
         }
         if (input_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (input_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (output_contents_annotated != 4 * 4 * 3) {
             fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
-            exit(-1);
+            exit(1);
         }
         if (output_previous == nullptr) {
             fprintf(stderr, "Failure: Expected to see annotations.\n");
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -394,31 +394,31 @@ int main() {
         reset_state(in, out);
         if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
-            exit(-1);
+            exit(1);
         }
         if (input_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (input_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (output_contents_annotated != 4 * 4 * 3) {
             fprintf(stderr, "Failure: output_contents_annotated is wrong (%d).\n", (int)output_contents_annotated);
-            exit(-1);
+            exit(1);
         }
         if (output_previous == nullptr) {
             fprintf(stderr, "Failure: Expected to see annotations.\n");
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -431,31 +431,31 @@ int main() {
         expect_intermediate_buffer_error = true;
         if (msan(in, out) == 0) {
             fprintf(stderr, "Failure (expected failure but did not)!\n");
-            exit(-1);
+            exit(1);
         }
         if (input_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (input_contents_checked != 1) {
             fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_checked != 0) {
             fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (output_contents_annotated != 0) {
             fprintf(stderr, "Failure: expected no output contents to be annotated.\n");
-            exit(-1);
+            exit(1);
         }
         if (output_previous != nullptr) {
             fprintf(stderr, "Failure: Expected NOT to see annotations.\n");
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -475,23 +475,23 @@ int main() {
         // we'll actually let it "complete" successfully and check the uninitialized state at the end.
         if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
-            exit(-1);
+            exit(1);
         }
         if (input_contents_uninitialized != sizeof(uint8_t)) {
             fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (input_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_uninitialized != 0) {
             fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
-            exit(-1);
+            exit(1);
         }
         // Don't bother checking outputs here.
     }
@@ -510,23 +510,23 @@ int main() {
         // we'll actually let it "complete" successfully and check the uninitialized state at the end.
         if (msan(in, out) != 0) {
             fprintf(stderr, "Failure!\n");
-            exit(-1);
+            exit(1);
         }
         if (input_contents_uninitialized != sizeof(uint8_t)) {
             fprintf(stderr, "Failure: input_contents_uninitialized is wrong (%d).\n", (int)input_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (input_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: input_contents_checked is wrong (%d).\n", (int)input_contents_checked);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_uninitialized != 4 * 4 * 3) {
             fprintf(stderr, "Failure: externresult_contents_uninitialized is wrong (%d).\n", (int)externresult_contents_uninitialized);
-            exit(-1);
+            exit(1);
         }
         if (externresult_contents_checked != 4 * 4 * 3) {
             fprintf(stderr, "Failure: externresult_contents_checked is wrong (%d).\n", (int)externresult_contents_checked);
-            exit(-1);
+            exit(1);
         }
         // Don't bother checking outputs here.
     }

--- a/test/generator/nested_externs_aottest.cpp
+++ b/test/generator/nested_externs_aottest.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
         if (actual != correct) {
             printf("result(%d, %d, %d) = %f instead of %f\n",
                    x, y, c, actual, correct);
-            exit(-1);
+            exit(1);
         }
     });
 

--- a/test/generator/sanitizercoverage_aottest.cpp
+++ b/test/generator/sanitizercoverage_aottest.cpp
@@ -84,7 +84,7 @@ void verify_out(const Buffer<int8_t, 3> &image) {
         int actual = image(x, y, c);
         if (actual != expected) {
             fprintf(stderr, "Failure @ %d %d %d: expected %d, got %d\n", x, y, c, expected, actual);
-            exit(-1);
+            exit(1);
         }
     });
 }
@@ -106,7 +106,7 @@ int main() {
     fprintf(stderr, "Performing the transformation.\n");
     if (sanitizercoverage_wrapper(out) != 0) {
         fprintf(stderr, "Failure!\n");
-        exit(-1);
+        exit(1);
     }
     fprintf(stderr, "Verifying the transformation.\n");
     verify_out(out);

--- a/test/generator/stubtest_aottest.cpp
+++ b/test/generator/stubtest_aottest.cpp
@@ -27,7 +27,7 @@ void verify(const Buffer<InputType, Dims> &input, float float_arg, int int_arg, 
     if (input.width() != output.width() ||
         input.height() != output.height()) {
         fprintf(stderr, "size mismatch: %dx%d vs %dx%d\n", input.width(), input.height(), output.width(), output.height());
-        exit(-1);
+        exit(1);
     }
     int channels = std::max(1, std::min(input.channels(), output.channels()));
     for (int x = 0; x < output.width(); x++) {
@@ -37,7 +37,7 @@ void verify(const Buffer<InputType, Dims> &input, float float_arg, int int_arg, 
                 const OutputType actual = output(x, y, c);
                 if (expected != actual) {
                     fprintf(stderr, "img[%d, %d, %d] = %f, expected %f (input = %f)\n", x, y, c, (double)actual, (double)expected, (double)input(x, y, c));
-                    exit(-1);
+                    exit(1);
                 }
             }
         }

--- a/test/generator/stubtest_jittest.cpp
+++ b/test/generator/stubtest_jittest.cpp
@@ -28,7 +28,7 @@ void verify(const Buffer<InputType, Dims> &input, float float_arg, int int_arg, 
     if (input.width() != output.width() ||
         input.height() != output.height()) {
         fprintf(stderr, "size mismatch: %dx%d vs %dx%d\n", input.width(), input.height(), output.width(), output.height());
-        exit(-1);
+        exit(1);
     }
     int channels = std::max(1, std::min(input.channels(), output.channels()));
     for (int x = 0; x < output.width(); x++) {
@@ -38,7 +38,7 @@ void verify(const Buffer<InputType, Dims> &input, float float_arg, int int_arg, 
                 const OutputType actual = output(x, y, c);
                 if (expected != actual) {
                     fprintf(stderr, "img[%d, %d, %d] = %f, expected %f (input = %f)\n", x, y, c, (double)actual, (double)expected, (double)input(x, y, c));
-                    exit(-1);
+                    exit(1);
                 }
             }
         }

--- a/test/generator/stubuser_aottest.cpp
+++ b/test/generator/stubuser_aottest.cpp
@@ -33,7 +33,7 @@ void verify(const Buffer<InputType, 3> &input, float float_arg, int int_arg, flo
     if (input.width() != output.width() ||
         input.height() != output.height()) {
         fprintf(stderr, "size mismatch\n");
-        exit(-1);
+        exit(1);
     }
     int channels = std::max(1, std::min(input.channels(), output.channels()));
     for (int x = 0; x < output.width(); x++) {
@@ -43,7 +43,7 @@ void verify(const Buffer<InputType, 3> &input, float float_arg, int int_arg, flo
                 const OutputType actual = output(x, y, c);
                 if (expected != actual) {
                     fprintf(stderr, "img[%d, %d, %d] = %f, expected %f\n", x, y, c, (double)actual, (double)expected);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }

--- a/test/generator/templated_aottest.cpp
+++ b/test/generator/templated_aottest.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
         if (val != input_val + 2) {
             printf("Output value was %f instead of %f\n",
                    val, input_val + 2);
-            exit(-1);
+            exit(1);
         }
     };
 

--- a/test/generator/user_context_aottest.cpp
+++ b/test/generator/user_context_aottest.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
     result = user_context(context_pointer, input, output);
     if (result != 0) {
         fprintf(stderr, "Result: %d\n", result);
-        exit(-1);
+        exit(1);
     }
     assert(called_malloc && called_free);
     assert(called_trace && !called_error);
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
     result = user_context_argv(args);
     if (result != 0) {
         fprintf(stderr, "Result: %d\n", result);
-        exit(-1);
+        exit(1);
     }
     assert(called_malloc && called_free);
     assert(called_trace && !called_error);
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     result = user_context(context_pointer, input, big_output);
     if (result == 0) {
         fprintf(stderr, "Expected this to fail, but got %d\n", result);
-        exit(-1);
+        exit(1);
     }
     assert(called_error);
 

--- a/test/performance/clamped_vector_load.cpp
+++ b/test/performance/clamped_vector_load.cpp
@@ -28,7 +28,7 @@ double test(Func f, bool test_correctness = true) {
                 if (output(x, y) != correct) {
                     printf("output(%d, %d) = %d instead of %d\n",
                            x, y, output(x, y), correct);
-                    exit(-1);
+                    exit(1);
                 }
             }
         }

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -240,7 +240,7 @@ public:
                                output(x, y, c),
                                reference_output(x, y, c),
                                x, y, c);
-                        exit(-1);
+                        exit(1);
                     }
                 }
             }

--- a/util/HalideTraceDump.cpp
+++ b/util/HalideTraceDump.cpp
@@ -51,7 +51,7 @@ struct FuncInfo {
         int real_dims = p->dimensions / p->type.lanes;
         if (real_dims > 16) {
             fprintf(stderr, "Error: found trace packet with dimensionality > 16. Aborting.\n");
-            exit(-1);
+            exit(1);
         }
         for (int i = 0; i < real_dims; i++) {
             min_coords[i] = INT32_MAX;
@@ -71,11 +71,11 @@ struct FuncInfo {
 
         if (scalar_type != type) {
             fprintf(stderr, "Error: packet type doesn't match previous packets of same Func. Aborting.\n");
-            exit(-1);
+            exit(1);
         }
         if (real_dims != dimensions) {
             fprintf(stderr, "Error: packet dimensionality doesn't match previous packets of same Func. Aborting.\n");
-            exit(-1);
+            exit(1);
         }
 
         for (int lane = 0; lane < lanes; lane++) {
@@ -98,7 +98,7 @@ struct FuncInfo {
         values = Buffer<>(type, extents);
         if (values.data() == nullptr) {
             fprintf(stderr, "Memory allocation failure. Aborting.\n");
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -129,7 +129,7 @@ struct FuncInfo {
             add_typed<bool>(p);
         } else {
             printf("Packet with unknown type\n");
-            exit(-1);
+            exit(1);
         }
     }
 
@@ -140,12 +140,12 @@ struct FuncInfo {
 
         if (!allocated()) {
             fprintf(stderr, "Packet storage not allocated. Aborting.\n");
-            exit(-1);
+            exit(1);
         }
 
         if (p->dimensions < 0) {
             fprintf(stderr, "Negative dimensionality found. Aborting.\n");
-            exit(-1);
+            exit(1);
         }
 
         for (int lane = 0; lane < lanes; lane++) {
@@ -222,7 +222,7 @@ void finish_dump(map<string, FuncInfo> &func_info, BufferOutputOpts output_opts)
             printf("float%d\n", info.type.bits);
         } else {
             fprintf(stderr, "Unsupported Func type. Aborting.\n");
-            exit(-1);
+            exit(1);
         }
 
         // Dimensions
@@ -359,7 +359,7 @@ int main(int argc, char *const *argv) {
     fseek(file_desc, 0, SEEK_SET);
     if (ferror(file_desc)) {
         fprintf(stderr, "Error: couldn't seek back to beginning of trace file. Aborting.\n");
-        exit(-1);
+        exit(1);
     }
 
     for (auto &pair : func_info) {
@@ -387,7 +387,7 @@ int main(int argc, char *const *argv) {
         if ((p.event == halide_trace_store) || (p.event == halide_trace_load)) {
             if (func_info.find(string(p.func())) == func_info.end()) {
                 fprintf(stderr, "Unable to find Func on 2nd pass. Aborting.\n");
-                exit(-1);
+                exit(1);
             }
             func_info[string(p.func())].add(&p);
         }

--- a/util/HalideTraceUtils.cpp
+++ b/util/HalideTraceUtils.cpp
@@ -38,7 +38,7 @@ bool Packet::read(void *d, size_t size, FILE *fdesc) {
     if (s != size) {
         if (ferror(fdesc) || !feof(fdesc)) {
             perror("Failed during read");
-            exit(-1);
+            exit(1);
         }
         return false;  // EOF
     }
@@ -48,7 +48,7 @@ bool Packet::read(void *d, size_t size, FILE *fdesc) {
 
 void bad_type_error(halide_type_t type) {
     fprintf(stderr, "Can't convert packet with type: %d bits: %d\n", type.code, type.bits);
-    exit(-1);
+    exit(1);
 }
 
 }  // namespace Internal


### PR DESCRIPTION
A program that terminates via `exit(-1)` leaves `$? = 255` (per the exit(3) manpage), as the value is chopped with `& 0377`.

This makes it hard to use `git bisect` to track down bugs, as considers any exit code > 127 (or = 15, oddly enough) equivalent to an `abort()` and terminates the bisect.

IMHO this is perverse behavior on the part of `git bisect`, but it is what it is, so let's revamp our tests to avoid calling `exit(-1);`.