### PR TITLE
Don't return negative values from main()

### DIFF
--- a/test/common/check_call_graphs.h
+++ b/test/common/check_call_graphs.h
@@ -59,12 +59,12 @@ inline int check_call_graphs(Halide::Pipeline p, CallGraphs &expected) {
 
     if (result.size() != expected.size()) {
         printf("Expect %d callers instead of %d\n", (int)expected.size(), (int)result.size());
-        return -1;
+        return 1;
     }
     for (auto &iter : expected) {
         if (result.count(iter.first) == 0) {
             printf("Expect %s to be in the call graphs\n", iter.first.c_str());
-            return -1;
+            return 1;
         }
         std::vector<std::string> &expected_callees = iter.second;
         std::vector<std::string> &result_callees = result[iter.first];
@@ -84,7 +84,7 @@ inline int check_call_graphs(Halide::Pipeline p, CallGraphs &expected) {
 
             printf("Expect callees of %s to be (%s); got (%s) instead\n",
                    iter.first.c_str(), expected_str.c_str(), result_str.c_str());
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -98,7 +98,7 @@ inline int check_image2(const Halide::Buffer<T> &im, const F &func) {
             if (im(x, y) != correct) {
                 std::cout << "im(" << x << ", " << y << ") = " << im(x, y)
                           << " instead of " << correct << "\n";
-                return -1;
+                return 1;
             }
         }
     }
@@ -114,7 +114,7 @@ inline int check_image3(const Halide::Buffer<T> &im, const F &func) {
                 if (im(x, y, z) != correct) {
                     std::cout << "im(" << x << ", " << y << ", " << z << ") = "
                               << im(x, y, z) << " instead of " << correct << "\n";
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/common/gpu_object_lifetime_tracker.h
+++ b/test/common/gpu_object_lifetime_tracker.h
@@ -67,12 +67,12 @@ public:
                 !(allow_globals && o.is_global)) {
                 printf("Error! %d objects created by %s still live\n",
                        o.live_count, o.created);
-                return -1;
+                return 1;
             }
             if (o.is_global && o.total_created > max_globals) {
                 printf("Error! %d global objects created by %s, max is %d\n",
                        o.total_created, o.created, max_globals);
-                return -1;
+                return 1;
             }
 
             total += o.total_created;
@@ -80,7 +80,7 @@ public:
         if (!allow_none && total == 0) {
             printf("Error! No objects created. Ensure gpu_debug is set, ");
             printf("and record_gpu_debug is called from halide_print.\n");
-            return -1;
+            return 1;
         }
         return 0;
     }

--- a/test/correctness/align_bounds.cpp
+++ b/test/correctness/align_bounds.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
         m.functions()[0].body.accept(&checker);
         if (checker.result) {
             printf("Lowered code contained a select\n");
-            return -1;
+            return 1;
         }
 
         p.set(3);
@@ -56,14 +56,14 @@ int main(int argc, char **argv) {
             if (result(i) != correct) {
                 printf("result(%d) = %d instead of %d\n",
                        i, result(i), correct);
-                return -1;
+                return 1;
             }
         }
 
         // Bounds of f should be [-p, 10+2*p] rounded outwards
         if (trace_min != -4 || trace_extent != 18) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
 
         // Increasing p by one should have no effect
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
         h.realize(result);
         if (trace_min != -4 || trace_extent != 18) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
 
         // But increasing it again should cause a jump of two in the bounds computed.
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
         h.realize(result);
         if (trace_min != -6 || trace_extent != 22) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
     }
 
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
         m.functions()[0].body.accept(&checker);
         if (checker.result) {
             printf("Lowered code contained a select\n");
-            return -1;
+            return 1;
         }
 
         p.set(3);
@@ -119,14 +119,14 @@ int main(int argc, char **argv) {
             if (result(i) != correct) {
                 printf("result(%d) = %d instead of %d\n",
                        i, result(i), correct);
-                return -1;
+                return 1;
             }
         }
 
         // Now the min/max should stick to odd numbers
         if (trace_min != -3 || trace_extent != 16) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
 
         // Increasing p by one should have no effect
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
         h.realize(result);
         if (trace_min != -5 || trace_extent != 20) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
 
         // But increasing it again should cause a jump of two in the bounds computed.
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
         h.realize(result);
         if (trace_min != -5 || trace_extent != 20) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
     }
 
@@ -170,14 +170,14 @@ int main(int argc, char **argv) {
             if (result(i) != correct) {
                 printf("result(%d) = %d instead of %d\n",
                        i, result(i), correct);
-                return -1;
+                return 1;
             }
         }
 
         // Now the min/max should stick to odd numbers
         if (trace_min != -3 || trace_extent != 32) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
 
         // Increasing p by one should have no effect
