### PR TITLE
Split WebGPU runtime into two variants (#7248 workaround)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -830,7 +830,8 @@ RUNTIME_CPP_COMPONENTS = \
   trace_helper \
   tracing \
   wasm_cpu_features \
-  webgpu \
+  webgpu_dawn \
+  webgpu_emscripten \
   windows_clock \
   windows_cuda \
   windows_d3d12compute_arm \

--- a/README_webgpu.md
+++ b/README_webgpu.md
@@ -29,8 +29,6 @@ device codegen may be required before it becomes profitable to use.
 
 Halide can generate WebGPU code that can be integrated with WASM code using
 Emscripten.
-Halide must currently be built *without* the `WEBGPU_NATIVE_LIB` flag when
-targeting Emscripten.
 
 When invoking `emcc` to link Halide-generated objects, include these flags:
 `-s USE_WEBGPU=1 -s ASYNCIFY`.
@@ -53,11 +51,13 @@ For testing purposes, Halide can also target native WebGPU libraries, such as
 This is currently the only path that can run the JIT correctness tests.
 See [below](#setting-up-dawn) for instructions on building Dawn.
 
-Due to differences between the APIs implemented by native WebGPU libraries and
-Emscripten, this currently requires a separate build of Halide.
 Pass `-DWEBGPU_NATIVE_LIB=/path/to/native/library.{so,dylib.dll}` to CMake when
 configuring Halide to enable this path, which will automatically use this
 library for the AOT and JIT tests.
+
+Note that it is explicitly legal to specify both WEBGPU_NATIVE_LIB and
+WEBGPU_NODE_BINDINGS for the same build; the correct executable environment
+will be selected based on the Halide target specified.
 
 ## Setting up Dawn
 

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -719,7 +719,7 @@ function(_Halide_target_link_gpu_libs TARGET VISIBILITY)
 
     if ("${ARGN}" MATCHES "webgpu")
         if (WEBGPU_NATIVE_LIB)
-            target_link_libraries(${TARGET} PRIVATE ${WEBGPU_NATIVE_LIB})
+            target_link_libraries(${TARGET} INTERFACE ${WEBGPU_NATIVE_LIB})
         endif ()
     endif ()
 endfunction()

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -118,12 +118,6 @@ function(add_wasm_executable TARGET)
         )
     endif ()
 
-    # TODO: Remove this when Emscripten and Dawn implement the same APIs.
-    # See https://github.com/halide/Halide/issues/7248
-    if (WEBGPU_NATIVE_LIB)
-        message(FATAL_ERROR "Cannot generate WASM executables when targeting native WebGPU implementations.")
-    endif ()
-
     set(SRCS)
     foreach (S IN LISTS args_SRCS)
         list(APPEND SRCS "${CMAKE_CURRENT_SOURCE_DIR}/${S}")

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -144,7 +144,10 @@ DECLARE_CPP_INITMOD(timer_profiler)
 DECLARE_CPP_INITMOD(to_string)
 DECLARE_CPP_INITMOD(trace_helper)
 DECLARE_CPP_INITMOD(tracing)
-DECLARE_CPP_INITMOD(webgpu)
+// TODO(https://github.com/halide/Halide/issues/7248)
+// DECLARE_CPP_INITMOD(webgpu)
+DECLARE_CPP_INITMOD(webgpu_dawn)
+DECLARE_CPP_INITMOD(webgpu_emscripten)
 DECLARE_CPP_INITMOD(windows_clock)
 DECLARE_CPP_INITMOD(windows_cuda)
 DECLARE_CPP_INITMOD(windows_get_symbol)
@@ -1194,7 +1197,13 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 // See https://github.com/halide/Halide/issues/7249
                 user_error << "WebGPU runtime not yet supported on Windows.\n";
             } else {
-                modules.push_back(get_initmod_webgpu(c, bits_64, debug));
+                // Select the right WebGPU runtime variant based on the Target's OS:
+                // if we are targeting wasm, use the Emscripten variant; in all other cases, use Dawn variant.
+                if (t.os == Target::WebAssemblyRuntime) {
+                    modules.push_back(get_initmod_webgpu_emscripten(c, bits_64, debug));
+                } else {
+                    modules.push_back(get_initmod_webgpu_dawn(c, bits_64, debug));
+                }
             }
         }
         if (t.arch != Target::Hexagon && t.has_feature(Target::HVX)) {

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -79,7 +79,10 @@ set(RUNTIME_CPP
     trace_helper
     tracing
     wasm_cpu_features
-    webgpu
+    # TODO(https://github.com/halide/Halide/issues/7248)
+    # webgpu
+    webgpu_dawn
+    webgpu_emscripten
     windows_clock
     windows_cuda
     windows_d3d12compute_arm
@@ -227,10 +230,6 @@ foreach (i IN LISTS RUNTIME_CPP)
         set(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${i}.cpp")
 
         set(RUNTIME_DEFINES -DCOMPILING_HALIDE_RUNTIME -DBITS_${j})
-        if (WEBGPU_NATIVE_LIB)
-            # TODO: Remove this once Emscripten and Dawn agree with each other.
-            set(RUNTIME_DEFINES -DWITH_DAWN_NATIVE ${RUNTIME_DEFINES})
-        endif ()
         set(RUNTIME_DEFINES_debug -g -DDEBUG_RUNTIME ${RUNTIME_DEFINES})
 
         foreach (SUFFIX IN ITEMS "" "_debug")

--- a/src/runtime/webgpu_dawn.cpp
+++ b/src/runtime/webgpu_dawn.cpp
@@ -1,0 +1,12 @@
+// TODO(https://github.com/halide/Halide/issues/7248):
+//
+// For now, we must build the webgpu runtime two ways:
+// - once for the native API (Dawn)
+// - once for the Emscripten API (Chrome)
+//
+// Once the API discrepancies are resolved we can
+// go back to building this in a sane manner, but for now,
+// we use this sad-but-effective approach.
+
+#define HALIDE_RUNTIME_WEBGPU_NATIVE_API 1
+#include "webgpu.cpp"

--- a/src/runtime/webgpu_emscripten.cpp
+++ b/src/runtime/webgpu_emscripten.cpp
@@ -1,0 +1,12 @@
+// TODO(https://github.com/halide/Halide/issues/7248):
+//
+// For now, we must build the webgpu runtime two ways:
+// - once for the native API (Dawn)
+// - once for the Emscripten API (Chrome)
+//
+// Once the API discrepancies are resolved we can
+// go back to building this in a sane manner, but for now,
+// we use this sad-but-effective approach.
+
+#define HALIDE_RUNTIME_WEBGPU_NATIVE_API 0
+#include "webgpu.cpp"

--- a/test/correctness/interpreter.cpp
+++ b/test/correctness/interpreter.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
     }
 
     // Workaround for https://github.com/halide/Halide/issues/7420
-    if (target.has_feature(Target::WebGPU));
+    if (target.has_feature(Target::WebGPU)) {
         printf("[SKIP] workaround for issue #7420\n");
         return 0;
     }

--- a/test/correctness/interpreter.cpp
+++ b/test/correctness/interpreter.cpp
@@ -13,6 +13,12 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    // Workaround for https://github.com/halide/Halide/issues/7420
+    if (target.has_feature(Target::WebGPU));
+        printf("[SKIP] workaround for issue #7420\n");
+        return 0;
+    }
+
     // This test demonstrates a trick for writing interpreters in
     // Halide, and as a side-effect tests our ability to correctly
     // emit switch statements.

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -128,7 +128,9 @@ function(_add_one_aot_test TARGET)
     if ("${Halide_TARGET}" MATCHES "webgpu")
         target_compile_definitions("${TARGET}" PRIVATE TEST_WEBGPU)
         target_include_directories("${TARGET}" PRIVATE ${args_INCLUDES} "${Halide_SOURCE_DIR}/src/runtime")
-        if (WEBGPU_NATIVE_LIB)
+        if ("${Halide_TARGET}" MATCHES "wasmrt")
+            # nothing
+        else ()
             # TODO: Remove this once Emscripten and Dawn agree with each other.
             target_compile_definitions("${TARGET}" PRIVATE WITH_DAWN_NATIVE)
         endif ()


### PR DESCRIPTION
Halide promises that you can crosscompile to *any* supported target from a 'stock' build of libHalide. Unfortunately, the initial landing of WebGPU support breaks that promise: we compile the webgpu runtime support (webgpu.cpp) with code that is predicated on `WITH_DAWN_NATIVE` (for Dawn vs Emscripten, respectively).

This means that if you build Halide with `WITH_DAWN_NATIVE` defined, you can *only* target Dawn with that build of Halide; similarly, if you build with `WITH_DAWN_NATIVE` not-defined, you can only target Emscripten. (Trying to use the 'wrong' version will produce link-time errors.)

For people who build everything from source, this isn't a big deal, but for people who just pull binary builds, this is a big problem.

This PR proposes a temporary workaround until the API discrepancies are resolved:
- Compile the existing webgpu.cpp runtime *both* ways
- in LLVM_Runtime_Linker.cpp, select the correct variant based on whether the Target is targeting wasm or not
- Profit!

This is a rather ugly hack, but it should hopefully be (relatively) temporary.

attn @jrprice 