### PR TITLE
Remove the result code from halide_reuse_device_allocations() et al

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1963,8 +1963,13 @@ extern double halide_float16_bits_to_double(uint16_t);
  *
  * If set to false, releases all unused device allocations back to the
  * underlying device APIs. For finer-grained control, see specific
- * methods in each device api runtime. */
-extern int halide_reuse_device_allocations(void *user_context, bool);
+ * methods in each device api runtime.
+ *
+ * Note that this call does not return an error; it is expected
+ * that the device implementation will defer any error(s) that result
+ * from this to the next relevent alloc/free call.
+ * */
+extern void halide_reuse_device_allocations(void *user_context, bool);
 
 /** Determines whether on device_free the memory is returned
  * immediately to the device API, or placed on a free list for future
@@ -1974,7 +1979,7 @@ extern int halide_reuse_device_allocations(void *user_context, bool);
 extern bool halide_can_reuse_device_allocations(void *user_context);
 
 struct halide_device_allocation_pool {
-    int (*release_unused)(void *user_context);
+    void (*release_unused)(void *user_context);
     struct halide_device_allocation_pool *next;
 };
 

--- a/src/runtime/HalideRuntimeCuda.h
+++ b/src/runtime/HalideRuntimeCuda.h
@@ -63,7 +63,7 @@ extern uintptr_t halide_cuda_get_device_ptr(void *user_context, struct halide_bu
 
 /** Release any currently-unused device allocations back to the cuda
  * driver. See halide_reuse_device_allocations. */
-extern int halide_cuda_release_unused_device_allocations(void *user_context);
+extern void halide_cuda_release_unused_device_allocations(void *user_context);
 
 // These typedefs treat both a CUcontext and a CUstream as a void *,
 // to avoid dependencies on cuda headers.

--- a/src/runtime/allocation_cache.cpp
+++ b/src/runtime/allocation_cache.cpp
@@ -20,7 +20,6 @@ extern "C" {
 WEAK void halide_reuse_device_allocations(void *user_context, bool flag) {
     halide_reuse_device_allocations_flag = flag;
 
-    int err = 0;
     if (!flag) {
         ScopedMutexLock lock(&allocation_pools_lock);
         for (halide_device_allocation_pool *p = device_allocation_pools; p != nullptr; p = p->next) {

--- a/src/runtime/allocation_cache.cpp
+++ b/src/runtime/allocation_cache.cpp
@@ -17,20 +17,16 @@ WEAK halide_device_allocation_pool *device_allocation_pools = nullptr;
 
 extern "C" {
 
-WEAK int halide_reuse_device_allocations(void *user_context, bool flag) {
+WEAK void halide_reuse_device_allocations(void *user_context, bool flag) {
     halide_reuse_device_allocations_flag = flag;
 
     int err = 0;
     if (!flag) {
         ScopedMutexLock lock(&allocation_pools_lock);
         for (halide_device_allocation_pool *p = device_allocation_pools; p != nullptr; p = p->next) {
-            int ret = p->release_unused(user_context);
-            if (ret) {
-                err = ret;
-            }
+            p->release_unused(user_context);
         }
     }
-    return err;
 }
 
 /** Determines whether on device_free the memory is returned

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -595,7 +595,7 @@ WEAK void halide_cuda_finalize_kernels(void *user_context, void *state_ptr) {
     }
 }
 
-WEAK int halide_cuda_release_unused_device_allocations(void *user_context) {
+WEAK void halide_cuda_release_unused_device_allocations(void *user_context) {
     FreeListItem *to_free;
     {
         ScopedMutexLock lock(&free_list_lock);
@@ -609,7 +609,6 @@ WEAK int halide_cuda_release_unused_device_allocations(void *user_context) {
         free(to_free);
         to_free = next;
     }
-    return 0;
 }
 
 namespace Halide {


### PR DESCRIPTION
(Split from #7403)

The current implementation of halide_reuse_device_allocations() and friends cannot ever return a nonzero error code. I'd argue that even if errors could be associated with reusing allocations, it is likely more sensible to return errors from the relevant alloc/free calls.

This PR proposes removing the result code entirely to remove confusion, at the cost of a (minor) API breakage, which should be easy to detect at compile time.