@@ -185,7 +185,7 @@ int main(int argc, char **argv) {
         h.realize(result);
         if (trace_min != -4 || trace_extent != 32) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
 
         // But increasing it again should cause a jump of two in the bounds computed.
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
         h.realize(result);
         if (trace_min != -5 || trace_extent != 32) {
             printf("%d: Wrong bounds: [%d, %d]\n", __LINE__, trace_min, trace_extent);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/argmax.cpp
+++ b/test/correctness/argmax.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
     if (result_f != 50) {
         printf("Arg max of f is %d, but should have been 50\n", result_f);
-        return -1;
+        return 1;
     }
 
     // Now try a multi-dimensional argmax.
@@ -43,13 +43,13 @@ int main(int argc, char **argv) {
 
     if (best_val != 4100) {
         printf("Arg max of g is %d, but should have been 4100\n", best_val);
-        return -1;
+        return 1;
     }
 
     if (best_x != 50 || best_y != 40) {
         printf("Arg max of g is %d, %d, but should have been 50, 40\n",
                best_x, best_y);
-        return -1;
+        return 1;
     }
 
     // Now try some inline argmaxs
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     if (best_x != 50 || best_y != 40 || best_val != 4100) {
         printf("Inline arg max of g is %d %d (%d), but should have been %d %d (%d)\n",
                best_x, best_y, best_val, 50, 40, 4100);
-        return -1;
+        return 1;
     }
 
     evaluate_may_gpu(argmin(g(r.x, r.y)), &best_x, &best_y, &best_val);
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     if (best_x != 0 || best_y != 99 || best_val != -1881) {
         printf("Inline arg max of g is %d %d (%d), but should have been %d %d (%d)\n",
                best_x, best_y, best_val, 50, 40, 4100);
-        return -1;
+        return 1;
     }
 
     // Try an in place argmax, using an elements at various places in
@@ -95,12 +95,12 @@ int main(int argc, char **argv) {
 
         if (best_val != 2500) {
             printf("Arg max of h is %d, but should have been 2500\n", best_val);
-            return -1;
+            return 1;
         }
 
         if (best_x != 50) {
             printf("Arg max of h is %d, but should have been 50\n", best_x);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/assertion_failure_in_parallel_for.cpp
+++ b/test/correctness/assertion_failure_in_parallel_for.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
 
     if (!error_occurred) {
         printf("There was supposed to be an error\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/async_device_copy.cpp
+++ b/test/correctness/async_device_copy.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/atomic_tuples.cpp
+++ b/test/correctness/atomic_tuples.cpp
@@ -48,14 +48,14 @@ int main(int argc, char **argv) {
                 if (out(x, y) != correct) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, out(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
 
         if (checker.count_atomics != 2 || checker.count_atomics_with_mutexes != 0) {
             printf("Expected two atomic nodes, neither of them with mutexes\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -83,14 +83,14 @@ int main(int argc, char **argv) {
                 if (out(x, y) != correct) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, out(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
 
         if (checker.count_atomics != 1 || checker.count_atomics_with_mutexes != 1) {
             printf("Expected one atomic node, with mutex\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -121,14 +121,14 @@ int main(int argc, char **argv) {
                 if (out(x, y) != correct) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, out(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
 
         if (checker.count_atomics != 1 || checker.count_atomics_with_mutexes != 1) {
             printf("Expected one atomic nodes, with mutex\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -161,14 +161,14 @@ int main(int argc, char **argv) {
                 if (out(x, y) != correct) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, out(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
 
         if (checker.count_atomics != 1 || checker.count_atomics_with_mutexes != 1) {
             printf("Expected one atomic node, with mutex\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -213,14 +213,14 @@ int main(int argc, char **argv) {
                 if (out(x, y) != correct) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, out(x, y), correct);
-                    // return -1;
+                    // return 1;
                 }
             }
         }
 
         if (checker.count_atomics != 4 || checker.count_atomics_with_mutexes != 0) {
             printf("Expected four atomic nodes, with no mutexes\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/bad_likely.cpp
+++ b/test/correctness/bad_likely.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
         int correct = (x < 10 || x > 20) ? 1 : 2;
         if (im(x) != correct) {
             printf("im(%d) = %d instead of %d\n", x, im(x), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/bit_counting.cpp
+++ b/test/correctness/bit_counting.cpp
@@ -84,7 +84,7 @@ int test_bit_counting(const Target &target) {
             printf("Popcount of %u [0b%s] returned %d (should be %d)\n",
                    input(i), bits_string.c_str(), popcount_result(i),
                    local_popcount(input(i)));
-            return -1;
+            return 1;
         }
     }
 
@@ -99,7 +99,7 @@ int test_bit_counting(const Target &target) {
             printf("Ctlz of %u [0b%s] returned %d (should be %d)\n",
                    input(i), bits_string.c_str(), ctlz_result(i),
                    local_count_leading_zeros(input(i)));
-            return -1;
+            return 1;
         }
     }
 
@@ -114,7 +114,7 @@ int test_bit_counting(const Target &target) {
             printf("Cttz of %u [0b%s] returned %d (should be %d)\n",
                    input(i), bits_string.c_str(), cttz_result(i),
                    local_count_trailing_zeros(input(i)));
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -123,8 +123,8 @@ int test_bit_counting(const Target &target) {
 int main() {
     Target target = get_jit_target_from_environment();
 
-    if (test_bit_counting<uint16_t>(target) != 0) return -1;
-    if (test_bit_counting<uint32_t>(target) != 0) return -1;
+    if (test_bit_counting<uint16_t>(target) != 0) return 1;
+    if (test_bit_counting<uint32_t>(target) != 0) return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/bitwise_ops.cpp
+++ b/test/correctness/bitwise_ops.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
         float c = Halide::Internal::reinterpret_bits<float>(input(x));
         if (halide != c && std::isnan(halide) ^ std::isnan(c)) {
             printf("reinterpret<float>(%x) -> %f instead of %f\n", input(x), halide, c);
-            return -1;
+            return 1;
         }
     }
 
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
         if (im2(x) != correct) {
             printf("%x ^ %x -> %x instead of %x\n",
                    input(x), input(x + 1), im2(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
         if (im3(x) != correct) {
             printf("%x & %x -> %x instead of %x\n",
                    input(x), input(x + 1), im3(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         if (im4(x) != correct) {
             printf("%x | %x -> %x instead of %x\n",
                    input(x), input(x + 1), im4(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
         if (im5(x) != correct) {
             printf("~%x = %x instead of %x\n",
                    input(x), im5(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -85,7 +85,7 @@ int main(int argc, char **argv) {
         if (im6(x) != correct) {
             printf("%x << (%x & 0xf) -> %x instead of %x\n",
                    input(x), input(x + 1), im6(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
         if (im7(x) != correct) {
             printf("%x >> (%x & 0xf) -> %x instead of %x\n",
                    input(x), input(x + 1), im7(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
         if (im8(x) != correct) {
             printf("%x >> uint32(%x & 0x1f) -> %x instead of %x\n",
                    input(x), input(x + 1), im8(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
         if (im9(x) != correct) {
             printf("%d >> %d -> %d instead of %d\n",
                    input(x), shift_amount, im9(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
         if (im10(x) != correct) {
             printf("%x << (%x & 0x1f) -> %x instead of %x\n",
                    input(x), input(x + 1), im10(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
         if (im11(x) != correct) {
             printf("%x >> (%x & 0x1f) -> %x instead of %x\n",
                    input(x), input(x + 1), im11(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -176,7 +176,7 @@ int main(int argc, char **argv) {
         if (im12(x) != correct) {
             printf("%x << (-1 * (%x & 0x1f)) -> %x instead of %x\n",
                    input(x), input(x + 1), im12(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -191,7 +191,7 @@ int main(int argc, char **argv) {
         if (im13(x) != correct) {
             printf("%x >> (-1 * (%x & 0x1f)) -> %x instead of %x\n",
                    input(x), input(x + 1), im13(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
         if (im14(x) != correct) {
             printf("%x << %x -> %x instead of %x\n",
                    input(x), b14, im14(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
         if (im15(x) != correct) {
             printf("%x >> %x -> %x instead of %x\n",
                    input(x), b15, im15(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
         if (im16(x) != correct) {
             printf("%x << %x -> %x instead of %x\n",
                    input(x), b16, im16(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -251,7 +251,7 @@ int main(int argc, char **argv) {
         if (im17(x) != correct) {
             printf("%x >> %x -> %x instead of %x\n",
                    input(x), b17, im17(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -265,7 +265,7 @@ int main(int argc, char **argv) {
         if (im18(x) != correct) {
             printf("(int8_t)%x & 0xf0 -> %x instead of %x\n",
                    input(x), im18(x), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/bound.cpp
+++ b/test/correctness/bound.cpp
@@ -20,12 +20,12 @@ int main(int argc, char **argv) {
         for (int j = 0; j < 32; j++) {
             if (imf(i, j) != (i > j ? i : j)) {
                 printf("imf[%d, %d] = %d\n", i, j, imf(i, j));
-                return -1;
+                return 1;
             }
             for (int c = 0; c < 3; c++) {
                 if (img(i, j, c) != c * (i > j ? i : j)) {
                     printf("img[%d, %d, %d] = %d\n", i, j, c, img(i, j, c));
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/bound_storage.cpp
+++ b/test/correctness/bound_storage.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
         Module m = g.compile_to_module({});
         if (s.allocation_size["f"] != fixed_alloc_size) {
             std::cerr << "Allocation size for f doesn't match one which was set explicitly \n";
-            return -1;
+            return 1;
         }
 
         // Also check that output is correct.
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -78,12 +78,12 @@ int main(int argc, char **argv) {
         Module m = g.compile_to_module({});
         if (s.allocation_size["f"] != fixed_alloc_size_f) {
             std::cerr << "Allocation size for f doesn't match one which was set explicitly \n";
-            return -1;
+            return 1;
         }
 
         if (s.allocation_size["h"] != fixed_alloc_size_h * fixed_alloc_size_h) {
             std::cerr << "Allocation size for h doesn't match one which was set explicitly \n";
-            return -1;
+            return 1;
         }
 
         // Also check that output is correct.
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/bounds.cpp
+++ b/test/correctness/bounds.cpp
@@ -40,18 +40,18 @@ int main(int argc, char **argv) {
         for (int j = 0; j < 32; j++) {
             if (imf(i, j) != (i > j ? i : j)) {
                 printf("imf[%d, %d] = %d\n", i, j, imf(i, j));
-                return -1;
+                return 1;
             }
             if (img(i, j) != (i < j ? i : j)) {
                 printf("img[%d, %d] = %d\n", i, j, img(i, j));
-                return -1;
+                return 1;
             }
             int href = i + j;
             if (href < 20) href = 20;
             if (href > 100) href = 100;
             if (imh(i, j) != href) {
                 printf("imh[%d, %d] = %d (not %d)\n", i, j, imh(i, j), href);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/bounds_inference.cpp
+++ b/test/correctness/bounds_inference.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < 32; x++) {
             if (out(x, y) != x * 4 + y) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), x * 4 + y);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/bounds_inference_chunk.cpp
+++ b/test/correctness/bounds_inference_chunk.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < 32; x++) {
             if (out(x, y) != x + y) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), x + y);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/bounds_inference_outer_split.cpp
+++ b/test/correctness/bounds_inference_outer_split.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
     if (!is_const(checker.result, 512)) {
         std::cerr << m.functions()[0].body << "\n\n"
                   << "Allocation size was supposed to be 512 in dimension 0 in the stmt above\n";
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/bounds_of_monotonic_math.cpp
+++ b/test/correctness/bounds_of_monotonic_math.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv) {
     int correct = 26;
     if (in.width() != correct) {
         printf("Width is %d instead of %d\n", in.width(), correct);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/bounds_query.cpp
+++ b/test/correctness/bounds_query.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != reference(x, y)) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), reference(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/c_function.cpp
+++ b/test/correctness/c_function.cpp
@@ -41,14 +41,14 @@ int main(int argc, char **argv) {
             float delta = imf(i, j) - correct;
             if (delta < -0.001 || delta > 0.001) {
                 printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                return -1;
+                return 1;
             }
         }
     }
 
     if (call_counter != 32 * 32) {
         printf("C function my_func was called %d times instead of %d\n", call_counter, 32 * 32);
-        return -1;
+        return 1;
     }
 
     Func g;
@@ -65,14 +65,14 @@ int main(int argc, char **argv) {
             float delta = imf2(i, j) - correct;
             if (delta < -0.001 || delta > 0.001) {
                 printf("imf2[%d, %d] = %f instead of %f\n", i, j, imf2(i, j), correct);
-                return -1;
+                return 1;
             }
         }
     }
 
     if (call_counter2 != 32 * 32) {
         printf("C function my_func2 was called %d times instead of %d\n", call_counter2, 32 * 32);
-        return -1;
+        return 1;
     }
 
     // Switch from my_func2 to my_func and verify a recompile happens.
@@ -86,14 +86,14 @@ int main(int argc, char **argv) {
             float delta = imf3(i, j) - correct;
             if (delta < -0.001 || delta > 0.001) {
                 printf("imf3[%d, %d] = %f instead of %f\n", i, j, imf3(i, j), correct);
-                return -1;
+                return 1;
             }
         }
     }
 
     if (call_counter3 != 32 * 32) {
         printf("C function my_func3 was called %d times instead of %d\n", call_counter3, 32 * 32);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/cascaded_filters.cpp
+++ b/test/correctness/cascaded_filters.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
 
     if (err > 0.01f) {
         printf("Error too large: %f!\n", err);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/cast_handle.cpp
+++ b/test/correctness/cast_handle.cpp
@@ -33,14 +33,14 @@ int main(int argc, char **argv) {
                    x,
                    (long long unsigned)out1(x),
                    (long long unsigned)correct);
-            return -1;
+            return 1;
         }
         if (out2(x) != correct) {
             printf("out2(%d) = %llu instead of %llu\n",
                    x,
                    (long long unsigned)out2(x),
                    (long long unsigned)correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/chunk.cpp
+++ b/test/correctness/chunk.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
         for (int j = 0; j < 32; j++) {
             if (im(i, j) != 2 * i) {
                 printf("im[%d, %d] = %d (expected %d)\n", i, j, im(i, j), 2 * i);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/chunk_sharing.cpp
+++ b/test/correctness/chunk_sharing.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
             int d = b + c;
             if (im(x, y) != d) {
                 printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), d);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/compare_vars.cpp
+++ b/test/correctness/compare_vars.cpp
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/compute_at_reordered_update_stage.cpp
+++ b/test/correctness/compute_at_reordered_update_stage.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
             const int expected = x + y;
             if (actual != expected) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, actual, expected);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/compute_at_split_rvar.cpp
+++ b/test/correctness/compute_at_split_rvar.cpp
@@ -28,13 +28,13 @@ int main(int argc, char **argv) {
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < im.width(); i++) {
             if (im(i) != i) {
                 printf("im(%d) = %d instead of %d\n", i, im(i), i);
-                return -1;
+                return 1;
             }
         }
         call_counter = 0;
@@ -57,13 +57,13 @@ int main(int argc, char **argv) {
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < im.width(); i++) {
             if (im(i) != i) {
                 printf("im(%d) = %d instead of %d\n", i, im(i), i);
-                return -1;
+                return 1;
             }
         }
         call_counter = 0;
@@ -86,13 +86,13 @@ int main(int argc, char **argv) {
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < im.width(); i++) {
             if (im(i) != i) {
                 printf("im(%d) = %d instead of %d\n", i, im(i), i);
-                return -1;
+                return 1;
             }
         }
         call_counter = 0;
@@ -117,14 +117,14 @@ int main(int argc, char **argv) {
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < im.width(); i++) {
             int correct = (i / 2) + ((i % 2 == 0) ? 0 : 5);
             if (im(i) != correct) {
                 printf("im(%d) = %d instead of %d\n", i, im(i), correct);
-                return -1;
+                return 1;
             }
         }
         call_counter = 0;
@@ -147,14 +147,14 @@ int main(int argc, char **argv) {
 
         if (call_counter != 20) {
             printf("Wrong number of calls to f: %d\n", call_counter);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < im.width(); i++) {
             int correct = i;
             if (im(i) != correct) {
                 printf("im(%d) = %d instead of %d\n", i, im(i), correct);
-                return -1;
+                return 1;
             }
         }
         call_counter = 0;
@@ -179,13 +179,13 @@ int main(int argc, char **argv) {
 
         if (call_counter != 10) {
             printf("Wrong number of calls to f: %d\n", call_counter);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < im.width(); i++) {
             if (im(i) != i) {
                 printf("im(%d) = %d instead of %d\n", i, im(i), i);
-                return -1;
+                return 1;
             }
         }
         call_counter = 0;

--- a/test/correctness/compute_outermost.cpp
+++ b/test/correctness/compute_outermost.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
             if (result(x, y) != correct) {
                 printf("result(%d, %d) = %d instead of %d\n",
                        x, y, result(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/compute_with.cpp
+++ b/test/correctness/compute_with.cpp
@@ -139,7 +139,7 @@ int split_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -194,7 +194,7 @@ int fuse_test() {
         return im_ref(x, y, z);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -278,7 +278,7 @@ int multiple_fuse_group_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -334,14 +334,14 @@ int multiple_outputs_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -416,7 +416,7 @@ int fuse_compute_at_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -473,7 +473,7 @@ int double_split_fuse_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -614,7 +614,7 @@ int rgb_yuv420_test() {
             too_many_memops = true;
         }
         if (too_many_memops) {
-            return -1;
+            return 1;
         }
     }
 
@@ -622,21 +622,21 @@ int rgb_yuv420_test() {
         return y_im_ref(x, y);
     };
     if (check_image(y_im, y_func)) {
-        return -1;
+        return 1;
     }
 
     auto u_func = [u_im_ref](int x, int y) {
         return u_im_ref(x, y);
     };
     if (check_image(u_im, u_func)) {
-        return -1;
+        return 1;
     }
 
     auto v_func = [v_im_ref](int x, int y) {
         return v_im_ref(x, y);
     };
     if (check_image(v_im, v_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -696,7 +696,7 @@ int vectorize_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -758,7 +758,7 @@ int some_are_skipped_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -812,14 +812,14 @@ int multiple_outputs_on_gpu_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -898,21 +898,21 @@ int mixed_tile_factor_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     auto h_func = [h_im_ref](int x, int y) {
         return h_im_ref(x, y);
     };
     if (check_image(h_im, h_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -996,21 +996,21 @@ int multi_tile_mixed_tile_factor_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     auto h_func = [h_im_ref](int x, int y) {
         return h_im_ref(x, y);
     };
     if (check_image(h_im, h_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1087,21 +1087,21 @@ int only_some_are_tiled_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     auto h_func = [h_im_ref](int x, int y) {
         return h_im_ref(x, y);
     };
     if (check_image(h_im, h_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1159,7 +1159,7 @@ int with_specialization_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -1224,14 +1224,14 @@ int nested_compute_with_test() {
         return g1_im_ref(x, y);
     };
     if (check_image(g1_im, g1_func)) {
-        return -1;
+        return 1;
     }
 
     auto g2_func = [g2_im_ref](int x, int y) {
         return g2_im_ref(x, y);
     };
     if (check_image(g2_im, g2_func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -1295,14 +1295,14 @@ int update_stage_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1368,14 +1368,14 @@ int update_stage2_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1441,14 +1441,14 @@ int update_stage3_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1514,14 +1514,14 @@ int update_stage_pairwise_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1592,14 +1592,14 @@ int update_stage_pairwise_zigzag_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1679,21 +1679,21 @@ int update_stage_diagonal_test() {
         return f_im_ref(x, y);
     };
     if (check_image(f_im, f_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     auto h_func = [h_im_ref](int x, int y) {
         return h_im_ref(x, y);
     };
     if (check_image(h_im, h_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1728,7 +1728,7 @@ int update_stage_rfactor_test() {
     const int reference = 9900;
     if (result(0) != reference) {
         printf("Wrong result: expected %d, got %d\n", reference, result(0));
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1820,7 +1820,7 @@ int vectorize_inlined_test() {
         }
 
         if (too_many_memops) {
-            return -1;
+            return 1;
         }
     }
 
@@ -1828,14 +1828,14 @@ int vectorize_inlined_test() {
         return h_im_ref(x, y, c);
     };
     if (check_image(h_im, h_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1897,14 +1897,14 @@ int mismatching_splits_test() {
         return h_im_ref(x, y, z);
     };
     if (check_image(h_im, h_func)) {
-        return -1;
+        return 1;
     }
 
     auto g_func = [g_im_ref](int x, int y) {
         return g_im_ref(x, y);
     };
     if (check_image(g_im, g_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -1981,7 +1981,7 @@ int different_arg_num_compute_at_test() {
             too_many_memops = true;
         }
         if (too_many_memops) {
-            return -1;
+            return 1;
         }
     }
 
@@ -1989,13 +1989,13 @@ int different_arg_num_compute_at_test() {
         return buffer_a_ref(x, y, c);
     };
     if (check_image(buffer_a, buffer_a_func)) {
-        return -1;
+        return 1;
     }
 
     for (int i = 0; i < buffer_b.width(); i++) {
         if (buffer_b(i) != buffer_b_ref(i)) {
             printf("Mismatch %d %d %d\n", i, buffer_b(i), buffer_b_ref(i));
-            return -1;
+            return 1;
         }
     }
 
@@ -2024,7 +2024,7 @@ int store_at_different_levels_test() {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -2111,7 +2111,7 @@ int rvar_bounds_test() {
     Buffer<int16_t> result = total_sum.realize();
 
     if (result() != 8192) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -2188,17 +2188,17 @@ int two_compute_at_test() {
         if (o1(x) != val) {
             printf("o1(%d) = %d instead of %d\n",
                    x, o1(x), val);
-            return -1;
+            return 1;
         }
         if (o2(x) != 2 * val) {
             printf("o2(%d) = %d instead of %d\n",
                    x, o2(x), 2 * val);
-            return -1;
+            return 1;
         }
         if (o3(x) != x + 2) {
             printf("o2(%d) = %d instead of %d\n",
                    x, o3(x), x + 2);
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -2257,7 +2257,7 @@ int main(int argc, char **argv) {
         const auto &task = tasks.at(t);
         std::cout << task.desc << "\n";
         if (task.fn() != 0) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/concat.cpp
+++ b/test/correctness/concat.cpp
@@ -34,13 +34,13 @@ int main(int argc, char **argv) {
         int correct = i < 100 ? i + 1 : i + 2;
         if (buf(i) != correct) {
             printf("buf(%d) = %d instead of %d\n", i, buf(i), correct);
-            return -1;
+            return 1;
         }
     }
 
     if (count[0] != 100 || count[1] != 100) {
         printf("Incorrect counts: %d %d\n", count[0], count[1]);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/constant_type.cpp
+++ b/test/correctness/constant_type.cpp
@@ -55,6 +55,6 @@ int main(int argc, char **argv) {
         printf("Success!\n");
         return 0;
     } else {
-        return -1;
+        return 1;
     }
 }

--- a/test/correctness/constraints.cpp
+++ b/test/correctness/constraints.cpp
@@ -32,7 +32,7 @@ int basic_constraints() {
 
     if (error_occurred) {
         printf("Error incorrectly raised\n");
-        return -1;
+        return 1;
     }
     // This should be an error, because dimension 0 of image 2 is not from 0 to 128 like we promised
     param.set(image2);
@@ -41,7 +41,7 @@ int basic_constraints() {
 
     if (!error_occurred) {
         printf("Error incorrectly not raised\n");
-        return -1;
+        return 1;
     }
 
     // Now try constraining the output buffer of a function
@@ -52,7 +52,7 @@ int basic_constraints() {
     g.realize(image1);
     if (!error_occurred) {
         printf("Error incorrectly not raised when constraining output buffer\n");
-        return -1;
+        return 1;
     }
 
     Func h;
@@ -74,7 +74,7 @@ int basic_constraints() {
     h.compile_to_assembly(assembly_file, {image1}, "h");
     if (error_occurred) {
         printf("Error incorrectly raised when constraining output buffer\n");
-        return -1;
+        return 1;
     }
 
     Internal::assert_file_exists(assembly_file);
@@ -123,7 +123,7 @@ int alignment_constraints() {
     std::string unaligned_code = load_file_to_string(unaligned_ll_file);
     if (unaligned_code.find("align 16") != std::string::npos) {
         printf("Found aligned load from unaligned buffer!\n");
-        return -1;
+        return 1;
     }
 
     std::string aligned_ll_file = Internal::get_test_tmp_dir() + "aligned.ll";
@@ -132,7 +132,7 @@ int alignment_constraints() {
     std::string aligned_code = load_file_to_string(aligned_ll_file);
     if (aligned_code.find("align 16") == std::string::npos) {
         printf("Did not find aligned load from aligned buffer!\n");
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -164,7 +164,7 @@ int unstructured_constraints() {
 
     if (error_occurred) {
         printf("Error incorrectly raised\n");
-        return -1;
+        return 1;
     }
     // This should be an error, because dimension 0 of image 2 is not from 0 to 128 like we promised
     param.set(image2);
@@ -173,7 +173,7 @@ int unstructured_constraints() {
 
     if (!error_occurred) {
         printf("Error incorrectly not raised\n");
-        return -1;
+        return 1;
     }
 
     // Now try constraining the output buffer of a function
@@ -190,7 +190,7 @@ int unstructured_constraints() {
     pg.realize(image1);
     if (!error_occurred) {
         printf("Error incorrectly not raised when constraining output buffer\n");
-        return -1;
+        return 1;
     }
 
     Func h;
@@ -210,7 +210,7 @@ int unstructured_constraints() {
 
     if (error_occurred) {
         printf("Error incorrectly raised when constraining output buffer\n");
-        return -1;
+        return 1;
     }
 
     return 0;

--- a/test/correctness/convolution.cpp
+++ b/test/correctness/convolution.cpp
@@ -106,11 +106,11 @@ int main(int argc, char **argv) {
                                 1 * in(x - 1, y + 1) + 2 * in(x, y + 1) + 1 * in(x + 1, y + 1));
             if (out1(x, y) != correct) {
                 printf("out1(%d, %d) = %d instead of %d\n", x, y, out1(x, y), correct);
-                return -1;
+                return 1;
             }
             if (out2(x, y) != correct) {
                 printf("out2(%d, %d) = %d instead of %d\n", x, y, out2(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/convolution_multiple_kernels.cpp
+++ b/test/correctness/convolution_multiple_kernels.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
 
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/cse_nan.cpp
+++ b/test/correctness/cse_nan.cpp
@@ -33,6 +33,6 @@ int main() {
     } else {
         fprintf(stderr, "ERROR: T = %f ; TR = %f ; F = %f ; FR = %f\n",
                 true_buf(0, 0, 0), true_result(0, 0), false_buf(0, 0, 0), false_result(0, 0));
-        return -1;
+        return 1;
     }
 }

--- a/test/correctness/custom_auto_scheduler.cpp
+++ b/test/correctness/custom_auto_scheduler.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
 
     if (call_count != 2) {
         printf("Should have called the custom autoscheduler twice. Instead called it %d times\n", call_count);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/custom_cuda_context.cpp
+++ b/test/correctness/custom_cuda_context.cpp
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
 
         if (halide_cuda_get_symbol == nullptr) {
             printf("Failed to extract halide_cuda_get_symbol from Halide cuda runtime\n");
-            return -1;
+            return 1;
         }
 
         // Go get the CUDA API functions we actually intend to use.
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
             cuMemAlloc == nullptr ||
             cuMemFree == nullptr) {
             printf("Failed to find cuda API\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -107,19 +107,19 @@ int main(int argc, char **argv) {
     int err = cuCtxCreate(&state.cuda_context, 0, 0);
     if (state.cuda_context == nullptr) {
         printf("Failed to initialize context: %d\n", err);
-        return -1;
+        return 1;
     }
 
     err = cuCtxSetCurrent(state.cuda_context);
     if (err) {
         printf("Failed to set context: %d\n", err);
-        return -1;
+        return 1;
     }
 
     err = cuStreamCreate(&state.cuda_stream, 1 /* non-blocking */);
     if (state.cuda_stream == nullptr) {
         printf("Failed to initialize stream: %d\n", err);
-        return -1;
+        return 1;
     }
 
     // Allocate some GPU memory on this context
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
 
     if (ptr == nullptr) {
         printf("cuMemAlloc failed: %d\n", err);
-        return -1;
+        return 1;
     }
 
     // Wrap a Halide buffer around it, with some host memory too.
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
                 float correct = 2.0f;
                 if (out(x, y) != 2.0f) {
                     printf("out(%d, %d) = %f instead of %f\n", x, y, out(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -176,7 +176,7 @@ int main(int argc, char **argv) {
         state.acquires.load() < height) {
         printf("Context acquires: %d releases: %d\n", state.acquires.load(), state.releases.load());
         printf("Expected these to match and be at least %d (the number of parallel tasks)\n", height);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/custom_error_reporter.cpp
+++ b/test/correctness/custom_error_reporter.cpp
@@ -68,5 +68,5 @@ int main(int argc, char **argv) {
     _halide_user_assert(argc == 0) << should_be_evaluated();
 
     printf("CompileTimeErrorReporter::error() must not return.\n");
-    return -1;
+    return 1;
 }

--- a/test/correctness/custom_jit_context.cpp
+++ b/test/correctness/custom_jit_context.cpp
@@ -40,21 +40,21 @@ int main(int argc, char **argv) {
     f.realize(&ctx1, {100});
     if (ctx1.which_handler != 1) {
         printf("Fail to call per-call custom print handler 1: %d\n", ctx1.which_handler);
-        return -1;
+        return 1;
     }
 
     ctx2.which_handler = 0;
     f.realize(&ctx2, {100});
     if (ctx2.which_handler != 2) {
         printf("Fail to call per-call custom print handler 2: %d\n", ctx2.which_handler);
-        return -1;
+        return 1;
     }
 
     ctx1.handlers.custom_print = nullptr;
     f.realize(&ctx1, {100});
     if (ctx1.which_handler != 3) {
         printf("Fail to call per-Pipeline custom print handler: %d\n", ctx1.which_handler);
-        return -1;
+        return 1;
     }
 
     Target t = get_jit_target_from_environment();
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
         bad_buf.copy_to_host(&ctx1);
         if (ctx1.which_handler != 4) {
             printf("Fail to call custom error handler from context passed to copy_to_host: %d\n", ctx1.which_handler);
-            return -1;
+            return 1;
         }
 
         ctx1.which_handler = 0;
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
         bad_buf.copy_to_device(t, &ctx1);
         if (ctx1.which_handler != 4) {
             printf("Fail to call custom error handler from context passed to copy_to_device: %d\n", ctx1.which_handler);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/custom_lowering_pass.cpp
+++ b/test/correctness/custom_lowering_pass.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
     if (multiply_count != size * 2) {
         printf("The multiplies weren't all counted. Got %d instead of %d\n",
                multiply_count, size);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/debug_to_file.cpp
+++ b/test/correctness/debug_to_file.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
                     // The min coord gets lost on debug_to_file, so f should be shifted up by one.
                     if (val != x + y + z - 1) {
                         printf("f(%d, %d, %d) = %d instead of %d\n", x, y, z, val, x + y);
-                        return -1;
+                        return 1;
                     }
                 }
             }
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
                 float correct = (float)(f(x, y, 1) + f(x + 1, y, 2));
                 if (val != correct) {
                     printf("g(%d, %d) = %f instead of %f\n", x, y, val, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
                 int32_t correct = f(x, y, 0) + g(x, y);
                 if (val != correct) {
                     printf("h(%d, %d) = %d instead of %d\n", x, y, val, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/debug_to_file_multiple_outputs.cpp
+++ b/test/correctness/debug_to_file_multiple_outputs.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
             int32_t val = f_data[y * (size_x + 1) + x];
             if (val != x + y) {
                 printf("f_data[%d, %d] = %d instead of %d\n", x, y, val, x + y);
-                return -1;
+                return 1;
             }
         }
     }
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
             float correct = (float)(f_data[y * (size_x + 1) + x] + f_data[y * (size_x + 1) + x + 1]);
             if (val != correct) {
                 printf("g_data[%d, %d] = %f instead of %f\n", x, y, val, correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
             float correct = f_data[y * (size_x + 1) + x] + g_data[y * size_x + x];
             if (val != correct) {
                 printf("h_data[%d, %d] = %f instead of %f\n", x, y, val, correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/debug_to_file_reorder.cpp
+++ b/test/correctness/debug_to_file_reorder.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
             int32_t val = f_data[y * (size_x + 1) + x];
             if (val != x + y) {
                 printf("f_data[%d, %d] = %d instead of %d\n", x, y, val, x + y);
-                return -1;
+                return 1;
             }
         }
     }
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
             float correct = (float)(f_data[y * (size_x + 1) + x] + f_data[y * (size_x + 1) + x + 1]);
             if (val != correct) {
                 printf("g_data[%d, %d] = %f instead of %f\n", x, y, val, correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
             float correct = f_data[y * (size_x + 1) + x] + g_data[y * size_x + x];
             if (val != correct) {
                 printf("h_data[%d, %d] = %f instead of %f\n", x, y, val, correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/deinterleave4.cpp
+++ b/test/correctness/deinterleave4.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     for (int x = 0; x < o2.width(); x++) {
         if (o1(x) != o2(x)) {
             printf("o1(%d) = %d but o2(%d) = %d\n", x, o1(x), x, o2(x));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/device_copy_at_inner_loop.cpp
+++ b/test/correctness/device_copy_at_inner_loop.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/dilate3x3.cpp
+++ b/test/correctness/dilate3x3.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
 
             if (out(x, y) != correct) {
                 std::cout << "out(" << x << ", " << y << ") = " << out(x, y) << " instead of " << correct << "\n";
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/dynamic_allocation_in_gpu_kernel.cpp
+++ b/test/correctness/dynamic_allocation_in_gpu_kernel.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("result[%d](%d, %d) = %f instead of %f\n",
                            i, x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/erf.cpp
+++ b/test/correctness/erf.cpp
@@ -46,6 +46,6 @@ int main(int argc, char **argv) {
         printf("Success!\n");
         return 0;
     } else {
-        return -1;
+        return 1;
     }
 }

--- a/test/correctness/exception.cpp
+++ b/test/correctness/exception.cpp
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
             std::cout << "result(" << i
                       << ") = " << result(i)
                       << " instead of " << correct << "\n";
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     sink.realize();
 
     if (!check_result())
-        return -1;
+        return 1;
 
     // Test ImageParam ExternFuncArgument via passed in image.
     Buffer<int32_t> buf = source.realize({10});
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
     sink2.realize();
 
     if (!check_result())
-        return -1;
+        return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/extern_error.cpp
+++ b/test/correctness/extern_error.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 bool extern_error_called = false;
 extern "C" HALIDE_EXPORT_SYMBOL int extern_error(JITUserContext *user_context, halide_buffer_t *out) {
     extern_error_called = true;
-    return -1;
+    return halide_error_code_generic_error;
 }
 
 bool error_occurred = false;
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
 
     if (!error_occurred || !extern_error_called) {
         printf("There was supposed to be an error\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/extern_output_expansion.cpp
+++ b/test/correctness/extern_output_expansion.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
             int32_t correct = i * i * i * 2;
             if (result(i) != correct) {
                 printf("result(%d) = %d instead of %d\n", i, result(i), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/extern_producer.cpp
+++ b/test/correctness/extern_producer.cpp
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         unsigned int error = evaluate_may_gpu<unsigned int>(sum(abs(output(r.x, r.y))));
         if (error != 0) {
             printf("Something went wrong\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
         unsigned int error_multi = evaluate<unsigned int>(sum(abs(output_multi(r.x, r.y))));
         if (error_multi != 0) {
             printf("Something went wrong in multi case\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/extern_sort.cpp
+++ b/test/correctness/extern_sort.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
 
     if (error != 0) {
         printf("Output incorrect\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/extern_stage.cpp
+++ b/test/correctness/extern_stage.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
         uint8_t correct = 4 * i * i;
         if (result(i) != correct) {
             printf("result(%d) = %d instead of %d\n", i, result(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/extern_stage_on_device.cpp
+++ b/test/correctness/extern_stage_on_device.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
                 printf("Something went wrong when "
                        "extern_on_device=%d, sink_on_device=%d \n",
                        extern_on_device, sink_on_device);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/extract_concat_bits.cpp
+++ b/test/correctness/extract_concat_bits.cpp
@@ -56,10 +56,10 @@ int main(int argc, char **argv) {
         if (vectorize) {
             if (counter.extracts > 0) {
                 printf("Saw an unwanted extract_bits call in lowered code\n");
-                return -1;
+                return 1;
             } else if (counter.reinterprets == 0) {
                 printf("Did not see a vector reinterpret in lowered code\n");
-                return -1;
+                return 1;
             }
         }
 
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
             uint8_t correct = (i / 4) >> (8 * (i % 4));
             if (out(i) != correct) {
                 printf("out(%d) = %d instead of %d\n", i, out(i), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -95,10 +95,10 @@ int main(int argc, char **argv) {
 
         if (counter.concats > 0) {
             printf("Saw an unwanted concat_bits call in lowered code\n");
-            return -1;
+            return 1;
         } else if (counter.reinterprets == 0) {
             printf("Did not see a vector reinterpret in lowered code\n");
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < 64; i++) {
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
                 uint8_t result = (out(i) >> (b * 8)) & 0xff;
                 if (result != correct) {
                     printf("out(%d) byte %d = %d instead of %d\n", i, b, result, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/fibonacci.cpp
+++ b/test/correctness/fibonacci.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
         if (i >= 10) {
             if (fib_ref[i] != out(i - 10)) {
                 printf("out(%d) = %d instead of %d\n", i - 10, out(i - 10), fib_ref[i]);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/fit_function.cpp
+++ b/test/correctness/fit_function.cpp
@@ -134,6 +134,6 @@ int main(int argc, char **argv) {
         return 0;
     } else {
         printf("Did not converge\n");
-        return -1;
+        return 1;
     }
 }

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -75,7 +75,7 @@ int run_test() {
     double d = evaluate<double>(g());
     if (d != 0) {
         fprintf(stderr, "Should be zero: %f\n", d);
-        return -1;
+        return 1;
     }
 
     // Check scalar parameters
@@ -87,7 +87,7 @@ int run_test() {
         float result = evaluate<float>(cast<float>(a) + cast<float>(b));
         if (result != 4.25f) {
             fprintf(stderr, "Incorrect result: %f != 4.25f\n", result);
-            return -1;
+            return 1;
         }
     }
 
@@ -100,7 +100,7 @@ int run_test() {
         float16_t result = evaluate<float16_t>(lerp(a, b, c));
         if (float(result) != 24.062500f) {
             fprintf(stderr, "Incorrect result: %f != 24.0625f\n", (float)result);
-            return -1;
+            return 1;
         }
     }
 
@@ -112,7 +112,7 @@ int run_test() {
         bfloat16_t result = evaluate<bfloat16_t>(lerp(a, b, c));
         if (float(result) != 24.5f) {
             fprintf(stderr, "Incorrect result: %f != 24.5f\n", (float)result);
-            return -1;
+            return 1;
         }
     }
 
@@ -133,7 +133,7 @@ int run_test() {
 
             if (!ok) {
                 fprintf(stderr, "Incorrect rounding: %x %x %x\n", a.to_bits(), ab.to_bits(), b.to_bits());
-                return -1;
+                return 1;
             }
         }
     }
@@ -155,7 +155,7 @@ int run_test() {
 
             if (!ok) {
                 fprintf(stderr, "Incorrect rounding: %x %x %x\n", a.to_bits(), ab.to_bits(), b.to_bits());
-                return -1;
+                return 1;
             }
         }
     }
@@ -193,7 +193,7 @@ int run_test() {
                 if (f32 != f16) {
                     fprintf(stderr, "%s outputs do not match: %f %f\n",
                             names[j], f32, f16);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -225,7 +225,7 @@ int run_test() {
                 if (buf(x, y).to_bits() != correct.to_bits()) {
                     fprintf(stderr, "buf(%d, %d) = 0x%x instead of 0x%x\n",
                             x, y, buf(x, y).to_bits(), correct.to_bits());
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -239,7 +239,7 @@ int run_test() {
         Buffer<float16_t> buf = out.realize();
         if (buf(0) != constant) {
             fprintf(stderr, "buf(0) = %f instead of %f\n", float(buf(0)), float(constant));
-            return -1;
+            return 1;
         }
     }
 
@@ -273,7 +273,7 @@ int run_test() {
                                      "float16_t maximum value plus", test_case.first,
                                      float16_t::make_infinity(), max_pos_val,
                                      "positive infinity", "maximum positive value")) {
-                return -1;
+                return 1;
             }
 
             float16_t min_minus_increment(min_neg_val - increment);
@@ -281,7 +281,7 @@ int run_test() {
                                      "float16_t minimum value minus", test_case.first,
                                      float16_t::make_negative_infinity(), min_neg_val,
                                      "negative infinity", "maximum negative value")) {
-                return -1;
+                return 1;
             }
 
             Param<float16_t> a("a"), b("b");
@@ -292,7 +292,7 @@ int run_test() {
                                      "Halide float16_t maximum value plus", test_case.first,
                                      float16_t::make_infinity(), max_pos_val,
                                      "positive infinity", "maximum positive value")) {
-                return -1;
+                return 1;
             }
 
             a.set(min_neg_val);
@@ -301,21 +301,21 @@ int run_test() {
                                      "Halide float16_t minimum value minus", test_case.first,
                                      float16_t::make_negative_infinity(), min_neg_val,
                                      "negative infinity", "maximum negative value")) {
-                return -1;
+                return 1;
             }
 
             float pos_inf = std::numeric_limits<float>::infinity();
             float16_t fp16_pos_inf(pos_inf);
             if (fp16_pos_inf != float16_t::make_infinity()) {
                 fprintf(stderr, "Conversion of 32-bit positive infinity to 16-bit float is %x, not positive infinity.\n", fp16_pos_inf.to_bits());
-                return -1;
+                return 1;
             }
 
             float neg_inf = -std::numeric_limits<float>::infinity();
             float16_t fp16_neg_inf(neg_inf);
             if (fp16_neg_inf != float16_t::make_negative_infinity()) {
                 fprintf(stderr, "Conversion of 32-bit negative infinity to 16-bit float is %x, not negative infinity.\n", fp16_neg_inf.to_bits());
-                return -1;
+                return 1;
             }
 
             Param<float> f_in("f_in");
@@ -323,14 +323,14 @@ int run_test() {
             c = evaluate<float16_t>(cast(Float(16), f_in));
             if (c != float16_t::make_infinity()) {
                 fprintf(stderr, "Halide conversion of 32-bit positive infinity to 16-bit float is %x, not positive infinity.\n", c.to_bits());
-                return -1;
+                return 1;
             }
 
             f_in.set(neg_inf);
             c = evaluate<float16_t>(cast(Float(16), f_in));
             if (c != float16_t::make_negative_infinity()) {
                 fprintf(stderr, "Halide conversion of 32-bit negative infinity to 16-bit float is %x, not negative infinity.\n", c.to_bits());
-                return -1;
+                return 1;
             }
         }
     }
@@ -347,14 +347,14 @@ int main(int argc, char **argv) {
     printf("Testing float16_t...\n");
     if (run_test<float16_t>() != 0) {
         fprintf(stderr, "float16_t test failed!\n");
-        return -1;
+        return 1;
     }
 
     printf("Testing _Float16...\n");
 #ifdef HALIDE_CPP_COMPILER_HAS_FLOAT16
     if (run_test<_Float16>() != 0) {
         fprintf(stderr, "_Float16 test failed!\n");
-        return -1;
+        return 1;
     }
 
 #ifdef __clang__
@@ -363,7 +363,7 @@ int main(int argc, char **argv) {
         _Float16 f2 = (_Float16)f;
         if (f2 != 1.0f16) {
             fprintf(stderr, "Roundtrip of 16-bit float via _Float16 failed.\n");
-            return -1;
+            return 1;
         }
     }
 #else

--- a/test/correctness/float16_t_constants.cpp
+++ b/test/correctness/float16_t_constants.cpp
@@ -155,7 +155,7 @@ int main() {
         const float16_t v(test.val);
         if (v.to_bits() != test.bits) {
             printf("Rounding error: %f -> %u instead of %u\n", test.val, v.to_bits(), test.bits);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/float16_t_image_type.cpp
+++ b/test/correctness/float16_t_image_type.cpp
@@ -41,6 +41,6 @@ int main() {
         printf("Success!\n");
         return 0;
     } else {
-        return -1;
+        return 1;
     }
 }

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -358,7 +358,7 @@ int main(int argc, char **argv) {
     bool success = test.test_all();
 
     if (!success) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/for_each_element.cpp
+++ b/test/correctness/for_each_element.cpp
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
 
     if (scalar_im() != 6) {
         printf("scalar_im() == %d instead of 6\n", scalar_im());
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
 
         if (!errored) {
             printf("There was supposed to be an error\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/func_clone.cpp
+++ b/test/correctness/func_clone.cpp
@@ -27,7 +27,7 @@ int calling_clone_no_op_test() {
             Func temp = f.clone_in(g);
             if (clone.name() != temp.name()) {
                 std::cerr << "Expect " << clone.name() << "; got " << temp.name() << " instead\n";
-                return -1;
+                return 1;
             }
         }
     }
@@ -44,7 +44,7 @@ int calling_clone_no_op_test() {
         Func clone2 = d.clone_in({g, f, e});
         if (clone1.name() != clone2.name()) {
             std::cerr << "Expect " << clone1.name() << "; got " << clone2.name() << " instead\n";
-            return -1;
+            return 1;
         }
     }
 
@@ -69,13 +69,13 @@ int func_clone_test() {
         {clone.name(), {}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) { return x; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -104,7 +104,7 @@ int multiple_funcs_sharing_clone_test() {
         {f.name(), {}},
     };
     if (check_call_graphs(p, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Realization r = p.realize({200, 200});
@@ -113,13 +113,13 @@ int multiple_funcs_sharing_clone_test() {
     Buffer<int> img3 = r[2];
     auto func = [](int x, int y) { return x; };
     if (check_image(img1, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img2, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img3, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -156,7 +156,7 @@ int update_defined_after_clone_test() {
         {clone.name(), {}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = g.realize({200, 200});
@@ -164,7 +164,7 @@ int update_defined_after_clone_test() {
         return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
 
     for (bool param_value : {false, true}) {
@@ -175,7 +175,7 @@ int update_defined_after_clone_test() {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
 
@@ -216,7 +216,7 @@ int clone_depend_on_mutated_func_test() {
         {a_clone_in_b.name(), {}},
     };
     if (check_call_graphs(p, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Realization r = p.realize({25, 25});
@@ -226,15 +226,15 @@ int clone_depend_on_mutated_func_test() {
 
     auto func_d = [](int x, int y) { return x + y + 6; };
     if (check_image(img_d, func_d)) {
-        return -1;
+        return 1;
     }
     auto func_e = [](int x, int y) { return x + y + 2; };
     if (check_image(img_e, func_e)) {
-        return -1;
+        return 1;
     }
     auto func_f = [](int x, int y) { return x + y + 7; };
     if (check_image(img_f, func_f)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -275,7 +275,7 @@ int clone_on_clone_test() {
         {a.name(), {}},
     };
     if (check_call_graphs(p, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Realization r = p.realize({25, 25});
@@ -286,19 +286,19 @@ int clone_on_clone_test() {
 
     auto func_c = [](int x, int y) { return x + y + 3; };
     if (check_image(img_c, func_c)) {
-        return -1;
+        return 1;
     }
     auto func_d = [](int x, int y) { return x + y + 4; };
     if (check_image(img_d, func_d)) {
-        return -1;
+        return 1;
     }
     auto func_e = [](int x, int y) { return 2 * x + 2 * y + 1; };
     if (check_image(img_e, func_e)) {
-        return -1;
+        return 1;
     }
     auto func_f = [](int x, int y) { return 2 * x + 2 * y + 2; };
     if (check_image(img_f, func_f)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -332,37 +332,37 @@ int clone_reduction_test() {
 int main(int argc, char **argv) {
     printf("Running calling clone no op test\n");
     if (calling_clone_no_op_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running func clone test\n");
     if (func_clone_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running multiple funcs sharing clone test\n");
     if (multiple_funcs_sharing_clone_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running update is defined after clone test\n");
     if (update_defined_after_clone_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running clone depend on mutated func test\n");
     if (clone_depend_on_mutated_func_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running clone on clone test\n");
     if (clone_on_clone_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running clone reduction test\n");
     if (clone_reduction_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/func_lifetime.cpp
+++ b/test/correctness/func_lifetime.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
 
         Buffer<int> imf = f.realize({32, 32}, target);
         if (!validate(imf, 1)) {
-            return -1;
+            return 1;
         }
     }
 
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
         Buffer<int> img = g.realize({32, 32}, target);
         if (!validate(img, 2)) {
-            return -1;
+            return 1;
         }
     }
 
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
 
     Buffer<int> imf2 = f.realize({32, 32}, target);
     if (!validate(imf2, 1)) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/func_lifetime_2.cpp
+++ b/test/correctness/func_lifetime_2.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
 
             Buffer<int> imf = f.realize({32, 32}, target);
             if (!validate(imf, 1)) {
-                return -1;
+                return 1;
             }
         }
 
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
         Buffer<int> img1 = g.realize({32, 32}, target);
         if (!validate(img1, 2)) {
-            return -1;
+            return 1;
         }
     }
 
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
 
     Buffer<int> img2 = g.realize({32, 32}, target);
     if (!validate(img2, 2.0f)) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/func_wrapper.cpp
+++ b/test/correctness/func_wrapper.cpp
@@ -28,7 +28,7 @@ int calling_wrapper_no_op_test() {
             Func temp = f.in(g);
             if (wrapper.name() != temp.name()) {
                 std::cerr << "Expect " << wrapper.name() << "; got " << temp.name() << " instead\n";
-                return -1;
+                return 1;
             }
         }
     }
@@ -43,7 +43,7 @@ int calling_wrapper_no_op_test() {
         Func wrapper2 = f.in();
         if (wrapper1.name() != wrapper2.name()) {
             std::cerr << "Expect " << wrapper1.name() << "; got " << wrapper2.name() << " instead\n";
-            return -1;
+            return 1;
         }
     }
 
@@ -59,7 +59,7 @@ int calling_wrapper_no_op_test() {
         Func wrapper2 = d.in({g, f, e});
         if (wrapper1.name() != wrapper2.name()) {
             std::cerr << "Expect " << wrapper1.name() << "; got " << wrapper2.name() << " instead\n";
-            return -1;
+            return 1;
         }
     }
 
@@ -84,13 +84,13 @@ int func_wrapper_test() {
         {f.name(), {}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) { return x; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -119,7 +119,7 @@ int multiple_funcs_sharing_wrapper_test() {
         {f.name(), {}},
     };
     if (check_call_graphs(p, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Realization r = p.realize({200, 200});
@@ -128,13 +128,13 @@ int multiple_funcs_sharing_wrapper_test() {
     Buffer<int> img3 = r[2];
     auto func = [](int x, int y) { return x; };
     if (check_image(img1, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img2, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img3, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -164,13 +164,13 @@ int global_wrapper_test() {
         {f.name(), {}},
     };
     if (check_call_graphs(h, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 2 * (x + y); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -205,7 +205,7 @@ int update_defined_after_wrapper_test() {
         {f.name(), {}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     for (bool param_value : {false, true}) {
@@ -216,7 +216,7 @@ int update_defined_after_wrapper_test() {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
 
@@ -251,13 +251,13 @@ int rdom_wrapper_test() {
         {f.name(), {}},
     };
     if (check_call_graphs(wrapper, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = wrapper.realize({W, H});
     auto func = [](int x, int y) { return 4 * x + 6 * y + 10; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -287,13 +287,13 @@ int global_and_custom_wrapper_test() {
         {f.name(), {}},
     };
     if (check_call_graphs(result, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = result.realize({200, 200});
     auto func = [](int x, int y) { return 2 * x; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -328,13 +328,13 @@ int wrapper_depend_on_mutated_func_test() {
         {e.name(), {}},
     };
     if (check_call_graphs(h, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return x + y; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -368,13 +368,13 @@ int wrapper_on_wrapper_test() {
         {e.name(), {}},
     };
     if (check_call_graphs(h, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 4 * (x + y); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -407,7 +407,7 @@ int wrapper_on_rdom_predicate_test() {
         {h.name(), {}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = g.realize({200, 200});
@@ -415,7 +415,7 @@ int wrapper_on_rdom_predicate_test() {
         return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x + y + 5 < 50)) ? 15 : 10;
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -443,13 +443,13 @@ int two_fold_wrapper_test() {
         {input.name(), {}},
     };
     if (check_call_graphs(output, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = output.realize({1024, 1024});
     auto func = [](int x, int y) { return 3 * x + 2 * y; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -485,7 +485,7 @@ int multi_folds_wrapper_test() {
         {f_in_g_in_g_in_h.name(), {f_in_g_in_g.name()}},
     };
     if (check_call_graphs(p, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Realization r = p.realize({1024, 1024});
@@ -493,10 +493,10 @@ int multi_folds_wrapper_test() {
     Buffer<int> img_h = r[1];
     auto func = [](int x, int y) { return 3 * x + 2 * y; };
     if (check_image(img_g, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img_h, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -541,67 +541,67 @@ int lots_of_wrappers_test() {
 int main(int argc, char **argv) {
     printf("Running calling wrap no op test\n");
     if (calling_wrapper_no_op_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running func wrap test\n");
     if (func_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running multiple funcs sharing wrapper test\n");
     if (multiple_funcs_sharing_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running global wrap test\n");
     if (global_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running update is defined after wrap test\n");
     if (update_defined_after_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running rdom wrapper test\n");
     if (rdom_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running global + custom wrapper test\n");
     if (global_and_custom_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running wrapper depend on mutated func test\n");
     if (wrapper_depend_on_mutated_func_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running wrapper on wrapper test\n");
     if (wrapper_on_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running wrapper on rdom predicate test\n");
     if (wrapper_on_rdom_predicate_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running two fold wrapper test\n");
     if (two_fold_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running multi folds wrapper test\n");
     if (multi_folds_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running lots of wrappers test\n");
     if (lots_of_wrappers_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/fuse.cpp
+++ b/test/correctness/fuse.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         int err = evaluate_may_gpu<uint32_t>(error());
         if (err != 0) {
             printf("Fusion caused a difference in the output\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/fuzz_bounds.cpp
+++ b/test/correctness/fuzz_bounds.cpp
@@ -506,7 +506,7 @@ int main(int argc, char **argv) {
         // Generate a random expr...
         Expr test = random_expr(expr_type, depth);
         if (!test_expression_bounds(test, trials, samples)) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/fuzz_cse.cpp
+++ b/test/correctness/fuzz_cse.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
             std::cerr << "Mismatch with seed " << fuzz_seed << "\n"
                       << "Original: " << orig << "\n"
                       << "CSE: " << csed << "\n";
-            return -1;
+            return 1;
         }
         fuzz_seed = rng();
     }

--- a/test/correctness/fuzz_float_stores.cpp
+++ b/test/correctness/fuzz_float_stores.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
             // the sort of thing FuzzFloatStores is trying to discourage.
             if (im_ref(i) != im_fuzzed(i)) {
                 printf("Expected exact floating point equality between %10.10g and %10.10g\n", im_ref(i), im_fuzzed(i));
-                return -1;
+                return 1;
             }
         }
     }
@@ -49,12 +49,12 @@ int main(int argc, char **argv) {
 
         if (differences == 0) {
             printf("fuzzing float stores should have done something\n");
-            return -1;
+            return 1;
         }
 
         if (differences == size) {
             printf("fuzzing float stores should not have changed every store\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/fuzz_simplify.cpp
+++ b/test/correctness/fuzz_simplify.cpp
@@ -355,7 +355,7 @@ int main(int argc, char **argv) {
         // Generate a random expr...
         Expr test = random_expr(VT, depth);
         if (!test_expression(test, samples)) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/gameoflife.cpp
+++ b/test/correctness/gameoflife.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
                     if (board1(x, y) != board2(x, y)) {
                         printf("At timestep %d, boards one and two disagree at %d, %d: %d vs %d\n",
                                i, x, y, board1(x, y), board2(x, y));
-                        return -1;
+                        return 1;
                     }
                 }
             }
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
                 if (board1(x, y) != board3(x, y)) {
                     printf("Boards one and three disagree at %d, %d: %d vs %d\n",
                            x, y, board1(x, y), board3(x, y));
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/gpu_arg_types.cpp
+++ b/test/correctness/gpu_arg_types.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
         if (out(i) != out2(i)) {
             printf("Incorrect result at %d: %d != %d\n", i, out(i), out2(i));
             printf("Failed\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/gpu_assertion_in_kernel.cpp
+++ b/test/correctness/gpu_assertion_in_kernel.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     g.realize({3, 100}, t);
     if (errored) {
         printf("There was not supposed to be an error\n");
-        return -1;
+        return 1;
     }
 
     // Should trap
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
 
     if (!errored) {
         printf("There was supposed to be an error\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/gpu_cpu_simultaneous_read.cpp
+++ b/test/correctness/gpu_cpu_simultaneous_read.cpp
@@ -43,12 +43,12 @@ int main() {
             if (result1(x, y) != c1) {
                 printf("result1(%d, %d) = %d instead of %d\n",
                        x, y, result1(x, y), c1);
-                return -1;
+                return 1;
             }
             if (result2(x, y) != c2) {
                 printf("result2(%d, %d) = %d instead of %d\n",
                        x, y, result2(x, y), c2);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/gpu_data_flows.cpp
+++ b/test/correctness/gpu_data_flows.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
             int correct = (input(x) + 1) * 2 + 3;
             if (output1(x) != correct) {
                 printf("output1(%d) = %d instead of %d\n", x, output1(x), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -84,7 +84,7 @@ int main(int argc, char **argv) {
             int correct = (input(x) + 1) * 2;
             if (output2(x) != correct) {
                 printf("output2(%d) = %d instead of %d\n", x, output2(x), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/gpu_dynamic_shared.cpp
+++ b/test/correctness/gpu_dynamic_shared.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
                 if (out(x) != correct) {
                     printf("out[%d|%d](%d) = %d instead of %d\n",
                            per_thread, (int)memory_type, x, out(x), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/gpu_large_alloc.cpp
+++ b/test/correctness/gpu_large_alloc.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
             const int expected = std::min(std::max(m, 20), 100);
             if (img(i, j) != expected) {
                 printf("img[%d, %d] = %d\n", i, j, img(i, j));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/gpu_mixed_dimensionality.cpp
+++ b/test/correctness/gpu_mixed_dimensionality.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
                 if (o(x, y, z) != correct) {
                     printf("out(%d, %d, %d) = %d instead of %d\n",
                            x, y, z, o(x, y, z), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/gpu_mixed_shared_mem_types.cpp
+++ b/test/correctness/gpu_mixed_shared_mem_types.cpp
@@ -10,7 +10,7 @@ int check_result(Buffer<T> output, int n_types, int offset) {
         if (output(x) != correct) {
             printf("output(%d) = %d instead of %d\n",
                    (unsigned int)x, (unsigned int)output(x), (unsigned int)correct);
-            return -1;
+            return 1;
         }
     }
     return 0;

--- a/test/correctness/gpu_multi_device.cpp
+++ b/test/correctness/gpu_multi_device.cpp
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
         pipe1.run(output1);
 
         if (!pipe1.verify(output1, pipe1.current_stage - 1, "const input")) {
-            return -1;
+            return 1;
         }
     }
 
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
         pipe2.run(output2);
 
         if (!pipe2.verify(output2, pipe2.current_stage - 1, "chained buffers intermediate")) {
-            return -1;
+            return 1;
         }
 
         Buffer<float> output3(100, 100, 3);
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
         pipe3.run(output3);
 
         if (!pipe3.verify(output3, pipe2.current_stage + pipe3.current_stage - 2, "chained buffers")) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/gpu_non_contiguous_copy.cpp
+++ b/test/correctness/gpu_non_contiguous_copy.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
                     }
                     if (full(x, y, z, w) != correct) {
                         printf("Error! Incorrect value %i != %i at %i, %i, %i, %i\n", full(x, y, z, w), correct, x, y, z, w);
-                        return -1;
+                        return 1;
                     }
                 }
             }

--- a/test/correctness/gpu_object_lifetime_1.cpp
+++ b/test/correctness/gpu_object_lifetime_1.cpp
@@ -49,7 +49,8 @@ int main(int argc, char *argv[]) {
 
     int ret = tracker.validate_gpu_object_lifetime(true /* allow_globals */, true /* allow_none */, 1 /* max_globals */);
     if (ret != 0) {
-        return ret;
+        fprintf(stderr, "validate_gpu_object_lifetime() failed\n");
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/gpu_object_lifetime_1.cpp
+++ b/test/correctness/gpu_object_lifetime_1.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
         for (int i = 0; i < 256; i++) {
             if (result(i) != i) {
                 std::cout << "Error! " << result(i) << " != " << i << "\n";
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/gpu_object_lifetime_2.cpp
+++ b/test/correctness/gpu_object_lifetime_2.cpp
@@ -49,7 +49,8 @@ int main(int argc, char *argv[]) {
 
     int ret = tracker.validate_gpu_object_lifetime(true /* allow_globals */, true /* allow_none */, 1 /* max_globals */);
     if (ret != 0) {
-        return ret;
+        fprintf(stderr, "validate_gpu_object_lifetime() failed\n");
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/gpu_object_lifetime_3.cpp
+++ b/test/correctness/gpu_object_lifetime_3.cpp
@@ -58,7 +58,8 @@ int main(int argc, char *argv[]) {
 
     int ret = tracker.validate_gpu_object_lifetime(true /* allow_globals */, true /* allow_none */, 1 /* max_globals */);
     if (ret != 0) {
-        return ret;
+        fprintf(stderr, "validate_gpu_object_lifetime() failed\n");
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/gpu_reuse_shared_memory.cpp
+++ b/test/correctness/gpu_reuse_shared_memory.cpp
@@ -34,7 +34,7 @@ int multi_thread_type_test(MemoryType memory_type) {
                 if (out(x, y, z) != correct) {
                     printf("out(%d, %d, %d) = %d instead of %d\n",
                            x, y, z, out(x, y, z), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -77,7 +77,7 @@ int pyramid_test(MemoryType memory_type) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -126,7 +126,7 @@ int inverted_pyramid_test(MemoryType memory_type) {
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -157,7 +157,7 @@ int dynamic_shared_test(MemoryType memory_type) {
         if (out(x) != correct) {
             printf("out(%d) = %d instead of %d\n",
                    x, out(x), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -175,17 +175,17 @@ int main(int argc, char **argv) {
     for (auto memory_type : {MemoryType::GPUShared, MemoryType::Heap}) {
         printf("Running multi thread type test\n");
         if (multi_thread_type_test(memory_type) != 0) {
-            return -1;
+            return 1;
         }
 
         printf("Running pyramid test\n");
         if (pyramid_test(memory_type) != 0) {
-            return -1;
+            return 1;
         }
 
         printf("Running inverted pyramid test\n");
         if (inverted_pyramid_test(memory_type) != 0) {
-            return -1;
+            return 1;
         }
 
         printf("Running dynamic shared test\n");
@@ -193,7 +193,7 @@ int main(int argc, char **argv) {
             printf("Skipping test because GL doesn't support dynamic sizes for shared memory\n");
         } else {
             if (dynamic_shared_test(memory_type) != 0) {
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/gpu_specialize.cpp
+++ b/test/correctness/gpu_specialize.cpp
@@ -57,12 +57,12 @@ int main(int argc, char **argv) {
                 if (out1(x, y) != correct) {
                     printf("out1(%d, %d) = %d instead of %d\n",
                            x, y, out1(x, y), correct);
-                    return -1;
+                    return 1;
                 }
                 if (out2(x, y) != correct) {
                     printf("out2(%d, %d) = %d instead of %d\n",
                            x, y, out2(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
                 if (out(x, y) != correct) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, out(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/gpu_store_in_register_with_no_lanes_loop.cpp
+++ b/test/correctness/gpu_store_in_register_with_no_lanes_loop.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
             if (result(x, y) != correct) {
                 printf("result(%d, %d) = %d instead of %d\n",
                        x, y, result(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/gpu_sum_scan.cpp
+++ b/test/correctness/gpu_sum_scan.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
         if (output(i) != correct) {
             printf("output(%d) = %d instead of %d\n",
                    i, output(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/gpu_texture.cpp
+++ b/test/correctness/gpu_texture.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
                 int correct = 2 * x + 10;
                 if (out(x) != correct) {
                     printf("out[1D][%d](%d) = %d instead of %d\n", (int)memory_type, x, out(x), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
                 int correct = 3 * x + 10;
                 if (out(x) != correct) {
                     printf("out[2D][%d](%d) = %d instead of %d\n", (int)memory_type, x, out(x), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
                 int correct = 4 * x + 10;
                 if (out(x) != correct) {
                     printf("out[3D][%d](%d) = %d instead of %d\n", (int)memory_type, x, out(x), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -141,7 +141,7 @@ int main(int argc, char **argv) {
                 int correct = 2 * x + 10;
                 if (out(x) != correct) {
                     printf("out[1D-shift][%d](%d) = %d instead of %d\n", (int)memory_type, x, out(x), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/gpu_thread_barrier.cpp
+++ b/test/correctness/gpu_thread_barrier.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
                 if (out(x, y) != correct) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, out(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/gpu_transpose.cpp
+++ b/test/correctness/gpu_transpose.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
             if (output(x, y) != correct) {
                 printf("output(%d, %d) = %d instead of %d\n",
                        x, y, output(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/gpu_vectorize.cpp
+++ b/test/correctness/gpu_vectorize.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
                 float correct = i * j + 2.4f;
                 if (fabs(imf(i, j) - correct) > 0.001f) {
                     printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
                 float correct = i * j + 2.4f + i + j;
                 if (fabs(imf(i, j) - correct) > 0.001f) {
                     printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
                 float correct = (i + j > 32 ? 1.0f : -1.0f) + i + j;
                 if (fabs(imf(i, j) - correct) > 0.001f) {
                     printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/gpu_vectorized_shared_memory.cpp
+++ b/test/correctness/gpu_vectorized_shared_memory.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
             if (out(x) != correct) {
                 printf("out(%d) = %d instead of %d\n",
                        x, out(x), correct);
-                return -1;
+                return 1;
             }
         }
 

--- a/test/correctness/half_native_interleave.cpp
+++ b/test/correctness/half_native_interleave.cpp
@@ -49,15 +49,15 @@ int main(int argc, char **argv) {
 
         if (out_p(x) != correct_p) {
             std::cout << "out_p(" << x << ") = " << out_p(x) << " instead of " << correct_p << "\n";
-            return -1;
+            return 1;
         }
         if (out_s(x) != correct_s) {
             std::cout << "out_s(" << x << ") = " << out_s(x) << " instead of " << correct_s << "\n";
-            return -1;
+            return 1;
         }
         if (out_d(x) != correct_d) {
             std::cout << "out_d(" << x << ") = " << out_d(x) << " instead of " << correct_d << "\n";
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -237,7 +237,7 @@ int main(int argc, char **argv) {
 
         if (counter != W * H * C) {
             printf("for_each_value didn't hit every element\n");
-            return -1;
+            return 1;
         }
 
         a.for_each_element([&](int x, int y, int c) {

--- a/test/correctness/handle.cpp
+++ b/test/correctness/handle.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
         if (result != correct) {
             printf("strlen(%s) -> %d instead of %d\n",
                    c_message, result, correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -62,18 +62,18 @@ int main(int argc, char **argv) {
         // As another sanity check, the internal pointer to the string constant should be aligned.
         if (handle & 0x3) {
             printf("Got handle: %llx. A handle should be aligned to at least four bytes\n", (long long)handle);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < im.width(); i++) {
             if (im(i) != im(0)) {
                 printf("im(%d) = %p instead of %p\n",
                        i, im(i), im(0));
-                return -1;
+                return 1;
             }
             if (std::string(im(i)) != msg) {
                 printf("Handle was %s instead of %s\n", im(i), msg.c_str());
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/hello_gpu.cpp
+++ b/test/correctness/hello_gpu.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
             float correct = i * j + 2.4f;
             if (fabs(imf(i, j) - correct) > 0.001f) {
                 printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/histogram_equalize.cpp
+++ b/test/correctness/histogram_equalize.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
         int correct = (in.width() * in.height()) / 16;
         if (out_hist[i] < correct / 2 || out_hist[i] > 2 * correct) {
             printf("Expected histogram entries of ~ %d\n", correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/hoist_loop_invariant_if_statements.cpp
+++ b/test/correctness/hoist_loop_invariant_if_statements.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
 
     if (checker.if_in_loop) {
         printf("Found an if statement inside a loop. This was not supposed to happen\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/host_alignment.cpp
+++ b/test/correctness/host_alignment.cpp
@@ -121,7 +121,7 @@ int test() {
     int cnt = count_host_alignment_asserts(f, m);
     if (cnt != 3) {
         printf("Error: expected 3 host alignment assertions in code, but got %d\n", cnt);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/image_of_lists.cpp
+++ b/test/correctness/image_of_lists.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
             int factor = *iter;
             if (i % factor) {
                 printf("Error: %d is not a factor of %d\n", factor, i);
-                return -1;
+                return 1;
             }
             // printf("%d ", factor);
         }

--- a/test/correctness/image_wrapper.cpp
+++ b/test/correctness/image_wrapper.cpp
@@ -27,7 +27,7 @@ int calling_wrapper_no_op_test() {
             Func temp = img.in(f);
             if (wrapper.name() != temp.name()) {
                 std::cerr << "Expect " << wrapper.name() << "; got " << temp.name() << " instead\n";
-                return -1;
+                return 1;
             }
         }
     }
@@ -42,7 +42,7 @@ int calling_wrapper_no_op_test() {
         Func wrapper2 = img.in();
         if (wrapper1.name() != wrapper2.name()) {
             std::cerr << "Expect " << wrapper1.name() << "; got " << wrapper2.name() << " instead\n";
-            return -1;
+            return 1;
         }
     }
 
@@ -58,7 +58,7 @@ int calling_wrapper_no_op_test() {
         Func wrapper2 = img.in({g, f, e});
         if (wrapper1.name() != wrapper2.name()) {
             std::cerr << "Expect " << wrapper1.name() << "; got " << wrapper2.name() << " instead\n";
-            return -1;
+            return 1;
         }
     }
 
@@ -88,13 +88,13 @@ int func_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = g.realize({200, 200});
     auto func = [](int x, int y) { return x; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -128,7 +128,7 @@ int multiple_funcs_sharing_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(p, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Realization r = p.realize({200, 200});
@@ -137,13 +137,13 @@ int multiple_funcs_sharing_wrapper_test() {
     Buffer<int> img3 = r[2];
     auto func = [](int x, int y) { return x; };
     if (check_image(img1, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img2, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img3, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -178,13 +178,13 @@ int global_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(h, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 2 * (x + y); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -227,7 +227,7 @@ int update_defined_after_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     for (bool param_value : {false, true}) {
@@ -238,7 +238,7 @@ int update_defined_after_wrapper_test() {
             return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x < y)) ? 3 * (x + y) : (x + y);
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
 
@@ -278,13 +278,13 @@ int rdom_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(wrapper, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = wrapper.realize({W, H});
     auto func = [](int x, int y) { return 4 * x + 6 * y + 10; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -318,13 +318,13 @@ int global_and_custom_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(result, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = result.realize({200, 200});
     auto func = [](int x, int y) { return 2 * x; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -364,13 +364,13 @@ int wrapper_depend_on_mutated_func_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(h, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return x + y; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -406,13 +406,13 @@ int wrapper_on_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(h, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = h.realize({200, 200});
     auto func = [](int x, int y) { return 4 * (x + y); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -451,7 +451,7 @@ int wrapper_on_rdom_predicate_test() {
         {h.name(), {}},
     };
     if (check_call_graphs(g, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = g.realize({200, 200});
@@ -459,7 +459,7 @@ int wrapper_on_rdom_predicate_test() {
         return ((0 <= x && x <= 99) && (0 <= y && y <= 99) && (x + y + 5 < 50)) ? 15 : 10;
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -492,13 +492,13 @@ int two_fold_wrapper_test() {
         {img_f.name(), {img.name()}},
     };
     if (check_call_graphs(output, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Buffer<int> im = output.realize({1024, 1024});
     auto func = [](int x, int y) { return 3 * x + 2 * y; };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -539,7 +539,7 @@ int multi_folds_wrapper_test() {
         {img_in_g_in_g_in_h.name(), {img_in_g_in_g.name()}},
     };
     if (check_call_graphs(p, expected) != 0) {
-        return -1;
+        return 1;
     }
 
     Realization r = p.realize({1024, 1024});
@@ -547,10 +547,10 @@ int multi_folds_wrapper_test() {
     Buffer<int> img_h = r[1];
     auto func = [](int x, int y) { return 3 * x + 2 * y; };
     if (check_image(img_g, func)) {
-        return -1;
+        return 1;
     }
     if (check_image(img_h, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -560,62 +560,62 @@ int multi_folds_wrapper_test() {
 int main(int argc, char **argv) {
     printf("Running calling wrap no op test\n");
     if (calling_wrapper_no_op_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running func wrap test\n");
     if (func_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running multiple funcs sharing wrapper test\n");
     if (multiple_funcs_sharing_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running global wrap test\n");
     if (global_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running update is defined after wrap test\n");
     if (update_defined_after_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running rdom wrapper test\n");
     if (rdom_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running global + custom wrapper test\n");
     if (global_and_custom_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running wrapper depend on mutated func test\n");
     if (wrapper_depend_on_mutated_func_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running wrapper on wrapper test\n");
     if (wrapper_on_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running wrapper on rdom predicate test\n");
     if (wrapper_on_rdom_predicate_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running two fold wrapper test\n");
     if (two_fold_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running multi folds wrapper test\n");
     if (multi_folds_wrapper_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/implicit_args.cpp
+++ b/test/correctness/implicit_args.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
                     if (result1(x, i, j, k) != correct) {
                         printf("result1(%d, %d, %d, %d) = %d instead of %d\n",
                                x, i, j, k, result1(x, i, j, k), correct);
-                        return -1;
+                        return 1;
                     }
                 }
             }
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
             if (result2(i, j) != correct) {
                 printf("result2(%d, %d) = %d instead of %d\n",
                        i, j, result2(i, j), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
                     if (transposed(i, j, k, l) != correct) {
                         printf("transposed(%d, %d, %d, %d) = %d instead of %d\n",
                                i, j, k, l, transposed(i, j, k, l), correct);
-                        return -1;
+                        return 1;
                     }
                 }
             }
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
                     if (hairy_transposed(i, j, k, l) != correct) {
                         printf("hairy_transposed(%d, %d, %d, %d) = %d instead of %d\n",
                                i, j, k, l, hairy_transposed(i, j, k, l), correct);
-                        return -1;
+                        return 1;
                     }
                 }
             }
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
                     if (hairy_transposed2(i, j, k, l) != correct) {
                         printf("hairy_transposed2(%d, %d, %d, %d) = %d instead of %d\n",
                                i, j, k, l, hairy_transposed2(i, j, k, l), correct);
-                        return -1;
+                        return 1;
                     }
                 }
             }

--- a/test/correctness/implicit_args_tests.cpp
+++ b/test/correctness/implicit_args_tests.cpp
@@ -17,7 +17,7 @@ int check_image(const Realization &r, const std::vector<FuncChecker> &funcs) {
                     if (im(x, y, z) != correct) {
                         printf("im(%d, %d, %d) = %d instead of %d\n",
                                x, y, z, im(x, y, z), correct);
-                        return -1;
+                        return 1;
                     }
                 }
             }
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
             return y + z + 2;
         };
         if (check_image(result, {func})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
             return (x == 0) || (x == 1) ? y + z + 3 : y + z + 1;
         };
         if (check_image(result, {func})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
             return (y + z + 3) + (y + z) * (y + 2);
         };
         if (check_image(result, {func})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
             return y + z + 2;
         };
         if (check_image(result, {func})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
             return (x + y) * (x + 2) + 3;
         };
         if (check_image(result, {func})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
             return x + 2;
         };
         if (check_image(result, {func1, func2})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
             return (x == 0) || (x == 1) ? y + z + 3 : y + z + 1;
         };
         if (check_image(result, {func})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
             return (y + z) * 3;
         };
         if (check_image(result, {func1, func2})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -229,7 +229,7 @@ int main(int argc, char **argv) {
             return (y - z + 4) + (y - z) * (y - 2);
         };
         if (check_image(result, {func1, func2})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -256,7 +256,7 @@ int main(int argc, char **argv) {
             return (x - y) * (x - 2) + 4;
         };
         if (check_image(result, {func1, func2})) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/in_place.cpp
+++ b/test/correctness/in_place.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
 
     if (err > 0.0001f) {
         printf("Failed\n");
-        return -1;
+        return 1;
     }
 
     // Undef on one side of a select doesn't destroy the entire
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
         }
         if (fabs(data(x) - correct) > 0.001) {
             printf("data(%d) = %f instead of %f\n", x, data(x), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/infer_arguments.cpp
+++ b/test/correctness/infer_arguments.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
 #define EXPECT(expect, actual)                                                                                     \
     if (expect != actual) {                                                                                        \
         std::cout << "Failure, expected " << #expect << " for " << #actual << ", got " << actual << " instead.\n"; \
-        return -1;                                                                                                 \
+        return 1;                                                                                                  \
     }
 
     {

--- a/test/correctness/inline_reduction.cpp
+++ b/test/correctness/inline_reduction.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
             float delta = correct - r;
             if (delta < -0.001 || delta > 0.001) {
                 printf("result(%d, %d) was %f instead of %f\n", x, y, r, correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -89,25 +89,25 @@ int main(int argc, char **argv) {
             delta = (correct_prod + 10) / (prod_im(x, y) + 10);
             if (delta < 0.99 || delta > 1.01) {
                 printf("prod_im(%d, %d) = %f instead of %f\n", x, y, prod_im(x, y), correct_prod);
-                return -1;
+                return 1;
             }
 
             delta = correct_min - min_im(x, y);
             if (delta < -0.001 || delta > 0.001) {
                 printf("min_im(%d, %d) = %f instead of %f\n", x, y, min_im(x, y), correct_min);
-                return -1;
+                return 1;
             }
 
             delta = correct_min - min_im_separable(x, y);
             if (delta < -0.001 || delta > 0.001) {
                 printf("min_im(%d, %d) = %f instead of %f\n", x, y, min_im_separable(x, y), correct_min);
-                return -1;
+                return 1;
             }
 
             delta = correct_max - max_im(x, y);
             if (delta < -0.001 || delta > 0.001) {
                 printf("max_im(%d, %d) = %f instead of %f\n", x, y, max_im(x, y), correct_max);
-                return -1;
+                return 1;
             }
         }
     }
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
         args[0].name() != Var(_0).name() ||
         args[1].name() != Var(_1).name()) {
         printf("sum_implicit_inner has the wrong args\n");
-        return -1;
+        return 1;
     }
 
     Func product_implicit;
@@ -155,13 +155,13 @@ int main(int argc, char **argv) {
     float result_f32 = evaluate<float>(minimum(RDom(0, 11) * -0.5f));
     if (result_f32 != -5.0f) {
         printf("minimum is %f instead of -5.0f\n", result_f32);
-        return -1;
+        return 1;
     }
 
     double result_f64 = evaluate<double>(minimum(RDom(0, 11) * cast<double>(-0.5f)));
     if (result_f64 != -5.0) {
         printf("minimum is %f instead of -5.0\n", result_f64);
-        return -1;
+        return 1;
     }
 
     // Check that min of a bunch of infinities is infinity.
@@ -172,22 +172,22 @@ int main(int argc, char **argv) {
     result_f32 = evaluate<float>(minimum(strict_float(RDom(1, 10) * inf_f32)));
     if (result_f32 != inf_f32) {
         printf("minimum is %f instead of infinity\n", result_f32);
-        return -1;
+        return 1;
     }
     result_f64 = evaluate<double>(minimum(strict_float(RDom(1, 10) * Expr(inf_f64))));
     if (result_f64 != inf_f64) {
         printf("minimum is %f instead of infinity\n", result_f64);
-        return -1;
+        return 1;
     }
     result_f32 = evaluate<float>(maximum(strict_float(RDom(1, 10) * -inf_f32)));
     if (result_f32 != -inf_f32) {
         printf("maximum is %f instead of -infinity\n", result_f32);
-        return -1;
+        return 1;
     }
     result_f64 = evaluate<double>(maximum(strict_float(RDom(1, 10) * Expr(-inf_f64))));
     if (result_f64 != -inf_f64) {
         printf("maximum is %f instead of -infinity\n", result_f64);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/integer_powers.cpp
+++ b/test/correctness/integer_powers.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
 
         if (error_1(0) > 0.0001 || error_2(0) > 0.0001) {
             printf("Approximate sin errors too large: %1.20f %1.20f\n", error_1(0), error_2(0));
-            return -1;
+            return 1;
         }
     }
 
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
 
         if (error_1(0) > 0.0001 || error_2(0) > 0.0001) {
             printf("Approximate exp errors too large: %1.20f %1.20f\n", error_1(0), error_2(0));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/interleave.cpp
+++ b/test/correctness/interleave.cpp
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
                 float delta = result(x) - correct;
                 if (delta > 0.01 || delta < -0.01) {
                     printf("result(%d) = %f instead of %f\n", x, result(x), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
                 float delta = buff3(x, y) - correct;
                 if (delta > 0.01 || delta < -0.01) {
                     printf("result(%d) = %f instead of %f\n", x, buff3(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
                 float delta = buff4(x, y) - correct;
                 if (delta > 0.01 || delta < -0.01) {
                     printf("result(%d) = %f instead of %f\n", x, buff4(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -252,7 +252,7 @@ int main(int argc, char **argv) {
                 float delta = buff5(x, y) - correct;
                 if (delta > 0.01 || delta < -0.01) {
                     printf("result(%d) = %f instead of %f\n", x, buff5(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -342,7 +342,7 @@ int main(int argc, char **argv) {
                             if (out(x, y) != ref(x, y)) {
                                 printf("result(%d, %d) = %d instead of %d\n",
                                        x, y, out(x, y), ref(x, y));
-                                return -1;
+                                return 1;
                             }
                         }
                     }
@@ -393,7 +393,7 @@ int main(int argc, char **argv) {
                     int correct = 5 * y + x;
                     if (result7(x, y) != correct) {
                         printf("result(%d) = %d instead of %d\n", x, result7(x, y), correct);
-                        return -1;
+                        return 1;
                     }
                 }
             }

--- a/test/correctness/interleave_rgb.cpp
+++ b/test/correctness/interleave_rgb.cpp
@@ -104,13 +104,13 @@ bool test_deinterleave(int x_stride) {
 
 int main(int argc, char **argv) {
     for (int x_stride : {3, 4}) {
-        if (!test_interleave<uint8_t>(x_stride)) return -1;
-        if (!test_interleave<uint16_t>(x_stride)) return -1;
-        if (!test_interleave<uint32_t>(x_stride)) return -1;
+        if (!test_interleave<uint8_t>(x_stride)) return 1;
+        if (!test_interleave<uint16_t>(x_stride)) return 1;
+        if (!test_interleave<uint32_t>(x_stride)) return 1;
 
-        if (!test_deinterleave<uint8_t>(x_stride)) return -1;
-        if (!test_deinterleave<uint16_t>(x_stride)) return -1;
-        if (!test_deinterleave<uint32_t>(x_stride)) return -1;
+        if (!test_deinterleave<uint8_t>(x_stride)) return 1;
+        if (!test_deinterleave<uint16_t>(x_stride)) return 1;
+        if (!test_deinterleave<uint32_t>(x_stride)) return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/interleave_x.cpp
+++ b/test/correctness/interleave_x.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
             uint16_t correct = x % 2 == 0 ? 3 : 7;
             if (out(x, y) != correct) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/interpreter.cpp
+++ b/test/correctness/interpreter.cpp
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
                 uint8_t correct = (uint8_t)(((int)in_buf(x + 1, y) - in_buf(x - 1, y)) >> 1);
                 if (out_buf(x, y) != correct) {
                     printf("out_buf(%d, %d) = %d instead of %d\n", x, y, out_buf(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -183,7 +183,7 @@ int main(int argc, char **argv) {
                 uint8_t correct = (uint8_t)((int)std::floor(std::sqrt(a * a + b * b)));
                 if (out_buf(x, y) != correct) {
                     printf("out_buf(%d, %d) = %d instead of %d\n", x, y, out_buf(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/isnan.cpp
+++ b/test/correctness/isnan.cpp
@@ -17,12 +17,12 @@ int check_nans(const Buffer<float> &im) {
             if ((x - y) < 0) {
                 if (im(x, y) != 0.0f) {
                     printf("undetected Nan for sqrt(%d - %d)\n", x, y);
-                    return -1;
+                    return 1;
                 }
             } else {
                 if (im(x, y) != 1.0f) {
                     printf("unexpected Nan for sqrt(%d - %d)\n", x, y);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -37,12 +37,12 @@ int check_infs(const Buffer<float> &im) {
             if (std::isinf(e)) {
                 if (im(x, y) != 1.0f) {
                     printf("undetected Inf for (%d-%d)/(%d-%d) -> %f\n", x, w / 2, y, h / 2, e);
-                    return -1;
+                    return 1;
                 }
             } else {
                 if (im(x, y) != 0.0f) {
                     printf("unexpected Inf for (%d-%d)/(%d-%d) -> %f\n", x, w / 2, y, h / 2, e);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -57,12 +57,12 @@ int check_finites(const Buffer<float> &im) {
             if (std::isfinite(e)) {
                 if (im(x, y) != 1.0f) {
                     printf("undetected finite for (%d-%d)/(%d-%d) -> %f\n", x, w / 2, y, h / 2, e);
-                    return -1;
+                    return 1;
                 }
             } else {
                 if (im(x, y) != 0.0f) {
                     printf("unexpected finite for (%d-%d)/(%d-%d) -> %f\n", x, w / 2, y, h / 2, e);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
 
         Buffer<float> im = f.realize({w, h});
         if (check_nans(im) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         in.set(non_halide_produced);
         Buffer<float> im = f.realize({w, h});
         if (check_nans(im) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
 
         Buffer<float> im = f.realize({w, h});
         if (check_infs(im) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
         in.set(non_halide_produced);
         Buffer<float> im = f.realize({w, h});
         if (check_infs(im) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
 
         Buffer<float> im = f.realize({w, h});
         if (check_finites(im) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -184,7 +184,7 @@ int main(int argc, char **argv) {
         in.set(non_halide_produced);
         Buffer<float> im = f.realize({w, h});
         if (check_finites(im) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
 
             Buffer<float> im = f.realize({w, h});
             if (check_nans(im) != 0) {
-                return -1;
+                return 1;
             }
         }
 
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
             in.set(non_halide_produced);
             Buffer<float> im = f.realize({w, h});
             if (check_nans(im) != 0) {
-                return -1;
+                return 1;
             }
         }
 
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
 
             Buffer<float> im = f.realize({w, h});
             if (check_infs(im) != 0) {
-                return -1;
+                return 1;
             }
         }
 
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
             in.set(non_halide_produced);
             Buffer<float> im = f.realize({w, h});
             if (check_infs(im) != 0) {
-                return -1;
+                return 1;
             }
         }
 
@@ -284,7 +284,7 @@ int main(int argc, char **argv) {
 
             Buffer<float> im = f.realize({w, h});
             if (check_finites(im) != 0) {
-                return -1;
+                return 1;
             }
         }
 
@@ -308,7 +308,7 @@ int main(int argc, char **argv) {
             in.set(non_halide_produced);
             Buffer<float> im = f.realize({w, h});
             if (check_finites(im) != 0) {
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/iterate_over_circle.cpp
+++ b/test/correctness/iterate_over_circle.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
                "within the circle x*x + y*y < 10*10. It was loaded %d "
                "times, but there are %d points within that circle\n",
                count, c);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/lambda.cpp
+++ b/test/correctness/lambda.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
             int correct = x + y;
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
                 int correct = x + y * y + z * z * z;
                 if (im2(x, y, z) != correct) {
                     printf("im2(%d, %d, %d) = %d instead of %d\n", x, y, z, im2(x, y, z), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/lazy_convolution.cpp
+++ b/test/correctness/lazy_convolution.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     // places, it should be smaller; roughly 100*100*20*20*0.5.
     if (call_count > 2100000) {
         printf("Expected call_count ~= 2000000. Instead it's %d\n", call_count);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/leak_device_memory.cpp
+++ b/test/correctness/leak_device_memory.cpp
@@ -67,6 +67,7 @@ int main(int argc, char **argv) {
         if (tracker.validate_gpu_object_lifetime(true /* allow_globals */,
                                                  true /* allow_none */,
                                                  1 /* max_globals */)) {
+            fprintf(stderr, "validate_gpu_object_lifetime() failed\n");
             return 1;
         }
     }

--- a/test/correctness/leak_device_memory.cpp
+++ b/test/correctness/leak_device_memory.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
         if (tracker.validate_gpu_object_lifetime(true /* allow_globals */,
                                                  true /* allow_none */,
                                                  1 /* max_globals */)) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/left_shift_negative.cpp
+++ b/test/correctness/left_shift_negative.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
         if (im1(i) != im2(i)) {
             printf("im1(%d) = %d, im2(%d) = %d\n",
                    i, im1(i), i, im2(i));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/legal_race_condition.cpp
+++ b/test/correctness/legal_race_condition.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
             if (out(i) != correct) {
                 printf("out(%d) = %d instead of %d\n",
                        i, out(i), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < 256; i++) {
             if (out(i) != i) {
                 printf("Error: after sorting, out(%d) was %d instead of %d\n", i, out(i), i);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/let_in_rdom_bound.cpp
+++ b/test/correctness/let_in_rdom_bound.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 10; i++) {
         if (buf(i) != correct) {
             printf("buf(%d) = %d instead of %d\n", i, buf(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/load_library.cpp
+++ b/test/correctness/load_library.cpp
@@ -89,5 +89,5 @@ int main(int argc, char **argv) {
     Buffer<int32_t> out = f.realize({64, 64}, target);
 
     fprintf(stderr, "Should not get here.\n");
-    return -1;
+    return 1;
 }

--- a/test/correctness/logical.cpp
+++ b/test/correctness/logical.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
                 uint8_t correct = cond ? 255 : 0;
                 if (correct != output(x, y)) {
                     fprintf(stderr, "output(%d, %d) = %d instead of %d\n", x, y, output(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
                 uint8_t correct = cond ? 255 : 0;
                 if (correct != output(x, y)) {
                     fprintf(stderr, "output(%d, %d) = %d instead of %d\n", x, y, output(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
                 uint8_t correct = cond ? 0 : input(x, y);
                 if (correct != output(x, y)) {
                     fprintf(stderr, "output(%d, %d) = %d instead of %d\n", x, y, output(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
                 uint8_t correct = cond ? 255 : 0;
                 if (correct != output(x, y)) {
                     fprintf(stderr, "output(%d, %d) = %d instead of %d\n", x, y, output(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
                     if (cpu_output(x, y) != gpu_output(x, y)) {
                         fprintf(stderr, "gpu_output(%d, %d) = %d instead of %d for uint%d -> uint%d\n",
                                 x, y, gpu_output(x, y), cpu_output(x, y), n, w);
-                        return -1;
+                        return 1;
                     }
                 }
             }

--- a/test/correctness/loop_invariant_extern_calls.cpp
+++ b/test/correctness/loop_invariant_extern_calls.cpp
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
             int correct = y + 32 * x + y;
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         printf("Call counters were %d %d %d instead of %d %d %d\n",
                call_counter[0], call_counter[1], call_counter[2],
                1, 32, 32 * 32);
-        return -1;
+        return 1;
     }
 
     // Note that pure things get lifted out of loops (even parallel ones), but impure things do not.
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
     if (call_counter[3] != 1 || call_counter[4] != 32 * 32) {
         printf("Call counter for parallel call was %d, %d instead of %d, %d\n",
                call_counter[3], call_counter[4], 1, 32 * 32);
-        return -1;
+        return 1;
     }
 
     // Check that something we can't compute on the GPU gets lifted
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
         if (call_counter[5] != 1) {
             printf("Call counter for GPU call was %d instead of %d\n",
                    call_counter[5], 1);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/lots_of_dimensions.cpp
+++ b/test/correctness/lots_of_dimensions.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv) {
         });
         if (count != (int)in.number_of_elements()) {
             printf("count = %d instead of %d\n", count, (int)in.number_of_elements());
-            return -1;
+            return 1;
         }
 
         // Write Halide code that squares it and subtracts 3

--- a/test/correctness/low_bit_depth_noise.cpp
+++ b/test/correctness/low_bit_depth_noise.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 
     if (std::abs((double)sum - correct_sum) / correct_sum > 1e-4) {
         printf("Suspiciously large relative difference between the sum of the dithered values and the full-precision sum: %d vs %d\n", sum, correct_sum);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/many_small_extern_stages.cpp
+++ b/test/correctness/many_small_extern_stages.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
             uint8_t correct = 0;
             if (result(x, y) != 0) {
                 printf("result(%d, %d) = %d instead of %d\n", x, y, result(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/median3x3.cpp
+++ b/test/correctness/median3x3.cpp
@@ -65,7 +65,7 @@ int main(int arch, char **argv) {
             uint8_t correct = inp[4];
             if (correct != out(x, y)) {
                 std::cout << "out(" << x << ", " << y << ") = " << out(x, y) << " instead of " << correct << "\n";
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/min_extent.cpp
+++ b/test/correctness/min_extent.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < out.width(); i++) {
         if (out(i + OUTOFF) != expected[i]) {
             printf("Unexpected output: %d != %d\n", out(i + OUTOFF), expected[i]);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/mod.cpp
+++ b/test/correctness/mod.cpp
@@ -54,5 +54,5 @@ int main(int argc, char **argv) {
     }
 
     printf("Failure!\n");
-    return -1;
+    return 1;
 }

--- a/test/correctness/multi_output_pipeline_with_bad_sizes.cpp
+++ b/test/correctness/multi_output_pipeline_with_bad_sizes.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 
     if (!error_occurred) {
         printf("There should have been an error\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/multi_pass_reduction.cpp
+++ b/test/correctness/multi_pass_reduction.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
             if (fabs(result(i) - ref[i]) > 0.0001f) {
                 printf("result(%d) = %f instead of %f\n",
                        i, result(i), ref[i]);
-                return -1;
+                return 1;
             }
         }
     }
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
             if (correct[i] != result(i)) {
                 printf("result(%d) = %d instead of %d\n",
                        i, result(i), correct[i]);
-                return -1;
+                return 1;
             }
         }
     }
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
             if (ref[i] != result(i)) {
                 printf("fibonacci(%d) = %d instead of %d\n",
                        i, result(i), ref[i]);
-                return -1;
+                return 1;
             }
         }
     }
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
                 if (fabs(ref(x, y) - result(x, y)) > 0.0001f) {
                     printf("integral image at (%d, %d) = %f instead of %f\n",
                            x, y, result(x, y), ref(x, y));
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/multi_splits_with_diff_tail_strategies.cpp
+++ b/test/correctness/multi_splits_with_diff_tail_strategies.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
             return x + y + c;
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
     printf("Success!\n");

--- a/test/correctness/multi_way_select.cpp
+++ b/test/correctness/multi_way_select.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
 
     if (err != 0) {
         printf("Multi-way select didn't equal equivalent reduction!\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/multipass_constraints.cpp
+++ b/test/correctness/multipass_constraints.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
                out_buf.dim(0).min(), out_buf.dim(0).extent(),
                out_buf.dim(1).min(), out_buf.dim(1).extent());
 
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/multiple_outputs.cpp
+++ b/test/correctness/multiple_outputs.cpp
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < g_im.width(); x++) {
             if (g_im(x) != x) {
                 printf("g(%d) = %d instead of %d\n", x, g_im(x), x);
-                return -1;
+                return 1;
             }
         }
     }
@@ -118,14 +118,14 @@ int main(int argc, char **argv) {
         for (int x = 0; x < g0_im.width(); x++) {
             if (g0_im(x) != x) {
                 printf("g0(%d) = %d instead of %d\n", x, (int)g0_im(x), x);
-                return -1;
+                return 1;
             }
         }
 
         for (int x = 0; x < g1_im.width(); x++) {
             if (g1_im(x) != x + 1) {
                 printf("g1(%d) = %d instead of %d\n", x, (int)g1_im(x), x + 1);
-                return -1;
+                return 1;
             }
         }
     }
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < 100; x++) {
             if (f_im(x) != x) {
                 printf("f(%d) = %d instead of %d\n", x, f_im(x), x);
-                return -1;
+                return 1;
             }
             if (x < 50) {
                 int c0 = f_im(x) + 17;
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
                 if (h_im0(x) != c0 || h_im1(x) != c1) {
                     printf("h(%d) = {%d, %d} instead of {%d, %d}\n",
                            x, h_im0(x), h_im1(x), c0, c1);
-                    return -1;
+                    return 1;
                 }
             }
             if (x < 20) {
@@ -183,7 +183,7 @@ int main(int argc, char **argv) {
                     if (g_im0(x, y) != c0 || g_im1(x, y) != c1 || g_im2(x, y) != c2) {
                         printf("g(%d) = {%d, %d, %d} instead of {%d, %d, %d}\n",
                                x, g_im0(x, y), g_im1(x, y), g_im2(x, y), c0, c1, c2);
-                        return -1;
+                        return 1;
                     }
                 }
             }

--- a/test/correctness/multiple_outputs_extern.cpp
+++ b/test/correctness/multiple_outputs_extern.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
         uint8_t correct = 4 * i * i;
         if (h_buf(i) != correct) {
             printf("result(%d) = %d instead of %d\n", i, h_buf(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/multiple_scatter.cpp
+++ b/test/correctness/multiple_scatter.cpp
@@ -90,11 +90,11 @@ int main(int argc, char **argv) {
         for (int j = 0; j < output1.dim(1).extent(); j++) {
             if (output1(i, j) != correct[j]) {
                 printf("output1(%d, %d) = %d instead of %d\n", i, j, output1(i, j), correct[j]);
-                return -1;
+                return 1;
             }
             if (output2(i, j) != correct[j]) {
                 printf("output2(%d, %d) = %d instead of %d\n", i, j, output2(i, j), correct[j]);
-                return -1;
+                return 1;
             }
         }
     }
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
                 if (output(x, y) != correct) {
                     printf("output(%d, %d) = %d instead of %d\n",
                            x, y, output(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
                 printf("Sort result is not correctly ordered at elements %d, %d:\n"
                        "(%d, %d) vs (%d, %d)\n",
                        i, i + 1, out_0(i), out_1(i), out_0(i + 1), out_1(i + 1));
-                return -1;
+                return 1;
             }
         }
     }
@@ -220,7 +220,7 @@ int main(int argc, char **argv) {
             int correct = i < 4 ? 5 : 0;
             if (out(i) != correct) {
                 printf("out(%d) = %d instead of %d\n", i, out(i), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
             int correct = i == 3 ? 9 : 0;
             if (out(i) != correct) {
                 printf("out(%d) = %d instead of %d\n", i, out(i), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/named_updates.cpp
+++ b/test/correctness/named_updates.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
 
     if (error) {
         printf("There was a difference between using named updates and not.\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/newtons_method.cpp
+++ b/test/correctness/newtons_method.cpp
@@ -64,7 +64,7 @@ int find_pi() {
         fabs(secant_result - correct) > tolerance) {
         printf("Incorrect results: %10.20f %10.20f %10.20f\n",
                newton_result, secant_result, correct);
-        return -1;
+        return 1;
     }
     return 0;
 }

--- a/test/correctness/obscure_image_references.cpp
+++ b/test/correctness/obscure_image_references.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
         int correct = i < im2(3) ? 37 : (i + 20);
         if (result(i) != correct) {
             printf("result(%d) = %d instead of %d\n", i, result(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/oddly_sized_output.cpp
+++ b/test/correctness/oddly_sized_output.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
             if (out(x, y) != input(x, y) * 2) {
                 printf("out(%d, %d) = %d instead of %d\n",
                        x, y, out(x, y), input(x, y) * 2);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/out_of_memory.cpp
+++ b/test/correctness/out_of_memory.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
 
     if (!error_occurred) {
         printf("There should have been an error\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/parallel.cpp
+++ b/test/correctness/parallel.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 16; i++) {
         if (im(i) != i * 3) {
             printf("im(%d) = %d\n", i, im(i));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/parallel_alloc.cpp
+++ b/test/correctness/parallel_alloc.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
             for (int y = 0; y < 8; y++) {
                 if (im(x, y) != (x - 1) * y + (x + 1) * y) {
                     printf("im(%d, %d) = %d\n", x, y, im(x, y));
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/parallel_gpu_nested.cpp
+++ b/test/correctness/parallel_gpu_nested.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
             for (int z = 0; z < 64; z++) {
                 if (im(x, y, z) != x * y + z * 3 + 1) {
                     printf("im(%d, %d, %d) = %d\n", x, y, z, im(x, y, z));
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/parallel_nested.cpp
+++ b/test/correctness/parallel_nested.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
             for (int z = 0; z < 64; z++) {
                 if (im(x, y, z) != x * y + z * 3 + 1) {
                     printf("im(%d, %d, %d) = %d\n", x, y, z, im(x, y, z));
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/parallel_nested_1.cpp
+++ b/test/correctness/parallel_nested_1.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
                 const int actual = im(x, y, z);
                 if (actual != expected) {
                     fprintf(stderr, "im(%d, %d, %d) = %d, expected %d\n", x, y, z, actual, expected);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/parallel_reductions.cpp
+++ b/test/correctness/parallel_reductions.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
         int correct = (256 * 255) / 2;
         if (im(0) != correct) {
             printf("im(0) = %d instead of %d\n", im(0), correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < 256; i++) {
             if (result(i) != correct(i)) {
                 printf("result(%d) = %d instead of %d\n", i, result(i), correct(i));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/parallel_rvar.cpp
+++ b/test/correctness/parallel_rvar.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 
     if (error != 0) {
         printf("Serial version did not match parallel version\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/param.cpp
+++ b/test/correctness/param.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
                 for (int i = 0; i < 1024; i++) {
                     printf("%d %d\n", out_17(i), out_123(i));
                 }
-                return -1;
+                return 1;
             }
         }
     }
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
                 for (int i = 0; i < 1024; i++) {
                     printf("%d %d\n", out_17(i), out_123(i));
                 }
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/parameter_constraints.cpp
+++ b/test/correctness/parameter_constraints.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
         f.realize({100, 100});
         if (error_occurred) {
             printf("Error incorrectly raised\n");
-            return -1;
+            return 1;
         }
 
         p.set(0);
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
         f.realize({100, 100});
         if (!error_occurred) {
             printf("Error should have been raised\n");
-            return -1;
+            return 1;
         }
     }
     // Use ctor arguments
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
         f.realize({100, 100});
         if (error_occurred) {
             printf("Error incorrectly raised\n");
-            return -1;
+            return 1;
         }
 
         p.set(0);
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
         f.realize({100, 100});
         if (!error_occurred) {
             printf("Error should have been raised\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/partial_application.cpp
+++ b/test/correctness/partial_application.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < 4; x++) {
             if (im(x, y) != 36.0f) {
                 printf("im(%d, %d) = %f\n", x, y, im(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/partial_realization.cpp
+++ b/test/correctness/partial_realization.cpp
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
             int correct = i + 1;
             if (h(i) != correct) {
                 printf("hist(%d) = %d instead of %d\n", i, h(i), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -43,12 +43,12 @@ int main(int argc, char **argv) {
         // returned a crop of it.
         if (buf.dim(0).extent() != 30 || buf.dim(1).extent() != 20) {
             printf("Incorrect size: %d %d\n", buf.dim(0).extent(), buf.dim(1).extent());
-            return -1;
+            return 1;
         }
 
         if (buf.dim(0).stride() != 1 || buf.dim(1).stride() != 32) {
             printf("Incorrect stride: %d %d\n", buf.dim(0).stride(), buf.dim(1).stride());
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < 20; y++) {
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
                 int correct = x + y;
                 if (buf(x, y) != correct) {
                     printf("buf(%d, %d) = %d instead of %d\n", x, y, buf(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/partition_loops.cpp
+++ b/test/correctness/partition_loops.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
                 if (im(x, y, c) != correct) {
                     printf("im(%d, %d, %d) = %f instead of %f\n",
                            x, y, c, im(x, y, c), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/partition_loops_bug.cpp
+++ b/test/correctness/partition_loops_bug.cpp
@@ -52,7 +52,7 @@ int main(int argc, char const *argv[]) {
                 printf("im1(%d, %d) = %f, im2(%d, %d) = %f\n",
                        x, y, im1(x, y),
                        x, y, im2(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/partition_max_filter.cpp
+++ b/test/correctness/partition_max_filter.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 
     if (counter.count != expected_loops) {
         printf("Loop was not partitioned into the expected number of cases\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -39,14 +39,14 @@ int main(int argc, char **argv) {
             float delta = imf(i, j) - correct;
             if (delta < -0.001 || delta > 0.001) {
                 printf("imf[%d, %d] = %f instead of %f\n", i, j, imf(i, j), correct);
-                return -1;
+                return 1;
             }
         }
     }
 
     if (call_counter != 32 * 32) {
         printf("In pipeline_set_jit_externs_func, my_func was called %d times instead of %d\n", call_counter, 32 * 32);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -105,7 +105,7 @@ int predicated_tail_test(const Target &t) {
             return x;
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -131,7 +131,7 @@ int predicated_tail_with_scalar_test(const Target &t) {
         return x + 10;
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -163,7 +163,7 @@ int vectorized_predicated_store_scalarized_predicated_load_test(const Target &t)
     Buffer<int> im = f.realize({170, 170});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -193,7 +193,7 @@ int vectorized_dense_load_with_stride_minus_one_test(const Target &t) {
         return (x < 23) ? im_ref(x, y, z) : im(x, y, z);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -226,7 +226,7 @@ int multiple_vectorized_predicate_test(const Target &t) {
     Buffer<int> im = f.realize({size, size});
     auto func = [&im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -258,7 +258,7 @@ int scalar_load_test(const Target &t) {
     Buffer<int> im = f.realize({160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -292,7 +292,7 @@ int scalar_store_test(const Target &t) {
     Buffer<int> im = f.realize({160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -325,7 +325,7 @@ int not_dependent_on_vectorized_var_test(const Target &t) {
     Buffer<int> im = f.realize({160, 160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -356,7 +356,7 @@ int no_op_store_test(const Target &t) {
     Buffer<int> im = f.realize({240, 240});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -387,7 +387,7 @@ int vectorized_predicated_predicate_with_pure_call_test(const Target &t) {
     Buffer<int> im = f.realize({160, 160});
     auto func = [im_ref](int x, int y, int z) { return im_ref(x, y, z); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -424,7 +424,7 @@ int vectorized_predicated_load_const_index_test(const Target &t) {
     Buffer<int> im = f.realize({100, 100});
     auto func = [im_ref](int x, int y) { return im_ref(x, y); };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -471,62 +471,62 @@ int main(int argc, char **argv) {
 
     printf("Running vectorized dense load test\n");
     if (predicated_tail_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running vectorized dense load with scalar test\n");
     if (predicated_tail_with_scalar_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running vectorized dense load with stride minus one test\n");
     if (vectorized_dense_load_with_stride_minus_one_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running multiple vectorized predicate test\n");
     if (multiple_vectorized_predicate_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running vectorized predicated store scalarized predicated load test\n");
     if (vectorized_predicated_store_scalarized_predicated_load_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running scalar load test\n");
     if (scalar_load_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running scalar store test\n");
     if (scalar_store_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running not dependent on vectorized var test\n");
     if (not_dependent_on_vectorized_var_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running no-op store test\n");
     if (no_op_store_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running vectorized predicated with pure call test\n");
     if (vectorized_predicated_predicate_with_pure_call_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running vectorized predicated load with constant index test\n");
     if (vectorized_predicated_load_const_index_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running vectorized predicated load lut test\n");
     if (vectorized_predicated_load_lut_test(t) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -88,7 +88,7 @@ int test1(const Target &t) {
 
     vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()), 0, 1, get_stride(t, 4)}};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -112,7 +112,7 @@ int test2(const Target &t) {
 
     vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()), 0, 1, get_stride(t, 4)}};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -136,7 +136,7 @@ int test3(const Target &t) {
 
     vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()), 0, 1, get_stride(t, 4)}};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -161,7 +161,7 @@ int test4(const Target &t) {
     // within the loop nest of 'g'
     vector<vector<Expr>> expected = {};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -182,7 +182,7 @@ int test5(const Target &t) {
 
     vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()), 0, 1, get_stride(t, 4)}};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -206,7 +206,7 @@ int test6(const Target &t) {
 
     vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()), 0, 1, get_stride(t, 4)}};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -230,7 +230,7 @@ int test7(const Target &t) {
 
     vector<vector<Expr>> expected = {{Variable::make(Handle(), f.name()), 0, 1, get_stride(t, 4)}};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -255,7 +255,7 @@ int test8(const Target &t) {
     // within the loop nest of 'g'
     vector<vector<Expr>> expected = {};
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -298,7 +298,7 @@ int test9(const Target &t) {
         }
     }
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -348,7 +348,7 @@ int test10(const Target &t) {
         }
     }
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -398,7 +398,7 @@ int test11(const Target &t) {
         }
     }
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -464,7 +464,7 @@ int test12(const Target &t) {
         }
     }
     if (!check(expected, collect.prefetches)) {
-        return -1;
+        return 1;
     }
     return 0;
 }

--- a/test/correctness/print.cpp
+++ b/test/correctness/print.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
 
         for (int32_t i = 0; i < 10; i++) {
             if (result(i) != i * i) {
-                return -1;
+                return 1;
             }
         }
 
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
 
         for (int32_t i = 0; i < 10; i++) {
             if (result(i) != i * i) {
-                return -1;
+                return 1;
             }
         }
 
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
         Buffer<uint64_t> result = f.realize({1});
 
         if (result(0) != 100) {
-            return -1;
+            return 1;
         }
 
         assert(messages.back().size() == 8191);
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
             if (!strcmp(correct, "-nan\n")) strcpy(correct, "nan\n");
             if (messages[i] != correct) {
                 printf("float %d: %s vs %s for %10.20e\n", i, messages[i].c_str(), correct, imf(i));
-                return -1;
+                return 1;
             }
         }
 
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
             if (!strcmp(correct, "-nan\n")) strcpy(correct, "nan\n");
             if (messages[i] != correct) {
                 printf("double %d: %s vs %s for %10.20e\n", i, messages[i].c_str(), correct, img(i));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/process_some_tiles.cpp
+++ b/test/correctness/process_some_tiles.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     // Check the right number of calls to powf occurred
     if (call_count != tile_size * tile_size) {
         printf("call_count = %d instead of %d\n", call_count, tile_size * tile_size);
-        return -1;
+        return 1;
     }
 
     // Check the output is correct
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
             if (fabs(correct - result(x, y)) > 0.001f) {
                 printf("result(%d, %d) = %f instead of %f\n",
                        x, y, result(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/pseudostack_shares_slots.cpp
+++ b/test/correctness/pseudostack_shares_slots.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
                 std::abs(mallocs[1] - sz2) > tolerance) {
                 printf("Incorrect allocations: %d %d %d\n", (int)mallocs.size(), (int)mallocs[0], (int)mallocs[1]);
                 printf("Expected: 2 %d %d\n", (int)sz1, (int)sz2);
-                return -1;
+                return 1;
             }
         }
     }
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
                 printf("Incorrect allocations: %d %d %d %d %d\n", (int)mallocs.size(),
                        mallocs[0], mallocs[1], mallocs[2], mallocs[3]);
                 printf("Expected: 4 %d %d %d %d\n", sz1, sz2, sz3, sz4);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/random.cpp
+++ b/test/correctness/random.cpp
@@ -40,32 +40,32 @@ int main(int argc, char **argv) {
 
         if (fabs(mean - 0.5) > tol) {
             printf("Bad mean: %f\n", mean);
-            return -1;
+            return 1;
         }
 
         if (fabs(variance - 1.0 / 12) > tol) {
             printf("Bad variance: %f\n", variance);
-            return -1;
+            return 1;
         }
 
         if (fabs(mean_dx) > tol) {
             printf("Bad mean_dx: %f\n", mean_dx);
-            return -1;
+            return 1;
         }
 
         if (fabs(variance_dx - 1.0 / 6) > tol) {
             printf("Bad variance_dx: %f\n", variance_dx);
-            return -1;
+            return 1;
         }
 
         if (fabs(mean_dy) > tol) {
             printf("Bad mean_dy: %f\n", mean_dy);
-            return -1;
+            return 1;
         }
 
         if (fabs(variance_dy - 1.0 / 6) > tol) {
             printf("Bad variance_dy: %f\n", variance_dy);
-            return -1;
+            return 1;
         }
     }
 
@@ -101,14 +101,14 @@ int main(int argc, char **argv) {
             printf("The same random seed should produce the same image. "
                    "Instead the mean absolute difference was: %f\n",
                    e1);
-            return -1;
+            return 1;
         }
 
         if (fabs(e2 - 1.0 / 3) > 0.01) {
             printf("Different random seeds should produce different images. "
                    "The mean absolute difference should be 1/3 but was %f\n",
                    e2);
-            return -1;
+            return 1;
         }
     }
 
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
         int correct = 512 * 1024 * 32;
         if (fabs(double(set_bits) / correct - 1) > tol) {
             printf("Set bits was %d instead of %d\n", set_bits, correct);
-            return -1;
+            return 1;
         }
 
         // Check to make sure adjacent bits are uncorrelated.
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
         set_bits = evaluate<int>(sum(popcount(val2)));
         if (fabs(double(set_bits) / correct - 1) > tol) {
             printf("Set bits was %d instead of %d\n", set_bits, correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -164,12 +164,12 @@ int main(int argc, char **argv) {
 
         if (fabs(f_var - 1.0 / 3) > tol) {
             printf("Variance of f was supposed to be 1/3: %f\n", f_var);
-            return -1;
+            return 1;
         }
 
         if (fabs(g_var - 1.0 / 6) > tol) {
             printf("Variance of g was supposed to be 1/6 %f\n", g_var);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/realize_over_shifted_domain.cpp
+++ b/test/correctness/realize_over_shifted_domain.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Err: f(50, 100) = %d (supposed to be 123)\n"
                         "f(99, 199) = %d (supposed to be 234)\n",
                 result(50, 100), result(99, 199));
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/recursive_box_filters.cpp
+++ b/test/correctness/recursive_box_filters.cpp
@@ -35,11 +35,11 @@ int main(int argc, char **argv) {
         int correct4 = i + (i - 1) + (i - 2) + (i - 3);
         if (r0(i) != correct2) {
             printf("r0[%d] = %d instead of %d\n", i, r0(i), correct2);
-            return -1;
+            return 1;
         }
         if (r1(i) != correct4) {
             printf("r1[%d] = %d instead of %d\n", i, r1(i), correct4);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/reduction_non_rectangular.cpp
+++ b/test/correctness/reduction_non_rectangular.cpp
@@ -100,7 +100,7 @@ int equality_inequality_bound_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -133,7 +133,7 @@ int split_fuse_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -162,7 +162,7 @@ int free_variable_bound_test(int index) {
                 if (im(x, y, z) != correct) {
                     printf("im(%d, %d, %d) = %d instead of %d\n",
                            x, y, z, im(x, y, z), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -205,14 +205,14 @@ int func_call_inside_bound_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
     if (niters_expected != niters) {
         printf("func_call_inside_bound_test : Expect niters on g to be %d but got %d instead\n",
                niters_expected, niters);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -244,7 +244,7 @@ int func_call_inside_bound_inline_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -292,14 +292,14 @@ int two_linear_bounds_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
     if (niters_expected != niters) {
         printf("two_linear_bounds_test : Expect niters on g to be %d but got %d instead\n",
                niters_expected, niters);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -339,7 +339,7 @@ int circle_bound_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -384,14 +384,14 @@ int intermediate_computed_if_param_test(int index) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
         if (niters_expected != niters) {
             printf("intermediate_computed_if_param_test : Expect niters on g to be %d but got %d instead\n",
                    niters_expected, niters);
-            return -1;
+            return 1;
         }
     }
 
@@ -408,14 +408,14 @@ int intermediate_computed_if_param_test(int index) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
         if (niters_expected != niters) {
             printf("intermediate_computed_if_param_test : Expect niters on g to be %d but got %d instead\n",
                    niters_expected, niters);
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -458,14 +458,14 @@ int intermediate_bound_depend_on_output_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
     if (niters_expected != niters) {
         printf("intermediate_bound_depend_on_output_test: Expect niters on g to be %d but got %d instead\n",
                niters_expected, niters);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -510,7 +510,7 @@ int tile_intermediate_bound_depend_on_output_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -518,7 +518,7 @@ int tile_intermediate_bound_depend_on_output_test(int index) {
     if (niters_expected != niters) {
         printf("intermediate_bound_depend_on_output_test: Expect niters on g to be %d but got %d instead\n",
                niters_expected, niters);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -551,7 +551,7 @@ int self_reference_bound_test(int index) {
             if (im1(x, y) != correct) {
                 printf("im1(%d, %d) = %d instead of %d\n",
                        x, y, im1(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -566,7 +566,7 @@ int self_reference_bound_test(int index) {
             if (im2(x, y) != correct) {
                 printf("im2(%d, %d) = %d instead of %d\n",
                        x, y, im2(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -602,13 +602,13 @@ int random_float_bound_test(int index) {
             if (im1(x, y) != correct) {
                 printf("im1(%d, %d) = %d instead of %d\n",
                        x, y, im1(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
     if (!(19000 <= n_true && n_true <= 21000)) {
         printf("Expected n_true to be between 19000 and 21000; got %d instead\n", n_true);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -637,13 +637,13 @@ int newton_method_test() {
             int num_iters = r1(i);
             if (num_iters == max_iters) {
                 printf("Newton's method didn't converge!\n");
-                return -1;
+                return 1;
             }
             if (std::abs(prod - 1) > 0.001) {
                 printf("Newton's method converged without producing the correct inverse:\n"
                        "%f * %f = %f (%d iterations)\n",
                        x, r0(i), prod, r1(i));
-                return -1;
+                return 1;
             }
         }
     }
@@ -675,7 +675,7 @@ int init_on_gpu_update_on_cpu_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -707,7 +707,7 @@ int init_on_cpu_update_on_gpu_test(int index) {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -756,7 +756,7 @@ int gpu_intermediate_computed_if_param_test(int index) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -778,7 +778,7 @@ int gpu_intermediate_computed_if_param_test(int index) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -812,7 +812,7 @@ int vectorize_predicated_rvar_test() {
             if (im(x, y) != correct) {
                 printf("im(%d, %d) = %d instead of %d\n",
                        x, y, im(x, y), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -822,72 +822,72 @@ int vectorize_predicated_rvar_test() {
 int main(int argc, char **argv) {
     printf("Running equality inequality bound test\n");
     if (equality_inequality_bound_test(0) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running split fuse test\n");
     if (split_fuse_test(1) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running bound depend on free variable test\n");
     if (free_variable_bound_test(2) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running function call inside bound test\n");
     if (func_call_inside_bound_test(3) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running function call inside bound inline test\n");
     if (func_call_inside_bound_inline_test(4) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running two linear bounds test\n");
     if (two_linear_bounds_test(5) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running circular bound test\n");
     if (circle_bound_test(6) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running intermediate only computed if param is bigger than certain value test\n");
     if (intermediate_computed_if_param_test(7) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running tile intermediate stage depend on output bound test\n");
     if (tile_intermediate_bound_depend_on_output_test(8) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running intermediate stage depend on output bound\n");
     if (intermediate_bound_depend_on_output_test(9) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running self reference bound test\n");
     if (self_reference_bound_test(10) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running random float bound test\n");
     if (random_float_bound_test(11) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running newton's method test\n");
     if (newton_method_test() != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running vectorize predicated rvar test\n");
     if (vectorize_predicated_rvar_test() != 0) {
-        return -1;
+        return 1;
     }
 
     // Run GPU tests now if there is support for GPU.
@@ -900,17 +900,17 @@ int main(int argc, char **argv) {
 
     printf("Running initialization on gpu and update on cpu test\n");
     if (init_on_gpu_update_on_cpu_test(12) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running initialization on cpu and update on gpu test\n");
     if (init_on_cpu_update_on_gpu_test(13) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running gpu intermediate only computed if param is bigger than certain value test\n");
     if (gpu_intermediate_computed_if_param_test(14) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/reduction_schedule.cpp
+++ b/test/correctness/reduction_schedule.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
             float delta = ref_energy(x, y) - im_energy(x, y);
             if (fabs(delta) > 1e-5) {
                 printf("energy(%d,%d) was %f instead of %f\n", x, y, im_energy(x, y), ref_energy(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/register_shuffle.cpp
+++ b/test/correctness/register_shuffle.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %f instead of %f\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %f instead of %f\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -177,7 +177,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -215,7 +215,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -309,7 +309,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %f instead of %f\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -370,7 +370,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %f instead of %f\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -427,7 +427,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %f instead of %f\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -487,7 +487,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("out(%d, %d) = %d instead of %d\n",
                            x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -534,7 +534,7 @@ int main(int argc, char **argv) {
             if (correct != actual) {
                 printf("out(%d) = %d instead of %d\n",
                        y, actual, correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/reorder_rvars.cpp
+++ b/test/correctness/reorder_rvars.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
 
         if (err != 0) {
             printf("Reordering rvars affected the meaning!\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/reschedule.cpp
+++ b/test/correctness/reschedule.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     // There should have been vector stores and scalar stores.
     if (!vector_store || !scalar_store) {
         printf("There should have been vector and scalar stores\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/reuse_stack_alloc.cpp
+++ b/test/correctness/reuse_stack_alloc.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < result.width(); i++) {
         if (result(i) != 2 * i) {
             printf("Error! Allocation did not get reused at %d (%d != %d)\n", i, result(i), 2 * i);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/rfactor.cpp
+++ b/test/correctness/rfactor.cpp
@@ -40,7 +40,7 @@ int simple_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Buffer<int> im = g.realize({80, 80});
@@ -48,7 +48,7 @@ int simple_rfactor_test() {
             return (10 <= x && x <= 29) && (30 <= y && y <= 69) ? std::max(40 + x + y, 40) : 40;
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -86,7 +86,7 @@ int reorder_split_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Buffer<int> im = g.realize({80, 80});
@@ -94,7 +94,7 @@ int reorder_split_rfactor_test() {
             return ((10 <= x && x <= 29) && (20 <= y && y <= 49)) ? x - y + 1 : 1;
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -135,7 +135,7 @@ int multi_split_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Buffer<int> im = g.realize({80, 80});
@@ -143,7 +143,7 @@ int multi_split_rfactor_test() {
             return ((10 <= x && x <= 29) && (20 <= y && y <= 49)) ? x - y + 1 : 1;
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -183,7 +183,7 @@ int reorder_fuse_wrapper_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Buffer<int> im = g.realize({20, 20, 20});
@@ -194,7 +194,7 @@ int reorder_fuse_wrapper_rfactor_test() {
                        1;
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -256,7 +256,7 @@ int non_trivial_lhs_rfactor_test() {
                 {c.name(), {}},
             };
             if (check_call_graphs(g, expected) != 0) {
-                return -1;
+                return 1;
             }
         } else {
             Buffer<int> im = g.realize({20, 20, 20});
@@ -264,7 +264,7 @@ int non_trivial_lhs_rfactor_test() {
                 return im_ref(x, y, z);
             };
             if (check_image(im, func)) {
-                return -1;
+                return 1;
             }
         }
     }
@@ -299,7 +299,7 @@ int simple_rfactor_with_specialize_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         {
@@ -309,7 +309,7 @@ int simple_rfactor_with_specialize_test() {
                 return (10 <= x && x <= 29) && (30 <= y && y <= 69) ? std::min(x + y + 2, 40) : 40;
             };
             if (check_image(im, func)) {
-                return -1;
+                return 1;
             }
         }
         {
@@ -319,7 +319,7 @@ int simple_rfactor_with_specialize_test() {
                 return (10 <= x && x <= 29) && (30 <= y && y <= 69) ? std::min(x + y + 2, 40) : 40;
             };
             if (check_image(im, func)) {
-                return -1;
+                return 1;
             }
         }
     }
@@ -355,7 +355,7 @@ int rdom_with_predicate_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Buffer<int> im = g.realize({20, 20, 20});
@@ -366,7 +366,7 @@ int rdom_with_predicate_rfactor_test() {
                        1;
         };
         if (check_image(im, func)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -414,7 +414,7 @@ int histogram_rfactor_test() {
 
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Buffer<int32_t> histogram = g.realize({10});  // buckets 10-20 only
@@ -422,7 +422,7 @@ int histogram_rfactor_test() {
             if (histogram(i - 10) != reference_hist[i]) {
                 printf("Error: bucket %d is %d instead of %d\n",
                        i, histogram(i), reference_hist[i]);
-                return -1;
+                return 1;
             }
         }
     }
@@ -480,13 +480,13 @@ int parallel_dot_product_rfactor_test() {
             {b.name(), {}},
         };
         if (check_call_graphs(dot, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Buffer<int32_t> im = dot.realize();
         if (ref(0) != im(0)) {
             printf("result = %d instead of %d\n", im(0), ref(0));
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -536,7 +536,7 @@ int tuple_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Realization rn = g.realize({80, 80});
@@ -550,14 +550,14 @@ int tuple_rfactor_test() {
             return ref_im1(x, y);
         };
         if (check_image(im1, func1)) {
-            return -1;
+            return 1;
         }
 
         auto func2 = [&ref_im2](int x, int y, int z) {
             return ref_im2(x, y);
         };
         if (check_image(im2, func2)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -611,7 +611,7 @@ int tuple_specialize_rdom_predicate_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         {
@@ -628,13 +628,13 @@ int tuple_specialize_rdom_predicate_rfactor_test() {
                 return ref_im1(x, y, z);
             };
             if (check_image(im1, func1)) {
-                return -1;
+                return 1;
             }
             auto func2 = [&ref_im2](int x, int y, int z) {
                 return ref_im2(x, y, z);
             };
             if (check_image(im2, func2)) {
-                return -1;
+                return 1;
             }
         }
         {
@@ -651,13 +651,13 @@ int tuple_specialize_rdom_predicate_rfactor_test() {
                 return ref_im1(x, y, z);
             };
             if (check_image(im1, func1)) {
-                return -1;
+                return 1;
             }
             auto func2 = [&ref_im2](int x, int y, int z) {
                 return ref_im2(x, y, z);
             };
             if (check_image(im2, func2)) {
-                return -1;
+                return 1;
             }
         }
         {
@@ -674,13 +674,13 @@ int tuple_specialize_rdom_predicate_rfactor_test() {
                 return ref_im1(x, y, z);
             };
             if (check_image(im1, func1)) {
-                return -1;
+                return 1;
             }
             auto func2 = [&ref_im2](int x, int y, int z) {
                 return ref_im2(x, y, z);
             };
             if (check_image(im2, func2)) {
-                return -1;
+                return 1;
             }
         }
         {
@@ -697,13 +697,13 @@ int tuple_specialize_rdom_predicate_rfactor_test() {
                 return ref_im1(x, y, z);
             };
             if (check_image(im1, func1)) {
-                return -1;
+                return 1;
             }
             auto func2 = [&ref_im2](int x, int y, int z) {
                 return ref_im2(x, y, z);
             };
             if (check_image(im2, func2)) {
-                return -1;
+                return 1;
             }
         }
     }
@@ -749,14 +749,14 @@ int complex_multiply_rfactor_test() {
         return ref_im1(x, y);
     };
     if (check_image(im1, func1)) {
-        return -1;
+        return 1;
     }
 
     auto func2 = [&ref_im2](int x, int y, int z) {
         return ref_im2(x, y);
     };
     if (check_image(im2, func2)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -805,21 +805,21 @@ int argmin_rfactor_test() {
         return ref_im1(x, y);
     };
     if (check_image(im1, func1)) {
-        return -1;
+        return 1;
     }
 
     auto func2 = [&ref_im2](int x, int y, int z) {
         return ref_im2(x, y);
     };
     if (check_image(im2, func2)) {
-        return -1;
+        return 1;
     }
 
     auto func3 = [&ref_im3](int x, int y, int z) {
         return ref_im3(x, y);
     };
     if (check_image(im3, func3)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -893,7 +893,7 @@ int rfactor_tile_reorder_test() {
         return im_ref(x, y);
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -943,7 +943,7 @@ int tuple_partial_reduction_rfactor_test() {
             {f.name(), {}},
         };
         if (check_call_graphs(g, expected) != 0) {
-            return -1;
+            return 1;
         }
     } else {
         Realization rn = g.realize({80, 80});
@@ -957,14 +957,14 @@ int tuple_partial_reduction_rfactor_test() {
             return ref_im1(x, y);
         };
         if (check_image(im1, func1)) {
-            return -1;
+            return 1;
         }
 
         auto func2 = [&ref_im2](int x, int y, int z) {
             return ref_im2(x, y);
         };
         if (check_image(im2, func2)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -987,7 +987,7 @@ int self_assignment_rfactor_test() {
         return x + y;
     };
     if (check_image(im, func)) {
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -1041,7 +1041,7 @@ int main(int argc, char **argv) {
         const auto &task = tasks.at(t);
         std::cout << task.desc << "\n";
         if (task.fn() != 0) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/scatter.cpp
+++ b/test/correctness/scatter.cpp
@@ -28,7 +28,7 @@ int main(int argc, char **argv) {
         int correct = i < 5 ? (1617 + i * 100) : 17;
         if (result(i, 0) != correct) {
             printf("Value at %d should have been %d but was instead %d\n", i, correct, result(i, 0));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/shifted_image.cpp
+++ b/test/correctness/shifted_image.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
     buf.data()[0] = 17;
     if (buf(100, 300, 500, 400) != 17) {
         printf("Image indexing into buffers with non-zero mins is broken\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/side_effects.cpp
+++ b/test/correctness/side_effects.cpp
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
     // Check draw_pixel was called the right number of times.
     if (call_count != 71 * 21) {
         printf("Something went wrong\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -401,7 +401,7 @@ public:
             compile_standalone_runtime(test.output_directory + "simd_op_check_runtime.o", test.target);
 
             if (!success) {
-                return -1;
+                return 1;
             }
         }
 

--- a/test/correctness/skip_stages_memoize.cpp
+++ b/test/correctness/skip_stages_memoize.cpp
@@ -47,7 +47,7 @@ int check_correctness_single(const Buffer<int> &out, bool toggle) {
         if (out(x) != correct) {
             printf("out(%d) = %d instead of %d\n",
                    x, out(x), correct);
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -68,7 +68,7 @@ int check_correctness_double(const Buffer<int> &out, bool toggle1, bool toggle2)
         if (out(x) != correct) {
             printf("out(%d) = %d instead of %d\n",
                    x, out(x), correct);
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -96,7 +96,7 @@ int single_memoize_test(int index) {
         toggle.set(set_toggle1);
         Buffer<int> out = f2.realize({10});
         if (check_correctness_single(out, set_toggle1) != 0) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -128,10 +128,10 @@ int tuple_memoize_test(int index) {
         Buffer<int> out1 = out[1];
 
         if (check_correctness_single(out0, set_toggle1) != 0) {
-            return -1;
+            return 1;
         }
         if (check_correctness_single(out1, set_toggle1) != 0) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -165,7 +165,7 @@ int non_trivial_allocate_predicate_test(int index) {
         toggle.set(set_toggle1);
         Buffer<int> out = f3.realize({10});
         if (check_correctness_single(out, set_toggle1) != 0) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -200,7 +200,7 @@ int double_memoize_test(int index) {
             toggle2.set(toggle_val2);
             Buffer<int> out = f3.realize({10});
             if (check_correctness_double(out, set_toggle1, set_toggle2) != 0) {
-                return -1;
+                return 1;
             }
         }
     }
@@ -210,22 +210,22 @@ int double_memoize_test(int index) {
 int main(int argc, char **argv) {
     printf("Running single_memoize_test\n");
     if (single_memoize_test(0) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running tuple_memoize_test\n");
     if (tuple_memoize_test(1) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running non_trivial_allocate_predicate_test\n");
     if (non_trivial_allocate_predicate_test(2) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Running double_memoize_test\n");
     if (double_memoize_test(3) != 0) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/sliding_backwards.cpp
+++ b/test/correctness/sliding_backwards.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
 
     if (call_counter != 11) {
         printf("g was called %d times instead of %d\n", call_counter, 11);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/sliding_reduction.cpp
+++ b/test/correctness/sliding_reduction.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
         int correct = 24;
         if (counter != correct) {
             printf("Failed sliding a reduction: %d evaluations instead of %d\n", counter, correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
         int correct = 60;
         if (counter != correct) {
             printf("Failed sliding a reduction: %d evaluations instead of %d\n", counter, correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
         int correct = 48;
         if (counter != correct) {
             printf("Failed sliding a reduction: %d evaluations instead of %d\n", counter, correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
         // f should be able to tell that it only needs to compute each value once
         if (count != 101) {
             printf("f was called %d times instead of %d times\n", count, 101);
-            return -1;
+            return 1;
         }
     }
 
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         Buffer<int> im = h.realize({100});
         if (count != 202) {
             printf("f was called %d times instead of %d times\n", count, 202);
-            return -1;
+            return 1;
         }
     }
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
         int correct = store_in == MemoryType::Register ? 103 : 102;
         if (count != correct) {
             printf("f was called %d times instead of %d times\n", count, correct);
-            return -1;
+            return 1;
         }
     }
 
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
         Buffer<int> im = h.realize({100});
         if (count != 101) {
             printf("f was called %d times instead of %d times\n", count, 101);
-            return -1;
+            return 1;
         }
     }
 
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
         Buffer<int> im = h.realize({100, 4});
         if (count != 404) {
             printf("f was called %d times instead of %d times\n", count, 404);
-            return -1;
+            return 1;
         }
     }
 
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
         // we can skip the y-1 case in all but the first iteration.
         if (count != 100 * 11) {
             printf("f was called %d times instead of %d times\n", count, 100 * 11);
-            return -1;
+            return 1;
         }
     }
 
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
 
         if (count != 11 * 11) {
             printf("f was called %d times instead of %d times\n", count, 11 * 11);
-            return -1;
+            return 1;
         }
     }
 
@@ -182,7 +182,7 @@ int main(int argc, char **argv) {
         Buffer<int> im = g.realize({10, 10});
         if (count != 1500) {
             printf("f was called %d times instead of %d times\n", count, 1500);
-            return -1;
+            return 1;
         }
     }
 
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
         // f should be able to tell that it only needs to compute each value once
         if (count != 6) {
             printf("f was called %d times instead of %d times\n", count, 6);
-            return -1;
+            return 1;
         }
     }
 
@@ -232,7 +232,7 @@ int main(int argc, char **argv) {
         // f should be able to tell that it only needs to compute each value once
         if (count != 34) {
             printf("f was called %d times instead of %d times\n", count, 34);
-            return -1;
+            return 1;
         }
     }
 
@@ -270,7 +270,7 @@ int main(int argc, char **argv) {
 
         if (count != 101) {
             printf("f was called %d times instead of %d times\n", count, 101);
-            return -1;
+            return 1;
         }
     }
 
@@ -287,7 +287,7 @@ int main(int argc, char **argv) {
         Buffer<int> im = g.realize({100});
         if (count != 104) {
             printf("f was called %d times instead of %d times\n", count, 104);
-            return -1;
+            return 1;
         }
     }
 
@@ -310,7 +310,7 @@ int main(int argc, char **argv) {
         Buffer<int> im = g.realize({100});
         if (count != 102) {
             printf("f was called %d times instead of %d times\n", count, 102);
-            return -1;
+            return 1;
         }
     }
 
@@ -332,7 +332,7 @@ int main(int argc, char **argv) {
         v.realize({10, 10});
         if (count != 14 * 14) {
             printf("f was called %d times instead of %d times\n", count, 14 * 14);
-            return -1;
+            return 1;
         }
     }
 
@@ -354,7 +354,7 @@ int main(int argc, char **argv) {
         v.realize({10, 10});
         if (count != 14 * 14) {
             printf("f was called %d times instead of %d times\n", count, 14 * 14);
-            return -1;
+            return 1;
         }
     }
 
@@ -371,7 +371,7 @@ int main(int argc, char **argv) {
         g.realize({10});
         if (count != 7) {
             printf("f was called %d times instead of %d times\n", count, 7);
-            return -1;
+            return 1;
         }
     }
 
@@ -389,7 +389,7 @@ int main(int argc, char **argv) {
         h.realize({10});
         if (count != 10) {
             printf("f was called %d times instead of %d times\n", count, 10);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/sort_exprs.cpp
+++ b/test/correctness/sort_exprs.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < N - 1; i++) {
         if (result(i) >= result(i + 1)) {
             printf("Results were not in order\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
         // Should have used vector stores
         if (!vector_store || scalar_store) {
             printf("This was supposed to use vector stores\n");
-            return -1;
+            return 1;
         }
 
         // Now try a smaller input
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
         // Should have used scalar stores
         if (vector_store || !scalar_store) {
             printf("This was supposed to use scalar stores\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -201,7 +201,7 @@ int main(int argc, char **argv) {
             printf("There were supposed to be 1 empty alloc, 2 nonempty allocs, and 3 frees.\n"
                    "Instead we got %d empty allocs, %d nonempty allocs, and %d frees.\n",
                    empty_allocs, nonempty_allocs, frees);
-            return -1;
+            return 1;
         }
 
         reset_alloc_counts();
@@ -212,7 +212,7 @@ int main(int argc, char **argv) {
             printf("There were supposed to be 2 empty allocs, 1 nonempty alloc, and 3 frees.\n"
                    "Instead we got %d empty allocs, %d nonempty allocs, and %d frees.\n",
                    empty_allocs, nonempty_allocs, frees);
-            return -1;
+            return 1;
         }
     }
 
@@ -237,7 +237,7 @@ int main(int argc, char **argv) {
         int m = im.get().min(0), e = im.get().extent(0);
         if (m != 0 || e != 5) {
             printf("min, extent = %d, %d instead of 0, 5\n", m, e);
-            return -1;
+            return 1;
         }
 
         // Check we don't crash with the small input, and that it uses scalar stores
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
         f.realize({5});
         if (!scalar_store || vector_store) {
             printf("These stores were supposed to be scalar.\n");
-            return -1;
+            return 1;
         }
 
         // Check we don't crash with a larger input, and that it uses vector stores
@@ -256,7 +256,7 @@ int main(int argc, char **argv) {
         f.realize({100});
         if (scalar_store || !vector_store) {
             printf("These stores were supposed to be vector.\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -284,7 +284,7 @@ int main(int argc, char **argv) {
         f.realize({100});
         if (!scalar_store || vector_store) {
             printf("These stores were supposed to be scalar.\n");
-            return -1;
+            return 1;
         }
 
         // Check that we used vector stores for a dense input.
@@ -295,7 +295,7 @@ int main(int argc, char **argv) {
         f.realize({100});
         if (scalar_store || !vector_store) {
             printf("These stores were supposed to be vector.\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -314,7 +314,7 @@ int main(int argc, char **argv) {
         int m = im.get().min(0);
         if (m != 10) {
             printf("min %d instead of 10\n", m);
-            return -1;
+            return 1;
         }
         param.set(false);
         im.reset();
@@ -322,7 +322,7 @@ int main(int argc, char **argv) {
         m = im.get().min(0);
         if (m != -10) {
             printf("min %d instead of -10\n", m);
-            return -1;
+            return 1;
         }
     }
 
@@ -391,14 +391,14 @@ int main(int argc, char **argv) {
 
         if (im.get().extent(0) != 3) {
             printf("extent(0) was supposed to be 3.\n");
-            return -1;
+            return 1;
         }
 
         if (im.get().extent(1) != 2) {
             // Height is 2, because the unrolling also happens in the
             // specialized case.
             printf("extent(1) was supposed to be 2.\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -451,7 +451,7 @@ int main(int argc, char **argv) {
 
         if (if_then_else_count != 1) {
             printf("Expected 1 IfThenElse stmts. Found %d.\n", if_then_else_count);
-            return -1;
+            return 1;
         }
     }
 
@@ -484,7 +484,7 @@ int main(int argc, char **argv) {
         // branch cannot be simplified.
         if (if_then_else_count != 2) {
             printf("Expected 2 IfThenElse stmts. Found %d.\n", if_then_else_count);
-            return -1;
+            return 1;
         }
     }
 
@@ -512,7 +512,7 @@ int main(int argc, char **argv) {
         int h = im.get().height();
         if (w != 10 || h != 1) {
             printf("Incorrect inferred size: %d %d\n", w, h);
-            return -1;
+            return 1;
         }
         im.reset();
 
@@ -522,7 +522,7 @@ int main(int argc, char **argv) {
         h = im.get().height();
         if (w != 1 || h != 10) {
             printf("Incorrect inferred size: %d %d\n", w, h);
-            return -1;
+            return 1;
         }
     }
 
@@ -546,7 +546,7 @@ int main(int argc, char **argv) {
         int h = im.get().height();
         if (w != 10 || h != 1) {
             printf("Incorrect inferred size: %d %d\n", w, h);
-            return -1;
+            return 1;
         }
         im.reset();
 
@@ -561,7 +561,7 @@ int main(int argc, char **argv) {
         h = im.get().height();
         if (w != 10 || h != 10) {
             printf("Incorrect inferred size: %d %d\n", w, h);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/specialize_to_gpu.cpp
+++ b/test/correctness/specialize_to_gpu.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
         uint32_t err = evaluate<uint32_t>(sum(abs(out(r) - reference(r))));
         if (err) {
             printf("Incorrect results for test %d\n", i);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/split_by_non_factor.cpp
+++ b/test/correctness/split_by_non_factor.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < result.width(); i++) {
             if (result(i) != i) {
                 printf("result(%d) was %d instead of %d\n", i, result(i), i);
-                return -1;
+                return 1;
             }
         }
     }
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
             int actual = result(i);
             if (actual != correct) {
                 printf("result(%d) = %d instead of %d\n", i, actual, correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -83,7 +83,7 @@ int main(int argc, char **argv) {
             int actual = result(i);
             if (actual != correct) {
                 printf("result(%d) = %d instead of %d\n", i, actual, correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/split_fuse_rvar.cpp
+++ b/test/correctness/split_fuse_rvar.cpp
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
                 int expected = i * 4 + j;
                 if (Rg(j, i) != expected) {
                     printf("Error! Expected %d at g(%d, %d), got %d\n", expected, j, i, Rg(j, i));
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
         for (int i = 0; i < 16; i++) {
             if (Rg(i) != i) {
                 printf("Error! Expected %d at g(%d), got %d\n", i, i, Rg(i));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/split_store_compute.cpp
+++ b/test/correctness/split_store_compute.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (!success) return -1;
+    if (!success) return 1;
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/stencil_chain_in_update_definitions.cpp
+++ b/test/correctness/stencil_chain_in_update_definitions.cpp
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
                " Expected: %d\n"
                " Actual: %d\n",
                expected, num_stores);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
 
         size_t expected_size = 101 * 4 * sizeof(int);
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
 
         size_t expected_size = 101 * 1002 * 3 * sizeof(int);
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
 
         size_t expected_size = 101 * 3 * sizeof(int);
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
     }
 
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
 
         if (!custom_malloc_sizes.empty()) {
             printf("There should not have been a heap allocation\n");
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -203,7 +203,7 @@ int main(int argc, char **argv) {
                 int correct = (2 * x) * (2 * y) + (2 * x + 1) * (2 * y + 1);
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -226,7 +226,7 @@ int main(int argc, char **argv) {
 
         if (!custom_malloc_sizes.empty()) {
             printf("There should not have been a heap allocation\n");
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -234,7 +234,7 @@ int main(int argc, char **argv) {
                 int correct = x * (2 * y) + (x + 3) * (2 * y + 1);
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -258,7 +258,7 @@ int main(int argc, char **argv) {
 
         size_t expected_size = 2 * 1000 * 4 * sizeof(int);
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -266,7 +266,7 @@ int main(int argc, char **argv) {
                 int correct = (2 * x) * y + (2 * x + 1) * (y + 3);
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -292,7 +292,7 @@ int main(int argc, char **argv) {
 
         size_t expected_size = 1000 * 8 * sizeof(int);
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -300,7 +300,7 @@ int main(int argc, char **argv) {
                 int correct = x * y;
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -325,7 +325,7 @@ int main(int argc, char **argv) {
 
         size_t expected_size = 2 * 1000 * 3 * sizeof(int);
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
                 int correct = (2 * x) * y + (2 * x + 1) * (y + 2);
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -353,7 +353,7 @@ int main(int argc, char **argv) {
 
         size_t expected_size = 1000 * 2 * sizeof(int);
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -361,7 +361,7 @@ int main(int argc, char **argv) {
                 int correct = (x) * (y / 2) + (x) * (y / 2 + 1);
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -385,7 +385,7 @@ int main(int argc, char **argv) {
         size_t expected_size_g = 1000 * 4 * sizeof(int) + sizeof(int);
         size_t expected_size_h = 1000 * 2 * sizeof(int) + sizeof(int);
         if (!check_expected_mallocs({expected_size_g, expected_size_h})) {
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -395,7 +395,7 @@ int main(int argc, char **argv) {
                 auto correct_f = [=](int x, int y) { return correct_g(x, y / 2) + correct_g(x, y / 2 + 1); };
                 if (im(x, y) != correct_f(x, y)) {
                     printf("im(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct_f(x, y));
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -425,7 +425,7 @@ int main(int argc, char **argv) {
             expected_size = 101 * 3 * sizeof(int);
         }
         if (!check_expected_mallocs({expected_size})) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/stream_compaction.cpp
+++ b/test/correctness/stream_compaction.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < result.width(); i++) {
         if (result(i) != next) {
             printf("result(%d) = %d instead of %d\n", i, result(i), next);
-            return -1;
+            return 1;
         } else {
             do {
                 next++;

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -12,20 +12,20 @@ int main(int argc, char **argv) {
     t2 = Target("");
     if (t2 != t1) {
         printf("parse_from_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     t1 = Target();
     ts = t1.to_string();
     if (ts != "arch_unknown-0-os_unknown") {
         printf("to_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
     // Note, this should *not* validate, since validate_target_string
     // now returns false if any of arch-bits-os are undefined
     if (Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // Don't attempt to roundtrip this: trying to create
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
     // t2 = Target(ts);
     // if (t2 != t1) {
     //     printf("roundtrip failure: %s\n", ts.c_str());
-    //     return -1;
+    //     return 1;
     // }
 
     // Full specification round-trip:
@@ -42,11 +42,11 @@ int main(int argc, char **argv) {
     ts = t1.to_string();
     if (ts != "x86-32-linux-sse41") {
         printf("to_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
     if (!Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // Full specification round-trip, crazy features
@@ -57,24 +57,24 @@ int main(int argc, char **argv) {
     ts = t1.to_string();
     if (ts != "arm-32-android-avx-avx2-cuda-debug-jit-opencl-openglcompute-sse41") {
         printf("to_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
     if (!Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // Expected failures:
     ts = "host-unknowntoken";
     if (Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     ts = "x86-23";
     if (Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // bits == 0 is allowed only if arch_unknown and os_unknown are specified,
@@ -82,20 +82,20 @@ int main(int argc, char **argv) {
     ts = "x86-0";
     if (Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     ts = "0-arch_unknown-os_unknown-sse41";
     if (Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // "host" is only supported as the first token
     ts = "opencl-host";
     if (Target::validate_target_string(ts)) {
         printf("validate_target_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // with_feature
@@ -104,7 +104,7 @@ int main(int argc, char **argv) {
     ts = t2.to_string();
     if (ts != "x86-32-linux-no_asserts-no_bounds_query-sse41") {
         printf("to_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // without_feature
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
     ts = t2.to_string();
     if (ts != "x86-32-linux-sse41") {
         printf("to_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     // natural_vector_size
@@ -122,19 +122,19 @@ int main(int argc, char **argv) {
     t1 = Target(Target::Linux, Target::X86, 32, {Target::SSE41});
     if (t1.natural_vector_size<uint8_t>() != 16) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<int16_t>() != 8) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<uint32_t>() != 4) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<float>() != 4) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
 
     // AVX is 32 bytes wide for float, but we treat as only 16 for integral types,
@@ -142,68 +142,68 @@ int main(int argc, char **argv) {
     t1 = Target(Target::Linux, Target::X86, 32, {Target::SSE41, Target::AVX});
     if (t1.natural_vector_size<uint8_t>() != 16) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<int16_t>() != 8) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<uint32_t>() != 4) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<float>() != 8) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
 
     // AVX2 is 32 bytes wide
     t1 = Target(Target::Linux, Target::X86, 32, {Target::SSE41, Target::AVX, Target::AVX2});
     if (t1.natural_vector_size<uint8_t>() != 32) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<int16_t>() != 16) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<uint32_t>() != 8) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<float>() != 8) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
 
     // NEON is 16 bytes wide
     t1 = Target(Target::Linux, Target::ARM, 32);
     if (t1.natural_vector_size<uint8_t>() != 16) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<int16_t>() != 8) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<uint32_t>() != 4) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
     if (t1.natural_vector_size<float>() != 4) {
         printf("natural_vector_size failure\n");
-        return -1;
+        return 1;
     }
 
     t1 = Target("x86-64-linux-trace_all");
     ts = t1.to_string();
     if (!t1.features_all_of({Target::TraceLoads, Target::TraceStores, Target::TraceRealizations})) {
         printf("trace_all failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
     if (ts != "x86-64-linux-trace_all") {
         printf("trace_all to_string failure: %s\n", ts.c_str());
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/tiled_matmul.cpp
+++ b/test/correctness/tiled_matmul.cpp
@@ -260,27 +260,27 @@ int main(int argc, char **argv) {
 
     printf("Running AMX matmul (signed/signed)\n");
     if (!run_tests(matmul_ss, 1)) {
-        return -1;
+        return 1;
     }
 
     printf("Running AMX matmul (signed/unsigned)\n");
     if (!run_tests(matmul_su, 1)) {
-        return -1;
+        return 1;
     }
 
     printf("Running AMX matmul (unsigned/signed)\n");
     if (!run_tests(matmul_us, 1)) {
-        return -1;
+        return 1;
     }
 
     printf("Running AMX matmul (unsigned/unsigned)\n");
     if (!run_tests(matmul_uu, 1)) {
-        return -1;
+        return 1;
     }
 
     printf("Running AMX matmul (bf16)\n");
     if (!run_tests(matmul_bf16, 2)) {
-        return -1;
+        return 1;
     }
 
     return 0;

--- a/test/correctness/tracing.cpp
+++ b/test/correctness/tracing.cpp
@@ -205,7 +205,7 @@ int main(int argc, char **argv) {
         {102, 1, 9, 3, 0, 0, 0, 0, {0, 0, 0, 0}, {0.000000f, 0.000000f, 0.000000f, 0.000000f}, ""},
     };
     if (!check_trace_correct(correct_pipeline_trace, 2)) {
-        return -1;
+        return 1;
     }
 
     // Test a more interesting trace.
@@ -276,7 +276,7 @@ int main(int argc, char **argv) {
 
     int correct_trace_length = sizeof(correct_trace) / sizeof(correct_trace[0]);
     if (!check_trace_correct(correct_trace, correct_trace_length)) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/tracing_stack.cpp
+++ b/test/correctness/tracing_stack.cpp
@@ -96,7 +96,7 @@ int main(int argc, char **argv) {
     h.realize({100, 100});
 
     printf("The code should not have reached this print statement.\n");
-    return -1;
+    return 1;
 }
 
 #else

--- a/test/correctness/trim_no_ops.cpp
+++ b/test/correctness/trim_no_ops.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
         if (s.count != 0) {
             std::cerr << "There were conditionals in the lowered code: \n"
                       << m.functions().front().body << "\n";
-            return -1;
+            return 1;
         }
 
         // Also check the output is correct
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
             if (im(x) != correct) {
                 printf("im(%d) = %d instead of %d\n",
                        x, im(x), correct);
-                return -1;
+                return 1;
             }
         }
     }
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
         if (s.count != 0) {
             std::cerr << "There were selects in the lowered code: \n"
                       << m.functions().front().body << "\n";
-            return -1;
+            return 1;
         }
 
         // Also check the output is correct
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
             if (s.count != 0) {
                 std::cerr << "There were selects in the lowered code: \n"
                           << m.functions().front().body << "\n";
-                return -1;
+                return 1;
             }
             hist_result = hist.realize({256});
         }
@@ -149,7 +149,7 @@ int main(int argc, char **argv) {
             if (hist_result(i) != true_hist_result(i)) {
                 printf("hist(%d) = %d instead of %d\n",
                        i, hist_result(i), true_hist_result(i));
-                return -1;
+                return 1;
             }
         }
     }
@@ -173,7 +173,7 @@ int main(int argc, char **argv) {
         if (s.count != 0) {
             std::cerr << "There were selects or ifs in the lowered code: \n"
                       << m.functions().front().body << "\n";
-            return -1;
+            return 1;
         }
     }
 
@@ -212,12 +212,12 @@ int main(int argc, char **argv) {
         if (s.count_select != 0) {
             std::cerr << "There were selects in the lowered code: \n"
                       << m.functions().front().body << "\n";
-            return -1;
+            return 1;
         }
         if (s.count_if != 1) {
             std::cerr << "There should be 1 if in the lowered code: \n"
                       << m.functions().front().body << "\n";
-            return -1;
+            return 1;
         }
 
         for (int y = 0; y < im.height(); y++) {
@@ -229,7 +229,7 @@ int main(int argc, char **argv) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/tuple_partial_update.cpp
+++ b/test/correctness/tuple_partial_update.cpp
@@ -25,7 +25,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/tuple_reduction.cpp
+++ b/test/correctness/tuple_reduction.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -123,7 +123,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/tuple_select.cpp
+++ b/test/correctness/tuple_select.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -67,7 +67,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/tuple_undef.cpp
+++ b/test/correctness/tuple_undef.cpp
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -97,7 +97,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/tuple_update_ops.cpp
+++ b/test/correctness/tuple_update_ops.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a) {
                     printf("result(%d, %d) = (%d) instead of (%d)\n",
                            x, y, a(x, y), correct_a);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
                     if (a(x, i, j) != correct_a || b(x, i, j) != correct_b) {
                         printf("result(%d, %d, %d) = (%d, %d) instead of (%d, %d)\n",
                                x, i, j, a(x, i, j), b(x, i, j), correct_a, correct_b);
-                        return -1;
+                        return 1;
                     }
                 }
             }
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a || b(x, y) != correct_b) {
                     printf("result(%d, %d) = (%d, %d) instead of (%d, %d)\n",
                            x, y, a(x, y), b(x, y), correct_a, correct_b);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
                 if (a(x, y) != correct_a) {
                     printf("result(%d, %d) = (%d) instead of (%d)\n",
                            x, y, a(x, y), correct_a);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/tuple_vector_reduce.cpp
+++ b/test/correctness/tuple_vector_reduce.cpp
@@ -47,22 +47,22 @@ int main(int argc, char **argv) {
         int b = Buffer<int>(result[1])();
         if (a != (N * (N + 1)) / 2 || b != N * (N + 1)) {
             printf("Incorrect output: %d %d\n", a, b);
-            return -1;
+            return 1;
         }
 
         if (!checker.vector_reduces) {
             printf("Expected VectorReduce nodes\n");
-            return -1;
+            return 1;
         }
 
         if (!checker.atomics) {
             printf("Expected atomic nodes\n");
-            return -1;
+            return 1;
         }
 
         if (checker.mutexes) {
             printf("Did not expect mutexes\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
         float mag = a * a + b * b;
         if (mag <= 0.9 || mag >= 1.1) {
             printf("Should have been magnitude one: %f + %f i\n", a, b);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/undef.cpp
+++ b/test/correctness/undef.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     int err = evaluate_may_gpu<int>(maximum(fib1(r) - fib2(r)));
     if (err > 0) {
         printf("Failed\n");
-        return -1;
+        return 1;
     }
 
     // Now use undef in a tuple. The following code ping-pongs between the two tuple components using a stencil:

--- a/test/correctness/unroll_dynamic_loop.cpp
+++ b/test/correctness/unroll_dynamic_loop.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
         float correct = i * 2 * 3 * 2;
         if (result(i) != correct) {
             printf("result(%d) = %f instead of %f\n", i, result(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/unsafe_dedup_lets.cpp
+++ b/test/correctness/unsafe_dedup_lets.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
     int correct = 131;
     if (result != correct) {
         printf("Bad GCD: %d != %d\n", result, correct);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/vector_bounds_inference.cpp
+++ b/test/correctness/vector_bounds_inference.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < 36; x++) {
             if (out(x, y) != x * 4 + y) {
                 printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), x * 4 + y);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/vector_extern.cpp
+++ b/test/correctness/vector_extern.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
         float correct = sqrtf((float)i);
         if (fabs(im(i) - correct) > 0.001) {
             printf("im(%d) = %f instead of %f\n", i, im(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/vectorize_guard_with_if.cpp
+++ b/test/correctness/vectorize_guard_with_if.cpp
@@ -37,20 +37,20 @@ int main(int argc, char **argv) {
         if (num_vector_stores != expected_vector_stores) {
             printf("There were %d vector stores instead of %d\n",
                    num_vector_stores, expected_vector_stores);
-            return -1;
+            return 1;
         }
 
         if (num_scalar_stores != expected_scalar_stores) {
             printf("There were %d scalar stores instead of %d\n",
                    num_vector_stores, w % 8);
-            return -1;
+            return 1;
         }
 
         for (int i = 0; i < w; i++) {
             if (result(i) != i) {
                 printf("result(%d) == %d instead of %d\n",
                        i, result(i), i);
-                return -1;
+                return 1;
             }
         }
     }
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
             if (result(i) != i / 2 + i / 2) {
                 printf("result(%d) == %d instead of %d\n",
                        i, result(i), i);
-                return -1;
+                return 1;
             }
         }
     }
@@ -107,7 +107,7 @@ int main(int argc, char **argv) {
             if (result(i) != correct) {
                 printf("result(%d) == %d instead of %d\n",
                        i, result(i), correct);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/correctness/vectorize_mixed_widths.cpp
+++ b/test/correctness/vectorize_mixed_widths.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 16; i++) {
         if (r(i) != i) {
             std::cout << "Error at " << i << ": " << r(i) << std::endl;
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/vectorize_nested.cpp
+++ b/test/correctness/vectorize_nested.cpp
@@ -23,7 +23,7 @@ int vectorize_2d_round_up() {
         return 3 * x + y;
     };
     if (check_image(result, cmp_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -50,7 +50,7 @@ int vectorize_2d_guard_with_if_and_predicate() {
             return 3 * x + y;
         };
         if (check_image(result, cmp_func)) {
-            return -1;
+            return 1;
         }
     }
     return 0;
@@ -78,7 +78,7 @@ int vectorize_2d_inlined_with_update() {
         return x + 2 * y + 45;
     };
     if (check_image(result, cmp_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -104,7 +104,7 @@ int vectorize_2d_with_inner_for() {
         return 3 * x + y + 7 * c;
     };
     if (check_image(result, cmp_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -129,7 +129,7 @@ int vectorize_2d_with_compute_at_vectorized() {
         return 6 * x + 3 + 2 * y;
     };
     if (check_image(result, cmp_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -157,7 +157,7 @@ int vectorize_2d_with_compute_at() {
         return 6 * x + 3 + 2 * y;
     };
     if (check_image(result, cmp_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -186,7 +186,7 @@ int vectorize_all_d() {
         return 3 * x + y;
     };
     if (check_image(result, cmp_func)) {
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -241,13 +241,13 @@ int vectorize_inner_of_scalarization() {
     if (is_x_loop_found) {
         std::cerr << "Found scalarized loop for " << x << "\n";
 
-        return -1;
+        return 1;
     }
 
     if (!is_y_loop_found) {
         std::cerr << "Expected to find scalarized loop for " << y << "\n";
 
-        return -1;
+        return 1;
     }
 
     return 0;
@@ -256,42 +256,42 @@ int vectorize_inner_of_scalarization() {
 int main(int argc, char **argv) {
     if (vectorize_2d_round_up()) {
         printf("vectorize_2d_round_up failed\n");
-        return -1;
+        return 1;
     }
 
     if (vectorize_2d_guard_with_if_and_predicate()) {
         printf("vectorize_2d_guard_with_if failed\n");
-        return -1;
+        return 1;
     }
 
     if (vectorize_2d_inlined_with_update()) {
         printf("vectorize_2d_inlined_with_update failed\n");
-        return -1;
+        return 1;
     }
 
     if (vectorize_2d_with_inner_for()) {
         printf("vectorize_2d_with_inner_for failed\n");
-        return -1;
+        return 1;
     }
 
     if (vectorize_2d_with_compute_at()) {
         printf("vectorize_2d_with_compute_at failed\n");
-        return -1;
+        return 1;
     }
 
     if (vectorize_2d_with_compute_at_vectorized()) {
         printf("vectorize_2d_with_compute_at_vectorized failed\n");
-        return -1;
+        return 1;
     }
 
     if (vectorize_all_d()) {
         printf("vectorize_all_d failed\n");
-        return -1;
+        return 1;
     }
 
     if (vectorize_inner_of_scalarization()) {
         printf("vectorize_inner_of_scalarization failed\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/vectorize_varying_allocation_size.cpp
+++ b/test/correctness/vectorize_varying_allocation_size.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv) {
         if (out(i) != correct) {
             printf("out(%d) = %d instead of %d\n",
                    i, out(i), correct);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/vectorized_gpu_allocation.cpp
+++ b/test/correctness/vectorized_gpu_allocation.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 12; ++i) {
         if (input_data[i] != output_data[i]) {
             printf("output(%d) = %f instead of %f\n", i, output_data[i], input_data[i]);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/correctness/vectorized_initialization.cpp
+++ b/test/correctness/vectorized_initialization.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     if (result(0) != 0 || result(1) != 2 || result(2) != 5 || result(3) != 9) {
         printf("Resulting sequence was: %d %d %d %d instead of 0 2 5 9\n",
                result(0), result(1), result(2), result(3));
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/correctness/vectorized_load_from_vectorized_allocation.cpp
+++ b/test/correctness/vectorized_load_from_vectorized_allocation.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
                 if (im(x, y, z) != correct) {
                     printf("im(%d, %d, %d) = %d instead of %d\n",
                            x, y, z, im(x, y, z), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/vectorized_reduction_bug.cpp
+++ b/test/correctness/vectorized_reduction_bug.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
                 if (im(x, y) != correct) {
                     printf("im(%d, %d) = %d instead of %d\n",
                            x, y, im(x, y), correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/widening_lerp.cpp
+++ b/test/correctness/widening_lerp.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
                     printf("Difference of lerp + cast and lerp alone is %f,"
                            " which exceeds threshold for seed %d\n",
                            err, fuzz_seed);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/correctness/widening_reduction.cpp
+++ b/test/correctness/widening_reduction.cpp
@@ -62,7 +62,7 @@ int main(int arch, char **argv) {
                 correct = std::min(std::max(correct / 16, 0), 255);
                 if (correct != out(x, y)) {
                     std::cout << "out(" << x << ", " << y << ") = " << (int)out(x, y) << " instead of " << correct << "\n";
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -105,7 +105,7 @@ int main(int arch, char **argv) {
                 correct = std::min(std::max(correct / 16, 0), 255);
                 if (correct != out(x, y)) {
                     std::cout << "out(" << x << ", " << y << ") = " << (int)out(x, y) << " instead of " << correct << "\n";
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -143,7 +143,7 @@ int main(int arch, char **argv) {
                 uint8_t correct = (static_cast<int16_t>(in(x, y)) + in(x + 1, y)) / 2;
                 if (correct != out(x, y)) {
                     std::cout << "out(" << x << ", " << y << ") = " << (int)out(x, y) << " instead of " << (int)correct << "\n";
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/error/five_d_gpu_buffer.cpp
+++ b/test/error/five_d_gpu_buffer.cpp
@@ -11,7 +11,7 @@ int main(int argc, char **argv) {
         printf("[SKIP] No GPU target enabled.\n");
         // This test is currently expected to error out. This is for the Makefile's benefit.
         printf("Error: pretending that there was an error\n");
-        return -1;
+        return 1;
     }
 
     Func f;
@@ -29,13 +29,13 @@ int main(int argc, char **argv) {
 
     // Delete this code once this test works.
     printf("Error: I should not have successfully compiled.\n");
-    return -1;
+    return 1;
 
     for (int i = 0; i < result.width(); i++) {
         if (i != result(i)) {
             printf("result(%d) = %d instead of %d\n",
                    i, result(i), i);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/failing_with_issue/3292_async_specialize.cpp
+++ b/test/failing_with_issue/3292_async_specialize.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
         size_t expected_size = 101 * 3 * sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {
             printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/failing_with_issue/3293_storage_folding_async.cpp
+++ b/test/failing_with_issue/3293_storage_folding_async.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
         size_t expected_size = 101 * 3 * sizeof(int) + sizeof(int);
         if (custom_malloc_size == 0 || custom_malloc_size != expected_size) {
             printf("Scratch space allocated was %d instead of %d\n", (int)custom_malloc_size, (int)expected_size);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/generator/acquire_release_aottest.cpp
+++ b/test/generator/acquire_release_aottest.cpp
@@ -169,11 +169,11 @@ bool run_test() {
 
 int main(int argc, char **argv) {
     if (!run_test()) {
-        return -1;
+        return 1;
     }
 
     if (!run_test()) {
-        return -1;
+        return 1;
     }
 
     return 0;

--- a/test/generator/can_use_target_aottest.cpp
+++ b/test/generator/can_use_target_aottest.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
     // First, test that the host features are usable. If not, something is wrong.
     if (!halide_can_use_target_features(host_features.kWordCount, host_features.bits)) {
         printf("Failure!\n");
-        return -1;
+        return 1;
     }
 
     // Now start subtracting features; we should still be usable.
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
             printf("host_features are: %x %x\n", (unsigned)host_features.bits[word], (unsigned)(host_features.bits[word] >> 32));
             if (!halide_can_use_target_features(host_features.kWordCount, host_features.bits)) {
                 printf("Failure!\n");
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/generator/cleanup_on_error_aottest.cpp
+++ b/test/generator/cleanup_on_error_aottest.cpp
@@ -73,32 +73,32 @@ int main(int argc, char **argv) {
                result,
                halide_error_code_out_of_memory,
                halide_error_code_device_malloc_failed);
-        return -1;
+        return 1;
     }
 
     if (failed_mallocs != 1) {
         printf("One of the mallocs was supposed to fail\n");
-        return -1;
+        return 1;
     }
 
     if (successful_mallocs != 1) {
         printf("One of the mallocs was supposed to succeed\n");
-        return -1;
+        return 1;
     }
 
     if (frees != 1) {
         printf("The successful malloc should have been freed\n");
-        return -1;
+        return 1;
     }
 
     if (errors != 1) {
         printf("%d errors. There was supposed to be one error\n", errors);
-        return -1;
+        return 1;
     }
 
     if (device_mallocs != device_frees) {
         printf("There were a different number of device mallocs (%d) and frees (%d)\n", device_mallocs, device_frees);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/generator/define_extern_opencl_aottest.cpp
+++ b/test/generator/define_extern_opencl_aottest.cpp
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
     for (int x = 0; x < W; x++) {
         if (input(x) + 1 != output(x)) {
             printf("Error at (%d): %d != %d\n", x, input(x) + 1, output(x));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/generator/gpu_object_lifetime_aottest.cpp
+++ b/test/generator/gpu_object_lifetime_aottest.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
             for (int x = 0; x < output.width(); x++) {
                 if (output(x) != x) {
                     printf("Error! (explicit copy back %d): %d != %d\n", wrap_memory, output(x), x);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
             for (int x = 0; x < output.width(); x++) {
                 if (output(x) != x) {
                     printf("Error! (explicit copy back, no device free %d): %d != %d\n", wrap_memory, output(x), x);
-                    return -1;
+                    return 1;
                 }
             }
         }
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
                 for (int x = 0; x < output.width(); x++) {
                     if (output(x) != wrap_test(x)) {
                         printf("Error! (wrap native test %d): %d != %d\n", i, output(x), wrap_test(x));
-                        return -1;
+                        return 1;
                     }
                 }
                 if (i == 1) {
@@ -166,7 +166,7 @@ int main(int argc, char **argv) {
             int result = halide_device_free(nullptr, &raw_buf);
             if (result != 0) {
                 printf("Error! halide_device_free() returned: %d\n", result);
-                return -1;
+                return 1;
             }
         }
 
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
                 for (int x = 0; x < output.width(); x++) {
                     if (output(x) != output2(x)) {
                         printf("Error! (device and host allocation test): %d != %d\n", output(x), output2(x));
-                        return -1;
+                        return 1;
                     }
                 }
             }

--- a/test/generator/gpu_object_lifetime_aottest.cpp
+++ b/test/generator/gpu_object_lifetime_aottest.cpp
@@ -213,7 +213,8 @@ int main(int argc, char **argv) {
 
     int ret = tracker.validate_gpu_object_lifetime(false /* allow_globals */, true /* allow_none */, 2 /* max_globals */);
     if (ret != 0) {
-        return ret;
+        fprintf(stderr, "validate_gpu_object_lifetime() failed\n");
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/generator/gpu_only_aottest.cpp
+++ b/test/generator/gpu_only_aottest.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < W; x++) {
             if (input(x, y) * 2 != output(x, y)) {
                 printf("Error at %d, %d: %d != %d\n", x, y, input(x, y), output(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/generator/gpu_texture_aottest.cpp
+++ b/test/generator/gpu_texture_aottest.cpp
@@ -46,11 +46,11 @@ int main(int argc, char **argv) {
 
     if (input.raw_buffer()->device_interface != halide_opencl_image_device_interface()) {
         printf("Expected input to be copied to texture storage");
-        return -1;
+        return 1;
     }
     if (output.raw_buffer()->device_interface != halide_opencl_image_device_interface()) {
         printf("Expected output to be copied to texture storage");
-        return -1;
+        return 1;
     }
 
     output.copy_to_host();
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
         for (int x = 0; x < W; x++) {
             if (input(x, y) * 2 != output(x, y)) {
                 printf("Error at %d, %d: %d != %d\n", x, y, input(x, y), output(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -93,7 +93,7 @@ extern "C" int msan_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
 
     if (in->type != out->type) {
         fprintf(stderr, "type mismatch\n");
-        return -1;
+        return halide_error_code_generic_error;
     }
     if (skip_extern_copy) {
         // Fill it with zero to mimic msan "poison".
@@ -102,7 +102,7 @@ extern "C" int msan_extern_stage(halide_buffer_t *in, halide_buffer_t *out) {
         MsanBuffer(*out).copy_from(MsanBuffer(*in));
     }
     out->set_host_dirty();
-    return 0;
+    return halide_error_code_success;
 }
 
 extern "C" void halide_error(void *user_context, const char *msg) {

--- a/test/generator/multitarget_aottest.cpp
+++ b/test/generator/multitarget_aottest.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
 
     if (HalideTest::multitarget(output) != 0) {
         printf("Error at multitarget\n");
-        return -1;
+        return 1;
     }
 
     // Verify output.
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
             const uint32_t actual = output(x, y);
             if (actual != expected) {
                 printf("Error at %d, %d: expected %x, got %x\n", x, y, expected, actual);
-                return -1;
+                return 1;
             }
         }
     }
@@ -84,12 +84,12 @@ int main(int argc, char **argv) {
     for (int i = 0; i < 10; ++i) {
         if (HalideTest::multitarget(output) != 0) {
             printf("Error at multitarget\n");
-            return -1;
+            return 1;
         }
     }
     if (can_use_count != 1) {
         printf("Error: halide_can_use_target_features was called %d times!\n", (int)can_use_count);
-        return -1;
+        return 1;
     }
 
     {
@@ -99,7 +99,7 @@ int main(int argc, char **argv) {
         int result = HalideTest::multitarget(bad_type);
         if (result != halide_error_code_bad_type) {
             printf("Error: expected to fail with halide_error_code_bad_type (%d) but actually got %d!\n", (int)halide_error_code_bad_type, result);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/generator/opencl_runtime_aottest.cpp
+++ b/test/generator/opencl_runtime_aottest.cpp
@@ -12,21 +12,21 @@ int main(int argc, char **argv) {
     halide_opencl_set_platform_name(platform_name.c_str());
     if (platform_name != halide_opencl_get_platform_name(nullptr)) {
         printf("Value returned from halide_opencl_get_platform_name doesn't match\n");
-        return -1;
+        return 1;
     }
 
     std::string device_type = "custom_device";
     halide_opencl_set_device_type(device_type.c_str());
     if (device_type != halide_opencl_get_device_type(nullptr)) {
         printf("Value returned from halide_opencl_get_device_type doesn't match\n");
-        return -1;
+        return 1;
     }
 
     std::string build_options = "-c ustom_build_option";
     halide_opencl_set_build_options(build_options.c_str());
     if (build_options != halide_opencl_get_build_options(nullptr)) {
         printf("Value returned from halide_opencl_get_build_options doesn't match\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/generator/pyramid_aottest.cpp
+++ b/test/generator/pyramid_aottest.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
             if (input(x, y) != levels[0](x, y)) {
                 printf("input(%d, %d) = %f, but levels[0](%d, %d) = %f\n",
                        x, y, input(x, y), x, y, levels[0](x, y));
-                return -1;
+                return 1;
             }
         }
     }
@@ -53,7 +53,7 @@ int main(int argc, char **argv) {
                 if (correct != actual) {
                     printf("levels[%d](%d, %d) = %f instead of %f\n",
                            l, x, y, actual, correct);
-                    return -1;
+                    return 1;
                 }
             }
         }

--- a/test/generator/shuffler_aottest.cpp
+++ b/test/generator/shuffler_aottest.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
             int actual = output(x);
             if (expected != actual) {
                 printf("at x = %d expected %d got %d\n", x, expected, actual);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/generator/string_param_aottest.cpp
+++ b/test/generator/string_param_aottest.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv) {
             int expected_value = (5 * y + x);
             if (output(x, y) != expected_value) {
                 printf("Unexpected output value : %d at output(%d, %d)\n", output(x, y), x, y);
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/generator/variable_num_threads_aottest.cpp
+++ b/test/generator/variable_num_threads_aottest.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
         int ret = variable_num_threads(out);
         if (ret) {
             printf("Non zero exit code: %d\n", ret);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/async_gpu.cpp
+++ b/test/performance/async_gpu.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
 
     if (times[1] > 1.2 * times[0]) {
         printf("Using async should have been faster\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/block_transpose.cpp
+++ b/test/performance/block_transpose.cpp
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
             if (im2(x, y) != im1(x, y)) {
                 printf("wrapper(%d, %d) = %d instead of %d\n",
                        x, y, im2(x, y), im1(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/performance/boundary_conditions.cpp
+++ b/test/performance/boundary_conditions.cpp
@@ -118,7 +118,7 @@ int main(int argc, char **argv) {
         if (tests[i].time > tests[0].time * 5) {
             printf("Error: %s is %f times slower than unbounded\n",
                    tests[i].name, tests[i].time / tests[0].time);
-            return -1;
+            return 1;
         }
     }
 
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
         if (tests[i].time > tests[0].time * 2) {
             printf("Error: %s is %f times slower than unbounded\n",
                    tests[i].name, tests[i].time / tests[0].time);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/clamped_vector_load.cpp
+++ b/test/performance/clamped_vector_load.cpp
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
                "Scalarize the load: %f\n"
                "Pad the input: %f\n",
                t_ref, t_clamped, t_scalar, t_pad);
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -166,7 +166,7 @@ int main(int argc, char **argv) {
     }
 
     if (!success) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/fan_in.cpp
+++ b/test/performance/fan_in.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
 
     if (times[0] < times[1]) {
         printf("Using async() was slower!\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/fast_pow.cpp
+++ b/test/performance/fast_pow.cpp
@@ -81,22 +81,22 @@ int main(int argc, char **argv) {
 
     if (fast_err() > 0.000001) {
         printf("Error for pow too large\n");
-        return -1;
+        return 1;
     }
 
     if (faster_err() > 0.0001) {
         printf("Error for fast_pow too large\n");
-        return -1;
+        return 1;
     }
 
     if (t1 < t2) {
         printf("powf is faster than Halide's pow\n");
-        return -1;
+        return 1;
     }
 
     if (t2 * 1.5 < t3) {
         printf("pow is more than 1.5x faster than fast_pow\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/fast_sine_cosine.cpp
+++ b/test/performance/fast_sine_cosine.cpp
@@ -41,12 +41,12 @@ int main(int argc, char **argv) {
 
     if (t_sin < t_fast_sin) {
         printf("fast_sin is not faster than sin\n");
-        return -1;
+        return 1;
     }
 
     if (t_cos < t_fast_cos) {
         printf("fast_cos is not faster than cos\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/gpu_half_throughput.cpp
+++ b/test/performance/gpu_half_throughput.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
 
     if (t2 > t1) {
         printf("Half should not have been slower than float\n");
-        return -1;
+        return 1;
     }
 
     f32_out.copy_to_host();
@@ -70,11 +70,11 @@ int main(int argc, char **argv) {
     for (int i = 0; i < size; i++) {
         if (f32_out(i) != 4.0f) {
             printf("f32_out(%d) = %f instead of 4\n", i, f32_out(i));
-            return -1;
+            return 1;
         }
         if (f16_out(i) != float16_t(4.0f)) {
             printf("f16_out(%d) = %f instead of 4\n", i, (float)f16_out(i));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/inner_loop_parallel.cpp
+++ b/test/performance/inner_loop_parallel.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
         } else if (min_time > correct_time * 5) {
             printf("Unacceptable overhead when using %d threads for 2 tasks: %f ms vs %f ms\n",
                    t, min_time, correct_time);
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/lots_of_inputs.cpp
+++ b/test/performance/lots_of_inputs.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv) {
         // We may or may not notice if the build bots start taking longer than 15 minutes on one test
         if (t_f > 15 * 60) {
             printf("Took too long\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
 
         if (t_f > 15 * 60) {
             printf("Took too long\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/lots_of_small_allocations.cpp
+++ b/test/performance/lots_of_small_allocations.cpp
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
 
     if (t[0] < t[1]) {
         printf("Heap allocation was faster than pseudostack!\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/memcpy.cpp
+++ b/test/performance/memcpy.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
     // memcpy will win by a little bit for large inputs because it uses streaming stores
     if (t1 > t2 * 3) {
         printf("Halide memcpy is slower than it should be.\n");
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/memory_profiler.cpp
+++ b/test/performance/memory_profiler.cpp
@@ -60,19 +60,19 @@ int check_error(int exp_heap_peak, int exp_num_mallocs,
             "stack_peak: %d\n", heap_peak, num_mallocs, malloc_avg, stack_peak);*/
     if (heap_peak != exp_heap_peak) {
         printf("Peak heap was %d instead of %d\n", heap_peak, exp_heap_peak);
-        return -1;
+        return 1;
     }
     if (num_mallocs != exp_num_mallocs) {
         printf("Num of mallocs was %d instead of %d\n", num_mallocs, exp_num_mallocs);
-        return -1;
+        return 1;
     }
     if (malloc_avg != exp_malloc_avg) {
         printf("Malloc average was %d instead of %d\n", malloc_avg, exp_malloc_avg);
-        return -1;
+        return 1;
     }
     if (stack_peak != exp_stack_peak) {
         printf("Stack peak was %d instead of %d\n", stack_peak, exp_stack_peak);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -85,19 +85,19 @@ int check_error_parallel(int min_heap_peak, int max_heap_peak, int exp_num_mallo
     if (heap_peak < min_heap_peak || heap_peak > max_heap_peak) {
         printf("Peak heap was %d which was outside the range of [%d, %d]\n",
                heap_peak, min_heap_peak, max_heap_peak);
-        return -1;
+        return 1;
     }
     if (num_mallocs != exp_num_mallocs) {
         printf("Num of mallocs was %d instead of %d\n", num_mallocs, exp_num_mallocs);
-        return -1;
+        return 1;
     }
     if (malloc_avg != exp_malloc_avg) {
         printf("Malloc average was %d instead of %d\n", malloc_avg, exp_malloc_avg);
-        return -1;
+        return 1;
     }
     if (stack_peak != exp_stack_peak) {
         printf("Stack peak was %d instead of %d\n", stack_peak, exp_stack_peak);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
         f1.realize({size_x, size_y}, t);
         int stack_size = size_x * size_y * sizeof(int);
         if (check_error(0, 0, 0, stack_size) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -150,7 +150,7 @@ int main(int argc, char **argv) {
         f2.realize({size_x, size_y}, t);
         int total = (size_x + 1) * (size_y + 1) * sizeof(int);
         if (check_error(total, 1, total, 0) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
         reset_stats();
         f3.realize({1000, 1000}, t);
         if (check_error(0, 0, 0, 0) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -184,7 +184,7 @@ int main(int argc, char **argv) {
         reset_stats();
         f3.realize({1000, 1000}, t);
         if (check_error(0, 0, 0, 0) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -216,7 +216,7 @@ int main(int argc, char **argv) {
         f6.realize({size_x}, t);
         total = size_x * sizeof(float);
         if (check_error(total, 1, total, 0) != 0) {
-            return -1;
+            return 1;
         }
 
         reset_stats();
@@ -225,7 +225,7 @@ int main(int argc, char **argv) {
         f6.realize({size_x}, t);
         total = size_x * sizeof(float);
         if (check_error(total, 1, total, 0) != 0) {
-            return -1;
+            return 1;
         }
 
         reset_stats();
@@ -234,7 +234,7 @@ int main(int argc, char **argv) {
         f6.realize({size_x}, t);
         total = size_x * sizeof(float);
         if (check_error(total, 1, total, 0) != 0) {
-            return -1;
+            return 1;
         }
 
         reset_stats();
@@ -242,7 +242,7 @@ int main(int argc, char **argv) {
         toggle2.set(false);
         f6.realize({size_x}, t);
         if (check_error(0, 0, 0, 0) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -266,7 +266,7 @@ int main(int argc, char **argv) {
         int peak = size_x * sizeof(int);
         int total = size_x * size_y * sizeof(int);
         if (check_error(peak, size_y, total / size_y, 0) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -292,7 +292,7 @@ int main(int argc, char **argv) {
         int min_heap_peak = size_x * sizeof(int);
         int total = size_x * size_y * sizeof(int);
         if (check_error_parallel(min_heap_peak, total, size_y, total / size_y, 0) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -312,7 +312,7 @@ int main(int argc, char **argv) {
         f11.realize({size_x, size_y}, t);
         int total = size_x * size_y * sizeof(int);
         if (check_error(total, 1, total, 0) != 0) {
-            return -1;
+            return 1;
         }
     }
 
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
         f12.realize({size_x, size_y}, t);
         int stack_size = size_x * size_y * sizeof(int);
         if (check_error(0, 0, 0, stack_size) != 0) {
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -132,7 +132,7 @@ int main(int argc, char **argv) {
                speed_up);
         if (speed_up < 0.5) {
             printf("The nested vectorization schedule was supposed to be faster!\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -219,7 +219,7 @@ int main(int argc, char **argv) {
                speed_up);
         if (speed_up < 0.5) {
             printf("The nested vectorization schedule was supposed to be faster!\n");
-            return -1;
+            return 1;
         }
     }
 
@@ -302,7 +302,7 @@ int main(int argc, char **argv) {
                speed_up);
         if (speed_up < 0.5) {
             printf("The nested vectorization schedule was supposed to be faster!\n");
-            return -1;
+            return 1;
         }
     }
     printf("Success!\n");
@@ -397,7 +397,7 @@ int main(int argc, char **argv) {
                speed_up);
         if (speed_up < 0.5) {
             printf("The nested vectorization schedule was supposed to be faster!\n");
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/packed_planar_fusion.cpp
+++ b/test/performance/packed_planar_fusion.cpp
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
                t_planar_packed,
                t_packed_planar);
 
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/parallel_performance.cpp
+++ b/test/performance/parallel_performance.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
             if (imf(x, y) != img(x, y)) {
                 printf("imf(%d, %d) = %f\n", x, y, imf(x, y));
                 printf("img(%d, %d) = %f\n", x, y, img(x, y));
-                return -1;
+                return 1;
             }
         }
     }

--- a/test/performance/profiler.cpp
+++ b/test/performance/profiler.cpp
@@ -63,7 +63,7 @@ int run_test(bool use_timer_profiler) {
         printf("Percentage of runtime spent in f13: %d\n"
                "This is suspiciously low. It should be more like 66%%\n",
                percentage);
-        return -1;
+        return 1;
     }
     return 0;
 }
@@ -77,14 +77,14 @@ int main(int argc, char **argv) {
 
     printf("Testing thread based profiler.\n");
     int result = run_test(false);
-    if (result == -1) {
-        return -1;
+    if (result != 0) {
+        return 1;
     }
     if (get_jit_target_from_environment().os == Target::Linux) {
         printf("Testing timer based profiler.\n");
         result = run_test(true);
-        if (result == -1) {
-            return -1;
+        if (result != 0) {
+            return 1;
         }
     }
     printf("Success!\n");

--- a/test/performance/sort.cpp
+++ b/test/performance/sort.cpp
@@ -198,11 +198,11 @@ int main(int argc, char **argv) {
     for (int i = 0; i < N; i++) {
         if (bitonic_sorted(i) != correct(i)) {
             printf("bitonic sort failed: %d -> %d instead of %d\n", i, bitonic_sorted(i), correct(i));
-            return -1;
+            return 1;
         }
         if (merge_sorted(i) != correct(i)) {
             printf("merge sort failed: %d -> %d instead of %d\n", i, merge_sorted(i), correct(i));
-            return -1;
+            return 1;
         }
     }
 

--- a/test/performance/vectorize.cpp
+++ b/test/performance/vectorize.cpp
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     ok = ok && test<int32_t>();
 
     if (!ok) {
-        return -1;
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/performance/wrap.cpp
+++ b/test/performance/wrap.cpp
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
             if (out3(x, y) != out1(x, y)) {
                 printf("wrapper(%d, %d) = %d instead of %d\n",
                        x, y, out3(x, y), out1(x, y));
-                return -1;
+                return 1;
             }
         }
     }
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
             if (out3(x, y) != out2(x, y)) {
                 printf("wrapper(%d, %d) = %d instead of %d\n",
                        x, y, out3(x, y), out2(x, y));
-                return -1;
+                return 1;
             }
         }
     }


### PR DESCRIPTION
A program that returns `-1` from `main()` leaves $? = 255 (per the exit(3) manpage), as the value is chopped with & 0377.

This makes it hard to use git bisect to track down bugs, as considers any exit code > 127 (or = 15, oddly enough) equivalent to an abort() and terminates the bisect.

IMHO this is perverse behavior on the part of git bisect, but it is what it is, so let's revamp our tests to avoid returning `-1` from main to indicate failure, and return `1` instead.