### PR TITLE
Fix overflow in x86 absd lowering

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2751,9 +2751,14 @@ void CodeGen_LLVM::visit(const Call *op) {
         string b_name = unique_name('b');
         Expr a_var = Variable::make(op->args[0].type(), a_name);
         Expr b_var = Variable::make(op->args[1].type(), b_name);
+        Expr cond = a_var < b_var;
+        // Cast to unsigned because we want wrapping semantics on the subtract
+        // in the signed case.
+        a_var = cast(op->type, a_var);
+        b_var = cast(op->type, b_var);
         codegen(Let::make(a_name, op->args[0],
                           Let::make(b_name, op->args[1],
-                                    Select::make(a_var < b_var, b_var - a_var, a_var - b_var))));
+                                    Select::make(cond, b_var - a_var, a_var - b_var))));
     } else if (op->is_intrinsic(Call::div_round_to_zero)) {
         // See if we can rewrite it to something faster (e.g. a shift)
         Expr e = lower_int_uint_div(op->args[0], op->args[1], /** round to zero */ true);

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -588,7 +588,12 @@ void CodeGen_X86::visit(const Call *op) {
             codegen(saturating_sub(op->args[0], op->args[1]) | saturating_sub(op->args[1], op->args[0]));
             return;
         } else if (op->args[0].type().is_int()) {
-            codegen(Max::make(op->args[0], op->args[1]) - Min::make(op->args[0], op->args[1]));
+            // In the signed case, we take the min/max, cast them to unsigned,
+            // and subtract. The cast to unsigned may wrap, but if it does, so
+            // will the subtract.
+            codegen(
+                cast(op->type, Max::make(op->args[0], op->args[1])) -
+                cast(op->type, Min::make(op->args[0], op->args[1])));
             return;
         }
     }


### PR DESCRIPTION
The existing code was codegenning an int32 replacement for an Expr of type uint32. One option was to cast the result to a uint32, but we want wrapping semantics on that subtract, so it's better to just do an unsigned subtraction.

This should fix the breakage with trunk llvm.