### PR TITLE
printer.h should include HalideRuntime.h

### DIFF
--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -1,6 +1,8 @@
 #ifndef HALIDE_RUNTIME_PRINTER_H
 #define HALIDE_RUNTIME_PRINTER_H
 
+#include "HalideRuntime.h"
+
 // This is useful for debugging threading issues in the Halide runtime:
 // prefix all `debug()` statements with the thread id that did the logging.
 // Left here (but disabled) for future reference.


### PR DESCRIPTION
printer.h uses uint64_t, so it needs to include something that ensures that type is defined. HalideRuntime.h is probably the right choice (since it always transitively includes runtime_internal.h when compiling runtime.