### PR TITLE
Backport xtensa_codegen to main

### DIFF
--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -172,6 +172,8 @@ void define_enums(py::module &m) {
         .value("SVE2", Target::Feature::SVE2)
         .value("ARMDotProd", Target::Feature::ARMDotProd)
         .value("ARMFp16", Target::Feature::ARMFp16)
+        .value("Xtensa", Target::Feature::Xtensa)
+        .value("XtensaQ8", Target::Feature::XtensaQ8)
         .value("LLVMLargeCodeModel", Target::Feature::LLVMLargeCodeModel)
         .value("RVV", Target::Feature::RVV)
         .value("ARMv81a", Target::Feature::ARMv81a)

--- a/python_bindings/src/halide/halide_/PyFunc.cpp
+++ b/python_bindings/src/halide/halide_/PyFunc.cpp
@@ -408,6 +408,8 @@ void define_func(py::module &m) {
 
             .def("infer_arguments", &Func::infer_arguments)
 
+            .def("dma", (Func & (Func::*)()) & Func::dma)
+
             .def("__repr__", [](const Func &func) -> std::string {
                 std::ostringstream o;
                 o << "<halide.Func '" << func.name() << "'>";

--- a/src/AssociativeOpsTable.cpp
+++ b/src/AssociativeOpsTable.cpp
@@ -33,12 +33,14 @@ enum class ValType {
     UInt64 = 4,
     Int8 = 5,
     Int16 = 6,
-    Int32 = 7,
-    Int64 = 8,
-    Float16 = 9,
-    Float32 = 10,
-    Float64 = 11,
-    All = 12,  // General type (including all previous types)
+    Int24 = 7,
+    Int32 = 8,
+    Int48 = 9,
+    Int64 = 10,
+    Float16 = 11,
+    Float32 = 12,
+    Float64 = 13,
+    All = 14,  // General type (including all previous types)
 };
 
 ValType convert_halide_type_to_val_type(const Type &halide_t) {
@@ -63,8 +65,12 @@ ValType convert_halide_type_to_val_type(const Type &halide_t) {
             val_t = ValType::Int8;
         } else if (halide_t.bits() == 16) {
             val_t = ValType::Int16;
+        } else if (halide_t.bits() == 24) {
+            val_t = ValType::Int24;
         } else if (halide_t.bits() == 32) {
             val_t = ValType::Int32;
+        } else if (halide_t.bits() == 48) {
+            val_t = ValType::Int48;
         } else {
             internal_assert(halide_t.bits() == 64);
             val_t = ValType::Int64;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ set(HEADER_FILES
     CodeGen_PyTorch.h
     CodeGen_Targets.h
     CodeGen_WebGPU_Dev.h
+    CodeGen_Xtensa.h
     CompilerLogger.h
     ConciseCasts.h
     CPlusPlusMangle.h
@@ -80,6 +81,7 @@ set(HEADER_FILES
     HexagonOptimize.h
     ImageParam.h
     InferArguments.h
+    InjectDmaTransfer.h
     InjectHostDevBufferCopies.h
     Inline.h
     InlineReductions.h
@@ -167,6 +169,7 @@ set(HEADER_FILES
     VectorizeLoops.h
     WasmExecutor.h
     WrapCalls.h
+    XtensaOptimize.h
     )
 
 set(SOURCE_FILES
@@ -209,6 +212,7 @@ set(SOURCE_FILES
     CodeGen_WebAssembly.cpp
     CodeGen_WebGPU_Dev.cpp
     CodeGen_X86.cpp
+    CodeGen_Xtensa.cpp
     CompilerLogger.cpp
     CPlusPlusMangle.cpp
     CSE.cpp
@@ -243,6 +247,7 @@ set(SOURCE_FILES
     HexagonOptimize.cpp
     ImageParam.cpp
     InferArguments.cpp
+    InjectDmaTransfer.cpp
     InjectHostDevBufferCopies.cpp
     Inline.cpp
     InlineReductions.cpp
@@ -346,6 +351,7 @@ set(SOURCE_FILES
     VectorizeLoops.cpp
     WasmExecutor.cpp
     WrapCalls.cpp
+    XtensaOptimize.cpp
     )
 
 ##

--- a/src/CodeGen_Xtensa.cpp
+++ b/src/CodeGen_Xtensa.cpp
@@ -1,0 +1,4366 @@
+#include "CodeGen_Xtensa.h"
+
+#include <string>
+
+#include "CodeGen_Internal.h"
+#include "IROperator.h"
+#include "IRVisitor.h"
+#include "Lerp.h"
+#include "Simplify.h"
+#include "Substitute.h"
+#include "XtensaOptimize.h"
+
+// 0 = off
+// 1 == outermost loops only
+// 2 == 2 outermost loop levels only
+// etc
+#define POOR_MANS_PROFILING_LOOP_LEVEL 0
+
+namespace Halide {
+namespace Internal {
+
+using std::ostream;
+using std::ostringstream;
+using std::string;
+using std::vector;
+
+namespace {
+
+std::string intrinsic_suffix_for_type(Type t) {
+    if (t.is_int() && (t.bits() == 8)) {
+        return "2NX8";
+    } else if (t.is_uint() && (t.bits() == 8)) {
+        return "2NX8U";
+    } else if (t.is_int() && (t.bits() == 16)) {
+        return "NX16";
+    } else if (t.is_uint() && (t.bits() == 16)) {
+        return "NX16U";
+    } else if (t.is_int() && (t.bits() == 32)) {
+        return "N_2X32";
+    } else if (t.is_uint() && (t.bits() == 32)) {
+        return "N_2X32U";
+    } else if (t.is_float() && (t.bits() == 32)) {
+        return "N_2XF32";
+    } else if (t.is_float() && (t.bits() == 16)) {
+        return "NXF16";
+    }
+
+    return "";
+}
+
+class UsesDmaCopy : public IRGraphVisitor {
+private:
+    using IRGraphVisitor::visit;
+
+protected:
+    void visit(const Call *op) override {
+        if ((op->name == "halide_xtensa_copy_1d") || (op->name == "halide_xtensa_copy_2d")) {
+            uses_dma = true;
+            max_channel_no = std::max<int>(max_channel_no, *as_const_int(op->args[0]));
+        }
+
+        IRGraphVisitor::visit(op);
+    }
+
+public:
+    bool uses_dma = false;
+    int max_channel_no = 0;
+};
+
+}  // namespace
+
+void CodeGen_Xtensa::add_platform_prologue() {
+    const char *headers = R"INLINE_CODE(
+
+#define XCHAL_VISION_SIMD8 (XCHAL_VISION_SIMD16 * 2)
+
+// TODO(vksnk): this is disabled by default, because iDMA is not part of cstub
+// so we need to get git repo compiling with xt-tools first (b/173159625)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void *halide_tcm_malloc(void *user_context, size_t x) __attribute__((malloc));
+extern void halide_tcm_free(void *user_context, void *ptr);
+extern void **halide_init_dma(int32_t channel_count);
+extern int32_t halide_xtensa_copy_1d(int32_t channel, void* dst, int32_t dst_base, void* src, int32_t src_base, int32_t extent, int32_t item_size);
+extern int32_t halide_xtensa_copy_2d(int32_t channel, void *dst, int32_t dst_base, int32_t dst_stride, void *src, int32_t src_base, int32_t src_stride, int32_t extent0, int32_t extent1, int32_t item_size);
+extern int32_t halide_xtensa_wait_for_copy(int32_t channel);
+extern int32_t halide_release_dma(int32_t channel_count, void** dma_desc);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+class ScopedDmaInitializer {
+  int channel_count_;
+  void** dma_desc_ = nullptr;
+ public:
+  ScopedDmaInitializer(int channel_count) : channel_count_(channel_count) {
+    dma_desc_ = halide_init_dma(channel_count_);
+  }
+
+  ScopedDmaInitializer() = delete;
+  ScopedDmaInitializer(const ScopedDmaInitializer&) = delete;
+  ScopedDmaInitializer& operator=(const ScopedDmaInitializer&) = delete;
+  ScopedDmaInitializer(ScopedDmaInitializer&&) = delete;
+
+  ~ScopedDmaInitializer() {
+    if (dma_desc_ != nullptr) {
+      halide_release_dma(channel_count_, dma_desc_);
+    }
+  }
+
+  bool is_valid() const { return dma_desc_ != nullptr; }
+};
+
+)INLINE_CODE";
+
+    stream << headers;
+}
+
+Stmt CodeGen_Xtensa::preprocess_function_body(const Stmt &stmt) {
+    Stmt new_body = match_xtensa_patterns(stmt, target);
+
+    UsesDmaCopy uses_dma;
+    new_body.accept(&uses_dma);
+    if (uses_dma.uses_dma) {
+        stream << get_indent() << "ScopedDmaInitializer dma_initializer(" << (uses_dma.max_channel_no) + 1 << ");\n";
+        stream << get_indent() << "if (!dma_initializer.is_valid()) {\n";
+        stream << get_indent() << "halide_error(_ucon, \"DMA initialization failed\");\n";
+        stream << get_indent() << "return halide_error_code_generic_error;\n";
+        stream << get_indent() << "}\n";
+    }
+
+    return new_body;
+}
+
+void CodeGen_Xtensa::add_vector_typedefs(const std::set<Type> &vector_types) {
+    stream << R"INLINE_CODE(
+#if defined(__XTENSA__)
+#include <xtensa/sim.h>
+#include <xtensa/tie/xt_ivpn.h>
+#include <xtensa/tie/xt_timer.h>
+
+// This inline function is needed by application to get the cycle count from ISS
+inline int GetCycleCount() {
+  return XT_RSR_CCOUNT();
+}
+
+#endif
+)INLINE_CODE";
+
+    if (!vector_types.empty()) {
+        const char *native_typedef_decl = R"INLINE_CODE(
+
+
+#include <xtensa/tie/xt_ivpn.h>
+
+#define HALIDE_MAYBE_UNUSED __attribute__ ((unused))
+
+#if XCHAL_VISION_TYPE == 7
+using common_int8x64_t __attribute__((ext_vector_type(64))) = int8_t;
+using common_uint8x64_t __attribute__((ext_vector_type(64))) = uint8_t;
+using common_int16x32_t __attribute__((ext_vector_type(32))) = int16_t;
+using common_uint16x32_t __attribute__((ext_vector_type(32))) = uint16_t;
+using common_int32x16_t __attribute__((ext_vector_type(16))) = int32_t;
+using common_uint32x16_t __attribute__((ext_vector_type(16))) = uint32_t;
+#elif XCHAL_VISION_TYPE == 8
+using common_int8x128_t __attribute__((ext_vector_type(128))) = int8_t;
+using common_uint8x128_t __attribute__((ext_vector_type(128))) = uint8_t;
+using common_int16x64_t __attribute__((ext_vector_type(64))) = int16_t;
+using common_uint16x64_t __attribute__((ext_vector_type(64))) = uint16_t;
+using common_int32x32_t __attribute__((ext_vector_type(32))) = int32_t;
+using common_uint32x32_t __attribute__((ext_vector_type(32))) = uint32_t;
+#else
+#error "Unsupported value for XCHAL_VISION_TYPE"
+#endif
+
+using int48_t = xb_int48;
+using float16_t = xb_f16;
+using native_vector_i8 = xb_vec2Nx8;
+using native_vector_u8 = xb_vec2Nx8U;
+using native_mask_i8 = vbool2N;
+using native_vector_i16 = xb_vecNx16;
+using native_vector_u16 = xb_vecNx16U;
+using native_mask_i16 = vboolN;
+using native_vector_i24 = xb_vec2Nx24;
+using native_vector_i32 = xb_vecN_2x32v;
+using native_vector_u32 = xb_vecN_2x32Uv;
+using native_mask_i32 = vboolN_2;
+using native_vector_i48 = xb_vecNx48;
+using native_vector_f16 = xb_vecNxf16;
+using native_vector_f32 = xb_vecN_2xf32;
+using native_vector_i64 = xb_vecN_2x64w;
+
+#if XCHAL_VISION_TYPE == 7
+using int8x64_t = xb_vec2Nx8;
+using uint8x64_t = xb_vec2Nx8U;
+using int16x32_t = xb_vecNx16;
+using uint16x32_t = xb_vecNx16U;
+using int24_t = xb_int24;
+using int24x64_t = xb_vec2Nx24;
+using uint24x64_t = xb_vec2Nx24;
+using int32x16_t = xb_vecN_2x32v;
+using uint32x16_t = xb_vecN_2x32Uv;
+using int48x32_t = xb_vecNx48;
+using uint48x32_t = xb_vecNx48;
+using int64x16_t = xb_vecN_2x64w;
+using uint1x16_t = vboolN_2;
+using uint1x32_t = vboolN;
+using uint1x64_t = vbool2N;
+using float16x16_t = xb_vecN_2xf16;
+using float16x32_t = xb_vecNxf16;
+using float32x16_t = xb_vecN_2xf32;
+#elif XCHAL_VISION_TYPE == 8
+using int8x128_t = xb_vec2Nx8;
+using uint8x128_t = xb_vec2Nx8U;
+using int16x64_t = xb_vecNx16;
+using uint16x64_t = xb_vecNx16U;
+using int24_t = xb_int24;
+using int24x128_t = xb_vec2Nx24;
+using uint24x128_t = xb_vec2Nx24;
+using int32x32_t = xb_vecN_2x32v;
+using uint32x32_t = xb_vecN_2x32Uv;
+using int48x64_t = xb_vecNx48;
+using uint48x64_t = xb_vecNx48;
+using uint1x32_t = vboolN_2;
+using uint1x64_t = vboolN;
+using uint1x128_t = vbool2N;
+using float16x32_t = xb_vecN_2xf16;
+using float16x64_t = xb_vecNxf16;
+using float32x32_t = xb_vecN_2xf32;
+using int64x32_t = xb_vecN_2x64w;
+#endif
+
+using int8x4_t = xb_int32pr;
+using uint8x4_t = xb_int32pr;
+using int8x8_t = xb_int64pr;
+using uint8x8_t = xb_int64pr;
+
+template <typename NativeVector, int N>
+struct MultipleOfNativeVector {
+  NativeVector  __attribute__((aligned(XCHAL_VISION_SIMD8))) native_vector[N];
+
+  MultipleOfNativeVector() {}
+
+  // TODO(vksnk): figure out a better/safer way to construct it.
+  enum FromCppVector { from_native_vector };
+  inline MultipleOfNativeVector(FromCppVector, const NativeVector &src1, const NativeVector &src2) {
+      static_assert(N == 2, "Wrong kind of constructor");
+      native_vector[0] = src1;
+      native_vector[1] = src2;
+  }
+
+  inline MultipleOfNativeVector(FromCppVector, const NativeVector &src1, const NativeVector &src2, const NativeVector &src3) {
+      static_assert(N == 3, "Wrong kind of constructor");
+      native_vector[0] = src1;
+      native_vector[1] = src2;
+      native_vector[2] = src3;
+  }
+
+  inline MultipleOfNativeVector(FromCppVector, const MultipleOfNativeVector<NativeVector, 2> &src1, const MultipleOfNativeVector<NativeVector, 2> &src2) {
+      static_assert(N == 4, "Wrong kind of constructor");
+      native_vector[0] = src1.native_vector[0];
+      native_vector[1] = src1.native_vector[1];
+      native_vector[2] = src2.native_vector[0];
+      native_vector[3] = src2.native_vector[1];
+}
+
+  inline MultipleOfNativeVector(FromCppVector, const NativeVector &src1, const NativeVector &src2, const NativeVector &src3, const NativeVector &src4) {
+      static_assert(N == 4, "Wrong kind of constructor");
+      native_vector[0] = src1;
+      native_vector[1] = src2;
+      native_vector[2] = src3;
+      native_vector[3] = src4;
+  }
+
+  inline MultipleOfNativeVector(FromCppVector, const NativeVector &src1, const NativeVector &src2, const NativeVector &src3, const NativeVector &src4,
+                                const NativeVector &src5, const NativeVector &src6) {
+      static_assert(N == 6, "Wrong kind of constructor");
+      native_vector[0] = src1;
+      native_vector[1] = src2;
+      native_vector[2] = src3;
+      native_vector[3] = src4;
+      native_vector[4] = src5;
+      native_vector[5] = src6;
+  }
+
+  inline MultipleOfNativeVector(FromCppVector, const NativeVector &src1, const NativeVector &src2, const NativeVector &src3, const NativeVector &src4,
+                                                const NativeVector &src5, const NativeVector &src6, const NativeVector &src7, const NativeVector &src8) {
+      static_assert(N == 8, "Wrong kind of constructor");
+      native_vector[0] = src1;
+      native_vector[1] = src2;
+      native_vector[2] = src3;
+      native_vector[3] = src4;
+      native_vector[4] = src5;
+      native_vector[5] = src6;
+      native_vector[6] = src7;
+      native_vector[7] = src8;
+  }
+
+  inline MultipleOfNativeVector(FromCppVector, const NativeVector &src1, const NativeVector &src2, const NativeVector &src3, const NativeVector &src4,
+                                                const NativeVector &src5, const NativeVector &src6, const NativeVector &src7, const NativeVector &src8,
+                                                const NativeVector &src9, const NativeVector &src10, const NativeVector &src11, const NativeVector &src12) {
+      static_assert(N == 12, "Wrong kind of constructor");
+      native_vector[0] = src1;
+      native_vector[1] = src2;
+      native_vector[2] = src3;
+      native_vector[3] = src4;
+      native_vector[4] = src5;
+      native_vector[5] = src6;
+      native_vector[6] = src7;
+      native_vector[7] = src8;
+      native_vector[8] = src9;
+      native_vector[9] = src10;
+      native_vector[10] = src11;
+      native_vector[11] = src12;
+  }
+
+  inline MultipleOfNativeVector(FromCppVector, const NativeVector &src1, const NativeVector &src2, const NativeVector &src3, const NativeVector &src4,
+                                                const NativeVector &src5, const NativeVector &src6, const NativeVector &src7, const NativeVector &src8,
+                                                const NativeVector &src9, const NativeVector &src10, const NativeVector &src11, const NativeVector &src12,
+                                                const NativeVector &src13, const NativeVector &src14, const NativeVector &src15, const NativeVector &src16) {
+      static_assert(N == 16, "Wrong kind of constructor");
+      native_vector[0] = src1;
+      native_vector[1] = src2;
+      native_vector[2] = src3;
+      native_vector[3] = src4;
+      native_vector[4] = src5;
+      native_vector[5] = src6;
+      native_vector[6] = src7;
+      native_vector[7] = src8;
+      native_vector[8] = src9;
+      native_vector[9] = src10;
+      native_vector[10] = src11;
+      native_vector[11] = src12;
+      native_vector[12] = src13;
+      native_vector[13] = src14;
+      native_vector[14] = src15;
+      native_vector[15] = src16;
+  }
+
+};
+
+#if XCHAL_VISION_TYPE == 7
+using uint1x96_t = MultipleOfNativeVector<uint1x32_t, 3>;
+using uint1x192_t = MultipleOfNativeVector<uint1x64_t, 3>;
+using uint1x256_t = MultipleOfNativeVector<uint1x64_t, 4>;
+using int8x128_t = MultipleOfNativeVector<int8x64_t, 2>;
+using int8x192_t = MultipleOfNativeVector<int8x64_t, 3>;
+using int8x256_t = MultipleOfNativeVector<int8x64_t, 4>;
+using uint8x128_t = MultipleOfNativeVector<uint8x64_t, 2>;
+using uint8x192_t = MultipleOfNativeVector<uint8x64_t, 3>;
+using uint8x256_t = MultipleOfNativeVector<uint8x64_t, 4>;
+using int16x64_t = MultipleOfNativeVector<int16x32_t, 2>;
+using uint16x64_t = MultipleOfNativeVector<uint16x32_t, 2>;
+using int16x96_t = MultipleOfNativeVector<int16x32_t, 3>;
+using uint16x96_t = MultipleOfNativeVector<uint16x32_t, 3>;
+using int16x128_t = MultipleOfNativeVector<int16x32_t, 4>;
+using uint16x128_t = MultipleOfNativeVector<uint16x32_t, 4>;
+using int24x128_t = MultipleOfNativeVector<int24x64_t, 2>;
+using int32x32_t = MultipleOfNativeVector<int32x16_t, 2>;
+using int32x48_t = MultipleOfNativeVector<int32x16_t, 3>;
+using uint32x32_t = MultipleOfNativeVector<uint32x16_t, 2>;
+using uint32x48_t = MultipleOfNativeVector<uint32x16_t, 3>;
+using int32x64_t = MultipleOfNativeVector<int32x16_t, 4>;
+using uint32x64_t = MultipleOfNativeVector<uint32x16_t, 4>;
+using int32x96_t = MultipleOfNativeVector<int32x16_t, 6>;
+using uint32x96_t = MultipleOfNativeVector<uint32x16_t, 6>;
+using int32x128_t = MultipleOfNativeVector<int32x16_t, 8>;
+using uint32x128_t = MultipleOfNativeVector<uint32x16_t, 8>;
+// TODO(vksnk): this one should be generated automatically, but isn't.
+using int32x192_t = MultipleOfNativeVector<int32x16_t, 12>;
+using int32x256_t = MultipleOfNativeVector<int32x16_t, 16>;
+using int48x64_t = MultipleOfNativeVector<int48x32_t, 2>;
+using int64x32_t = MultipleOfNativeVector<int64x16_t, 2>;
+using float32x32_t = MultipleOfNativeVector<float32x16_t, 2>;
+using float32x48_t = MultipleOfNativeVector<float32x16_t, 3>;
+using float32x64_t = MultipleOfNativeVector<float32x16_t, 4>;
+#elif XCHAL_VISION_TYPE == 8
+using uint1x192_t = MultipleOfNativeVector<uint1x64_t, 3>;
+using uint1x384_t = MultipleOfNativeVector<uint1x128_t, 3>;
+using uint1x512_t = MultipleOfNativeVector<uint1x128_t, 4>;
+using int8x256_t = MultipleOfNativeVector<int8x128_t, 2>;
+using int8x512_t = MultipleOfNativeVector<int8x128_t, 4>;
+using uint8x256_t = MultipleOfNativeVector<uint8x128_t, 2>;
+using uint8x384_t = MultipleOfNativeVector<uint8x128_t, 3>;
+using uint8x512_t = MultipleOfNativeVector<uint8x128_t, 4>;
+using int16x128_t = MultipleOfNativeVector<int16x64_t, 2>;
+using uint16x128_t = MultipleOfNativeVector<uint16x64_t, 2>;
+using int16x192_t = MultipleOfNativeVector<int16x64_t, 3>;
+using uint16x192_t = MultipleOfNativeVector<uint16x64_t, 3>;
+using int16x256_t = MultipleOfNativeVector<int16x64_t, 4>;
+using uint16x256_t = MultipleOfNativeVector<uint16x64_t, 4>;
+using int24x256_t = MultipleOfNativeVector<int24x128_t, 2>;
+using int32x64_t = MultipleOfNativeVector<int32x32_t, 2>;
+using uint32x64_t = MultipleOfNativeVector<uint32x32_t, 2>;
+using int32x128_t = MultipleOfNativeVector<int32x32_t, 4>;
+using uint32x128_t = MultipleOfNativeVector<uint32x32_t, 4>;
+using int32x192_t = MultipleOfNativeVector<int32x32_t, 6>;
+using uint32x192_t = MultipleOfNativeVector<uint32x32_t, 6>;
+using int32x256_t = MultipleOfNativeVector<int32x32_t, 8>;
+using uint32x256_t = MultipleOfNativeVector<uint32x32_t, 8>;
+// TODO(vksnk): this one should be generated automatically, but isn't.
+using int32x382_t = MultipleOfNativeVector<int32x32_t, 12>;
+using int32x512_t = MultipleOfNativeVector<int32x32_t, 16>;
+using int48x128_t = MultipleOfNativeVector<int48x64_t, 2>;
+using int64x64_t = MultipleOfNativeVector<int64x32_t, 2>;
+using float32x64_t = MultipleOfNativeVector<float32x32_t, 2>;
+using float32x128_t = MultipleOfNativeVector<float32x32_t, 4>;
+#endif
+
+#if XCHAL_VISION_TYPE == 7
+#define VECTOR_WIDTH_I8 64
+#define VECTOR_WIDTH_U8 64
+#define VECTOR_WIDTH_I16 32
+#define VECTOR_WIDTH_U16 32
+#define VECTOR_WIDTH_F16 32
+#define VECTOR_WIDTH_I32 16
+#define VECTOR_WIDTH_U32 16
+#define VECTOR_WIDTH_F32 16
+#elif XCHAL_VISION_TYPE == 8
+#define VECTOR_WIDTH_I8 128
+#define VECTOR_WIDTH_U8 128
+#define VECTOR_WIDTH_I16 64
+#define VECTOR_WIDTH_U16 64
+#define VECTOR_WIDTH_F16 64
+#define VECTOR_WIDTH_I32 32
+#define VECTOR_WIDTH_U32 32
+#define VECTOR_WIDTH_F32 32
+#endif
+
+using native_vector_i8_x2 = MultipleOfNativeVector<native_vector_i8, 2>;
+using native_vector_i8_x3 = MultipleOfNativeVector<native_vector_i8, 3>;
+using native_vector_i8_x4 = MultipleOfNativeVector<native_vector_i8, 4>;
+
+using native_vector_u8_x2 = MultipleOfNativeVector<native_vector_u8, 2>;
+using native_vector_u8_x3 = MultipleOfNativeVector<native_vector_u8, 3>;
+using native_vector_u8_x4 = MultipleOfNativeVector<native_vector_u8, 4>;
+using native_vector_u8_x6 = MultipleOfNativeVector<native_vector_u8, 6>;
+
+using native_vector_i16_x2 = MultipleOfNativeVector<native_vector_i16, 2>;
+using native_vector_i16_x4 = MultipleOfNativeVector<native_vector_i16, 4>;
+
+using native_vector_u16_x2 = MultipleOfNativeVector<native_vector_u16, 2>;
+using native_vector_u16_x3 = MultipleOfNativeVector<native_vector_u16, 3>;
+using native_vector_u16_x4 = MultipleOfNativeVector<native_vector_u16, 4>;
+using native_vector_u16_x6 = MultipleOfNativeVector<native_vector_u16, 6>;
+
+using native_vector_i24_x2 = MultipleOfNativeVector<native_vector_i24, 2>;
+
+using native_vector_i32_x2 = MultipleOfNativeVector<native_vector_i32, 2>;
+using native_vector_i32_x4 = MultipleOfNativeVector<native_vector_i32, 4>;
+using native_vector_i32_x6 = MultipleOfNativeVector<native_vector_i32, 6>;
+using native_vector_i32_x8 = MultipleOfNativeVector<native_vector_i32, 8>;
+using native_vector_i32_x12 = MultipleOfNativeVector<native_vector_i32, 12>;
+using native_vector_i32_x16 = MultipleOfNativeVector<native_vector_i32, 16>;
+
+using native_vector_u32_x2 = MultipleOfNativeVector<native_vector_u32, 2>;
+using native_vector_u32_x4 = MultipleOfNativeVector<native_vector_u32, 4>;
+
+using native_vector_i48_x2 = MultipleOfNativeVector<native_vector_i48, 2>;
+
+using native_vector_f32_x2 = MultipleOfNativeVector<native_vector_f32, 2>;
+using native_vector_f32_x4 = MultipleOfNativeVector<native_vector_f32, 4>;
+
+using native_vector_i64_x2 = MultipleOfNativeVector<native_vector_i64, 2>;
+
+using native_mask_i8_x3 = MultipleOfNativeVector<native_mask_i8, 3>;
+using native_mask_i8_x4 = MultipleOfNativeVector<native_mask_i8, 4>;
+using native_mask_i8_x6 = MultipleOfNativeVector<native_mask_i8, 6>;
+using native_mask_i16_x2 = MultipleOfNativeVector<native_mask_i16, 2>;
+using native_mask_i16_x3 = MultipleOfNativeVector<native_mask_i16, 3>;
+
+
+template <typename ToType, typename FromType>
+HALIDE_ALWAYS_INLINE ToType convert(const FromType& from_type) = delete;
+
+template <typename ResultType>
+HALIDE_ALWAYS_INLINE ResultType ramp(int32_t base, int32_t stride) = delete;
+
+template <typename ResultType>
+HALIDE_ALWAYS_INLINE ResultType dense_ramp(int32_t base) = delete;
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 ramp<native_vector_i32_x2>(int32_t base, int32_t stride) {
+    native_vector_i32 one_to_n = IVP_SEQN_2X32();
+    native_vector_i32 base_w = base;
+    native_vector_i32 stride_w = stride;
+    native_vector_i32 lanes_2 = VECTOR_WIDTH_I32;
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector, IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(one_to_n, stride_w))),
+            IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_2 + one_to_n, stride_w))));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 dense_ramp<native_vector_i32_x2>(int32_t base) {
+    const native_vector_i32 base_w = native_vector_i32(base) + IVP_SEQN_2X32();
+    const native_vector_i32 lanes_2 = VECTOR_WIDTH_I32;
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector, base_w, base_w + lanes_2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 ramp<native_vector_i32_x4>(int32_t base, int32_t stride) {
+    native_vector_i32 one_to_n = IVP_SEQN_2X32();
+    native_vector_i32 base_w = base;
+    native_vector_i32 stride_w = stride;
+    native_vector_i32 lanes_2 = VECTOR_WIDTH_I32;
+    native_vector_i32 lanes_3 = VECTOR_WIDTH_I32 * 2;
+    native_vector_i32 lanes_4 = VECTOR_WIDTH_I32 * 3;
+
+    return native_vector_i32_x4(native_vector_i32_x4::from_native_vector,
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_2 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_3 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_4 + one_to_n, stride_w))));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 dense_ramp<native_vector_i32_x4>(int32_t base) {
+    native_vector_i32 base_w = IVP_ADDN_2X32(native_vector_i32(base), IVP_SEQN_2X32());
+    native_vector_i32 lanes_2 = VECTOR_WIDTH_I32;
+    native_vector_i32 lanes_3 = VECTOR_WIDTH_I32 * 2;
+    native_vector_i32 lanes_4 = VECTOR_WIDTH_I32 * 3;
+
+    return native_vector_i32_x4(native_vector_i32_x4::from_native_vector,
+                        base_w,
+                        IVP_ADDN_2X32(base_w, lanes_2),
+                        IVP_ADDN_2X32(base_w, lanes_3),
+                        IVP_ADDN_2X32(base_w, lanes_4));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x8 ramp<native_vector_i32_x8>(int32_t base, int32_t stride) {
+    native_vector_i32 one_to_n = IVP_SEQN_2X32();
+    native_vector_i32 base_w = base;
+    native_vector_i32 stride_w = stride;
+    native_vector_i32 lanes_2 = VECTOR_WIDTH_I32;
+    native_vector_i32 lanes_3 = VECTOR_WIDTH_I32 * 2;
+    native_vector_i32 lanes_4 = VECTOR_WIDTH_I32 * 3;
+    native_vector_i32 lanes_5 = VECTOR_WIDTH_I32 * 4;
+    native_vector_i32 lanes_6 = VECTOR_WIDTH_I32 * 5;
+    native_vector_i32 lanes_7 = VECTOR_WIDTH_I32 * 6;
+    native_vector_i32 lanes_8 = VECTOR_WIDTH_I32 * 7;
+
+    return native_vector_i32_x8(native_vector_i32_x8::from_native_vector,
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_2 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_3 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_4 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_5 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_6 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_7 + one_to_n, stride_w))),
+                IVP_ADDN_2X32(base_w, IVP_PACKLN_2X64W(IVP_MULN_2X32(lanes_8 + one_to_n, stride_w))));
+}
+
+template <typename ResultType, typename BaseType>
+HALIDE_ALWAYS_INLINE ResultType broadcast(BaseType value) = delete;
+
+template <>
+HALIDE_ALWAYS_INLINE uint8x4_t broadcast<uint8x4_t, uint8_t>(uint8_t value) {
+    native_vector_u8 v = value;
+    return IVP_EXTRPRN_2X32(IVP_MOVN_2X32_FROMNX16(IVP_MOVNX16_FROM2NX8(v)), 0);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE uint8x8_t broadcast<uint8x8_t, uint8_t>(uint8_t value) {
+    native_vector_u8 v = value;
+    return IVP_EXTRPR64N_2X32(IVP_MOVN_2X32_FROMNX16(IVP_MOVNX16_FROM2NX8(v)), 0);
+}
+
+template <typename VectorType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE VectorType aligned_load(const void *base, int32_t offset) {
+    return *((const VectorType *)((const BaseType*)base + offset));
+}
+
+template <typename VectorType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE VectorType load(const void *base, int32_t offset) {
+    VectorType r;
+    memcpy(&r, ((const BaseType*)base + offset), sizeof(BaseType) * Lanes);
+    return r;
+}
+
+template <typename VectorType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE void aligned_store(const VectorType& a, void *base, int32_t offset) {
+    *((VectorType *)((BaseType*)base + offset)) = a;
+}
+
+template <typename VectorType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE void store(const VectorType& a, void *base, int32_t offset) {
+    memcpy(((BaseType*)base + offset), &a, sizeof(BaseType) * Lanes);
+}
+
+template <typename VectorType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE VectorType load_variable(const void *base, int32_t offset, int32_t count) {
+    VectorType r;
+    memcpy(&r, ((const BaseType*)base + offset), sizeof(BaseType) * count);
+    return r;
+}
+
+template <typename VectorType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE void store_variable(const VectorType& a, void *base, int32_t offset, int32_t count) {
+    memcpy(((BaseType*)base + offset), &a, sizeof(BaseType) * count);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE void store_variable<native_vector_u8, uint8_t, VECTOR_WIDTH_U8>(const native_vector_u8& a, void *base, int32_t offset, int32_t count) {
+    valign align = IVP_ZALIGN();
+    xb_vec2Nx8U* __restrict ptr  = (xb_vec2Nx8U*)((uint8_t*)base + offset);
+    IVP_SAV2NX8U_XP(a, align, ptr, count);
+    IVP_SAPOS2NX8U_FP(align, ptr);
+}
+
+template <typename VectorType, typename OffsetType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE void store_scatter(const VectorType& a, void *base, const OffsetType& offset) {
+    BaseType __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[Lanes];
+    aligned_store<VectorType, BaseType, Lanes>(a, &tmp[0], 0);
+
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[Lanes];
+    aligned_store<OffsetType, int32_t, Lanes>(offset, &offsets[0], 0);
+
+    for (int i = 0; i < Lanes; i++) {
+        ((BaseType*)base)[offsets[i]] = tmp[i];
+    }
+}
+
+template <typename VectorType, typename OffsetType, typename PredicateType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE VectorType load_predicated(const void *base, const OffsetType& offset, const PredicateType& predicate) = delete;
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_u8 load_predicated<native_vector_u8, native_vector_i32_x4, native_mask_i8, uint8_t, VECTOR_WIDTH_U8>(const void *base, const native_vector_i32_x4& offset, const native_mask_i8& predicate) {
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[VECTOR_WIDTH_U8];
+    aligned_store<native_vector_i32_x4, int32_t, VECTOR_WIDTH_U8>(offset, &offsets[0], 0);
+    native_vector_u8 vmask = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate);
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[VECTOR_WIDTH_U8];
+    aligned_store<native_vector_u8, uint8_t, VECTOR_WIDTH_U8>(vmask, &mask[0], 0);
+
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) output[VECTOR_WIDTH_U8];
+    for (int i = 0; i < VECTOR_WIDTH_U8; i++) {
+        if (mask[i] == 1) {
+            output[i] = ((const uint8_t*)base)[offsets[i]];
+        } else {
+            output[i] = 0;
+        }
+    }
+
+    return *((native_vector_u8 *)output);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_i16 load_predicated<native_vector_i16, native_vector_i32_x2, native_mask_i16, int16_t, VECTOR_WIDTH_I16>(const void *base, const native_vector_i32_x2& offset, const native_mask_i16& predicate) {
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[VECTOR_WIDTH_I16];
+    aligned_store<native_vector_i32_x2, int32_t, VECTOR_WIDTH_I16>(offset, &offsets[0], 0);
+    native_vector_i16 vmask = IVP_MOVNX16T(native_vector_i16(1), native_vector_i16(0), predicate);
+    int16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[VECTOR_WIDTH_I16];
+    aligned_store<native_vector_i16, int16_t, VECTOR_WIDTH_I16>(vmask, &mask[0], 0);
+
+    int16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) output[VECTOR_WIDTH_I16];
+    for (int i = 0; i < VECTOR_WIDTH_I16; i++) {
+        if (mask[i] == 1) {
+            output[i] = ((const int16_t*)base)[offsets[i]];
+        } else {
+            output[i] = 0;
+        }
+    }
+
+    return *((native_vector_i16 *)output);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_mask_i16_x2 convert<native_mask_i16_x2, native_mask_i8>(const native_mask_i8& src);
+
+template <>
+HALIDE_ALWAYS_INLINE
+native_vector_i16_x2
+load_predicated<native_vector_i16_x2, native_vector_i32_x4, native_mask_i8 , int16_t, 2 * VECTOR_WIDTH_I16>(
+        const void *base, const native_vector_i32_x4& offset, const native_mask_i8& predicate) {
+    native_mask_i16_x2 c_predicate = convert<native_mask_i16_x2, native_mask_i8>(predicate);
+    native_vector_i16 p1 = load_predicated<native_vector_i16, native_vector_i32_x2, native_mask_i16, int16_t, VECTOR_WIDTH_I16>(
+        base,
+        native_vector_i32_x2(
+          native_vector_i32_x2::from_native_vector,
+          offset.native_vector[0], offset.native_vector[1]),
+        c_predicate.native_vector[0]);
+
+    native_vector_i16 p2 = load_predicated<native_vector_i16, native_vector_i32_x2, native_mask_i16, int16_t, VECTOR_WIDTH_I16>(
+        base,
+        native_vector_i32_x2(
+          native_vector_i32_x2::from_native_vector,
+          offset.native_vector[2], offset.native_vector[3]),
+        c_predicate.native_vector[1]);
+    return native_vector_i16_x2(native_vector_i16_x2::from_native_vector, p1, p2);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_u16 load_predicated<native_vector_u16, native_vector_i32_x2, native_mask_i16, uint16_t, VECTOR_WIDTH_U16>(const void *base, const native_vector_i32_x2& offset, const native_mask_i16& predicate) {
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[VECTOR_WIDTH_U16];
+    aligned_store<native_vector_i32_x2, int32_t, VECTOR_WIDTH_U16>(offset, &offsets[0], 0);
+    native_vector_i16 vmask = IVP_MOVNX16T(native_vector_i16(1), native_vector_i16(0), predicate);
+    int16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[VECTOR_WIDTH_U16];
+    aligned_store<native_vector_i16, int16_t, VECTOR_WIDTH_U16>(vmask, &mask[0], 0);
+
+    uint16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) output[VECTOR_WIDTH_U16];
+    for (int i = 0; i < VECTOR_WIDTH_U16; i++) {
+        if (mask[i] == 1) {
+            output[i] = ((const uint16_t*)base)[offsets[i]];
+        } else {
+            output[i] = 0;
+        }
+    }
+
+    return *((native_vector_u16 *)output);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 load_predicated<native_vector_i32_x2, native_vector_i32_x2, native_mask_i16, int32_t, 2 * VECTOR_WIDTH_I32>(const void *base, const native_vector_i32_x2& offset, const native_mask_i16& predicate) {
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[2 * VECTOR_WIDTH_I32];
+    aligned_store<native_vector_i32_x2, int32_t, 2 * VECTOR_WIDTH_I32>(offset, &offsets[0], 0);
+    native_vector_i16 vmask = IVP_MOVNX16T(native_vector_i16(1), native_vector_i16(0), predicate);
+    int16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[2 * VECTOR_WIDTH_I32];
+    aligned_store<native_vector_i16, int16_t, 2 * VECTOR_WIDTH_I32>(vmask, &mask[0], 0);
+
+    int32_t __attribute__((aligned(XCHAL_VISION_SIMD8))) output[2 * VECTOR_WIDTH_I32];
+    for (int i = 0; i < 2 * VECTOR_WIDTH_I32; i++) {
+        if (mask[i] == 1) {
+            output[i] = ((const int32_t*)base)[offsets[i]];
+        } else {
+            output[i] = 0;
+        }
+    }
+
+    return *((native_vector_i32_x2 *)output);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 load_predicated<native_vector_f32_x2, native_vector_i32_x2, native_mask_i16, float, 2 * VECTOR_WIDTH_F32>(const void *base, const native_vector_i32_x2& offset, const native_mask_i16& predicate) {
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[2 * VECTOR_WIDTH_F32];
+    aligned_store<native_vector_i32_x2, int32_t, 2 * VECTOR_WIDTH_F32>(offset, &offsets[0], 0);
+    native_vector_u16 vmask = IVP_MOVNX16T(native_vector_u16(1), native_vector_u16(0), predicate);
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[2 * VECTOR_WIDTH_F32];
+    aligned_store<native_vector_u16, uint16_t, 2 * VECTOR_WIDTH_F32>(vmask, &mask[0], 0);
+
+    float __attribute__((aligned(XCHAL_VISION_SIMD8))) output[2 * VECTOR_WIDTH_F32];
+    for (int i = 0; i < 2 * VECTOR_WIDTH_F32; i++) {
+        if (mask[i] == 1) {
+            output[i] = ((const float*)base)[offsets[i]];
+        } else {
+            output[i] = 0;
+        }
+    }
+
+    return *((native_vector_f32_x2 *)output);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_f32_x4 load_predicated<native_vector_f32_x4, native_vector_i32_x4, native_mask_i8, float, 4 * VECTOR_WIDTH_F32>(const void *base, const native_vector_i32_x4& offset, const native_mask_i8& predicate) {
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[4 * VECTOR_WIDTH_F32];
+    aligned_store<native_vector_i32_x4, int32_t, 4 * VECTOR_WIDTH_F32>(offset, &offsets[0], 0);
+    native_vector_u8 vmask = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate);
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[4 * VECTOR_WIDTH_F32];
+    aligned_store<native_vector_u8, uint8_t, 4 * VECTOR_WIDTH_F32>(vmask, &mask[0], 0);
+
+    float __attribute__((aligned(XCHAL_VISION_SIMD8))) output[4 * VECTOR_WIDTH_F32];
+    for (int i = 0; i < 4 * VECTOR_WIDTH_F32; i++) {
+        if (mask[i] == 1) {
+            output[i] = ((const float*)base)[offsets[i]];
+        } else {
+            output[i] = 0;
+        }
+    }
+
+    return *((native_vector_f32_x4 *)output);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 load_predicated<native_vector_i32_x4, native_vector_i32_x4, native_mask_i8, int32_t, 4 * VECTOR_WIDTH_I32>(const void *base, const native_vector_i32_x4& offset, const native_mask_i8& predicate) {
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[4 * VECTOR_WIDTH_I32];
+    aligned_store<native_vector_i32_x4, int32_t, 4 * VECTOR_WIDTH_I32>(offset, &offsets[0], 0);
+    native_vector_u8 vmask = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate);
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[4 * VECTOR_WIDTH_I32];
+    aligned_store<native_vector_u8, uint8_t, 4 * VECTOR_WIDTH_I32>(vmask, &mask[0], 0);
+
+    int32_t __attribute__((aligned(XCHAL_VISION_SIMD8))) output[4 * VECTOR_WIDTH_I32];
+    for (int i = 0; i < 4 * VECTOR_WIDTH_I32; i++) {
+        if (mask[i] == 1) {
+            output[i] = ((const int32_t*)base)[offsets[i]];
+        } else {
+            output[i] = 0;
+        }
+    }
+
+    return *((native_vector_i32_x4 *)output);
+}
+
+template <typename VectorType, typename OffsetType, typename PredicateType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE void store_predicated(const VectorType& a, void *base, const OffsetType& offset, const PredicateType& predicate) = delete;
+
+template <>
+HALIDE_ALWAYS_INLINE void store_predicated<native_vector_u8, native_vector_i32_x4, native_mask_i8, uint8_t, VECTOR_WIDTH_U8>(const native_vector_u8& a, void *base, const native_vector_i32_x4& offset, const native_mask_i8& predicate) {
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[VECTOR_WIDTH_U8];
+    aligned_store<native_vector_u8, uint8_t, VECTOR_WIDTH_U8>(a, &tmp[0], 0);
+
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[VECTOR_WIDTH_U8];
+    aligned_store<native_vector_i32_x4, int32_t, VECTOR_WIDTH_U8>(offset, &offsets[0], 0);
+
+    native_vector_u8 vmask = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate);
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[VECTOR_WIDTH_U8];
+    aligned_store<native_vector_u8, uint8_t, VECTOR_WIDTH_U8>(vmask, &mask[0], 0);
+
+    for (int i = 0; i < VECTOR_WIDTH_U8; i++) {
+        if (mask[i]) {
+            ((uint8_t*)base)[offsets[i]] = tmp[i];
+        }
+    }
+}
+
+template <>
+HALIDE_ALWAYS_INLINE void store_predicated<native_vector_u8_x3, native_vector_i32_x12, native_mask_i8_x3, uint8_t, 3 * VECTOR_WIDTH_U8>(const native_vector_u8_x3& a, void *base, const native_vector_i32_x12& offset, const native_mask_i8_x3& predicate) {
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[3 * VECTOR_WIDTH_U8];
+    aligned_store<native_vector_u8_x3, uint8_t, 3 * VECTOR_WIDTH_U8>(a, &tmp[0], 0);
+
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[3 * VECTOR_WIDTH_U8];
+    aligned_store<native_vector_i32_x12, int32_t, 3 * VECTOR_WIDTH_U8>(offset, &offsets[0], 0);
+
+    native_vector_u8 vmask0 = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate.native_vector[0]);
+    native_vector_u8 vmask1 = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate.native_vector[1]);
+    native_vector_u8 vmask2 = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate.native_vector[2]);
+
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[3 * VECTOR_WIDTH_U8];
+    aligned_store<native_vector_u8_x3, uint8_t, 3 * VECTOR_WIDTH_U8>(
+        native_vector_u8_x3(native_vector_u8_x3::from_native_vector, vmask0, vmask1, vmask2), &mask[0], 0);
+
+    for (int i = 0; i < 3 * VECTOR_WIDTH_U8; i++) {
+        if (mask[i]) {
+            ((uint8_t*)base)[offsets[i]] = tmp[i];
+        }
+    }
+}
+
+template <>
+HALIDE_ALWAYS_INLINE void store_predicated<native_vector_u8_x4, native_vector_i32_x16, native_mask_i8_x4, uint8_t, 4 * VECTOR_WIDTH_U8>(const native_vector_u8_x4& a, void *base, const native_vector_i32_x16& offset, const native_mask_i8_x4& predicate) {
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[4 * VECTOR_WIDTH_U8];
+    aligned_store<native_vector_u8_x4, uint8_t, 4 * VECTOR_WIDTH_U8>(a, &tmp[0], 0);
+
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[4 * VECTOR_WIDTH_U8];
+    aligned_store<native_vector_i32_x16, int32_t, 4 * VECTOR_WIDTH_U8>(offset, &offsets[0], 0);
+
+    native_vector_u8 vmask0 = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate.native_vector[0]);
+    native_vector_u8 vmask1 = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate.native_vector[1]);
+    native_vector_u8 vmask2 = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate.native_vector[2]);
+    native_vector_u8 vmask3 = IVP_MOV2NX8T(native_vector_u8(1), native_vector_u8(0), predicate.native_vector[3]);
+
+    uint8_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[4 * VECTOR_WIDTH_U8];
+    aligned_store<native_vector_u8_x4, uint8_t, 4 * VECTOR_WIDTH_U8>(
+        native_vector_u8_x4(native_vector_u8_x4::from_native_vector, vmask0, vmask1, vmask2, vmask3), &mask[0], 0);
+
+    for (int i = 0; i < 4 * VECTOR_WIDTH_U8; i++) {
+        if (mask[i]) {
+            ((uint8_t*)base)[offsets[i]] = tmp[i];
+        }
+    }
+}
+
+template <>
+HALIDE_ALWAYS_INLINE void store_predicated<native_vector_u16_x3, native_vector_i32_x6, native_mask_i16_x3, uint16_t, 3 * VECTOR_WIDTH_U16>(const native_vector_u16_x3& a, void *base, const native_vector_i32_x6& offset, const native_mask_i16_x3& predicate) {
+    uint16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[3 * VECTOR_WIDTH_U16];
+    aligned_store<native_vector_u16_x3, uint16_t, 3 * VECTOR_WIDTH_U16>(a, &tmp[0], 0);
+
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[3 * VECTOR_WIDTH_U16];
+    aligned_store<native_vector_i32_x6, int32_t, 3 * VECTOR_WIDTH_U16>(offset, &offsets[0], 0);
+
+    native_vector_u16 vmask0 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), predicate.native_vector[0]);
+    native_vector_u16 vmask1 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), predicate.native_vector[1]);
+    native_vector_u16 vmask2 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), predicate.native_vector[2]);
+
+    uint16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[3 * VECTOR_WIDTH_U16];
+    aligned_store<native_vector_u16_x3, uint16_t, 3 * VECTOR_WIDTH_U16>(
+        native_vector_u16_x3(native_vector_u16_x3::from_native_vector, vmask0, vmask1, vmask2), &mask[0], 0);
+
+    for (int i = 0; i < 3 * VECTOR_WIDTH_U16; i++) {
+        if (mask[i]) {
+            ((uint16_t*)base)[offsets[i]] = tmp[i];
+        }
+    }
+}
+
+template <>
+HALIDE_ALWAYS_INLINE void store_predicated<native_vector_u16_x6, native_vector_i32_x12, native_mask_i8_x3, uint16_t, 6 * VECTOR_WIDTH_U16>(const native_vector_u16_x6& a, void *base, const native_vector_i32_x12& offset, const native_mask_i8_x3& predicate) {
+    uint16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[6 * VECTOR_WIDTH_U16];
+    aligned_store<native_vector_u16_x6, uint16_t, 6 * VECTOR_WIDTH_U16>(a, &tmp[0], 0);
+
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[3 * VECTOR_WIDTH_U16];
+    aligned_store<native_vector_i32_x12, int32_t, 6 * VECTOR_WIDTH_U16>(offset, &offsets[0], 0);
+
+    native_mask_i16_x2 c_predicate0 = convert<native_mask_i16_x2, native_mask_i8>(predicate.native_vector[0]);
+    native_mask_i16_x2 c_predicate1 = convert<native_mask_i16_x2, native_mask_i8>(predicate.native_vector[1]);
+    native_mask_i16_x2 c_predicate2 = convert<native_mask_i16_x2, native_mask_i8>(predicate.native_vector[2]);
+
+    native_vector_u16 vmask0 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), c_predicate0.native_vector[0]);
+    native_vector_u16 vmask1 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), c_predicate0.native_vector[1]);
+    native_vector_u16 vmask2 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), c_predicate1.native_vector[0]);
+    native_vector_u16 vmask3 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), c_predicate1.native_vector[1]);
+    native_vector_u16 vmask4 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), c_predicate2.native_vector[0]);
+    native_vector_u16 vmask5 = IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), c_predicate2.native_vector[1]);
+
+    uint16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[6 * VECTOR_WIDTH_U16];
+    aligned_store<native_vector_u16_x6, uint16_t, 6 * VECTOR_WIDTH_U16>(
+        native_vector_u16_x6(native_vector_u16_x6::from_native_vector, vmask0, vmask1, vmask2, vmask3, vmask4, vmask5), &mask[0], 0);
+
+    for (int i = 0; i < 6 * VECTOR_WIDTH_U16; i++) {
+        if (mask[i]) {
+            ((uint16_t*)base)[offsets[i]] = tmp[i];
+        }
+    }
+}
+
+template <>
+HALIDE_ALWAYS_INLINE void store_predicated<native_vector_i32_x2, native_vector_i32_x2, native_mask_i16, int32_t, 2 * VECTOR_WIDTH_I32>(const native_vector_i32_x2& a, void *base, const native_vector_i32_x2& offset, const native_mask_i16& predicate) {
+    int32_t __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[2 * VECTOR_WIDTH_I32];
+    aligned_store<native_vector_i32_x2, int32_t, 2 * VECTOR_WIDTH_I32>(a, &tmp[0], 0);
+
+    int __attribute__((aligned(XCHAL_VISION_SIMD8))) offsets[2 * VECTOR_WIDTH_I32];
+    aligned_store<native_vector_i32_x2, int32_t, 2 * VECTOR_WIDTH_I32>(offset, &offsets[0], 0);
+
+    native_vector_i16 vmask = IVP_MOVNX16T(native_vector_i16(1), native_vector_i16(0), predicate);
+    int16_t __attribute__((aligned(XCHAL_VISION_SIMD8))) mask[2 * VECTOR_WIDTH_I32];
+    aligned_store<native_vector_i16, int16_t, 2 * VECTOR_WIDTH_I32>(vmask, &mask[0], 0);
+
+    for (int i = 0; i < 2 * VECTOR_WIDTH_I32; i++) {
+        if (mask[i]) {
+            ((int32_t*)base)[offsets[i]] = tmp[i];
+        }
+    }
+}
+
+inline uint8_t halide_shift_right(uint8_t a, uint8_t b) {
+    return (uint16_t)a >> (uint16_t)b;
+}
+
+inline int8_t halide_shift_right(int8_t a, int8_t b) {
+    return (int16_t)a >> (int16_t)b;
+}
+
+inline uint8_t halide_shift_left(uint8_t a, uint8_t b) {
+    return (uint16_t)a << (uint16_t)b;
+}
+
+inline int8_t halide_shift_left(int8_t a, int8_t b) {
+    return (int16_t)a << (int16_t)b;
+}
+
+template <typename VectorType, typename ScalarArgumentType, typename ScalarReturnType, int Lanes>
+VectorType scalarize_unary(ScalarReturnType (*fn)(ScalarArgumentType), VectorType a) {
+    ScalarArgumentType __attribute__((aligned(64))) tmp[Lanes];
+    aligned_store<VectorType, ScalarArgumentType, Lanes>(a, &tmp[0], 0);
+
+    for (int i = 0; i < Lanes; i++) {
+        // Just update in-place, because it's a tmp buffer anyway.
+        tmp[i] = fn(tmp[i]);
+    }
+
+    return *((VectorType *)tmp);
+}
+
+template <typename VectorType, typename ScalarArgumentType, typename ScalarReturnType, int Lanes>
+VectorType scalarize_binary(ScalarReturnType (*fn)(ScalarArgumentType, ScalarArgumentType), VectorType a, VectorType b) {
+    ScalarArgumentType __attribute__((aligned(64))) tmp_a[Lanes];
+    aligned_store<VectorType, ScalarArgumentType, Lanes>(a, &tmp_a[0], 0);
+
+    ScalarArgumentType __attribute__((aligned(64))) tmp_b[Lanes];
+    aligned_store<VectorType, ScalarArgumentType, Lanes>(b, &tmp_b[0], 0);
+
+    for (int i = 0; i < Lanes; i++) {
+        // Just update in-place, because it's a tmp buffer anyway.
+        tmp_a[i] = fn(tmp_a[i], tmp_b[i]);
+    }
+
+    return *((VectorType *)tmp_a);
+}
+
+template <typename VectorTypeFrom, typename VectorTypeTo, typename BaseType, int LanesFrom, int LanesTo>
+HALIDE_ALWAYS_INLINE VectorTypeTo shuffle(const VectorTypeFrom& a, const int32_t indices[LanesTo]) {
+    BaseType  __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp1[LanesFrom];
+    BaseType  __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp2[LanesTo];
+    store<VectorTypeFrom, BaseType, LanesFrom>(a, &tmp1[0], 0);
+    for (int i = 0; i < LanesTo; i++) {
+        tmp2[i] = tmp1[indices[i]];
+    }
+
+    return *((VectorTypeTo *)tmp2);
+}
+
+template <typename ResultType, typename ArgType, typename BaseType, int LanesResult, int LanesArg>
+HALIDE_ALWAYS_INLINE ResultType concat(const ArgType& a, const ArgType& b) {
+    BaseType  __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[LanesResult];
+
+    store<ArgType, BaseType, LanesArg>(a, &tmp[0], 0);
+    store<ArgType, BaseType, LanesArg>(b, &tmp[0], LanesArg);
+
+    return *((ResultType *)tmp);
+}
+
+template <typename ResultType, typename ArgType, typename BaseType, int LanesResult, int LanesArg>
+HALIDE_ALWAYS_INLINE ResultType concat(const ArgType& a, const ArgType& b, const ArgType& c) {
+    BaseType  __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[LanesResult];
+
+    store<ArgType, BaseType, LanesArg>(a, &tmp[0], 0);
+    store<ArgType, BaseType, LanesArg>(b, &tmp[0], LanesArg);
+    store<ArgType, BaseType, LanesArg>(c, &tmp[0], 2 * LanesArg);
+
+    return *((ResultType *)tmp);
+}
+
+template <typename ResultType, typename ArgType, typename BaseType, int LanesResult, int LanesArg>
+HALIDE_ALWAYS_INLINE ResultType concat(const ArgType& a, const ArgType& b, const ArgType& c, const ArgType& d) {
+    BaseType  __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[LanesResult];
+
+    store<ArgType, BaseType, LanesArg>(a, &tmp[0], 0);
+    store<ArgType, BaseType, LanesArg>(b, &tmp[0], LanesArg);
+    store<ArgType, BaseType, LanesArg>(c, &tmp[0], 2 * LanesArg);
+    store<ArgType, BaseType, LanesArg>(d, &tmp[0], 3 * LanesArg);
+
+    return *((ResultType *)tmp);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 concat<native_vector_i32_x2, native_vector_i32, int32_t, 2 * VECTOR_WIDTH_I32, VECTOR_WIDTH_I32>(const native_vector_i32& a, const native_vector_i32& b) {
+  return native_vector_i32_x2(native_vector_i32_x2::from_native_vector, a, b);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 concat<native_vector_i32_x4, native_vector_i32, int32_t, 4 * VECTOR_WIDTH_I32, VECTOR_WIDTH_I32>(const native_vector_i32& a, const native_vector_i32& b, const native_vector_i32& c, const native_vector_i32& d) {
+  return native_vector_i32_x4(native_vector_i32_x4::from_native_vector, a, b, c, d);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 concat<native_vector_i16_x2, native_vector_i16, int16_t, 2 * VECTOR_WIDTH_I16, VECTOR_WIDTH_I16>(const native_vector_i16& a, const native_vector_i16& b) {
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a, b);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 concat<native_vector_u16_x2, native_vector_u16, uint16_t, 2 * VECTOR_WIDTH_U16, VECTOR_WIDTH_U16>(const native_vector_u16& a, const native_vector_u16& b) {
+  return native_vector_u16_x2(native_vector_u16_x2::from_native_vector, a, b);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_u8_x2 concat<native_vector_u8_x2, native_vector_u8, uint8_t, 2 * VECTOR_WIDTH_U8, VECTOR_WIDTH_U8>(const native_vector_u8& a, const native_vector_u8& b) {
+  return native_vector_u8_x2(native_vector_u8_x2::from_native_vector, a, b);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 concat<native_vector_f32_x2, native_vector_f32, float, 2 * VECTOR_WIDTH_F32, VECTOR_WIDTH_F32>(const native_vector_f32& a, const native_vector_f32& b) {
+  return native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a, b);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_i24_x2 concat<native_vector_i24_x2, native_vector_i24, int24_t, 128, 64>(const native_vector_i24& a, const native_vector_i24& b) {
+  return native_vector_i24_x2(native_vector_i24_x2::from_native_vector, a, b);
+}
+
+template <typename VectorTypeFrom, typename VectorTypeTo, typename BaseType, int LanesFrom, int LanesTo>
+HALIDE_ALWAYS_INLINE VectorTypeTo halide_xtensa_pad_to_native(const VectorTypeFrom& a, int lanes) {
+    BaseType  __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[LanesTo];
+    store<VectorTypeFrom, BaseType, LanesFrom>(a, tmp, 0);
+    return load<VectorTypeTo, BaseType, LanesTo>(tmp, 0);
+}
+
+template <typename VectorTypeFrom, typename VectorTypeTo, typename BaseType, int LanesFrom, int LanesTo>
+HALIDE_ALWAYS_INLINE VectorTypeTo halide_xtensa_slice_from_padded(const VectorTypeFrom& a, int lanes) {
+    BaseType  __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[LanesFrom];
+    store<VectorTypeFrom, BaseType, LanesFrom>(a, tmp, 0);
+    return load<VectorTypeTo, BaseType, LanesTo>(tmp, 0);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_slice_from_padded<native_vector_u16_x2, native_vector_u16, uint16_t, 2 * VECTOR_WIDTH_U16, VECTOR_WIDTH_U16>(const native_vector_u16_x2& a, int lanes) {
+  return a.native_vector[0];
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_mask_i16 halide_xtensa_pad_to_native<native_mask_i32, native_mask_i16, bool, VECTOR_WIDTH_I32, VECTOR_WIDTH_I16>(const native_mask_i32& a, int lanes) {
+    return IVP_JOINBN_2(a, a);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_mask_i8 halide_xtensa_pad_to_native<native_mask_i16, native_mask_i8, bool, VECTOR_WIDTH_I16, VECTOR_WIDTH_I8>(const native_mask_i16& a, int lanes) {
+    return IVP_JOINBN(a, a);
+}
+
+template <>
+HALIDE_ALWAYS_INLINE native_mask_i8 halide_xtensa_pad_to_native<native_mask_i32, native_mask_i8, bool, VECTOR_WIDTH_I32, VECTOR_WIDTH_I8>(const native_mask_i32& a, int lanes) {
+    return IVP_JOINBN(IVP_JOINBN_2(a, a), IVP_JOINBN_2(a, a));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_convert_u1_to_i16(const native_mask_i16& a) {
+    return IVP_MOVNX16T(native_vector_i16(1), native_vector_i16(0), a);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED int8x4_t load<int8x4_t, int8_t, 4>(const void *base, int32_t offset) {
+    return *((const int8x4_t*)((const int8_t*)base + offset));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED uint8x4_t load<uint8x4_t, uint8_t, 4>(const void *base, int32_t offset) {
+    return *((const uint8x4_t*)((const uint8_t*)base + offset));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u8 load<native_vector_u8, uint8_t, VECTOR_WIDTH_U8>(const void *base, int32_t offset) {
+    native_vector_u8 r;
+    const xb_vec2Nx8U*  __restrict ptr = (const xb_vec2Nx8U*)((const uint8_t*)base + offset);
+    IVP_L2U2NX8U_XP(r, ptr, 0);
+    return r;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store<native_vector_i8, int8_t, VECTOR_WIDTH_I8>(const native_vector_i8& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vec2Nx8* __restrict ptr  = (xb_vec2Nx8*)((int8_t*)base + offset);
+    IVP_SA2NX8_IP(a, align, ptr);
+    IVP_SAPOS2NX8_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store<native_vector_u8, uint8_t, VECTOR_WIDTH_U8>(const native_vector_u8& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vec2Nx8U* __restrict ptr  = (xb_vec2Nx8U*)((uint8_t*)base + offset);
+    IVP_SA2NX8U_IP(a, align, ptr);
+    IVP_SAPOS2NX8U_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i16 load<native_vector_i16, int16_t, VECTOR_WIDTH_I16>(const void *base, int32_t offset) {
+    xb_vecNx16 r;
+    const xb_vec2Nx8*  __restrict ptr8 = (const xb_vec2Nx8*)((const int16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LANX16_IP(r, align, (const xb_vecNx16*)ptr8);
+    return r;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store<native_vector_i16, int16_t, VECTOR_WIDTH_I16>(const native_vector_i16& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecNx16* ptr = (xb_vecNx16*)((int16_t*)base + offset);
+    IVP_SANX16_IP(a, align, ptr);
+    // Flush alignment register.
+    IVP_SAPOSNX16_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store<native_vector_i16_x2, int16_t, 2 * VECTOR_WIDTH_I16>(const native_vector_i16_x2& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecNx16* ptr = (xb_vecNx16*)((int16_t*)base + offset);
+    IVP_SANX16_IP(a.native_vector[0], align, ptr);
+    IVP_SANX16_IP(a.native_vector[1], align, ptr);
+    // Flush alignment register.
+    IVP_SAPOSNX16_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u16 load<native_vector_u16, uint16_t, VECTOR_WIDTH_U16>(const void *base, int32_t offset) {
+    xb_vecNx16U r;
+    const xb_vec2Nx8*  __restrict ptr8 = (const xb_vec2Nx8*)((const uint16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LANX16U_IP(r, align, (const xb_vecNx16U*)ptr8);
+
+    return r;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store<native_vector_u16, uint16_t, VECTOR_WIDTH_U16>(const native_vector_u16& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecNx16U* ptr  = (xb_vecNx16U*)((uint16_t*)base + offset);
+    IVP_SANX16U_IP(a, align, ptr);
+    IVP_SAPOSNX16U_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i16_x2 load<native_vector_i16_x2, int16_t, 2 * VECTOR_WIDTH_I16>(const void *base, int32_t offset) {
+    xb_vecNx16 r1, r2;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const int16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LANX16_IP(r1, align, (const xb_vecNx16*)ptr8);
+    IVP_LANX16_IP(r2, align, (const xb_vecNx16*)ptr8);
+
+    return native_vector_i16_x2(native_vector_i16_x2::from_native_vector, r1, r2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u16_x2 load<native_vector_u16_x2, uint16_t, 2 * VECTOR_WIDTH_U16>(const void *base, int32_t offset) {
+    xb_vecNx16U r1, r2;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const int16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LANX16U_IP(r1, align, (const xb_vecNx16U*)ptr8);
+    IVP_LANX16U_IP(r2, align, (const xb_vecNx16U*)ptr8);
+
+    return native_vector_u16_x2(native_vector_u16_x2::from_native_vector, r1, r2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i32_x2 load<native_vector_i32_x2, int32_t, 2 * VECTOR_WIDTH_I32>(const void *base, int32_t offset) {
+    xb_vecN_2x32v nv8_0, nv8_1;
+    const xb_vecN_2x32v* __restrict ptr = (const xb_vecN_2x32v*)((const int32_t*)base + offset);
+    valign align = IVP_LA_PP((const xb_vec2Nx8 *)ptr);
+    IVP_LAN_2X32_IP(nv8_0, align, ptr);
+    IVP_LAN_2X32_IP(nv8_1, align, ptr);
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector, nv8_0, nv8_1);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i32_x4 load<native_vector_i32_x4, int32_t, 4 * VECTOR_WIDTH_I32>(const void *base, int32_t offset) {
+    xb_vecN_2x32v nv8_0, nv8_1, nv8_2, nv8_3;
+    const xb_vecN_2x32v* __restrict ptr = (const xb_vecN_2x32v*)((const int32_t*)base + offset);
+    valign align = IVP_LA_PP((const xb_vec2Nx8 *)ptr);
+    IVP_LAN_2X32_IP(nv8_0, align, ptr);
+    IVP_LAN_2X32_IP(nv8_1, align, ptr);
+    IVP_LAN_2X32_IP(nv8_2, align, ptr);
+    IVP_LAN_2X32_IP(nv8_3, align, ptr);
+    return native_vector_i32_x4(native_vector_i32_x4::from_native_vector, nv8_0, nv8_1, nv8_2, nv8_3);
+}
+
+template <typename ResultType, typename LoadType>
+HALIDE_ALWAYS_INLINE ResultType widening_load(const void *base, int32_t offset) = delete;
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i16 widening_load<native_vector_i16, uint8_t>(const void *base, int32_t offset) {
+    xb_vecNx16 r;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const uint8_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LANX8U_IP(r, align, (const xb_vecNx8U*)ptr8);
+    return r;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i16_x2 widening_load<native_vector_i16_x2, uint8_t>(const void *base, int32_t offset) {
+    xb_vecNx16 r1, r2;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const uint8_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LANX8U_IP(r1, align, (const xb_vecNx8U*)ptr8);
+    // Pointer is automatically incremented by previous call.
+    IVP_LANX8U_IP(r2, align, (const xb_vecNx8U*)ptr8);
+
+    return native_vector_i16_x2(native_vector_i16_x2::from_native_vector, r1, r2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u16_x2 widening_load<native_vector_u16_x2, uint8_t>(const void *base, int32_t offset) {
+    xb_vecNx16 r1, r2;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const uint8_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LANX8U_IP(r1, align, (const xb_vecNx8U*)ptr8);
+    // Pointer is automatically incremented by previous call.
+    IVP_LANX8U_IP(r2, align, (const xb_vecNx8U*)ptr8);
+
+    return native_vector_u16_x2(native_vector_u16_x2::from_native_vector, r1, r2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i32 widening_load<native_vector_i32, int16_t>(const void *base, int32_t offset) {
+    native_vector_i32 r1;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const int16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LAN_2X16S_IP(r1, align, (const xb_vecN_2x16*)ptr8);
+    return r1;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i32_x2 widening_load<native_vector_i32_x2, int16_t>(const void *base, int32_t offset) {
+    native_vector_i32 r1, r2;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const int16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LAN_2X16S_IP(r1, align, (const xb_vecN_2x16*)ptr8);
+    // Pointers is automatically incremented by previous call.
+    IVP_LAN_2X16S_IP(r2, align, (const xb_vecN_2x16*)ptr8);
+
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector, r1, r2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i32_x2 widening_load<native_vector_i32_x2, uint16_t>(const void *base, int32_t offset) {
+    native_vector_i32 r1, r2;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const uint16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LAN_2X16U_IP(r1, align, (const xb_vecN_2x16U*)ptr8);
+    // Pointers is automatically incremented by previous call.
+    IVP_LAN_2X16U_IP(r2, align, (const xb_vecN_2x16U*)ptr8);
+
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector, r1, r2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u32_x2 widening_load<native_vector_u32_x2, uint16_t>(const void *base, int32_t offset) {
+    native_vector_u32 r1, r2;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const uint16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LAN_2X16U_IP(r1, align, (const xb_vecN_2x16U*)ptr8);
+    // Pointers is automatically incremented by previous call.
+    IVP_LAN_2X16U_IP(r2, align, (const xb_vecN_2x16U*)ptr8);
+
+    return native_vector_u32_x2(native_vector_u32_x2::from_native_vector, r1, r2);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i32_x4 widening_load<native_vector_i32_x4, uint16_t>(const void *base, int32_t offset) {
+    native_vector_i32 r1, r2, r3, r4;
+    const xb_vec2Nx8* __restrict ptr8 = (const xb_vec2Nx8*)((const uint16_t*)base + offset);
+    valign align = IVP_LA_PP(ptr8);
+    IVP_LAN_2X16U_IP(r1, align, (const xb_vecN_2x16U*)ptr8);
+    // Pointers is automatically incremented by previous call.
+    IVP_LAN_2X16U_IP(r2, align, (const xb_vecN_2x16U*)ptr8);
+    IVP_LAN_2X16U_IP(r3, align, (const xb_vecN_2x16U*)ptr8);
+    IVP_LAN_2X16U_IP(r4, align, (const xb_vecN_2x16U*)ptr8);
+
+    return native_vector_i32_x4(native_vector_i32_x4::from_native_vector, r1, r2, r3, r4);
+}
+
+template <typename VectorType, typename BaseType, int Lanes>
+HALIDE_ALWAYS_INLINE void store_narrowing(const VectorType& a, void *base, int32_t offset) = delete;
+
+template<>
+HALIDE_ALWAYS_INLINE void store_narrowing<native_vector_i16, int8_t, VECTOR_WIDTH_I16>(const native_vector_i16& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecNx8* __restrict ptr  = (xb_vecNx8*)((int8_t*)base + offset);
+    IVP_SANX8S_IP(a, align, ptr);
+    IVP_SAPOSNX8S_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store_narrowing<native_vector_i16, uint8_t, VECTOR_WIDTH_I16>(const native_vector_i16& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecNx8U* __restrict ptr  = (xb_vecNx8U*)((uint8_t*)base + offset);
+    IVP_SANX8U_IP(a, align, ptr);
+    IVP_SAPOSNX8U_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store_narrowing<native_vector_u16, uint8_t, VECTOR_WIDTH_U16>(const native_vector_u16& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecNx8U* __restrict ptr  = (xb_vecNx8U*)((uint8_t*)base + offset);
+    IVP_SANX8U_IP(a, align, ptr);
+    IVP_SAPOSNX8U_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store_narrowing<native_vector_i32, int16_t, VECTOR_WIDTH_I32>(const native_vector_i32& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecN_2x16* __restrict ptr  = (xb_vecN_2x16*)((int16_t*)base + offset);
+    IVP_SAN_2X16S_IP(a, align, ptr);
+    IVP_SAPOSN_2X16S_FP(align, ptr);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE void store_narrowing<native_vector_u32, uint16_t, VECTOR_WIDTH_U32>(const native_vector_u32& a, void *base, int32_t offset) {
+    valign align = IVP_ZALIGN();
+    xb_vecN_2x16U* __restrict ptr  = (xb_vecN_2x16U*)((uint16_t*)base + offset);
+    IVP_SAN_2X16U_IP(a, align, ptr);
+    IVP_SAPOSN_2X16U_FP(align, ptr);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 halide_xtensa_interleave_i16(const native_vector_i16& a, const native_vector_i16& b) {
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+                                IVP_SELNX16I(b, a, IVP_SELI_16B_INTERLEAVE_1_LO),
+                                IVP_SELNX16I(b, a, IVP_SELI_16B_INTERLEAVE_1_HI)
+                                );
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 halide_xtensa_interleave_i32(const native_vector_i32& a, const native_vector_i32& b) {
+  return native_vector_i32_x2(
+    native_vector_i32_x2::from_native_vector,
+    IVP_SELN_2X32I(b, a, IVP_SELI_32B_INTERLEAVE_1_LO),
+    IVP_SELN_2X32I(b, a, IVP_SELI_32B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16_x4 halide_xtensa_interleave_i16(const native_vector_i16_x2& a, const native_vector_i16_x2& b) {
+  return native_vector_i16_x4(native_vector_i16_x4::from_native_vector,
+                                IVP_SELNX16I(b.native_vector[0], a.native_vector[0], IVP_SELI_16B_INTERLEAVE_1_LO),
+                                IVP_SELNX16I(b.native_vector[0], a.native_vector[0], IVP_SELI_16B_INTERLEAVE_1_HI),
+                                IVP_SELNX16I(b.native_vector[1], a.native_vector[1], IVP_SELI_16B_INTERLEAVE_1_LO),
+                                IVP_SELNX16I(b.native_vector[1], a.native_vector[1], IVP_SELI_16B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 halide_xtensa_interleave_i32(const native_vector_i32_x2& a, const native_vector_i32_x2& b) {
+  return native_vector_i32_x4(
+    native_vector_i32_x4::from_native_vector,
+    IVP_SELN_2X32I(b.native_vector[0], a.native_vector[0], IVP_SELI_32B_INTERLEAVE_1_LO),
+    IVP_SELN_2X32I(b.native_vector[0], a.native_vector[0], IVP_SELI_32B_INTERLEAVE_1_HI),
+    IVP_SELN_2X32I(b.native_vector[1], a.native_vector[1], IVP_SELI_32B_INTERLEAVE_1_LO),
+    IVP_SELN_2X32I(b.native_vector[1], a.native_vector[1], IVP_SELI_32B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 halide_xtensa_interleave_u16(const native_vector_u16& a, const native_vector_u16& b) {
+  return native_vector_u16_x2(native_vector_u16_x2::from_native_vector,
+                                IVP_SELNX16UI(b, a, IVP_SELI_16B_INTERLEAVE_1_LO),
+                                IVP_SELNX16UI(b, a, IVP_SELI_16B_INTERLEAVE_1_HI)
+                                );
+}
+
+// This sequence of instructions is taken from the user guide.
+HALIDE_ALWAYS_INLINE native_vector_u16_x3 halide_xtensa_interleave_u16(const native_vector_u16& a, const native_vector_u16& b, const native_vector_u16& c) {
+  // 16-bit interleave patterns
+  #if XCHAL_VISION_TYPE == 7
+  __attribute__((aligned(XCHAL_VISION_SIMD8))) unsigned char int_16B_c3_step_0[64] = {
+      0,  42, 1,  22, 32, 23, 2,  43, 3,  24, 33, 25, 4,  44, 5,  26,
+      34, 27, 6,  45, 7,  28, 35, 29, 8,  46, 9,  30, 36, 31, 10, 47,
+      11, 0,  37, 33, 12, 48, 13, 2,  38, 35, 14, 49, 15, 4,  39, 37,
+      16, 50, 17, 6,  40, 39, 18, 51, 19, 8,  41, 41, 20, 52, 21, 10};
+  __attribute__((aligned(XCHAL_VISION_SIMD8))) unsigned char int_16B_c3_step_1[64] = {
+      11, 42, 53, 22, 12, 23, 13, 43, 54, 24, 14, 25, 15, 44, 55, 26,
+      16, 27, 17, 45, 56, 28, 18, 29, 19, 46, 57, 30, 20, 31, 21, 47,
+      58, 0,  22, 1,  23, 48, 59, 2,  24, 3,  25, 49, 60, 4,  26, 5,
+      27, 50, 61, 6,  28, 7,  29, 51, 62, 8,  30, 9,  31, 52, 63, 10};
+  unsigned long long int_16B_c3_step_1_msk = 0xffffffff55555555ULL;
+  #elif XCHAL_VISION_TYPE == 8
+    __attribute__((aligned(XCHAL_VISION_SIMD8))) unsigned char int_16B_c3_step_0[128] = {
+      0, 43, 1, 85, 64, 44, 2, 45, 3, 86, 65, 46, 4, 47, 5, 87,
+      66, 48, 6, 49, 7, 88, 67, 50, 8, 51, 9, 89, 68, 52, 10, 53,
+      11, 90, 69, 54, 12, 55, 13, 91, 70, 56, 14, 57, 15, 92, 71, 58,
+      16, 59, 17, 93, 72, 60, 18, 61, 19, 94, 73, 62, 20, 63, 21, 95,
+      74, 0, 22, 1, 23, 96, 75, 2, 24, 3, 25, 97, 76, 4, 26, 5,
+      27, 98, 77, 6, 28, 7, 29, 99, 78, 8, 30, 9, 31, 100, 79, 10,
+      32, 11, 33, 101, 80, 12, 34, 13, 35, 102, 81, 14, 36, 15, 37, 103,
+      82, 16, 38, 17, 39, 104, 83, 18, 40, 19, 41, 105, 84, 20, 42, 21};
+  __attribute__((aligned(XCHAL_VISION_SIMD8))) unsigned char int_16B_c3_step_1[128] = {
+      106, 43, 21, 85, 22, 44, 107, 45, 22, 86, 23, 46, 108, 47, 23, 87,
+      24, 48, 109, 49, 24, 88, 25, 50, 110, 51, 25, 89, 26, 52, 111, 53,
+      26, 90, 27, 54, 112, 55, 27, 91, 28, 56, 113, 57, 28, 92, 29, 58,
+      114, 59, 29, 93, 30, 60, 115, 61, 30, 94, 31, 62, 116, 63, 31, 95,
+      32, 0, 117, 1, 32, 96, 33, 2, 118, 3, 33, 97, 34, 4, 119, 5,
+      34, 98, 35, 6, 120, 7, 35, 99, 36, 8, 121, 9, 36, 100, 37, 10,
+      122, 11, 37, 101, 38, 12, 123, 13, 38, 102, 39, 14, 124, 15, 39, 103,
+      40, 16, 125, 17, 40, 104, 41, 18, 126, 19, 41, 105, 42, 20, 127, 21};
+  __attribute__((aligned(16))) unsigned char int_16B_c3_step_1_msk[16] = {
+    0x55,0x55,0x55,0x55,0x55,0x55,0x55,0x55,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff};
+  #endif
+  native_vector_u16 vRG0, vRG1, vRGB0, vRGB1, vRGB2;
+  // interleave RG
+  IVP_DSELNX16UI(vRG1, vRG0, b, a, IVP_DSELI_INTERLEAVE_1);
+  // interleave RG, B
+  IVP_DSELNX16U(vRGB1, vRGB0, c, vRG0, *((xb_vec2Nx8*)int_16B_c3_step_0));
+  IVP_DSELNX16UT(vRGB1, vRGB2, c, vRG1, *((xb_vec2Nx8*)int_16B_c3_step_1),
+                *((vbool2N*)&int_16B_c3_step_1_msk));
+
+  return native_vector_u16_x3(native_vector_u16_x3::from_native_vector, vRGB0, vRGB1, vRGB2);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16_x6 halide_xtensa_interleave_u16(const native_vector_u16_x2& a, const native_vector_u16_x2& b, const native_vector_u16_x2& c) {
+  native_vector_u16_x3 d = halide_xtensa_interleave_u16(a.native_vector[0], b.native_vector[0], c.native_vector[0]);
+  native_vector_u16_x3 e = halide_xtensa_interleave_u16(a.native_vector[1], b.native_vector[1], c.native_vector[1]);
+
+  return native_vector_u16_x6(
+    native_vector_u16_x6::from_native_vector,
+    d.native_vector[0], e.native_vector[0],
+    d.native_vector[1], e.native_vector[1],
+    d.native_vector[2], e.native_vector[2]);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16_x4 halide_xtensa_interleave_u16(const native_vector_u16_x2& a, const native_vector_u16_x2& b) {
+  return native_vector_u16_x4(native_vector_u16_x4::from_native_vector,
+                                IVP_SELNX16UI(b.native_vector[0], a.native_vector[0], IVP_SELI_16B_INTERLEAVE_1_LO),
+                                IVP_SELNX16UI(b.native_vector[0], a.native_vector[0], IVP_SELI_16B_INTERLEAVE_1_HI),
+                                IVP_SELNX16UI(b.native_vector[1], a.native_vector[1], IVP_SELI_16B_INTERLEAVE_1_LO),
+                                IVP_SELNX16UI(b.native_vector[1], a.native_vector[1], IVP_SELI_16B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16_x4 halide_xtensa_interleave_u16(const native_vector_u16& a, const native_vector_u16& b, const native_vector_u16& c, const native_vector_u16& d) {
+  const native_vector_u16 ab0 = IVP_SELNX16UI(b, a, IVP_SELI_16B_INTERLEAVE_1_LO);
+  const native_vector_u16 ab1 = IVP_SELNX16UI(b, a, IVP_SELI_16B_INTERLEAVE_1_HI);
+  const native_vector_u16 cd0 = IVP_SELNX16UI(d, c, IVP_SELI_16B_INTERLEAVE_1_LO);
+  const native_vector_u16 cd1 = IVP_SELNX16UI(d, c, IVP_SELI_16B_INTERLEAVE_1_HI);
+
+
+  return native_vector_u16_x4(native_vector_u16_x4::from_native_vector,
+                                IVP_SELNX16UI(cd0, ab0, IVP_SELI_16B_INTERLEAVE_2_LO),
+                                IVP_SELNX16UI(cd0, ab0, IVP_SELI_16B_INTERLEAVE_2_HI),
+                                IVP_SELNX16UI(cd1, ab1, IVP_SELI_16B_INTERLEAVE_2_LO),
+                                IVP_SELNX16UI(cd1, ab1, IVP_SELI_16B_INTERLEAVE_2_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8_x2 halide_xtensa_interleave_u8(const native_vector_u8& a, const native_vector_u8& b) {
+  return native_vector_u8_x2(native_vector_u8_x2::from_native_vector,
+                                IVP_SEL2NX8UI(b, a, IVP_SELI_8B_INTERLEAVE_1_LO),
+                                IVP_SEL2NX8UI(b, a, IVP_SELI_8B_INTERLEAVE_1_HI)
+                                );
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8_x3 halide_xtensa_interleave_u8(
+    const native_vector_u8& a, const native_vector_u8& b, const native_vector_u8& c) {
+  native_vector_u8 vRG0, vRG1, vRGB0, vRGB1, vRGB2;
+  IVP_DSEL2NX8UI(vRG1, vRG0, b, a, IVP_DSELI_8B_INTERLEAVE_1);
+  IVP_DSEL2NX8UI(vRGB1, vRGB0, c, vRG0, IVP_DSELI_8B_INTERLEAVE_C3_STEP_0);
+  IVP_DSEL2NX8UI_H(vRGB1, vRGB2, c, vRG1, IVP_DSELI_8B_INTERLEAVE_C3_STEP_1);
+  return native_vector_u8_x3(native_vector_u8_x3::from_native_vector, vRGB0, vRGB1, vRGB2);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8_x4 halide_xtensa_interleave_u8(const native_vector_u8& a, const native_vector_u8& b, const native_vector_u8& c, const native_vector_u8& d) {
+  const native_vector_u8 ab0 = IVP_SEL2NX8UI(b, a, IVP_SELI_8B_INTERLEAVE_1_LO);
+  const native_vector_u8 ab1 = IVP_SEL2NX8UI(b, a, IVP_SELI_8B_INTERLEAVE_1_HI);
+  const native_vector_u8 cd0 = IVP_SEL2NX8UI(d, c, IVP_SELI_8B_INTERLEAVE_1_LO);
+  const native_vector_u8 cd1 = IVP_SEL2NX8UI(d, c, IVP_SELI_8B_INTERLEAVE_1_HI);
+
+
+  return native_vector_u8_x4(native_vector_u8_x4::from_native_vector,
+                                IVP_SEL2NX8UI(cd0, ab0, IVP_SELI_8B_INTERLEAVE_2_LO),
+                                IVP_SEL2NX8UI(cd0, ab0, IVP_SELI_8B_INTERLEAVE_2_HI),
+                                IVP_SEL2NX8UI(cd1, ab1, IVP_SELI_8B_INTERLEAVE_2_LO),
+                                IVP_SEL2NX8UI(cd1, ab1, IVP_SELI_8B_INTERLEAVE_2_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_mask_i8_x4 halide_xtensa_interleave_u1(const native_mask_i8& a, const native_mask_i8& b, const native_mask_i8& c, const native_mask_i8& d) {
+    native_vector_u8 a8 = 0, b8 = 0, c8 = 0, d8 = 0;
+    IVP_INJBI2NX8(a8, a, 0);
+    IVP_INJBI2NX8(b8, b, 0);
+    IVP_INJBI2NX8(c8, c, 0);
+    IVP_INJBI2NX8(d8, d, 0);
+
+    native_vector_u8_x4 interleaved8 = halide_xtensa_interleave_u8(a8, b8, c8, d8);
+
+    native_mask_i8 ra = IVP_EXTBI2NX8(interleaved8.native_vector[0], 0);
+    native_mask_i8 rb = IVP_EXTBI2NX8(interleaved8.native_vector[1], 0);
+    native_mask_i8 rc = IVP_EXTBI2NX8(interleaved8.native_vector[2], 0);
+    native_mask_i8 rd = IVP_EXTBI2NX8(interleaved8.native_vector[3], 0);
+
+    return native_mask_i8_x4(native_mask_i8_x4::from_native_vector, ra, rb, rc, rd);
+}
+
+HALIDE_ALWAYS_INLINE native_mask_i8_x3 halide_xtensa_interleave_u1(const native_mask_i8& a, const native_mask_i8& b, const native_mask_i8& c) {
+    native_vector_u8 a8 = 0, b8 = 0, c8 = 0;
+    IVP_INJBI2NX8(a8, a, 0);
+    IVP_INJBI2NX8(b8, b, 0);
+    IVP_INJBI2NX8(c8, c, 0);
+
+    native_vector_u8_x3 interleaved8 = halide_xtensa_interleave_u8(a8, b8, c8);
+
+    native_mask_i8 ra = IVP_EXTBI2NX8(interleaved8.native_vector[0], 0);
+    native_mask_i8 rb = IVP_EXTBI2NX8(interleaved8.native_vector[1], 0);
+    native_mask_i8 rc = IVP_EXTBI2NX8(interleaved8.native_vector[2], 0);
+
+    return native_mask_i8_x3(native_mask_i8_x3::from_native_vector, ra, rb, rc);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 halide_xtensa_interleave_f32(const native_vector_f32& a, const native_vector_f32& b) {
+  return native_vector_f32_x2(native_vector_f32_x2::from_native_vector,
+                                IVP_SELN_2XF32I(b, a, IVP_SELI_32B_INTERLEAVE_1_LO),
+                                IVP_SELN_2XF32I(b, a, IVP_SELI_32B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32_x4 halide_xtensa_interleave_f32(const native_vector_f32_x2& a, const native_vector_f32_x2& b) {
+  return native_vector_f32_x4(native_vector_f32_x4::from_native_vector,
+                                IVP_SELN_2XF32I(b.native_vector[0], a.native_vector[0], IVP_SELI_32B_INTERLEAVE_1_LO),
+                                IVP_SELN_2XF32I(b.native_vector[0], a.native_vector[0], IVP_SELI_32B_INTERLEAVE_1_HI),
+                                IVP_SELN_2XF32I(b.native_vector[1], a.native_vector[1], IVP_SELI_32B_INTERLEAVE_1_LO),
+                                IVP_SELN_2XF32I(b.native_vector[1], a.native_vector[1], IVP_SELI_32B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32_x4 halide_xtensa_interleave_f32(const native_vector_f32& a, const native_vector_f32& b,
+                                                               const native_vector_f32& c, const native_vector_f32& d) {
+  const native_vector_f32 ab0 = IVP_SELN_2XF32I(b, a, IVP_SELI_32B_INTERLEAVE_1_LO);
+  const native_vector_f32 ab1 = IVP_SELN_2XF32I(b, a, IVP_SELI_32B_INTERLEAVE_1_HI);
+  const native_vector_f32 cd0 = IVP_SELN_2XF32I(d, c, IVP_SELI_32B_INTERLEAVE_1_LO);
+  const native_vector_f32 cd1 = IVP_SELN_2XF32I(d, c, IVP_SELI_32B_INTERLEAVE_1_HI);
+
+
+  return native_vector_f32_x4(native_vector_f32_x4::from_native_vector,
+                                IVP_SELN_2XF32I(cd0, ab0, IVP_SELI_32B_INTERLEAVE_2_LO),
+                                IVP_SELN_2XF32I(cd0, ab0, IVP_SELI_32B_INTERLEAVE_2_HI),
+                                IVP_SELN_2XF32I(cd1, ab1, IVP_SELI_32B_INTERLEAVE_2_LO),
+                                IVP_SELN_2XF32I(cd1, ab1, IVP_SELI_32B_INTERLEAVE_2_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_extract_0_of_3_u8(const native_vector_u8& a0, const native_vector_u8& a1, const native_vector_u8& a2) {
+  // TODO(vksnk): there is likely a better way to do it.
+  native_vector_u8 vR, vG, vB, vRG0, vRG1;
+  IVP_DSEL2NX8UI(vB, vRG0, a1, a0, IVP_DSELI_8B_DEINTERLEAVE_C3_STEP_0);
+  IVP_DSEL2NX8UI_H(vB, vRG1, a2, a1, IVP_DSELI_8B_DEINTERLEAVE_C3_STEP_1);
+  IVP_DSEL2NX8UI (vG,vR, vRG1,vRG0, IVP_DSELI_8B_DEINTERLEAVE_1);
+  return vR;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_extract_0_of_3_u8(const native_vector_u8_x3& a) {
+  return halide_xtensa_extract_0_of_3_u8(a.native_vector[0], a.native_vector[1], a.native_vector[2]);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_extract_0_of_3_i8(const native_vector_i8& a0, const native_vector_i8& a1, const native_vector_i8& a2) {
+  // TODO(aelphy): there is likely a better way to do it.
+  native_vector_i8 vR, vG, vB, vRG0, vRG1;
+  IVP_DSEL2NX8I(vB, vRG0, a1, a0, IVP_DSELI_8B_DEINTERLEAVE_C3_STEP_0);
+  IVP_DSEL2NX8I_H(vB, vRG1, a2, a1, IVP_DSELI_8B_DEINTERLEAVE_C3_STEP_1);
+  IVP_DSEL2NX8I (vG,vR, vRG1,vRG0, IVP_DSELI_8B_DEINTERLEAVE_1);
+  return vR;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_extract_0_of_3_i8(const native_vector_i8_x3& a) {
+  return halide_xtensa_extract_0_of_3_i8(a.native_vector[0], a.native_vector[1], a.native_vector[2]);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_deinterleave_even_i16(const native_vector_i16_x2& a) {
+  return  IVP_SELNX16I(a.native_vector[1], a.native_vector[0], IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_deinterleave_odd_i16(const native_vector_i16_x2& a) {
+  return  IVP_SELNX16I(a.native_vector[1], a.native_vector[0], IVP_SELI_16B_EXTRACT_1_OF_2_OFF_1);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 halide_xtensa_deinterleave_even_i16(const native_vector_i16_x4& a) {
+  return native_vector_i16_x2(
+      native_vector_i16_x2::from_native_vector,
+      halide_xtensa_deinterleave_even_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+      halide_xtensa_deinterleave_even_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[2], a.native_vector[3])));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 halide_xtensa_deinterleave_odd_i16(const native_vector_i16_x4& a) {
+  return native_vector_i16_x2(
+      native_vector_i16_x2::from_native_vector,
+      halide_xtensa_deinterleave_odd_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+      halide_xtensa_deinterleave_odd_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[2], a.native_vector[3])));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_deinterleave_even_u16(const native_vector_u16_x2& a) {
+  return  IVP_SELNX16UI(a.native_vector[1], a.native_vector[0], IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_deinterleave_odd_u16(const native_vector_u16_x2& a) {
+  return  IVP_SELNX16UI(a.native_vector[1], a.native_vector[0], IVP_SELI_16B_EXTRACT_1_OF_2_OFF_1);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 halide_xtensa_deinterleave_even_u16(const native_vector_u16_x4& a) {
+  return native_vector_u16_x2(
+      native_vector_u16_x2::from_native_vector,
+      halide_xtensa_deinterleave_even_u16(native_vector_u16_x2(native_vector_u16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+      halide_xtensa_deinterleave_even_u16(native_vector_u16_x2(native_vector_u16_x2::from_native_vector, a.native_vector[2], a.native_vector[3])));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 halide_xtensa_deinterleave_odd_u16(const native_vector_u16_x4& a) {
+  return native_vector_u16_x2(
+      native_vector_u16_x2::from_native_vector,
+      halide_xtensa_deinterleave_odd_u16(native_vector_u16_x2(native_vector_u16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+      halide_xtensa_deinterleave_odd_u16(native_vector_u16_x2(native_vector_u16_x2::from_native_vector, a.native_vector[2], a.native_vector[3])));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_deinterleave_even_f32(const native_vector_f32_x2& a) {
+  return  IVP_SELN_2XF32I(a.native_vector[1], a.native_vector[0], IVP_SELI_32B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_deinterleave_odd_f32(const native_vector_f32_x2& a) {
+  return  IVP_SELN_2XF32I(a.native_vector[1], a.native_vector[0], IVP_SELI_32B_EXTRACT_1_OF_2_OFF_1);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 halide_xtensa_deinterleave_even_f32(const native_vector_f32_x4& a) {
+  return native_vector_f32_x2(
+      native_vector_f32_x2::from_native_vector,
+      halide_xtensa_deinterleave_even_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+      halide_xtensa_deinterleave_even_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[2], a.native_vector[3])));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 halide_xtensa_deinterleave_odd_f32(const native_vector_f32_x4& a) {
+  return native_vector_f32_x2(
+      native_vector_f32_x2::from_native_vector,
+      halide_xtensa_deinterleave_odd_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+      halide_xtensa_deinterleave_odd_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[2], a.native_vector[3])));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_extract_0_of_4_f32(const native_vector_f32_x4& a) {
+  return halide_xtensa_deinterleave_even_f32(
+          native_vector_f32_x2(native_vector_f32_x2::from_native_vector,
+          halide_xtensa_deinterleave_even_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_even_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_extract_1_of_4_f32(const native_vector_f32_x4& a) {
+  return halide_xtensa_deinterleave_even_f32(
+          native_vector_f32_x2(native_vector_f32_x2::from_native_vector,
+          halide_xtensa_deinterleave_odd_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_odd_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_extract_2_of_4_f32(const native_vector_f32_x4& a) {
+  return halide_xtensa_deinterleave_odd_f32(
+          native_vector_f32_x2(native_vector_f32_x2::from_native_vector,
+          halide_xtensa_deinterleave_even_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_even_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_extract_3_of_4_f32(const native_vector_f32_x4& a) {
+  return halide_xtensa_deinterleave_odd_f32(
+          native_vector_f32_x2(native_vector_f32_x2::from_native_vector,
+          halide_xtensa_deinterleave_odd_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_odd_f32(native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_extract_0_of_4_i16(const native_vector_i16_x4& a) {
+  return halide_xtensa_deinterleave_even_i16(
+          native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+          halide_xtensa_deinterleave_even_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_even_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_extract_1_of_4_i16(const native_vector_i16_x4& a) {
+  return halide_xtensa_deinterleave_even_i16(
+          native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+          halide_xtensa_deinterleave_odd_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_odd_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_extract_2_of_4_i16(const native_vector_i16_x4& a) {
+  return halide_xtensa_deinterleave_odd_i16(
+          native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+          halide_xtensa_deinterleave_even_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_even_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_extract_3_of_4_i16(const native_vector_i16_x4& a) {
+  return halide_xtensa_deinterleave_odd_i16(
+          native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+          halide_xtensa_deinterleave_odd_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[0], a.native_vector[1])),
+          halide_xtensa_deinterleave_odd_i16(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, a.native_vector[2], a.native_vector[3]))
+        ));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_slice_i16(const native_vector_i16_x2& a, int start) {
+  return IVP_SELNX16(a.native_vector[1], a.native_vector[0], IVP_SEQNX16() + native_vector_i16(start));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_slice_u16(const native_vector_u16_x2& a, int start) {
+  return IVP_SELNX16U(a.native_vector[1], a.native_vector[0], IVP_SEQNX16() + native_vector_i16(start));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_slice_i32(const native_vector_i32_x2& a, int start) {
+  return IVP_SELN_2X32(a.native_vector[1], a.native_vector[0], IVP_SEQN_2X32() + native_vector_i32(start));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u32 halide_xtensa_slice_u32(const native_vector_u32_x2& a, int start) {
+  return IVP_SELN_2X32U(a.native_vector[1], a.native_vector[0], IVP_SEQN_2X32() + native_vector_i32(start));
+}
+
+/*
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_deinterleave_even_i8(const int8x128_t& a) {
+  return  IVP_SEL2NX8I(a.native_vector[1], a.native_vector[0], IVP_SELI_8B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_deinterleave_odd_i8(const int8x128_t& a) {
+  return  IVP_SEL2NX8I(a.native_vector[1], a.native_vector[0], IVP_SELI_8B_EXTRACT_1_OF_2_OFF_1);
+}
+*/
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_deinterleave_even_u8(const native_vector_u8_x2& a) {
+  return  IVP_SEL2NX8UI(a.native_vector[1], a.native_vector[0], IVP_SELI_8B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_deinterleave_odd_u8(const native_vector_u8_x2& a) {
+  return  IVP_SEL2NX8UI(a.native_vector[1], a.native_vector[0], IVP_SELI_8B_EXTRACT_1_OF_2_OFF_1);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_slice_f32(const native_vector_f32_x2& a, int start) {
+  return IVP_SELN_2XF32(a.native_vector[1], a.native_vector[0], IVP_ADDN_2X32(IVP_SEQN_2X32(), native_vector_i32(start)));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_dynamic_shuffle(const native_vector_u8_x2& a, const native_vector_i8& b) {
+  return IVP_SEL2NX8(a.native_vector[1], a.native_vector[0], b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_dynamic_shuffle(const native_vector_i16_x2& a, const native_vector_i16& b) {
+  return IVP_SELNX16(a.native_vector[1], a.native_vector[0], b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_dynamic_shuffle(const native_vector_u16_x2& a, const native_vector_i16& b) {
+  return IVP_SELNX16U(a.native_vector[1], a.native_vector[0], b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 halide_xtensa_dynamic_shuffle(const native_vector_i16_x2& a, const native_vector_i16_x2& b) {
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+                    IVP_SELNX16(a.native_vector[1], a.native_vector[0], b.native_vector[0]),
+                    IVP_SELNX16(a.native_vector[1], a.native_vector[0], b.native_vector[1])
+                  );
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 halide_xtensa_dynamic_shuffle(const native_vector_u16_x2& a, const native_vector_i16_x2& b) {
+  return native_vector_u16_x2(native_vector_u16_x2::from_native_vector,
+                    IVP_SELNX16U(a.native_vector[1], a.native_vector[0], b.native_vector[0]),
+                    IVP_SELNX16U(a.native_vector[1], a.native_vector[0], b.native_vector[1])
+                  );
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32 halide_xtensa_dynamic_shuffle(const native_vector_f32_x2& a, const native_vector_i32& b) {
+  return IVP_SELN_2XF32(a.native_vector[1], a.native_vector[0], b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_sat_add_i32(const native_vector_i32& a,
+                                                                      const native_vector_i32& b) {
+  // I am not 100% about it.
+  xb_vecN_2x32v one = 1;
+  xb_vecN_2x64w l0 = IVP_MULN_2X32(a, one);
+  IVP_MULAN_2X32(l0, b, one);
+  return IVP_PACKVRN_2X64W(l0, 0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 halide_xtensa_sat_add_i32(const native_vector_i32_x2& a,
+                                                                      const native_vector_i32_x2& b) {
+  // I am not 100% about it.
+  xb_vecN_2x32v zero = 0;
+  xb_vecN_2x32v one = 1;
+  xb_vecN_2x64w l0 = a.native_vector[0] * one;
+  IVP_MULAN_2X32(l0, b.native_vector[0], one);
+  xb_vecN_2x64w l1 = a.native_vector[1] * one;
+  IVP_MULAN_2X32(l1, b.native_vector[1], one);
+  return native_vector_i32_x2(native_vector_i32_x2::from_native_vector, IVP_PACKVN_2X64W(l0, zero), IVP_PACKVN_2X64W(l1, zero));
+
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_pred_add_i16(const native_vector_i16& a, const native_mask_i16& p, const native_vector_i16& b, const native_vector_i16& c) {
+  native_vector_i16 r = a;
+  IVP_ADDNX16T(r, b, c, p);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_pred_sub_i16(const native_vector_i16& a, const native_mask_i16& p, const native_vector_i16& b, const native_vector_i16& c) {
+  native_vector_i16 r = a;
+  IVP_SUBNX16T(r, b, c, p);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_pred_max_i16(const native_vector_i16& a, const native_mask_i16& p, const native_vector_i16& b, const native_vector_i16& c) {
+  native_vector_i16 r = a;
+  IVP_MAXNX16T(r, b, c, p);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_pred_min_i16(const native_vector_i16& a, const native_mask_i16& p, const native_vector_i16& b, const native_vector_i16& c) {
+  native_vector_i16 r = a;
+  IVP_MINNX16T(r, b, c, p);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_pred_sat_add_i16(const native_mask_i16& p, const native_vector_i16& b, const native_vector_i16& c, const native_vector_i16& a) {
+  native_vector_i16 r = a;
+  IVP_ADDSNX16T(r, b, c, p);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_pred_sat_sub_i16(const native_vector_i16& a, const native_mask_i16& p, const native_vector_i16& b, const native_vector_i16& c) {
+  native_vector_i16 r = a;
+  IVP_SUBSNX16T(r, b, c, p);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i64 halide_xtensa_widen_mul_i64(const native_vector_i32& a, const native_vector_i32& b) {
+  return IVP_MULN_2X32(a, b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i64 halide_xtensa_widen_mul_add_i64(const native_vector_i64& r, const native_vector_i32& a, const native_vector_i32& b) {
+  native_vector_i64 r1 = r;
+  IVP_MULAN_2X32(r1, a, b);
+  return r1;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i64 halide_xtensa_widen_mul_add_i64(const native_vector_i32& a, const native_vector_i32& b, const native_vector_i32& c) {
+  xb_vecN_2x64w r = IVP_MULN_2X32(c, native_vector_i32(1));
+  IVP_MULAN_2X32(r, a, b);
+  return r;
+}
+
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_mul_add_i48(const native_vector_i48& a, const native_vector_i16& b, const native_vector_i16& c) {
+  native_vector_i48 r = a;
+  IVP_MULANX16(r, b, c);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_mul_add_u24(const native_vector_i24& a, const native_vector_u8& b, const native_vector_u8& c) {
+  native_vector_i24 r = a;
+  IVP_MULUUA2NX8(r, b, c);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_mul_sub_u24(const native_vector_i24& a, const native_vector_u8& b, const native_vector_u8& c) {
+  native_vector_i24 r = a;
+  IVP_MULUUS2NX8(r, b, c);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_mul_add_i24(const native_vector_i24& a, const native_vector_i8& b, const native_vector_i8& c) {
+  native_vector_i24 r = a;
+  IVP_MULA2NX8(r, b, c);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_mul_i24(const native_vector_i8& a, const native_vector_i8& b ) {
+  return IVP_MUL2NX8(a, b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_mul_u24(const native_vector_u8& a, const native_vector_u8& b ) {
+  return IVP_MULUU2NX8(a, b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_quad_mul_add_i24(
+                                            const native_vector_i24& acc,
+                                            const native_vector_i8& a0,
+                                            const int8_t& s0,
+                                            const native_vector_i8& a1,
+                                            const int8_t& s1,
+                                            const native_vector_i8& a2,
+                                            const int8_t& s2,
+                                            const native_vector_i8& a3,
+                                            const int8_t& s3
+                                            ) {
+  native_vector_i24 r = acc;
+  const int8_t scalar_coef[] = {s3, s2, s1, s0};
+  const xb_int32pr * __restrict coef = (const xb_int32pr*)scalar_coef;
+  IVP_MULQA2N8XR8(r, a0, a1, a2, a3, coef[0]);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_quad_mul_add_i24(
+                                            const native_vector_i24& acc,
+                                            const native_vector_i8& a0,
+                                            const native_vector_i8& a1,
+                                            const native_vector_i8& a2,
+                                            const native_vector_i8& a3,
+                                            const int8x4_t& s
+                                            ) {
+  native_vector_i24 r = acc;
+  IVP_MULQA2N8XR8(r, a3, a2, a1, a0, s);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_quad_mul_add_i24(
+                                            const native_vector_i24& acc,
+                                            const native_vector_i8_x4& a,
+                                            const int8x4_t& s
+                                            ) {
+  native_vector_i24 r = acc;
+  IVP_MULQA2N8XR8(r, a.native_vector[3], a.native_vector[2], a.native_vector[1], a.native_vector[0], s);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_quad_mul_add_u24(
+                                            const native_vector_i24& acc,
+                                            const native_vector_u8& a0,
+                                            const native_vector_u8& a1,
+                                            const native_vector_u8& a2,
+                                            const native_vector_u8& a3,
+                                            const uint8x4_t& s
+                                            ) {
+  native_vector_i24 r = acc;
+  IVP_MULUUQA2N8XR8(r, a3, a2, a1, a0, s);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_quad_mul_add_u24(
+                                            const native_vector_i24& acc,
+                                            const native_vector_u8_x4& a,
+                                            const uint8x4_t& s
+                                            ) {
+  native_vector_i24 r = acc;
+  IVP_MULUUQA2N8XR8(r, a.native_vector[3], a.native_vector[2], a.native_vector[1], a.native_vector[0], s);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_quad_mul_add_by_scalar_u24(
+                                            const native_vector_i24& acc,
+                                            const native_vector_u8_x4& a,
+                                            const uint8_t& s
+                                            ) {
+  const xb_int32pr coef = s | (s << 8) | (s << 16) | (s << 24);
+
+  native_vector_i24 r = acc;
+  IVP_MULUUQA2N8XR8(r, a.native_vector[3], a.native_vector[2], a.native_vector[1], a.native_vector[0], coef);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24_x2 halide_xtensa_dual_widen_quad_mul_add_i24(
+                                            const native_vector_i24_x2& acc,
+                                            const native_vector_i8_x4& a,
+                                            const int8x8_t& s) {
+  native_vector_i24_x2 r(acc);
+  IVP_DMULQA2N8XR8(r.native_vector[1], r.native_vector[0], a.native_vector[3], a.native_vector[2], a.native_vector[1], a.native_vector[0], s);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24_x2 halide_xtensa_dual_widen_quad_mul_add_u24(
+                                            const native_vector_i24_x2& acc,
+                                            const native_vector_u8_x4& a,
+                                            const uint8x8_t& s) {
+  native_vector_i24_x2 r(acc);
+  IVP_DMULUUQA2N8XR8(r.native_vector[1], r.native_vector[0], a.native_vector[3], a.native_vector[2], a.native_vector[1], a.native_vector[0], s);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_pair_mul_i24(const native_vector_i8& a, const native_vector_i8& b,
+                                                                  const native_vector_i8& c, const native_vector_i8& d) {
+  return IVP_MULP2NX8(a, b, c, d);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_pair_mul_add_i24(const native_vector_i24& a, const native_vector_i8& b,
+                                                                  const native_vector_i8& c, const native_vector_i8& d, const native_vector_i8& e) {
+  native_vector_i24 r = a;
+  IVP_MULPA2NX8(r, b, c, d, e);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_pair_mul_add_u24(const native_vector_i24& a, const native_vector_u8& b,
+                                                                  const native_vector_u8& c, const native_vector_u8& d, const native_vector_u8& e) {
+  native_vector_i24 r = a;
+  IVP_MULUUPA2NX8(r, b, c, d, e);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_pair_mul_u24(const native_vector_u8& a, const native_vector_u8& b,
+                                                                  const native_vector_u8& c, const native_vector_u8& d) {
+  return IVP_MULUUP2NX8(a, b, c, d);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_pair_mul_i48(const native_vector_i16& a, const native_vector_i16& b,
+                                                                  const native_vector_i16& c, const native_vector_i16& d) {
+  return IVP_MULPNX16(a, b, c, d);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_pair_mul_add_i48(const native_vector_i48& a, const native_vector_i16& b,
+                                                                  const native_vector_i16& c, const native_vector_i16& d, const native_vector_i16& e) {
+  native_vector_i48 r = a;
+  IVP_MULPANX16(r, b, c, d, e);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_pair_mul_u48(const native_vector_u16& a, const native_vector_u16& b,
+                                                                  const native_vector_u16& c, const native_vector_u16& d) {
+  return IVP_MULUUPNX16(a, b, c, d);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_mul_add_by_diff_u24(const native_vector_i24& a, const native_vector_u8& d1,
+                                                                  const native_vector_u8& d2, const native_vector_u8& c) {
+  native_vector_i24 r = a;
+  IVP_MULUUPDA2NX8(r, d1, c, d2, c);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_add_i48(const native_vector_i16& a, const native_vector_i16& b) {
+  return IVP_ADDWNX16(a, b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_add_i48(const native_vector_i48& a, const native_vector_i16& b) {
+  native_vector_i48 r = a;
+  IVP_ADDWANX16(r, b, native_vector_i16(0));
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_pair_add_i48(const native_vector_i48& a, const native_vector_i16& b, const native_vector_i16& c) {
+  native_vector_i48 r = a;
+  IVP_ADDWANX16(r, b, c);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_add_u48(const native_vector_u16& a, const native_vector_u16& b) {
+  return IVP_ADDWUNX16U(a, b);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_add_u48(const native_vector_i48& a, const native_vector_u16& b) {
+  native_vector_i48 r = a;
+  IVP_ADDWUANX16U(r, b, native_vector_u16(0));
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_quad_add_i48(
+                                      const native_vector_i16& a, const native_vector_i16& b,
+                                      const native_vector_i16& c, const native_vector_i16& d) {
+  native_vector_i48 r = IVP_ADDWNX16(a, b);
+  IVP_ADDWANX16(r, c, d);
+  return r;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32_x2 convert<native_vector_u32_x2, native_vector_u16>(const native_vector_u16& src);
+
+HALIDE_ALWAYS_INLINE native_vector_i64_x2 halide_xtensa_widen_right_mul_u64(const native_vector_u32_x2& a, const native_vector_u16 &b) {
+  native_vector_u32_x2 b32 = convert<native_vector_u32_x2, native_vector_u16>(b);
+
+  return native_vector_i64_x2(native_vector_i64_x2::from_native_vector,
+    IVP_MULUSN_2X32(a.native_vector[0], xb_vecN_2x32Uv_rtor_xb_vecN_2x32v(b32.native_vector[0])),
+    IVP_MULUSN_2X32(a.native_vector[1], xb_vecN_2x32Uv_rtor_xb_vecN_2x32v(b32.native_vector[1])));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i48 halide_xtensa_widen_pair_add_u48(const native_vector_i48& a, const native_vector_u16& b, const native_vector_u16& c) {
+  native_vector_i48 r = a;
+  IVP_ADDWUANX16U(r, b, c);
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i24 halide_xtensa_widen_add_i24(const native_vector_i24& a, const native_vector_i8& b) {
+  native_vector_i24 r = a;
+  IVP_ADDWA2NX8(r, b, native_vector_i8(0));
+  return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_sat_narrow_i24x_with_shift_i8(const native_vector_i24& a, int shift) {
+  return IVP_PACKVRNR2NX24(a, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_sat_narrow_i24x_with_shift_u8(const native_vector_i24& a, int shift) {
+  return xb_vec2Nx8_rtor_xb_vec2Nx8U(IVP_PACKVRNR2NX24(a, shift));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 halide_xtensa_narrow_i24_with_shift_i16(const native_vector_i24& a, int shift) {
+    native_vector_i16 even = xb_vecNx16U_rtor_xb_vecNx16(IVP_PACKVRNR2NX24_0(a, shift));
+    native_vector_i16 odd = xb_vecNx16U_rtor_xb_vecNx16(IVP_PACKVRNR2NX24_1(a, shift));
+    native_vector_i16_x2 r;
+    IVP_DSELNX16I(r.native_vector[1], r.native_vector[0], odd, even, IVP_DSELI_INTERLEAVE_1);
+    return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_narrow_i24_with_shift_i8(const native_vector_i24& a, int shift) {
+  return IVP_PACKVR2NX24(a, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_narrow_i24_with_shift_u8(const native_vector_i24& a, int shift) {
+  return IVP_PACKVRU2NX24(a, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 halide_xtensa_narrow_i48_with_shift_i32(const native_vector_i48& a, int shift) {
+    native_vector_i32 even = IVP_PACKVRNRNX48_0(a, shift);
+    native_vector_i32 odd = IVP_PACKVRNRNX48_1(a, shift);
+    native_vector_i32_x2 r;
+    IVP_DSELN_2X32I(r.native_vector[1], r.native_vector[0], odd, even, IVP_DSELI_INTERLEAVE_2);
+    return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u32_x2 halide_xtensa_narrow_i48_with_shift_u32(const native_vector_i48& a, int shift) {
+    native_vector_u32 even = IVP_PACKVRNRNX48_0(a, shift);
+    native_vector_u32 odd = IVP_PACKVRNRNX48_1(a, shift);
+    native_vector_u32_x2 r;
+    IVP_DSELN_2X32UI(r.native_vector[1], r.native_vector[0], odd, even, IVP_DSELI_INTERLEAVE_2);
+    return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_narrow_i48_with_shift_u16(const native_vector_i48& a, int shift) {
+  return xb_vecNx16_rtor_xb_vecNx16U(IVP_PACKVRNRNX48(a, shift));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_narrow_with_shift_i16(const native_vector_i32_x2& a, int shift) {
+  xb_vecNx48 wide = IVP_CVT48SNX32(a.native_vector[1], a.native_vector[0]);
+  return IVP_PACKVRNRNX48(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_narrow_with_shift_u16(const native_vector_i32_x2& a, int shift) {
+  xb_vecNx48 wide = IVP_CVT48SNX32(a.native_vector[1], a.native_vector[0]);
+  return xb_vecNx16_rtor_xb_vecNx16U(IVP_PACKVRNRNX48(wide, shift));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_narrow_high_i32(const native_vector_i64& a) {
+  return IVP_PACKHN_2X64W(a);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_sat_narrow_shift_i32(const native_vector_i64& a, int shift) {
+  return IVP_PACKVN_2X64W(a, shift);
+}
+
+
+
+HALIDE_ALWAYS_INLINE int32_t halide_xtensa_full_reduce_add_u8_to_i32(const native_vector_u8& a) {
+    return xb_int16U_rtor_uint16(IVP_RADDU2NX8(a));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_lerp_i16(const native_vector_i16& a, const native_vector_i16& b, uint16_t w) {
+  // TODO(vksnk): Halide lerp actually uses full range, but it's not clear from the documentation
+  // if we can pass unsigned type to IVP_MULPN16XR16, so just to be extra careful reduce it to 14-bit
+  // for now.
+  uint32_t w32 = ((uint32_t(w)) >> 0);
+  uint32_t alphaMalpha = ((65536 - w32) << 16) | w32;
+  xb_vecNx48 output = IVP_MULSUPN16XR16(a, b, alphaMalpha);
+  IVP_DECNEGWNX48(output);
+  return IVP_PACKVRNX48(output, 16);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 convert<native_vector_i16_x2, native_vector_i8>(const native_vector_i8& src) {
+  xb_vec2Nx24 wide = src * native_vector_i8(1);
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+                        IVP_CVT16S2NX24L(wide), IVP_CVT16S2NX24H(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 convert<native_vector_u16_x2, native_vector_u8>(const native_vector_u8& src) {
+  xb_vec2Nx24 wide = src * native_vector_u8(1);
+  return native_vector_u16_x2(native_vector_u16_x2::from_native_vector,
+                        IVP_CVT16U2NX24L(wide), IVP_CVT16U2NX24H(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 convert<native_vector_i16_x2, native_vector_u8>(const native_vector_u8& src) {
+  xb_vec2Nx24 wide = src * native_vector_u8(1);
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+                        IVP_CVT16S2NX24L(wide), IVP_CVT16S2NX24H(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 convert<native_vector_i16_x2, native_vector_i24>(const native_vector_i24& wide) {
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+                        IVP_CVT16S2NX24L(wide), IVP_CVT16S2NX24H(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 convert<native_vector_u16_x2, native_vector_i24>(const native_vector_i24& wide) {
+  return native_vector_u16_x2(native_vector_u16_x2::from_native_vector,
+                        IVP_CVT16U2NX24L(wide), IVP_CVT16U2NX24H(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i8 convert<native_vector_i8, native_vector_i16_x2>(const native_vector_i16_x2& src) {
+  xb_vec2Nx24 wide = IVP_CVT24S2NX16(src.native_vector[1], src.native_vector[0]);
+  return IVP_PACKL2NX24(wide);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u8 convert<native_vector_u8, native_vector_i16_x2>(const native_vector_i16_x2& src) {
+  xb_vec2Nx24 wide = IVP_CVT24S2NX16(src.native_vector[1], src.native_vector[0]);
+  return xb_vec2Nx8_rtor_xb_vec2Nx8U(IVP_PACKL2NX24(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i8 convert<native_vector_i8, native_vector_i32_x4>(const native_vector_i32_x4& src) {
+  xb_vec2Nx24 wide = IVP_CVT24UNX32L(src.native_vector[1], src.native_vector[0]);
+  IVP_CVT24UNX32H(wide, src.native_vector[3], src.native_vector[2]);
+  return IVP_PACKL2NX24(wide);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i8 convert<native_vector_i8, native_mask_i8>(const native_mask_i8& src) {
+  return IVP_MOV2NX8T(native_vector_i8(1), native_vector_i8(0), src);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u8 convert<native_vector_u8, native_mask_i8>(const native_mask_i8& src) {
+  return IVP_MOV2NX8UT(native_vector_u8(1), native_vector_u8(0), src);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u8 convert<native_vector_u8, native_vector_i32_x4>(const native_vector_i32_x4& src) {
+  xb_vec2Nx24 wide = IVP_CVT24UNX32L(src.native_vector[1], src.native_vector[0]);
+  IVP_CVT24UNX32H(wide, src.native_vector[3], src.native_vector[2]);
+  return xb_vec2Nx8_rtor_xb_vec2Nx8U(IVP_PACKL2NX24(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u8 convert<native_vector_u8, native_vector_u16_x2>(const native_vector_u16_x2& src) {
+  return IVP_SEL2NX8UI(IVP_MOV2NX8U_FROMNX16(src.native_vector[1]),
+                       IVP_MOV2NX8U_FROMNX16(src.native_vector[0]),
+                       IVP_SELI_8B_EXTRACT_1_OF_2_OFF_0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16 convert<native_vector_i16, native_mask_i16>(const native_mask_i16& src) {
+  return IVP_MOVNX16T(native_vector_i16(1), native_vector_i16(0), src);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_mask_i16_x2 convert<native_mask_i16_x2, native_mask_i8>(const native_mask_i8& src) {
+  return native_mask_i16_x2(native_mask_i16_x2::from_native_vector,
+            IVP_EXTRACTBL2N(src),
+            IVP_EXTRACTBH2N(src));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 convert<native_vector_i16_x2, native_mask_i8>(const native_mask_i8& src) {
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector,
+            convert<native_vector_i16, native_mask_i16>(IVP_EXTRACTBL2N(src)),
+            convert<native_vector_i16, native_mask_i16>(IVP_EXTRACTBH2N(src)));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16 convert<native_vector_i16, native_vector_i32_x2>(const native_vector_i32_x2& src) {
+  return IVP_SELNX16I(IVP_MOVNX16_FROMN_2X32(src.native_vector[1]),
+                      IVP_MOVNX16_FROMN_2X32(src.native_vector[0]),
+                      IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i48 convert<native_vector_i48, native_vector_i32_x2>(const native_vector_i32_x2& src) {
+  return IVP_CVT48SNX32(src.native_vector[1], src.native_vector[0]);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i48 convert<native_vector_i48, native_vector_u32_x2>(const native_vector_u32_x2& src) {
+  return IVP_CVT48UNX32(src.native_vector[1], src.native_vector[0]);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16 convert<native_vector_i16, native_vector_u32_x2>(const native_vector_u32_x2& src) {
+  return IVP_SELNX16I(IVP_MOVNX16_FROMN_2X32U(src.native_vector[1]),
+                      IVP_MOVNX16_FROMN_2X32U(src.native_vector[0]),
+                      IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 convert<native_vector_i16_x2, native_vector_i32_x4>(const native_vector_i32_x4& src) {
+  xb_vecNx48 wide0 = IVP_CVT48SNX32(src.native_vector[1], src.native_vector[0]);
+  xb_vecNx48 wide1 = IVP_CVT48SNX32(src.native_vector[3], src.native_vector[2]);
+
+  return native_vector_i16_x2(native_vector_i16_x2::from_native_vector, IVP_PACKLNX48(wide0), IVP_PACKLNX48(wide1));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16 convert<native_vector_u16, native_vector_i32_x2>(const native_vector_i32_x2& src) {
+  return IVP_SELNX16UI(IVP_MOVNX16_FROMN_2X32(src.native_vector[1]),
+                       IVP_MOVNX16_FROMN_2X32(src.native_vector[0]),
+                       IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16 convert<native_vector_u16, native_mask_i16>(const native_mask_i16& src) {
+  return IVP_MOVNX16UT(native_vector_u16(1), native_vector_u16(0), src);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 convert<native_vector_u16_x2, native_mask_i8>(const native_mask_i8& src) {
+  return native_vector_u16_x2(native_vector_u16_x2::from_native_vector,
+            convert<native_vector_u16, native_mask_i16>(IVP_EXTRACTBL2N(src)),
+            convert<native_vector_u16, native_mask_i16>(IVP_EXTRACTBH2N(src)));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16 convert<native_vector_u16, native_vector_u32_x2>(const native_vector_u32_x2& src) {
+  return IVP_SELNX16UI(IVP_MOVNX16_FROMN_2X32U(src.native_vector[1]),
+                       IVP_MOVNX16_FROMN_2X32U(src.native_vector[0]),
+                       IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32 convert<native_vector_u32, native_vector_i64>(const native_vector_i64& src) {
+  return IVP_PACKLN_2X64W(src);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32 convert<native_vector_i32, native_mask_i32>(const native_mask_i32& src) {
+  xb_vecN_2x32v r = 0;
+  IVP_INJBIN_2X32(r, src, 0);
+  return r;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 convert<native_vector_i32_x4, native_vector_u8>(const native_vector_u8& src) {
+    xb_vec2Nx24 wide = src * native_vector_u8(1);
+    return native_vector_i32_x4(native_vector_i32_x4::from_native_vector, IVP_CVT32S2NX24LL(wide), IVP_CVT32S2NX24LH(wide),
+                                                      IVP_CVT32S2NX24HL(wide), IVP_CVT32S2NX24HH(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32_x4 convert<native_vector_u32_x4, native_vector_u8>(const native_vector_u8& src) {
+    xb_vec2Nx24 wide = src * native_vector_u8(1);
+    return native_vector_u32_x4(native_vector_u32_x4::from_native_vector, IVP_CVT32S2NX24LL(wide), IVP_CVT32S2NX24LH(wide),
+                                                      IVP_CVT32S2NX24HL(wide), IVP_CVT32S2NX24HH(wide));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 convert<native_vector_i32_x4, native_vector_i24>(const native_vector_i24& src) {
+    return native_vector_i32_x4(native_vector_i32_x4::from_native_vector, IVP_CVT32S2NX24LL(src), IVP_CVT32S2NX24LH(src),
+                                                      IVP_CVT32S2NX24HL(src), IVP_CVT32S2NX24HH(src));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 convert<native_vector_i32_x2, native_vector_i16>(const native_vector_i16& src) {
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector,
+      IVP_MOVN_2X32_FROMNX16(
+        IVP_SELNX16UI(native_vector_i16(0), src, IVP_SELI_16B_INTERLEAVE_1_LO)),
+      IVP_MOVN_2X32_FROMNX16(
+        IVP_SELNX16UI(native_vector_i16(0), src, IVP_SELI_16B_INTERLEAVE_1_HI)));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x4 convert<native_vector_i32_x4, native_vector_i16_x2>(const native_vector_i16_x2& src) {
+    auto r0 = convert<native_vector_i32_x2, native_vector_i16>(src.native_vector[0]);
+    auto r1 = convert<native_vector_i32_x2, native_vector_i16>(src.native_vector[1]);
+
+    return native_vector_i32_x4(native_vector_i32_x4::from_native_vector, r0.native_vector[0], r0.native_vector[1],
+                                                      r1.native_vector[0], r1.native_vector[1]);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 convert<native_vector_i32_x2, native_vector_u16>(const native_vector_u16& src) {
+  return native_vector_i32_x2(native_vector_i32_x2::from_native_vector,
+                    IVP_MOVN_2X32_FROMNX16(IVP_SELNX16UI(native_vector_u16(0), src, IVP_SELI_16B_INTERLEAVE_1_LO)),
+                    IVP_MOVN_2X32_FROMNX16(IVP_SELNX16UI(native_vector_u16(0), src, IVP_SELI_16B_INTERLEAVE_1_HI)));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 convert<native_vector_i32_x2, native_vector_u32_x2>(const native_vector_u32_x2& src) {
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector,
+                      src.native_vector[0], src.native_vector[1]);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32_x2 convert<native_vector_u32_x2, native_vector_i32_x2>(const native_vector_i32_x2& src) {
+    return native_vector_u32_x2(native_vector_u32_x2::from_native_vector,
+                      src.native_vector[0], src.native_vector[1]);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16_x2 convert<native_vector_u16_x2, native_vector_i16_x2>(const native_vector_i16_x2& src) {
+    return native_vector_u16_x2(native_vector_u16_x2::from_native_vector,
+                      src.native_vector[0], src.native_vector[1]);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 convert<native_vector_i32_x2, native_vector_i48>(const native_vector_i48& src) {
+    return native_vector_i32_x2(native_vector_i32_x2::from_native_vector,
+                                IVP_CVT32SNX48L(src),
+                                IVP_CVT32SNX48H(src));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32_x2 convert<native_vector_u32_x2, native_vector_u16>(const native_vector_u16& src) {
+    xb_vec2Nx24 wide = IVP_CVT24U2NX16(0, xb_vecNx16U_rtor_xb_vecNx16(src));
+    return native_vector_u32_x2(native_vector_u32_x2::from_native_vector,
+                        xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32S2NX24LL(wide)),
+                        xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32S2NX24LH(wide)));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32_x2 convert<native_vector_u32_x2, native_vector_i48>(const native_vector_i48& src) {
+    return native_vector_u32_x2(native_vector_u32_x2::from_native_vector,
+                                xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32UNX48L(src)),
+                                xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32UNX48H(src)));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16_x2 convert<native_vector_i16_x2, native_vector_u16_x2>(const native_vector_u16_x2& src) {
+    return native_vector_i16_x2(native_vector_i16_x2::from_native_vector, src.native_vector[0], src.native_vector[1]);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f32 convert<native_vector_f32, native_vector_i32>(const native_vector_i32& src) {
+  return IVP_FLOATN_2X32(src, 0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 convert<native_vector_f32_x2, native_vector_i32_x2>(const native_vector_i32_x2& src) {
+  return native_vector_f32_x2(native_vector_f32_x2::from_native_vector,
+                  convert<native_vector_f32, native_vector_i32>(src.native_vector[0]),
+                  convert<native_vector_f32, native_vector_i32>(src.native_vector[1]));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 convert<native_vector_f32_x2, native_vector_i16>(const native_vector_i16& src) {
+    native_vector_i32_x2 tmp = convert<native_vector_i32_x2, native_vector_i16>(src);
+    return convert<native_vector_f32_x2, native_vector_i32_x2>(tmp);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 convert<native_vector_f32_x2, native_vector_u16>(const native_vector_u16& src) {
+    native_vector_i32_x2 tmp = convert<native_vector_i32_x2, native_vector_u16>(src);
+    return convert<native_vector_f32_x2, native_vector_i32_x2>(tmp);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32 convert<native_vector_i32, native_vector_f32>(const native_vector_f32& src) {
+  return IVP_TRUNCN_2XF32(src, 0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32 convert<native_vector_u32, native_vector_f32>(const native_vector_f32& src) {
+  return IVP_UTRUNCN_2XF32(src, 0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 convert<native_vector_i32_x2, native_vector_f32_x2>(const native_vector_f32_x2& src) {
+  return native_vector_i32_x2(native_vector_i32_x2::from_native_vector,
+                  convert<native_vector_i32, native_vector_f32>(src.native_vector[0]),
+                  convert<native_vector_i32, native_vector_f32>(src.native_vector[1]));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u32_x2 convert<native_vector_u32_x2, native_vector_f32_x2>(const native_vector_f32_x2& src) {
+  return native_vector_u32_x2(native_vector_u32_x2::from_native_vector,
+                  convert<native_vector_u32, native_vector_f32>(src.native_vector[0]),
+                  convert<native_vector_u32, native_vector_f32>(src.native_vector[1]));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 convert<native_vector_f32_x2, native_vector_f16>(const native_vector_f16& src) {
+    native_vector_f32_x2 output;
+
+    IVP_DSELN_2XF32I(
+      output.native_vector[1],
+      output.native_vector[0],
+      IVP_CVTF32NXF16_1(src),
+      IVP_CVTF32NXF16_0(src),
+      IVP_DSELI_INTERLEAVE_2);
+
+    return output;
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f16 convert<native_vector_f16, native_vector_f32_x2>(const native_vector_f32_x2& src) {
+    return IVP_SELNXF16I(
+      IVP_CVTF16N_2XF32_0(src.native_vector[1]),
+      IVP_CVTF16N_2XF32_0(src.native_vector[0]),
+      IVP_SELI_EXTRACT_1_OF_2_OFF_0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f16 convert<native_vector_f16, native_vector_i32_x2>(const native_vector_i32_x2& src) {
+    return convert<native_vector_f16, native_vector_f32_x2>(
+      native_vector_f32_x2(
+        native_vector_f32_x2::from_native_vector,
+        IVP_FLOATN_2X32(src.native_vector[0], 0),
+        IVP_FLOATN_2X32(src.native_vector[1], 0)));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i32_x2 convert<native_vector_i32_x2, native_vector_f16>(const native_vector_f16& src) {
+    native_vector_f32_x2 tmp = convert<native_vector_f32_x2, native_vector_f16>(src);
+    return convert<native_vector_i32_x2, native_vector_f32_x2>(tmp);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16 convert<native_vector_u16, native_vector_f32_x2>(const native_vector_f32_x2& src) {
+  return convert<native_vector_u16, native_vector_u32_x2>(
+    convert<native_vector_u32_x2, native_vector_f32_x2>(src));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16 convert<native_vector_i16, native_vector_f32_x2>(const native_vector_f32_x2& src) {
+    native_vector_i32_x2 tmp = convert<native_vector_i32_x2, native_vector_f32_x2>(src);
+    return convert<native_vector_i16, native_vector_i32_x2>(tmp);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f16 convert<native_vector_f16, native_vector_i16>(const native_vector_i16& src) {
+    return IVP_FLOAT16NX16(src, 0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_i16 convert<native_vector_i16, native_vector_f16>(const native_vector_f16& src) {
+    return IVP_TRUNC16NXF16(src, 0);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_f16 convert<native_vector_f16, native_vector_u16>(const native_vector_u16& src) {
+    return convert<native_vector_f16, native_vector_i16>(xb_vecNx16U_rtor_xb_vecNx16(src));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u16 convert<native_vector_u16, native_vector_f16>(const native_vector_f16& src) {
+    return xb_vecNx16U_rtor_xb_vecNx16(convert<native_vector_i16, native_vector_f16>(src));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE native_vector_u8 convert<native_vector_u8, native_vector_f32_x4>(const native_vector_f32_x4& src) {
+    native_vector_i32_x4 tmp(native_vector_i32_x4::from_native_vector,
+                  convert<native_vector_i32, native_vector_f32>(src.native_vector[0]),
+                  convert<native_vector_i32, native_vector_f32>(src.native_vector[1]),
+                  convert<native_vector_i32, native_vector_f32>(src.native_vector[2]),
+                  convert<native_vector_i32, native_vector_f32>(src.native_vector[3]));
+    return convert<native_vector_u8, native_vector_i32_x4>(tmp);
+}
+
+HALIDE_ALWAYS_INLINE native_mask_i32 halide_xtensa_slice_to_native(const native_mask_i16& src, int index, int native_lanes, int total_lanes) {
+  return (index == 0)?IVP_EXTRACTBLN(src):IVP_EXTRACTBHN(src);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_convert_i16_low_i32(const native_vector_i16& src) {
+    const native_vector_i32 m = native_vector_i32(1U << (16 - 1));
+    native_vector_i32 x = IVP_MOVN_2X32_FROMNX16(IVP_SELNX16I(native_vector_i16(0), src, IVP_SELI_16B_INTERLEAVE_1_LO));
+    native_vector_i32 r = (x ^ m) - m;
+    return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_convert_i16_high_i32(const native_vector_i16& src) {
+    const native_vector_i32 m = native_vector_i32(1U << (16 - 1));
+    native_vector_i32 x = IVP_MOVN_2X32_FROMNX16(IVP_SELNX16I(native_vector_i16(0), src, IVP_SELI_16B_INTERLEAVE_1_HI));
+    native_vector_i32 r = (x ^ m) - m;
+    return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_convert_u16_low_i32(const native_vector_u16& src) {
+    return IVP_MOVN_2X32_FROMNX16(IVP_SELNX16UI(native_vector_u16(0), src, IVP_SELI_16B_INTERLEAVE_1_LO));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_convert_u16_high_i32(const native_vector_u16& src) {
+    return IVP_MOVN_2X32_FROMNX16(IVP_SELNX16UI(native_vector_u16(0), src, IVP_SELI_16B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u32 halide_xtensa_convert_u16_low_u32(const native_vector_u16& src) {
+    return IVP_MOVN_2X32_FROMNX16(IVP_SELNX16UI(native_vector_u16(0), src, IVP_SELI_16B_INTERLEAVE_1_LO));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u32 halide_xtensa_convert_u16_high_u32(const native_vector_u16& src) {
+    return IVP_MOVN_2X32_FROMNX16(IVP_SELNX16UI(native_vector_u16(0), src, IVP_SELI_16B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_convert_i32_u16(const native_vector_i32& src0, const native_vector_i32& src1) {
+  xb_vecNx48 wide = IVP_CVT48SNX32(src1, src0);
+  return xb_vecNx16_rtor_xb_vecNx16U(IVP_PACKLNX48(wide));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_convert_concat_i16_to_i8(const native_vector_i16& a, const native_vector_i16& b) {
+  xb_vec2Nx24 wide = IVP_CVT24S2NX16(b, a);
+  return IVP_PACKL2NX24(wide);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_sat_narrow_u8(const native_vector_i16_x2& a) {
+  xb_vec2Nx24 wide = IVP_CVT24S2NX16(a.native_vector[1], a.native_vector[0]);
+  return IVP_PACKVRU2NX24(wide, 0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_sat_narrow_i16(const native_vector_i32_x2& a) {
+  native_vector_i32 a0 = IVP_SLSIN_2X32(a.native_vector[0], 16);
+  native_vector_i32 a1 = IVP_SLSIN_2X32(a.native_vector[1], 16);
+  return IVP_MOVNX16_FROMN_2X32(IVP_SELN_2X32I(a1, a0, IVP_SELI_16B_DEINTERLEAVE_1_ODD));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_sat_narrow_with_rounding_shift_i8(const native_vector_i16_x2& a, uint32_t shift) {
+  xb_vec2Nx24 wide = IVP_CVT24S2NX16(a.native_vector[1], a.native_vector[0]);
+  return IVP_PACKVR2NX24(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_sat_narrow_with_rounding_shift_u8(const native_vector_i16_x2& a, uint32_t shift) {
+  xb_vec2Nx24 wide = IVP_CVT24S2NX16(a.native_vector[1], a.native_vector[0]);
+  return IVP_PACKVRU2NX24(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_narrow_with_rounding_shift_i16(const native_vector_i32_x2& a, uint32_t shift) {
+  xb_vecNx48 wide = convert<native_vector_i48, native_vector_i32_x2>(a);
+  // Add rounding factor.
+  const uint16_t half_shift_1 = (shift - 1) >> 1;
+  const uint16_t half_shift_2 = (shift - 1) - half_shift_1;
+  native_vector_u16 v1 = IVP_SLLNX16U(1, half_shift_1);
+  native_vector_u16 v2 = IVP_SLLNX16U(1, half_shift_2);
+  IVP_MULUUANX16(wide, v1, v2);
+  return IVP_PACKVRNRNX48(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_sat_narrow_with_rounding_shift_i16(const native_vector_i32_x2& a, uint32_t shift) {
+  xb_vecNx48 wide = convert<native_vector_i48, native_vector_i32_x2>(a);
+  return IVP_PACKVRNX48(wide, shift);
+}
+
+// TODO(vksnk): this is pretty inefficient.
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_sat_narrow_with_signed_rounding_shift_i16(const native_vector_i32_x2& a, int32_t shift) {
+  if (shift >= 0) {
+    return halide_xtensa_sat_narrow_with_rounding_shift_i16(a, (uint32_t)shift);
+  }
+
+  return halide_xtensa_sat_narrow_i16(
+            native_vector_i32_x2(native_vector_i32_x2::from_native_vector,
+                        IVP_SLAN_2X32(a.native_vector[0], -shift),
+                        IVP_SLAN_2X32(a.native_vector[1], -shift)));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_rounding_mul_shift_right_i16(const native_vector_i16& a, const native_vector_i16& b, uint16_t shift) {
+  xb_vecNx48 wide = a * b;
+  return IVP_PACKVRNRNX48(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_rounding_shift_right_i16(const native_vector_i16& a, uint32_t shift) {
+  xb_vecNx48 wide = a * (native_vector_i16)1;
+  return IVP_PACKVRNX48(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i32 halide_xtensa_rounding_shift_right_i32(const native_vector_i32& a, uint32_t shift) {
+  xb_vecN_2x64w wide = a * (native_vector_i32)1;
+  return IVP_PACKVRN_2X64W(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u32 halide_xtensa_rounding_shift_right_u32(const native_vector_u32& a, uint32_t shift) {
+  xb_vecN_2x64w wide = IVP_MULUUN_2X16X32_0((native_vector_u16)1, a);
+  return IVP_PACKVRN_2X64W(wide, shift);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_convert_concat_i16_to_u8(const native_vector_i16& a, const native_vector_i16& b) {
+  return IVP_SEL2NX8UI(IVP_MOV2NX8_FROMNX16(b), IVP_MOV2NX8_FROMNX16(a), IVP_SELI_8B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i8 halide_xtensa_convert_concat_u16_to_i8(const native_vector_u16& a, const native_vector_u16& b) {
+  xb_vec2Nx24 wide = IVP_CVT24U2NX16(xb_vecNx16U_rtor_xb_vecNx16(b), xb_vecNx16U_rtor_xb_vecNx16(a));
+  return IVP_PACKL2NX24(wide);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u8 halide_xtensa_convert_concat_u16_to_u8(const native_vector_u16& a, const native_vector_u16& b) {
+  xb_vec2Nx24 wide = IVP_CVT24U2NX16(xb_vecNx16U_rtor_xb_vecNx16(b), xb_vecNx16U_rtor_xb_vecNx16(a));
+  return xb_vec2Nx8_rtor_xb_vec2Nx8U(IVP_PACKL2NX24(wide));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_convert_i8_low_i16(const native_vector_i8& src, int native_lanes, int total_lines) {
+    const native_vector_i16 m = native_vector_i16(1U << (8 - 1));
+    native_vector_i16 x =  IVP_MOVNX16_FROM2NX8(IVP_SEL2NX8I(native_vector_i8(0), src, IVP_SELI_8B_INTERLEAVE_1_LO));
+    native_vector_i16 r = (x ^ m) - m;
+    return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_convert_i8_high_i16(const native_vector_i8& src, int native_lanes, int total_lines) {
+    const native_vector_i16 m = native_vector_i16(1U << (8 - 1));
+    native_vector_i16 x =  IVP_MOVNX16_FROM2NX8(IVP_SEL2NX8I(native_vector_i8(0), src, IVP_SELI_8B_INTERLEAVE_1_HI));
+    native_vector_i16 r = (x ^ m) - m;
+    return r;
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_convert_u8_low_i16(const native_vector_u8& src, int native_lanes, int total_lines) {
+    return IVP_MOVNX16_FROM2NX8U(IVP_SEL2NX8UI(native_vector_u8(0), src, IVP_SELI_8B_INTERLEAVE_1_LO));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_convert_u8_high_i16(const native_vector_u8& src, int native_lanes, int total_lines) {
+    return IVP_MOVNX16_FROM2NX8U(IVP_SEL2NX8UI(native_vector_u8(0), src, IVP_SELI_8B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_convert_u8_low_u16(const native_vector_u8& src, int native_lanes, int total_lines) {
+    return IVP_MOVNX16_FROM2NX8U(IVP_SEL2NX8UI(native_vector_u8(0), src, IVP_SELI_8B_INTERLEAVE_1_LO));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_convert_u8_high_u16(const native_vector_u8& src, int native_lanes, int total_lines) {
+    return IVP_MOVNX16_FROM2NX8U(IVP_SEL2NX8UI(native_vector_u8(0), src, IVP_SELI_8B_INTERLEAVE_1_HI));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_convert_concat_i32_to_i16(const native_vector_i32& a, const native_vector_i32& b) {
+  return IVP_SELNX16I(IVP_MOVNX16_FROMN_2X32(b), IVP_MOVNX16_FROMN_2X32(a), IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_convert_concat_i32_to_u16(const native_vector_i32& a, const native_vector_i32& b) {
+  return IVP_SELNX16UI(IVP_MOVNX16_FROMN_2X32(b), IVP_MOVNX16_FROMN_2X32(a), IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_i16 halide_xtensa_convert_concat_u32_to_i16(const native_vector_u32& a, const native_vector_u32& b) {
+  return IVP_SELNX16I(IVP_MOVNX16_FROMN_2X32U(b), IVP_MOVNX16_FROMN_2X32U(a), IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u16 halide_xtensa_convert_concat_u32_to_u16(const native_vector_u32& a, const native_vector_u32& b) {
+  return IVP_SELNX16UI(IVP_MOVNX16_FROMN_2X32U(b), IVP_MOVNX16_FROMN_2X32U(a), IVP_SELI_16B_EXTRACT_1_OF_2_OFF_0);
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u32 halide_xtensa_convert_i48_low_u32(const native_vector_i48& src, int native_lanes, int total_lines) {
+    return xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32UNX48L(src));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_u32 halide_xtensa_convert_i48_high_u32(const native_vector_i48& src, int native_lanes, int total_lines) {
+    return xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32UNX48H(src));
+}
+
+HALIDE_ALWAYS_INLINE native_mask_i16 halide_xtensa_concat_from_native(const native_mask_i32& a, const native_mask_i32& b) {
+        return IVP_JOINBN_2(b, a);
+}
+
+HALIDE_ALWAYS_INLINE native_mask_i8 halide_xtensa_concat_from_native(const native_mask_i16& a, const native_mask_i16& b) {
+        return IVP_JOINBN(b, a);
+}
+
+HALIDE_ALWAYS_INLINE native_mask_i8 halide_xtensa_concat_from_native(const native_mask_i32& a, const native_mask_i32& b, const native_mask_i32& c, const native_mask_i32& d) {
+    return halide_xtensa_concat_from_native(halide_xtensa_concat_from_native(a, b), halide_xtensa_concat_from_native(c, d));
+}
+
+HALIDE_ALWAYS_INLINE native_vector_f32_x2 halide_xtensa_concat_from_native(const native_vector_f32& a, const native_vector_f32& b) {
+    return native_vector_f32_x2(native_vector_f32_x2::from_native_vector, a, b);
+}
+
+template <typename VectorType, typename OffsetType, typename BaseType, int Lanes, bool IsTCM>
+VectorType gather_load(const void *base, const OffsetType& offset) {
+    BaseType __attribute__((aligned(XCHAL_VISION_SIMD8))) tmp[Lanes];
+    int offsets[Lanes];
+    store<OffsetType, int32_t, Lanes>(offset, &offsets[0], 0);
+    for (int i = 0; i < Lanes; i++) {
+        tmp[i] = ((const BaseType*)base)[offsets[i]];
+    }
+
+    return *((VectorType *)tmp);
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i8 gather_load<native_vector_i8, native_vector_i32_x4, int8_t, VECTOR_WIDTH_U8, true>(const void *base, const native_vector_i32_x4& offset) {
+  auto addresses1 = native_vector_i32_x2(native_vector_i32_x2::from_native_vector, offset.native_vector[0], offset.native_vector[1]);
+  auto output1 = IVP_GATHERDNX8S(
+    IVP_GATHERANX8S(
+      (const int8_t*) base,
+      convert<native_vector_u16, native_vector_i32_x2>(addresses1)
+    )
+  );
+
+  auto addresses2 = native_vector_i32_x2(native_vector_i32_x2::from_native_vector, offset.native_vector[2], offset.native_vector[3]);
+  auto output2 = IVP_GATHERDNX8S(
+    IVP_GATHERANX8S(
+      (const int8_t*) base,
+      convert<native_vector_u16, native_vector_i32_x2>(addresses2)
+    )
+  );
+
+  // NOTE(aelphy): the intrinsic for gathering 8-bit elements extends them to 16-bit, and the conversion back to 8-bit is needed
+  return convert<native_vector_i8, native_vector_i16_x2>(native_vector_i16_x2(native_vector_i16_x2::from_native_vector, output1, output2));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u8 gather_load<native_vector_u8, native_vector_i32_x4, uint8_t, VECTOR_WIDTH_U8, true>(const void *base, const native_vector_i32_x4& offset) {
+  auto addresses1 = native_vector_i32_x2(native_vector_i32_x2::from_native_vector, offset.native_vector[0], offset.native_vector[1]);
+  auto output1 = IVP_GATHERDNX8U(
+    IVP_GATHERANX8U(
+      (const uint8_t*) base,
+      convert<native_vector_u16, native_vector_i32_x2>(addresses1)
+    )
+  );
+
+  auto addresses2 = native_vector_i32_x2(native_vector_i32_x2::from_native_vector, offset.native_vector[2], offset.native_vector[3]);
+  auto output2 = IVP_GATHERDNX8U(
+    IVP_GATHERANX8U(
+      (const uint8_t*) base,
+      convert<native_vector_u16, native_vector_i32_x2>(addresses2)
+    )
+  );
+
+  // NOTE(aelphy): the intrinsic for gathering 8-bit elements extends them to 16-bit, and the conversion back to 8-bit is needed
+  return convert<native_vector_u8, native_vector_u16_x2>(native_vector_u16_x2(native_vector_u16_x2::from_native_vector, output1, output2));
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i16 gather_load<native_vector_i16, native_vector_i32_x2, int16_t, VECTOR_WIDTH_U16, true>(const void *base, const native_vector_i32_x2& offset) {
+  // NOTE(aelphy): the shift is needed because offests are expected to be in bytes
+  return IVP_GATHERDNX16(
+    IVP_GATHERANX16(
+      (const int16_t*) base,
+      convert<native_vector_u16, native_vector_i32_x2>(offset) << 1
+    )
+  );
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u16 gather_load<native_vector_u16, native_vector_i32_x2, uint16_t, VECTOR_WIDTH_U16, true>(const void *base, const native_vector_i32_x2& offset) {
+  // NOTE(aelphy): the shift is needed because offests are expected to be in bytes
+  return IVP_GATHERDNX16U(
+    IVP_GATHERANX16U(
+      (const uint16_t*) base,
+      convert<native_vector_u16, native_vector_i32_x2>(offset) << 1
+    )
+  );
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_i32 gather_load<native_vector_i32, native_vector_i32, int32_t, VECTOR_WIDTH_I32, true>(const void *base, const native_vector_i32& offset) {
+  // NOTE(aelphy): the shift is needed because offests are expected to be in bytes
+  return IVP_GATHERDN_2X32(
+    IVP_GATHERAN_2X32(
+      (const int32_t*) base,
+      xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(offset) << 2
+    )
+  );
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_u32 gather_load<native_vector_u32, native_vector_i32, uint32_t, VECTOR_WIDTH_I32, true>(const void *base, const native_vector_i32& offset) {
+  // NOTE(aelphy): the shift is needed because offests are expected to be in bytes
+  return IVP_GATHERDN_2X32U(
+    IVP_GATHERAN_2X32U(
+      (const uint32_t*) base,
+      xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(offset) << 2
+    )
+  );
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_f32 gather_load<native_vector_f32, native_vector_i32, float, VECTOR_WIDTH_F32, true>(const void *base, const native_vector_i32& offset) {
+  // NOTE(aelphy): the shift is needed because offests are expected to be in bytes
+  return IVP_GATHERDN_2XF32(
+    IVP_GATHERAN_2XF32(
+      (const float*) base,
+      xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(offset) << 2
+    )
+  );
+}
+
+template<>
+HALIDE_ALWAYS_INLINE HALIDE_MAYBE_UNUSED native_vector_f32_x2 gather_load<native_vector_f32_x2, native_vector_i32_x2, float, 2 * VECTOR_WIDTH_F32, true>(const void *base, const native_vector_i32_x2& offset) {
+  // NOTE(aelphy): the shift is needed because offests are expected to be in bytes
+  auto gsr0 = IVP_GATHERAN_2XF32((const float*) base,
+                                  xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(offset.native_vector[0]) << 2);
+  auto gsr1 = IVP_GATHERAN_2XF32((const float*) base,
+                                  xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(offset.native_vector[1]) << 2);
+
+  return native_vector_f32_x2(native_vector_f32_x2::from_native_vector,
+                              IVP_GATHERDN_2XF32(gsr0),
+                              IVP_GATHERDN_2XF32(gsr1));
+}
+
+)INLINE_CODE";
+
+        // Fix: on at least one config (our arm32 buildbot running gcc 5.4),
+        // emitting this long text string was regularly garbled in a predictable
+        // pattern; flushing the stream before or after heals it. Since C++
+        // codegen is rarely on a compilation critical path, we'll just band-aid
+        // it in this way.
+        stream << std::flush;
+        stream << native_typedef_decl;
+        stream << std::flush;
+
+        std::set<Type> native_vector_types = {
+            Type(Type::Int, 8, target.natural_vector_size<int8_t>()),
+            Type(Type::UInt, 8, target.natural_vector_size<uint8_t>()),
+            Type(Type::Int, 16, target.natural_vector_size<int16_t>()),
+            Type(Type::UInt, 16, target.natural_vector_size<uint16_t>()),
+            Type(Type::Int, 32, target.natural_vector_size<int32_t>()),
+            Type(Type::UInt, 32, target.natural_vector_size<uint32_t>()),
+            Type(Type::Int, 24, target.natural_vector_size<int8_t>()),
+            Type(Type::UInt, 24, target.natural_vector_size<uint8_t>()),
+            Type(Type::Int, 48, target.natural_vector_size<int16_t>()),
+            Type(Type::UInt, 48, target.natural_vector_size<uint16_t>()),
+            Type(Type::Int, 64, target.natural_vector_size<int32_t>()),
+            Type(Type::Float, 16, target.natural_vector_size<float16_t>()),
+            Type(Type::Float, 32, target.natural_vector_size<float>()),
+        };
+
+        std::set<Type> predefined_vectors = {
+            Int(8, 4),
+            UInt(8, 4),
+            UInt(8, 8),
+            Float(16, 16)};
+
+        std::set<Type> multiple_of_native_types;
+        for (const auto &type : vector_types) {
+            if (predefined_vectors.count(type) > 0) {
+                continue;
+            }
+            for (const auto &native_vector : native_vector_types) {
+                if ((native_vector.code() == type.code()) && (native_vector.bits() == type.bits()) && (type.lanes() > native_vector.lanes()) && (type.lanes() % native_vector.lanes() == 0)) {
+                    stream << "using " << print_type(type) << " = MultipleOfNativeVector<" << print_type(native_vector) << ", " << type.lanes() / native_vector.lanes() << ">;\n";
+                    multiple_of_native_types.insert(type);
+                    break;
+                }
+            }
+        }
+
+        std::set<Type> filtered_vector_types;
+        for (const auto &t : vector_types) {
+            if ((native_vector_types.count(t) > 0) || (predefined_vectors.count(t) > 0) || (multiple_of_native_types.count(t) > 0)) {
+                continue;
+            }
+            filtered_vector_types.insert(t);
+        }
+
+        CodeGen_C::add_vector_typedefs(filtered_vector_types);
+    }
+}
+
+string CodeGen_Xtensa::print_assignment(Type t, const std::string &rhs) {
+    auto cached = cache.find(rhs);
+    if (cached == cache.end()) {
+        id = unique_name('_');
+        const char *const_flag = output_kind == CPlusPlusImplementation ? "const " : "";
+        if (t.is_handle()) {
+            // Don't print void *, which might lose useful type information. just use auto.
+            stream << get_indent() << "auto * ";
+        } else {
+            stream << get_indent() << print_type(t, AppendSpace);
+        }
+        stream << const_flag << id << " = " << rhs << ";\n";
+        cache[rhs] = id;
+    } else {
+        id = cached->second;
+    }
+    return id;
+}
+
+std::string CodeGen_Xtensa::print_type(Type t, AppendSpaceIfNeeded space_option) {
+    if (t.bits() == 1 && t.is_vector()) {
+        return "uint1x" + std::to_string(t.lanes()) + "_t" + (space_option == AppendSpace ? " " : "");
+    } else if (t.is_float() && t.is_vector()) {
+        return "float" + std::to_string(t.bits()) + "x" + std::to_string(t.lanes()) + "_t" + (space_option == AppendSpace ? " " : "");
+    }
+    return CodeGen_C::print_type(t, space_option);
+}
+
+void CodeGen_Xtensa::visit(const IntImm *op) {
+    if (op->type.is_int() && (op->type.bits() <= 32)) {
+        id = std::to_string(op->value);
+    } else {
+        static const char *const suffixes[3] = {
+            "ll",  // PlainC
+            "l",   // OpenCL
+            "",    // HLSL
+        };
+        print_assignment(op->type, "(" + print_type(op->type) + ")(" + std::to_string(op->value) + suffixes[(int)integer_suffix_style] + ")");
+    }
+}
+void CodeGen_Xtensa::visit(const Mul *op) {
+    int bits;
+    if (is_const_power_of_two_integer(op->b, &bits)) {
+        print_expr(Call::make(op->type, Call::shift_left, {op->a, Expr(bits)}, Call::PureIntrinsic));
+    } else {
+        if (is_native_xtensa_vector<int16_t>(op->type, target)) {
+            string sa = print_expr(op->a);
+            string sb = print_expr(op->b);
+            print_assignment(op->type, "IVP_MULNX16PACKL(" + sa + ", " + sb + ")");
+        } else if (is_native_xtensa_vector<uint16_t>(op->type, target)) {
+            string sa = print_expr(op->a);
+            string sb = print_expr(op->b);
+            print_assignment(op->type, "IVP_MULNX16UPACKL(" + sa + ", " + sb + ")");
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+            string sa = print_expr(op->a);
+            string sb = print_expr(op->b);
+            print_assignment(op->type, "IVP_PACKLN_2X64W(IVP_MULN_2X32(" + sa + ", " + sb + "))");
+        } else {
+            visit_binop(op->type, op->a, op->b, "*");
+        }
+    }
+}
+
+string CodeGen_Xtensa::print_xtensa_call(const Call *op) {
+    ostringstream rhs;
+
+    vector<string> args(op->args.size());
+
+    if (op->name == "halide_xtensa_widening_load") {
+        internal_assert(op->args.size() == 3);
+        const Variable *src = op->args[0].as<Variable>();
+        internal_assert(src != nullptr);
+        args[0] = print_name(src->name);
+        args[1] = print_expr(op->args[1]);
+        // We are only using args[2] argument to get the type of the load.
+
+        rhs << "widening_load<" << print_type(op->type) << ", " << print_type(op->args[2].type()) << ">(" << args[0] << ", " << args[1] << ")";
+        return rhs.str();
+    }
+
+    for (size_t i = 0; i < op->args.size(); i++) {
+        args[i] = print_expr(op->args[i]);
+    }
+
+    if (op->name == "halide_xtensa_pad_to_native" || op->name == "halide_xtensa_slice_from_padded") {
+        internal_assert(op->args.size() == 2);
+        // TODO(vksnk): bools are tricky, because they are bitmasks, so need to be
+        // handled differently.
+        const int bytes_in_vector = target.natural_vector_size<uint8_t>();
+        if (op->type.is_bool()) {
+            internal_assert((op->type.lanes() == bytes_in_vector && op->args[0].type().lanes() == bytes_in_vector / 2) || (op->type.lanes() == bytes_in_vector / 2 && op->args[0].type().lanes() == bytes_in_vector / 4) || (op->type.lanes() == bytes_in_vector && op->args[0].type().lanes() == bytes_in_vector / 4)) << Expr(op);
+        }
+        rhs << op->name << "<" << print_type(op->args[0].type()) << ", "
+            << print_type(op->type) << ", " << print_type(op->type.element_of())
+            << ", " << op->args[0].type().lanes() << ", " << op->type.lanes()
+            << ">(" << args[0] << ", " << args[1] << ")";
+        return rhs.str();
+    }
+
+    if (op->name == "halide_xtensa_slice_to_native" && !op->type.is_bool()) {
+        Type native_vector_type = get_native_xtensa_vector(op->type, target);
+        int vector_count = op->type.lanes() / native_vector_type.lanes();
+
+        if (vector_count == 1) {
+            rhs << args[0] << ".native_vector[" << args[1] << "]";
+        } else {
+            rhs << print_type(op->type) << "(" << print_type(op->type) << "::from_native_vector, ";
+            std::vector<std::string> native_vectors;
+            for (int ix = 0; ix < vector_count; ix++) {
+                native_vectors.push_back(args[0] + ".native_vector[" + args[1] + " * " + std::to_string(vector_count) + " + " + std::to_string(ix) + "]");
+            }
+            rhs << with_commas(native_vectors) << ")";
+        }
+        return rhs.str();
+    }
+
+    if (op->name == "halide_xtensa_concat_from_native" && !op->type.is_bool()) {
+        rhs << print_type(op->type) << "(" << print_type(op->type) << "::from_native_vector, " << with_commas(args) << ")";
+        return rhs.str();
+    }
+
+    if ((op->name.find("halide_xtensa_slice_right") == 0) || (op->name.find("halide_xtensa_slice_left") == 0)) {
+        string intrinsic_name;
+        string shift_define;
+        string direction = (op->name.find("halide_xtensa_slice_right") == 0) ? "RIGHT_" : "LEFT_";
+        if (is_native_xtensa_vector<int8_t>(op->type, target)) {
+            intrinsic_name = "IVP_SEL2NX8I";
+            shift_define = "IVP_SELI_8B_ROTATE_";
+        } else if (is_native_xtensa_vector<uint8_t>(op->type, target)) {
+            intrinsic_name = "IVP_SEL2NX8UI";
+            shift_define = "IVP_SELI_8B_ROTATE_";
+        } else if (is_native_xtensa_vector<int16_t>(op->type, target)) {
+            intrinsic_name = "IVP_SELNX16I";
+            shift_define = "IVP_SELI_16B_ROTATE_";
+        } else if (is_native_xtensa_vector<uint16_t>(op->type, target)) {
+            intrinsic_name = "IVP_SELNX16UI";
+            shift_define = "IVP_SELI_16B_ROTATE_";
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+            intrinsic_name = "IVP_SELN_2X32I";
+            shift_define = "IVP_SELI_32B_ROTATE_";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target)) {
+            intrinsic_name = "IVP_SELN_2X32UI";
+            shift_define = "IVP_SELI_32B_ROTATE_";
+        } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+            intrinsic_name = "IVP_SELNXF16I";
+            shift_define = "IVP_SELI_16B_ROTATE_";
+        } else if (is_native_xtensa_vector<float>(op->type, target)) {
+            intrinsic_name = "IVP_SELN_2XF32I";
+            shift_define = "IVP_SELI_32B_ROTATE_";
+        } else {
+            internal_assert(false) << "Unsupported type for slicing";
+        }
+
+        rhs << intrinsic_name << "(" << args[0] << ".native_vector[1], " << args[0] << ".native_vector[0], " << shift_define << direction << args[1] << ")";
+
+        return rhs.str();
+    }
+    // absd needs extra cast to uint*
+    if (op->name == "halide_xtensa_absd_i16") {
+        rhs << "xb_vecNx16_rtor_xb_vecNx16U(IVP_ABSSUBNX16(" << args[0] + ", " + args[1] + "))";
+        return rhs.str();
+    } else if (op->name == "halide_xtensa_narrow_i48_with_shift_u16") {
+        rhs << "xb_vecNx16_rtor_xb_vecNx16U(IVP_PACKVRNRNX48(" << args[0] + ", " + args[1] + "))";
+        return rhs.str();
+    } else if (op->name == "halide_xtensa_convert_i48_low_u32") {
+        rhs << "xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32UNX48L(" << args[0] + "))";
+        return rhs.str();
+    } else if (op->name == "halide_xtensa_convert_i48_high_u32") {
+        rhs << "xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_CVT32UNX48H(" << args[0] + "))";
+        return rhs.str();
+    }
+
+    if (op->name == "halide_xtensa_extract_i32" || op->name == "halide_xtensa_extract_u32") {
+        rhs << "IVP_EXTRN_2X32(IVP_MOVN_2X32_FROMNX16(IVP_MOVNX16_FROM2NX8(" << args[0] + ")), " + args[1] + ")";
+        return rhs.str();
+    }
+
+    if (op->name == "halide_xtensa_dual_extract_i32") {
+        rhs << "IVP_DEXTRPRN_2X32("
+            << "IVP_MOVN_2X32_FROMNX16(IVP_MOVNX16_FROM2NX8(" + args[0] + ")), "
+            << "IVP_MOVN_2X32_FROMNX16(IVP_MOVNX16_FROM2NX8(" + args[1] + ")), "
+            << args[2] + ", " + args[3] + ")";
+        return rhs.str();
+    }
+
+    if (op->name == "halide_xtensa_dynamic_shuffle") {
+        if (is_native_vector_type(op->args[0].type(), target) && is_native_vector_type(op->args[1].type(), target)) {
+            rhs << "IVP_SHFL" << intrinsic_suffix_for_type(op->type) << "("
+                << args[0] + ", " + args[1] + ")";
+            return rhs.str();
+        }
+    }
+
+    string op_name = op->name;
+    std::map<string, string> op_name_to_intrinsic = {
+        {"halide_xtensa_abs_i8", "IVP_ABS2NX8"},
+        {"halide_xtensa_abs_i16", "IVP_ABSNX16"},
+        {"halide_xtensa_abs_i32", "IVP_ABSN_2X32"},
+        {"halide_xtensa_abs_f32", "IVP_ABSN_2XF32"},
+        {"halide_xtensa_sat_add_i16", "IVP_ADDSNX16"},
+        {"halide_xtensa_sat_sub_i16", "IVP_SUBSNX16"},
+        {"halide_xtensa_avg_i8", "IVP_AVG2NX8"},
+        {"halide_xtensa_avg_u8", "IVP_AVGU2NX8"},
+        {"halide_xtensa_avg_i16", "IVP_AVGNX16"},
+        {"halide_xtensa_avg_u16", "IVP_AVGUNX16"},
+        {"halide_xtensa_avg_round_i8", "IVP_AVGR2NX8"},
+        {"halide_xtensa_avg_round_u8", "IVP_AVGRU2NX8U"},
+        {"halide_xtensa_avg_round_i16", "IVP_AVGRNX16"},
+        {"halide_xtensa_avg_round_u16", "IVP_AVGRUNX16U"},
+        {"halide_xtensa_widen_mul_i24", "IVP_MUL2NX8"},
+        {"halide_xtensa_widen_mul_u24", "IVP_MULUU2NX8"},
+        {"halide_xtensa_widen_mul_i48", "IVP_MULNX16"},
+        {"halide_xtensa_widen_mul_u48", "IVP_MULUUNX16U"},
+        {"halide_xtensa_mul_i32", "IVP_MULN_2X32"},
+        {"halide_xtensa_widen_mul_ui48", "IVP_MULUSNX16"},
+        {"halide_xtensa_widen_pair_mul_u48", "IVP_MULUUPNX16"},
+        {"halide_xtensa_convert_i48_low_i32", "IVP_CVT32SNX48L"},
+        {"halide_xtensa_convert_i48_high_i32", "IVP_CVT32SNX48H"},
+        {"halide_xtensa_convert_i48_low_u32", "IVP_CVT32UNX48L"},
+        {"halide_xtensa_convert_i48_high_u32", "IVP_CVT32UNX48H"},
+        {"halide_xtensa_narrow_i48_with_shift_i16", "IVP_PACKVRNRNX48"},
+        {"halide_xtensa_narrow_i48_with_rounding_shift_i16", "IVP_PACKVRNX48"},
+        {"halide_xtensa_sat_narrow_i48_with_shift_i16", "IVP_PACKVRNX48"},
+        {"halide_xtensa_sat_narrow_with_rounding_shift_i32", "IVP_PACKVRN_2X64W"},
+        {"halide_xtensa_full_reduce_add_i8", "IVP_RADD2NX8"},
+        {"halide_xtensa_full_reduce_add_i16", "IVP_RADDNX16"},
+        {"halide_xtensa_full_reduce_add_i32", "IVP_RADDN_2X32"},
+
+        {"halide_xtensa_full_reduce_min_u8", "IVP_RMINU2NX8U"},
+        {"halide_xtensa_full_reduce_min_u16", "IVP_RMINUNX16U"},
+        {"halide_xtensa_full_reduce_min_u32", "IVP_RMINUN_2X32U"},
+        {"halide_xtensa_full_reduce_min_i8", "IVP_RMIN2NX8"},
+        {"halide_xtensa_full_reduce_min_i16", "IVP_RMINNX16"},
+        {"halide_xtensa_full_reduce_min_i32", "IVP_RMINN_2X32"},
+
+        {"halide_xtensa_full_reduce_max_u8", "IVP_RMAXU2NX8U"},
+        {"halide_xtensa_full_reduce_max_u16", "IVP_RMAXUNX16U"},
+        {"halide_xtensa_full_reduce_max_u32", "IVP_RMAXUN_2X32U"},
+        {"halide_xtensa_full_reduce_max_i8", "IVP_RMAX2NX8"},
+        {"halide_xtensa_full_reduce_max_i16", "IVP_RMAXNX16"},
+        {"halide_xtensa_full_reduce_max_i32", "IVP_RMAXN_2X32"},
+
+        {"halide_xtensa_sat_left_shift_i16", "IVP_SLSNX16"},
+        {"halide_xtensa_sat_left_shift_i32", "IVP_SLSN_2X32"},
+    };
+
+    if (op_name_to_intrinsic.count(op_name) > 0) {
+        op_name = op_name_to_intrinsic[op_name];
+    }
+
+    rhs << op_name << "(" << with_commas(args) << ")";
+    return rhs.str();
+}
+
+void CodeGen_Xtensa::visit(const Div *op) {
+    int bits;
+    if (is_const_power_of_two_integer(op->b, &bits)) {
+        print_expr(Call::make(op->type, Call::shift_right, {op->a, Expr(bits)}, Call::PureIntrinsic));
+    } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+        ostringstream rhs;
+        rhs << "IVP_DIVNXF16(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        print_assignment(op->type, rhs.str());
+    } else if (is_native_xtensa_vector<float>(op->type, target)) {
+        ostringstream rhs;
+        rhs << "IVP_DIVN_2XF32(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        print_assignment(op->type, rhs.str());
+    } else {
+        string sa = print_expr(op->a);
+        string sb = print_expr(op->b);
+        // Just cast to clang vector types and use division defined on them.
+        if (is_native_xtensa_vector<uint8_t>(op->type, target) ||
+            is_native_xtensa_vector<int8_t>(op->type, target) ||
+            is_native_xtensa_vector<int32_t>(op->type, target) ||
+            is_native_xtensa_vector<uint32_t>(op->type, target)) {
+            print_assignment(
+                op->type,
+                "(common_" + print_type(op->type) + ")" + sa + " / (common_" + print_type(op->type) + ")" + sb);
+        } else {
+            print_assignment(op->type, sa + " / " + sb);
+        }
+    }
+}
+
+void CodeGen_Xtensa::visit(const Mod *op) {
+    if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+        string sa = print_expr(op->a);
+        string sb = print_expr(op->b);
+        string common_type = "common_" + print_type(op->type);
+        print_assignment(op->type, "(" + common_type + ")" + sa + " % (" + common_type + ")" + sb);
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_Xtensa::visit(const Max *op) {
+    if (op->type.is_scalar()) {
+        print_expr(Call::make(op->type, "::halide_cpp_max<" + print_type(op->type) + ">", {op->a, op->b}, Call::Extern));
+    } else {
+        ostringstream rhs;
+        if (is_native_xtensa_vector<int8_t>(op->type, target)) {
+            rhs << "IVP_MAX2NX8(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<uint8_t>(op->type, target)) {
+            rhs << "IVP_MAXU2NX8(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<int16_t>(op->type, target)) {
+            rhs << "IVP_MAXNX16(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<uint16_t>(op->type, target)) {
+            rhs << "IVP_MAXUNX16U(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+            rhs << "IVP_MAXN_2X32(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target)) {
+            rhs << "IVP_MAXUN_2X32(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+            rhs << "IVP_MAXNXF16(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<float>(op->type, target)) {
+            rhs << "IVP_MAXN_2XF32(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else {
+            rhs << print_type(op->type) << "::max(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        }
+        print_assignment(op->type, rhs.str());
+    }
+}
+
+void CodeGen_Xtensa::visit(const Min *op) {
+    if (op->type.is_scalar()) {
+        print_expr(Call::make(op->type, "::halide_cpp_min<" + print_type(op->type) + ">", {op->a, op->b}, Call::Extern));
+    } else {
+        ostringstream rhs;
+        if (is_native_xtensa_vector<int8_t>(op->type, target)) {
+            rhs << "IVP_MIN2NX8(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<uint8_t>(op->type, target)) {
+            rhs << "IVP_MINU2NX8(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<int16_t>(op->type, target)) {
+            rhs << "IVP_MINNX16(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<uint16_t>(op->type, target)) {
+            rhs << "IVP_MINUNX16U(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+            rhs << "IVP_MINN_2X32(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target)) {
+            rhs << "IVP_MINUN_2X32(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+            rhs << "IVP_MINNXF16(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else if (is_native_xtensa_vector<float>(op->type, target)) {
+            rhs << "IVP_MINN_2XF32(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        } else {
+            rhs << print_type(op->type) << "::min(" << print_expr(op->a) << ", " << print_expr(op->b) << ")";
+        }
+        print_assignment(op->type, rhs.str());
+    }
+}
+
+void CodeGen_Xtensa::visit(const Select *op) {
+    ostringstream rhs;
+    string type = print_type(op->type);
+    string true_val = print_expr(op->true_value);
+    string false_val = print_expr(op->false_value);
+    string cond = print_expr(op->condition);
+
+    if (op->condition.type().is_scalar()) {
+        rhs << "(" << type << ")"
+            << "(" << cond
+            << " ? " << true_val
+            << " : " << false_val
+            << ")";
+    } else {
+        if (is_native_xtensa_vector<int8_t>(op->type, target)) {
+            rhs << "IVP_MOV2NX8T(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else if (is_native_xtensa_vector<uint8_t>(op->type, target)) {
+            rhs << "IVP_MOV2NX8UT(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else if (is_native_xtensa_vector<int16_t>(op->type, target)) {
+            rhs << "IVP_MOVNX16T(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else if (is_native_xtensa_vector<uint16_t>(op->type, target)) {
+            rhs << "IVP_MOVNX16UT(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+            rhs << "IVP_MOVN_2X32T(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target)) {
+            rhs << "IVP_MOVN_2X32UT(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+            rhs << "IVP_MOVNXF16T(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else if (is_native_xtensa_vector<float>(op->type, target)) {
+            rhs << "IVP_MOVN_2XF32T(" << true_val << ", " << false_val << ", " << cond << ")";
+        } else {
+            rhs << type << "::select(" << cond << ", " << true_val << ", " << false_val << ")";
+        }
+    }
+    print_assignment(op->type, rhs.str());
+}
+
+void CodeGen_Xtensa::visit(const Ramp *op) {
+    Type vector_type = op->type.with_lanes(op->lanes);
+    string id_base = print_expr(op->base);
+    string id_stride = print_expr(op->stride);
+    int int32_lanes = target.natural_vector_size<int32_t>();
+    if (is_const_one(op->stride)) {
+        if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+            print_assignment(vector_type, "/* ramp */ int32x" + std::to_string(int32_lanes) + "_t(" + id_base + ") + IVP_SEQN_2X32()");
+        } else {
+            // If it's wide enough split it here into concat of smaller ramps.
+            if (op->type.is_int() && (op->type.bits() == 32) && (op->type.lanes() % int32_lanes == 0) && (op->type.lanes() / int32_lanes > 4)) {
+                int split_to = op->type.lanes() / int32_lanes;
+
+                std::vector<Expr> concat_args;
+                for (int ix = 0; ix < split_to; ix++) {
+                    Expr r = Ramp::make(op->base + op->stride * (int32_lanes * ix), op->stride, int32_lanes);
+                    concat_args.push_back(std::move(r));
+                }
+                Expr concat = Call::make(op->type,
+                                         "halide_xtensa_concat_from_native",
+                                         concat_args, Call::PureExtern);
+
+                concat.accept(this);
+            } else {
+                print_assignment(vector_type, "dense_ramp<" + print_type(vector_type) + ">(" + id_base + ")");
+            }
+        }
+    } else {
+        if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+            print_assignment(vector_type, "/* ramp */ int32x" + std::to_string(int32_lanes) + "_t(" + id_base + ") + IVP_PACKLN_2X64W(IVP_SEQN_2X32() * int32x" + std::to_string(int32_lanes) + "_t(" + id_stride + "))");
+        } else if ((op->type.lanes() == 32 || op->type.lanes() == 64 || op->type.lanes() == 128) && op->type.is_int_or_uint() && op->type.bits() == 32) {
+            print_assignment(vector_type, "ramp<" + print_type(vector_type) + ">(" + id_base + ", " + id_stride + ")");
+        } else {
+            print_assignment(vector_type, print_type(vector_type) + "_ops::ramp(" + id_base + ", " + id_stride + ")");
+        }
+    }
+}
+
+void CodeGen_Xtensa::visit(const Broadcast *op) {
+    Type vector_type = op->type.with_lanes(op->lanes);
+    string rhs;
+    if (op->type.is_int() && ((op->type.bits() == 24) || (op->type.bits() == 48)) && is_const(op->value)) {
+        // Assigning a constant to wide vector is tricky.
+        if (is_const_zero(op->value)) {
+            if (op->type.bits() == 24) {
+                rhs = "IVP_ZERO2NX24()";
+            } else if (op->type.bits() == 48) {
+                rhs = "IVP_ZERONX48()";
+            }
+        } else {
+            rhs = std::to_string(op->value.as<IntImm>()->value);
+        }
+    } else if (op->type.is_int_or_uint() && op->type.bits() == 8 && ((op->type.lanes() == 4) || (op->type.lanes() == 8))) {
+        string id_value = print_expr(op->value);
+        rhs = "broadcast<" + print_type(op->type) + ", " + print_type(op->value.type()) + ">(" + id_value + ")";
+    } else {
+        string id_value = print_expr(op->value);
+
+        if (is_native_vector_type(op->type, target)) {
+            // TODO(vsknk): why it this extra cast to scalar is needed?
+            rhs = print_type(vector_type) + "((" + print_type(op->type.with_lanes(1)) + ")" + id_value + ")";
+        } else if (op->lanes > 1) {
+            if (op->type.is_bool()) {
+                // TODO(vksnk): figure out how to broadcast bool.
+                if (op->type.lanes() == 16) {
+                    rhs = id_value + "? (int32x16_t(1) == int32x16_t(1)) : (int32x16_t(1) == int32x16_t(0))";
+                } else if (op->type.lanes() == 32) {
+                    rhs = id_value + "? (int16x32_t(1) == int16x32_t(1)) : (int16x32_t(1) == int16x32_t(0))";
+                } else if (op->type.lanes() == 64) {
+                    rhs = id_value + "? (int8x64_t(1) == int8x64_t(1)) : (int8x64_t(1) == int8x64_t(0))";
+                }
+            } else {
+                rhs = id_value;
+            }
+        } else {
+            rhs = id_value;
+        }
+    }
+
+    print_assignment(vector_type, rhs);
+}
+
+void CodeGen_Xtensa::visit(const LE *op) {
+    string sa = print_expr(op->a);
+    string sb = print_expr(op->b);
+
+    if (is_native_xtensa_vector<int8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LE2NX8(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LEU2NX8U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LENX16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LEUNX16U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LEN_2X32(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LEUN_2X32U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OLENXF16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OLEN_2XF32(" + sa + ", " + sb + ")");
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_Xtensa::visit(const LT *op) {
+    string sa = print_expr(op->a);
+    string sb = print_expr(op->b);
+
+    if (is_native_xtensa_vector<int8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LT2NX8(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LTU2NX8U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LTNX16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LTUNX16U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LTN_2X32(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_LTUN_2X32U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OLTNXF16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OLTN_2XF32(" + sa + ", " + sb + ")");
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_Xtensa::visit(const GE *op) {
+    string sa = print_expr(op->a);
+    string sb = print_expr(op->b);
+
+    if (is_native_xtensa_vector<int8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GE2NX8(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GEU2NX8U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GENX16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GEUNX16U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GEN_2X32(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GEUN_2X32U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OGENXF16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OGEN_2XF32(" + sa + ", " + sb + ")");
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_Xtensa::visit(const GT *op) {
+    string sa = print_expr(op->a);
+    string sb = print_expr(op->b);
+
+    if (is_native_xtensa_vector<int8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GT2NX8(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GTU2NX8U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GTNX16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GTUNX16U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GTN_2X32(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_GTUN_2X32U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OGTNXF16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OGTN_2XF32(" + sa + ", " + sb + ")");
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_Xtensa::visit(const Or *op) {
+    string sa = print_expr(op->a);
+    string sb = print_expr(op->b);
+
+    if (op->a.type().is_bool() && op->type.is_vector()) {
+        if (op->a.type().lanes() == 16) {
+            print_assignment(op->type, "IVP_ORBN_2(" + sa + ", " + sb + ")");
+        } else if (op->a.type().lanes() == 32) {
+            print_assignment(op->type, "IVP_ORBN(" + sa + ", " + sb + ")");
+        } else if (op->a.type().lanes() == 64) {
+            print_assignment(op->type, "IVP_ORB2N(" + sa + ", " + sb + ")");
+        } else {
+            internal_assert(false) << "Unhandled boolean type in the || op\n";
+        }
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_Xtensa::visit(const EQ *op) {
+    string sa = print_expr(op->a);
+    string sb = print_expr(op->b);
+
+    if (is_native_xtensa_vector<int8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_EQ2NX8(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint8_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_EQ2NX8U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_EQNX16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_EQNX16U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<int32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_EQN_2X32(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<uint32_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_EQN_2X32U(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float16_t>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OEQNXF16(" + sa + ", " + sb + ")");
+    } else if (is_native_xtensa_vector<float>(op->a.type(), target)) {
+        print_assignment(op->type, "IVP_OEQN_2XF32(" + sa + ", " + sb + ")");
+    } else {
+        CodeGen_C::visit(op);
+    }
+}
+
+void CodeGen_Xtensa::visit(const Load *op) {
+    // TODO: We could replicate the logic in the llvm codegen which decides whether
+    // the vector access can be aligned. Doing so would also require introducing
+    // aligned type equivalents for all the vector types.
+    ostringstream rhs;
+
+    Type t = op->type;
+    string name = print_name(op->name);
+
+    // If we're loading a contiguous ramp into a vector, just load the vector
+    Expr dense_ramp_base = strided_ramp_base(op->index, 1);
+    if (!is_const_one(op->predicate)) {
+        const Call *pred = op->predicate.as<Call>();
+        if (pred && (pred->name == "clamped_dense_ramp") && dense_ramp_base.defined()) {
+            internal_assert(t.is_vector());
+            // The number of elements is difference between upper bound and base of the ramp
+            // plus one (because the predicate is <=).
+            Expr count = simplify(pred->args[1] - pred->args[0] + 1);
+            string id_ramp_base = print_expr(dense_ramp_base);
+            string id_count = print_expr(count);
+            rhs << "load_variable"
+                << "<" << print_type(t) << ", "
+                << print_type(t.element_of()) << ", " << t.lanes()
+                << ">(" << name << ", " << id_ramp_base << ", " << id_count << ")";
+        } else {
+            string id_index = print_expr(op->index);
+            string id_predicate = print_expr(op->predicate);
+            rhs << "load_predicated<" << print_type(t) << ", "
+                << print_type(op->index.type()) << ", "
+                << print_type(op->predicate.type()) << ", "
+                << print_type(t.element_of()) << ", " << t.lanes()
+                << ">(" << name << ", " << id_index << ", " << id_predicate << ")";
+        }
+    } else if (dense_ramp_base.defined()) {
+        internal_assert(t.is_vector());
+        std::string op_name;
+        const int bytes_in_vector = target.natural_vector_size<uint8_t>();
+        int native_lanes = (bytes_in_vector / op->type.element_of().bytes());
+        if (op->type.element_of().bytes() == 3) {
+            native_lanes = bytes_in_vector;
+        }
+        if (op->type.element_of().bytes() == 6) {
+            native_lanes = bytes_in_vector / 2;
+        }
+        bool is_aligned_load = (op->alignment.modulus % native_lanes == 0) && (op->alignment.remainder % native_lanes == 0);
+        if (external_buffers.count(op->name) > 0) {
+            is_aligned_load = is_aligned_load && (op->param.host_alignment() % bytes_in_vector == 0);
+        }
+        if (is_aligned_load) {
+            op_name = "aligned_load";
+        } else {
+            op_name = "load";
+        }
+        string id_ramp_base = print_expr(dense_ramp_base);
+        rhs << op_name << "<" << print_type(t) << ", "
+            << print_type(t.element_of()) << ", " << t.lanes()
+            << ">(" << name << ", " << id_ramp_base << ")";
+    } else if (op->index.type().is_vector()) {
+        // If index is a vector, gather vector elements.
+        internal_assert(t.is_vector());
+        // NOTE(vksnk): strided_load may be a good idea, but needs more work.
+        // const Ramp* maybe_ramp = op->index.as<Ramp>();
+        // if (maybe_ramp && is_const(maybe_ramp->stride)) {
+        //     string id_index_base = print_expr(maybe_ramp->base);
+        //     string id_index_stride = print_expr(maybe_ramp->stride);
+        //     rhs << print_type(t) + "_strided_load(" << name << ", "
+        //         << id_index_base << ", " << id_index_stride << ")";
+        // } else {
+        string id_index = print_expr(op->index);
+        // Is not allocated on the heap and is not a buffer
+        bool is_tcm = !(heap_allocations.contains(name) || external_buffers.count(op->name) > 0);
+
+        rhs << "gather_load<" << print_type(t) << ", "
+            << print_type(Int(32, t.lanes())) << ", "
+            << print_type(t.element_of()) << ", "
+            << t.lanes() << ", " << is_tcm << ">("
+            << name << ", " << id_index << ")";
+        // }
+    } else {
+        string id_index = print_expr(op->index);
+        bool type_cast_needed = !(allocations.contains(op->name) &&
+                                  allocations.get(op->name).type.element_of() == t.element_of());
+        if (type_cast_needed) {
+            rhs << "((const " << print_type(t.element_of()) << " *)" << name << ")";
+        } else {
+            rhs << name;
+        }
+        rhs << "[" << id_index << "]";
+    }
+    print_assignment(t, rhs.str());
+}
+
+void CodeGen_Xtensa::visit(const Store *op) {
+    Type t = op->value.type();
+
+    if (inside_atomic_mutex_node) {
+        user_assert(t.is_scalar())
+            << "The vectorized atomic operation for the store" << op->name
+            << " is lowered into a mutex lock, which does not support vectorization.\n";
+    }
+
+    // Issue atomic store if we are in the designated producer.
+    if (emit_atomic_stores) {
+        stream << "#if defined(_OPENMP)\n";
+        stream << "#pragma omp atomic\n";
+        stream << "#else\n";
+        stream << "#error \"Atomic stores in the C backend are only supported in compilers that support OpenMP.\"\n";
+        stream << "#endif\n";
+    }
+
+    bool is_narrowing = false;
+    bool is_sat_narrowing = false;
+    Expr value = op->value;
+    if (const Cast *cast = value.as<Cast>()) {
+        if (cast->value.type().is_vector() && cast->type.is_int_or_uint() && cast->value.type().is_int_or_uint() && (cast->value.type().bits() == value.type().bits() * 2)) {
+            is_narrowing = true;
+            value = cast->value;
+        }
+    }
+    if (const Call *call = value.as<Call>()) {
+        // TODO: more checks for this one are needed.
+        if (call->name == "halide_xtensa_slice_from_padded") {
+            if (const Cast *cast = call->args[0].as<Cast>()) {
+                if (cast->value.type().is_vector() && cast->type.is_int_or_uint() && cast->value.type().is_int_or_uint() && (cast->value.type().bits() == value.type().bits() * 2)) {
+                    if (const Call *inner_call = cast->value.as<Call>()) {
+                        if (inner_call->name == "halide_xtensa_pad_to_native") {
+                            is_narrowing = true;
+                            value = inner_call->args[0];
+                        }
+                    }
+                }
+            }
+        }
+        // TODO(vksnk): disabled for now, because corresponding implementation
+        // is missing.
+        // if (call->name.find("halide_xtensa_sat_narrow_i") == 0) {
+        //     is_sat_narrowing = true;
+        //     value = call->args[0];
+        // }
+    }
+
+    string id_value = print_expr(value);
+    string name = print_name(op->name);
+
+    // TODO: We could replicate the logic in the llvm codegen which decides whether
+    // the vector access can be aligned. Doing so would also require introducing
+    // aligned type equivalents for all the vector types.
+
+    // If we're writing a contiguous ramp, just store the vector.
+    Expr dense_ramp_base = strided_ramp_base(op->index, 1);
+
+    if (!is_const_one(op->predicate)) {
+        const Call *pred = op->predicate.as<Call>();
+        if (pred && (pred->name == "clamped_dense_ramp") && dense_ramp_base.defined()) {
+            // The number of elements is difference between upper bound and base of the ramp
+            // plus one (because the predicate is <=).
+            Expr count = simplify(pred->args[1] - pred->args[0] + 1);
+            internal_assert(op->value.type().is_vector());
+            string id_ramp_base = print_expr(dense_ramp_base);
+            string id_count = print_expr(count);
+            string op_name = "store_variable";
+            if (is_narrowing) {
+                op_name = op_name + "_narrowing";
+            }
+            if (is_sat_narrowing) {
+                op_name = op_name + "_narrowing_sat";
+            }
+            stream << get_indent() << op_name << "<";
+            if (is_narrowing) {
+                stream << print_type(value.type());
+            } else {
+                stream << print_type(t);
+            }
+            stream << ", " << print_type(t.element_of()) << ", " << t.lanes()
+                   << ">(" << id_value << ", " << name << ", " << id_ramp_base << ", " << id_count << ");\n";
+        } else {
+            string id_index = print_expr(op->index);
+            string id_predicate = print_expr(op->predicate);
+            stream << get_indent() << "store_predicated<" << print_type(t) << ", "
+                   << print_type(op->index.type()) << ", "
+                   << print_type(op->predicate.type()) << ", "
+                   << print_type(t.element_of()) << ", " << t.lanes()
+                   << ">(" << id_value << ", " << name << ", " << id_index << ", " << id_predicate << ");\n";
+        }
+    } else if (dense_ramp_base.defined()) {
+        internal_assert(op->value.type().is_vector());
+        string op_name;
+        const int bytes_in_vector = target.natural_vector_size<uint8_t>();
+        int native_lanes = (bytes_in_vector / op->value.type().element_of().bytes());
+        if (op->value.type().element_of().bytes() == 3) {
+            native_lanes = bytes_in_vector;
+        }
+        if (op->value.type().element_of().bytes() == 6) {
+            native_lanes = bytes_in_vector / 2;
+        }
+
+        bool is_aligned_store = (op->alignment.modulus % native_lanes == 0) && (op->alignment.remainder % native_lanes == 0);
+        if (external_buffers.count(op->name) > 0) {
+            is_aligned_store = is_aligned_store && (op->param.host_alignment() % bytes_in_vector == 0);
+        }
+
+        if (is_aligned_store) {
+            op_name = "aligned_store";
+        } else {
+            op_name = "store";
+        }
+
+        if (is_narrowing) {
+            op_name = op_name + "_narrowing";
+        }
+        if (is_sat_narrowing) {
+            op_name = op_name + "_narrowing_sat";
+        }
+
+        string id_ramp_base = print_expr(dense_ramp_base);
+        stream << get_indent() << op_name << "<";
+        if (is_narrowing) {
+            stream << print_type(value.type());
+        } else {
+            stream << print_type(t);
+        }
+        stream << ", " << print_type(t.element_of()) << ", " << t.lanes()
+               << ">(" << id_value << ", " << name << ", " << id_ramp_base << ");\n";
+    } else if (op->index.type().is_vector()) {
+        // If index is a vector, scatter vector elements.
+        internal_assert(t.is_vector());
+        string id_index = print_expr(op->index);
+        stream << get_indent() << "store_scatter<" << print_type(t) << ", "
+               << print_type(op->index.type()) << ", "
+               << print_type(t.element_of()) << ", " << t.lanes()
+               << ">(" << id_value << ", " << name << ", " << id_index << ");\n";
+    } else {
+        bool type_cast_needed =
+            t.is_handle() ||
+            !allocations.contains(op->name) ||
+            allocations.get(op->name).type != t;
+
+        string id_index = print_expr(op->index);
+        stream << get_indent();
+        if (type_cast_needed) {
+            stream << "((" << print_type(t) << " *)" << name << ")";
+        } else {
+            stream << name;
+        }
+        stream << "[" << id_index << "] = " << id_value << ";\n";
+    }
+    cache.clear();
+}
+
+bool CodeGen_Xtensa::is_stack_private_to_thread() const {
+    return true;
+}
+
+void CodeGen_Xtensa::visit(const Call *op) {
+    ostringstream rhs;
+
+    // Handle intrinsics first
+    if (op->is_intrinsic(Call::shift_left)) {
+        internal_assert(op->args.size() == 2);
+        string a0 = print_expr(op->args[0]);
+        const int64_t *bits = as_const_int(op->args[1]);
+        if (is_native_xtensa_vector<uint8_t>(op->type, target) && bits) {
+            rhs << "IVP_SLLI2NX8U(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<int8_t>(op->type, target) && bits) {
+            rhs << "IVP_SLLI2NX8(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<uint16_t>(op->type, target) && bits) {
+            rhs << "IVP_SLLINX16U(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<int16_t>(op->type, target) && bits) {
+            rhs << "IVP_SLLINX16(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target) && bits) {
+            rhs << "IVP_SLLIN_2X32U(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target) && bits) {
+            rhs << "IVP_SLLIN_2X32(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else {
+            string a1 = print_expr(op->args[1]);
+            if (is_native_xtensa_vector<uint16_t>(op->type, target)) {
+                rhs << "IVP_SLLNX16U(" << a0 << ", xb_vecNx16U_rtor_xb_vecNx16(" << a1 << "))";
+            } else if (is_native_xtensa_vector<int16_t>(op->type, target)) {
+                rhs << "IVP_SLANX16(" << a0 << ", " << a1 << ")";
+            } else if (is_native_xtensa_vector<uint32_t>(op->type, target)) {
+                rhs << "IVP_SLLN_2X32U(" << a0 << ", xb_vecN_2x32Uv_rtor_xb_vecN_2x32v( " << a1 << "))";
+            } else if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+                rhs << "IVP_SLAN_2X32(" << a0 << ", " << a1 << ")";
+            } else {
+                if (op->args[1].type().is_uint()) {
+                    if (op->type.is_vector()) {
+                        rhs << "scalarize_binary<" << print_type(op->type) << ", "
+                            << print_type(op->type.with_lanes(1)) << ", "
+                            << print_type(op->type.with_lanes(1)) << ", "
+                            << op->type.lanes() << ">(&halide_shift_left, "
+                            << print_expr(op->args[0])
+                            << ", " << print_expr(op->args[1]) << ")";
+
+                    } else {
+                        string a0 = print_expr(op->args[0]);
+                        string a1 = print_expr(op->args[1]);
+                        rhs << a0 << " << " << a1;
+                    }
+                } else {
+                    rhs << print_expr(lower_signed_shift_left(op->args[0], op->args[1]));
+                }
+            }
+        }
+    } else if (op->is_intrinsic(Call::shift_right)) {
+        internal_assert(op->args.size() == 2);
+        string a0 = print_expr(op->args[0]);
+        const int64_t *bits = as_const_int(op->args[1]);
+        if (is_native_xtensa_vector<uint8_t>(op->type, target) && bits) {
+            rhs << "IVP_SRLI2NX8U(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<int8_t>(op->type, target) && bits) {
+            rhs << "IVP_SRAI2NX8U(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<int16_t>(op->type, target) && bits) {
+            rhs << "IVP_SRAINX16(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<uint16_t>(op->type, target) && bits) {
+            rhs << "IVP_SRLINX16U(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target) && bits) {
+            rhs << "IVP_SRAIN_2X32(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target) && bits) {
+            rhs << "IVP_SRLIN_2X32U(" << a0 << ", " << std::to_string(*bits) << ")";
+        } else {
+            string a1 = print_expr(op->args[1]);
+            if (is_native_xtensa_vector<uint16_t>(op->type, target)) {
+                rhs << "IVP_SRLNX16(" << a0 << ", " << a1 << ")";
+            } else if (is_native_xtensa_vector<int16_t>(op->type, target)) {
+                rhs << "IVP_SRANX16(" << a0 << ", " << a1 << ")";
+            } else if (is_native_xtensa_vector<uint32_t>(op->type, target)) {
+                rhs << "IVP_SRLN_2X32U(" << a0 << ", " << a1 << ")";
+            } else if (is_native_xtensa_vector<int32_t>(op->type, target)) {
+                rhs << "IVP_SRAN_2X32(" << a0 << ", (" << print_type(op->type) << ")" << a1 << ")";
+            } else {
+                if (op->args[1].type().is_uint()) {
+                    if (op->type.is_vector()) {
+                        rhs << "scalarize_binary<" << print_type(op->type) << ", "
+                            << print_type(op->type.with_lanes(1)) << ", "
+                            << print_type(op->type.with_lanes(1)) << ", "
+                            << op->type.lanes() << ">(&halide_shift_right, "
+                            << print_expr(op->args[0])
+                            << ", " << print_expr(op->args[1]) << ")";
+                    } else {
+                        string a0 = print_expr(op->args[0]);
+                        string a1 = print_expr(op->args[1]);
+                        rhs << a0 << " >> " << a1;
+                    }
+                } else {
+                    rhs << print_expr(lower_signed_shift_right(op->args[0], op->args[1]));
+                }
+            }
+        }
+    } else if (op->is_intrinsic(Call::count_leading_zeros)) {
+        internal_assert(op->args.size() == 1);
+        if (is_native_xtensa_vector<int16_t>(op->type, target) || is_native_xtensa_vector<uint16_t>(op->type, target)) {
+            // TODO(vksnk): it seems that what Halide does is always matching IVP_NSAUN*?
+            string intrins_name = op->type.is_int() ? "(IVP_NSAUNX16(" : "xb_vecNx16_rtor_xb_vecNx16U(IVP_NSAUNX16U(";
+            rhs << intrins_name << print_expr(op->args[0]) << "))";
+        } else if (is_native_xtensa_vector<int32_t>(op->type, target) || is_native_xtensa_vector<uint32_t>(op->type, target)) {
+            // TODO(vksnk): it seems that what Halide does is always matching IVP_NSAUN*?
+            string intrins_name = op->type.is_int() ? "(IVP_NSAUN_2X32(" : "xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(IVP_NSAUN_2X32U(";
+            rhs << intrins_name << print_expr(op->args[0]) << "))";
+        } else if (op->args[0].type().is_vector()) {
+            // Xtensa doesn't have 8-bit intrinsics for count_leading_zeros.
+            rhs << "scalarize_unary<" << print_type(op->type) << ", "
+                << print_type(op->type.with_lanes(1)) << ", "
+                // return type of halide_count_leading_zeros is always int.
+                << "int, "
+                << op->type.lanes() << ">(&halide_count_leading_zeros, " << print_expr(op->args[0]) << ")";
+        } else {
+            string a0 = print_expr(op->args[0]);
+            rhs << "halide_" << op->name << "(" << a0 << ")";
+        }
+    } else if (op->is_intrinsic(Call::popcount)) {
+        internal_assert(op->args.size() == 1);
+        if (is_native_xtensa_vector<int8_t>(op->type, target)) {
+            rhs << "IVP_POPC2NX8(" << print_expr(op->args[0]) << ")";
+        } else if (is_native_xtensa_vector<uint8_t>(op->type, target)) {
+            rhs << "IVP_POPC2NX8U(" << print_expr(op->args[0]) << ")";
+        } else if (op->type.is_vector()) {
+            // Xtensa only has popcount intrinsics for 8-bit vector types.
+            rhs << "scalarize_unary<" << print_type(op->type) << ", "
+                << print_type(op->type.with_lanes(1)) << ", "
+                // return type of halide_popcount is always int.
+                << "int, "
+                << op->type.lanes() << ">(&halide_popcount, " << print_expr(op->args[0]) << ")";
+        } else {
+            CodeGen_C::visit(op);
+            return;
+        }
+    } else if (op->is_intrinsic(Call::count_trailing_zeros)) {
+        internal_assert(op->args.size() == 1);
+        if (op->type.is_vector()) {
+            // Xtensa doesn't have intrinsics for count_trailing_zeros.
+            rhs << "scalarize_unary<" << print_type(op->type) << ", "
+                << print_type(op->type.with_lanes(1)) << ", "
+                // return type of halide_count_trailing_zeros is always int.
+                << "int, "
+                << op->type.lanes() << ">(&halide_count_trailing_zeros, " << print_expr(op->args[0]) << ")";
+        } else {
+            CodeGen_C::visit(op);
+            return;
+        }
+    } else if (op->is_intrinsic(Call::prefetch)) {
+        user_error << "Prefetch is not supported by Xtensa backend." << Expr(op) << "\n";
+    } else if (op->name == "sqrt" || op->name == "sqrt_f32") {
+        string a0 = print_expr(op->args[0]);
+        if (is_native_xtensa_vector<float>(op->type, target)) {
+            rhs << "IVP_FSQRTN_2XF32(" << a0 << ")";
+        } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+            rhs << "IVP_FSQRTNXF16(" << a0 << ")";
+        } else {
+            rhs << "sqrtf(" << a0 << ")";
+        }
+    } else if (op->name == "round" || op->name == "round_f32") {
+        string a0 = print_expr(op->args[0]);
+        if (is_native_xtensa_vector<float>(op->type, target)) {
+            rhs << "IVP_FIRINTN_2XF32(" << a0 << ")";
+        } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+            rhs << "IVP_FIRINTNXF16(" << a0 << ")";
+        } else {
+            rhs << "nearbyint(" << a0 << ")";
+        }
+    } else if (op->name == "floor" || op->name == "floor_f32") {
+        string a0 = print_expr(op->args[0]);
+        if (is_native_xtensa_vector<float>(op->type, target)) {
+            rhs << "IVP_FIFLOORN_2XF32(" << a0 << ")";
+        } else if (is_native_xtensa_vector<float16_t>(op->type, target)) {
+            rhs << "IVP_FIFLOORNXF16(" << a0 << ")";
+        } else {
+            rhs << "floor_f32(" << a0 << ")";
+        }
+    } else if (op->name.find("halide_xtensa_") == 0) {
+        rhs << print_xtensa_call(op);
+    } else {
+        CodeGen_C::visit(op);
+        return;
+    }
+
+    print_assignment(op->type, rhs.str());
+}
+
+void CodeGen_Xtensa::visit(const Cast *op) {
+    const Type &t = op->type;
+    const Expr &e = op->value;
+    string value = print_expr(e);
+    string type = print_type(t);
+    if ((is_native_xtensa_vector<int8_t>(t, target) || is_native_xtensa_vector<uint8_t>(t, target)) && (is_native_xtensa_vector<int8_t>(e.type(), target) || is_native_xtensa_vector<uint8_t>(e.type(), target))) {
+        if (e.type().is_int()) {
+            id = print_assignment(t, "xb_vec2Nx8_rtor_xb_vec2Nx8U(" + value + ")");
+        } else {
+            id = print_assignment(t, "xb_vec2Nx8U_rtor_xb_vec2Nx8(" + value + ")");
+        }
+    } else if ((is_native_xtensa_vector<int16_t>(t, target) || is_native_xtensa_vector<uint16_t>(t, target)) && (is_native_xtensa_vector<int16_t>(e.type(), target) || is_native_xtensa_vector<uint16_t>(e.type(), target))) {
+        if (e.type().is_int()) {
+            id = print_assignment(t, "xb_vecNx16_rtor_xb_vecNx16U(" + value + ")");
+        } else {
+            id = print_assignment(t, "xb_vecNx16U_rtor_xb_vecNx16(" + value + ")");
+        }
+    } else if ((is_native_xtensa_vector<int32_t>(t, target) || is_native_xtensa_vector<uint32_t>(t, target)) && (is_native_xtensa_vector<int32_t>(e.type(), target) || is_native_xtensa_vector<uint32_t>(e.type(), target))) {
+        if (e.type().is_int()) {
+            id = print_assignment(t, "xb_vecN_2x32v_rtor_xb_vecN_2x32Uv(" + value + ")");
+        } else {
+            id = print_assignment(t, "xb_vecN_2x32Uv_rtor_xb_vecN_2x32v(" + value + ")");
+        }
+    } else if (is_native_xtensa_vector<int64_t>(e.type(), target) && is_native_xtensa_vector<int32_t>(t, target)) {
+        id = print_assignment(t, "IVP_PACKLN_2X64W(" + value + ")");
+    } else if (t.is_vector() &&
+               t.lanes() == e.type().lanes() &&
+               t != e.type()) {
+        id = print_assignment(t, "convert<" + type + "," + print_type(e.type()) + ">(" + value + ")");
+    } else {
+        id = print_assignment(t, "(" + type + ")(" + value + ")");
+    }
+}
+
+void CodeGen_Xtensa::visit(const Reinterpret *op) {
+    if (is_native_vector_type(op->type, target) && is_native_vector_type(op->value.type(), target)) {
+        string op_name = "";
+        if (is_native_xtensa_vector<int32_t>(op->type, target) && is_native_xtensa_vector<uint32_t>(op->value.type(), target)) {
+            op_name = "xb_vecN_2x32Uv_rtor_xb_vecN_2x32v";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target) && is_native_xtensa_vector<int32_t>(op->value.type(), target)) {
+            op_name = "xb_vecN_2x32v_rtor_xb_vecN_2x32Uv";
+        } else if (is_native_xtensa_vector<uint32_t>(op->type, target) && is_native_xtensa_vector<float>(op->value.type(), target)) {
+            op_name = "IVP_MOVN_2X32_FROMN_2XF32";
+        } else if (is_native_xtensa_vector<float>(op->type, target) && is_native_xtensa_vector<uint32_t>(op->value.type(), target)) {
+            op_name = "IVP_MOVN_2XF32_FROMN_2X32";
+        }
+        if (!op_name.empty()) {
+            string value = print_expr(op->value);
+            id = print_assignment(op->type, op_name + "(" + value + ")");
+            return;
+        }
+    }
+    CodeGen_C::visit(op);
+}
+
+void CodeGen_Xtensa::visit(const For *op) {
+    current_loop_level++;
+    string id_min = print_expr(op->min);
+    string id_extent = print_expr(op->extent);
+
+    if (op->for_type == ForType::Parallel) {
+        stream << get_indent() << "#pragma omp parallel for\n";
+    } else {
+        internal_assert(op->for_type == ForType::Serial)
+            << "Can only emit serial or parallel for loops to C\n";
+    }
+
+#if POOR_MANS_PROFILING_LOOP_LEVEL > 0
+    std::string n = op->name;
+    for (auto &c : n) {
+        if (c == '$' || c == '.') {
+            c = '_';
+        }
+    }
+    if (current_loop_level <= POOR_MANS_PROFILING_LOOP_LEVEL) {
+        open_scope();
+        stream << get_indent() << "const int cycles_start_" << n << " = GetCycleCount();\n";
+    }
+#endif
+
+    stream << get_indent() << "for (int "
+           << print_name(op->name)
+           << " = " << id_min
+           << "; "
+           << print_name(op->name)
+           << " < " << id_min
+           << " + " << id_extent
+           << "; "
+           << print_name(op->name)
+           << "++)\n";
+    open_scope();
+
+    op->body.accept(this);
+
+    close_scope("for " + print_name(op->name));
+#if POOR_MANS_PROFILING_LOOP_LEVEL > 0
+    if (current_loop_level <= POOR_MANS_PROFILING_LOOP_LEVEL) {
+        stream << get_indent() << "const int cycles_stop_" << n << " = GetCycleCount();\n";
+        stream << get_indent() << "const int cycles_tot_" << n << " = cycles_stop_" << n << " - cycles_start_" << n << ";\n";
+        stream << get_indent() << "printf(\"@" << current_loop_level << ": " << op->name << ": %d\\n\", cycles_tot_" << n << ");\n";
+        close_scope("profiler" + print_name(op->name));
+    }
+#endif
+    current_loop_level--;
+}
+
+void CodeGen_Xtensa::visit(const Shuffle *op) {
+    internal_assert(!op->vectors.empty());
+    for (size_t i = 1; i < op->vectors.size(); i++) {
+        internal_assert(op->vectors[0].type() == op->vectors[i].type());
+    }
+    internal_assert(op->type.lanes() == (int)op->indices.size());
+    const int max_index = (int)(op->vectors[0].type().lanes() * op->vectors.size());
+    for (int i : op->indices) {
+        internal_assert(i >= -1 && i < max_index);
+    }
+
+    // Generate intrinsics for the interleave op.
+    int vector_size_in_bytes = target.natural_vector_size<uint8_t>();
+    if (op->is_interleave() && (is_native_vector_type(op->vectors[0].type(), target) || is_double_native_vector_type(op->vectors[0].type(), target) || (op->vectors[0].type().is_bool() && op->vectors[0].type().lanes() == vector_size_in_bytes))) {
+        string type_suffix = suffix_for_type(op->type);
+
+        Expr call = Call::make(op->type, "halide_xtensa_interleave" + type_suffix,
+                               op->vectors, Call::PureExtern);
+        call.accept(this);
+        return;
+    }
+
+    if (op->is_slice() && (op->slice_stride() == 1) &&
+        (is_native_xtensa_vector<int8_t>(op->type, target) || is_native_xtensa_vector<uint8_t>(op->type, target) || is_native_xtensa_vector<int16_t>(op->type, target) || is_native_xtensa_vector<uint16_t>(op->type, target) || is_native_xtensa_vector<int32_t>(op->type, target) || is_native_xtensa_vector<uint32_t>(op->type, target) || is_native_xtensa_vector<float>(op->type, target) || is_native_xtensa_vector<float16_t>(op->type, target))) {
+        string type_suffix = suffix_for_type(op->type);
+        string function_name = "halide_xtensa_slice";
+        int slice_begin = op->slice_begin();
+        if (op->slice_begin() < 5 || (op->slice_begin() == 6) || (op->slice_begin() == 8)) {
+            function_name += "_right";
+        }
+        if ((op->type.lanes() - op->slice_begin() < 5) && (op->type.lanes() > op->slice_begin())) {
+            function_name += "_left";
+            slice_begin = op->type.lanes() - op->slice_begin();
+        }
+        Expr call = Call::make(op->type, function_name + type_suffix,
+                               {op->vectors[0], slice_begin}, Call::PureExtern);
+        call.accept(this);
+        return;
+    }
+
+    if (op->vectors.size() == 1) {
+        if (op->is_slice() && (op->slice_begin() < 2) && (op->slice_stride() == 2) && ((int)op->indices.size() == op->vectors[0].type().lanes() / 2)) {
+            string type_suffix = suffix_for_type(op->type);
+            string function_name = std::string("halide_xtensa_deinterleave") + ((op->slice_begin() == 0) ? "_even" : "_odd");
+            Expr call = Call::make(op->type, function_name + type_suffix,
+                                   {op->vectors[0]}, Call::PureExtern);
+            call.accept(this);
+            return;
+        }
+        if (op->is_slice() && (op->slice_begin() >= 0 && op->slice_begin() < 4) && (op->slice_stride() == 4) && ((int)op->indices.size() == op->vectors[0].type().lanes() / 4)) {
+            string type_suffix = suffix_for_type(op->type);
+            string function_name = std::string("halide_xtensa_extract_" + std::to_string(op->slice_begin()) + "_of_4");
+            Expr call = Call::make(op->type, function_name + type_suffix,
+                                   {op->vectors[0]}, Call::PureExtern);
+            call.accept(this);
+            return;
+        }
+    }
+
+    if (op->is_concat() && is_native_vector_type(op->vectors[0].type(), target)) {
+        Expr call = Call::make(op->type, "halide_xtensa_concat_from_native", op->vectors, Call::PureExtern);
+        call.accept(this);
+        return;
+    }
+
+    std::vector<string> vecs;
+    for (const Expr &v : op->vectors) {
+        vecs.push_back(print_expr(v));
+    }
+    string src = vecs[0];
+    Type src_type = op->vectors[0].type();
+    if (op->vectors.size() > 1) {
+        ostringstream rhs;
+        rhs << "concat<"
+            << print_type(op->type) << ", "
+            << print_type(op->vectors[0].type()) << ", "
+            << print_type(op->type.element_of()) << ", "
+            << op->type.lanes() << ", "
+            << op->vectors[0].type().lanes()
+            << ">(" << with_commas(vecs) << ")";
+        src = print_assignment(op->type, rhs.str());
+        src_type = src_type.with_lanes(src_type.lanes() * op->vectors.size());
+    }
+    ostringstream rhs;
+    if (op->type.is_scalar()) {
+        rhs << src << "[" << op->indices[0] << "]";
+    } else if (op->is_concat()) {
+        // Do nothing if it's just concat.
+        return;
+    } else if (op->type.bits() == 24 && op->vectors[0].type().lanes() == 128 && op->type.is_int()) {
+        if (op->is_slice() && op->slice_begin() == 0 && op->slice_stride() == 1 && op->indices.size() == 64) {
+            rhs << src << ".native_vector[0]";
+        }
+        if (op->is_slice() && op->slice_begin() == 64 &&
+            op->slice_stride() == 1 && op->indices.size() == 64) {
+            rhs << src << ".native_vector[1]";
+        }
+    } else {
+        string indices_name = unique_name('_');
+        stream << get_indent() << "const int32_t " << indices_name << "[" << op->indices.size() << "] = { " << with_commas(op->indices) << " };\n";
+        rhs << "shuffle"
+            << "<"
+            << print_type(src_type) << ", "
+            << print_type(op->type) << ", "
+            << print_type(op->type.element_of()) << ", " << src_type.lanes()
+            << ", " << op->type.lanes()
+            << ">(" << src << ", " << indices_name << ")";
+    }
+    print_assignment(op->type, rhs.str());
+}
+
+void CodeGen_Xtensa::visit(const Allocate *op) {
+    open_scope();
+
+    string op_name = print_name(op->name);
+    string op_type = print_type(op->type, AppendSpace);
+
+    // For sizes less than 8k, do a stack allocation
+    bool on_stack = false;
+    int32_t constant_size;
+    string size_id;
+    Type size_id_type;
+
+    if (op->new_expr.defined()) {
+        Allocation alloc;
+        alloc.type = op->type;
+        allocations.push(op->name, alloc);
+        heap_allocations.push(op->name);
+        stream << op_type << "*" << op_name << " = (" << print_expr(op->new_expr) << ");\n";
+    } else {
+        constant_size = op->constant_allocation_size();
+        if (constant_size > 0) {
+            int64_t stack_bytes = constant_size * op->type.bytes();
+
+            if (stack_bytes > ((int64_t(1) << 31) - 1)) {
+                user_error << "Total size for allocation "
+                           << op->name << " is constant but exceeds 2^31 - 1.\n";
+            } else {
+                size_id_type = Int(32);
+                size_id = print_expr(make_const(size_id_type, constant_size));
+
+                if (op->memory_type == MemoryType::Stack ||
+                    op->memory_type == MemoryType::Register) {
+                    on_stack = true;
+                }
+            }
+        } else {
+            // Check that the allocation is not scalar (if it were scalar
+            // it would have constant size).
+            internal_assert(!op->extents.empty());
+
+            size_id = print_assignment(Int(64), print_expr(op->extents[0]));
+            size_id_type = Int(64);
+
+            for (size_t i = 1; i < op->extents.size(); i++) {
+                // Make the code a little less cluttered for two-dimensional case
+                string new_size_id_rhs;
+                string next_extent = print_expr(op->extents[i]);
+                if (i > 1) {
+                    new_size_id_rhs = "(" + size_id + " > ((int64_t(1) << 31) - 1)) ? " + size_id + " : (" + size_id + " * " + next_extent + ")";
+                } else {
+                    new_size_id_rhs = size_id + " * " + next_extent;
+                }
+                size_id = print_assignment(Int(64), new_size_id_rhs);
+            }
+        }
+
+        // Check the condition to see if this allocation should actually be created.
+        // If the allocation is on the stack, the only condition we can respect is
+        // unconditional false (otherwise a non-constant-sized array declaration
+        // will be generated).
+        if (!on_stack || is_const_zero(op->condition)) {
+            Expr conditional_size = Select::make(op->condition,
+                                                 Variable::make(size_id_type, size_id),
+                                                 make_const(size_id_type, 0));
+            conditional_size = simplify(conditional_size);
+            size_id = print_assignment(Int(64), print_expr(conditional_size));
+        }
+
+        Allocation alloc;
+        alloc.type = op->type;
+        allocations.push(op->name, alloc);
+
+        stream << get_indent() << op_type;
+
+        if (on_stack) {
+            stream << "__attribute__((aligned(XCHAL_VISION_SIMD8))) " << op_name
+                   << "[" << size_id << "];\n";
+        } else if (op->memory_type == MemoryType::VTCM) {
+            stream << "*"
+                   << "__attribute__((aligned(XCHAL_VISION_SIMD8))) "
+                   << " __restrict "
+                   << op_name
+                   << " = ("
+                   << op_type
+                   << " *)halide_tcm_malloc(_ucon, sizeof("
+                   << op_type
+                   << ")*" << size_id << ");\n";
+        } else {
+            stream << "*"
+                   << "__attribute__((aligned(XCHAL_VISION_SIMD8)))  "
+                   << " __restrict "
+                   << op_name
+                   << " = ("
+                   << op_type
+                   << " *)halide_malloc(_ucon, sizeof("
+                   << op_type
+                   << ")*" << size_id << ");\n";
+            heap_allocations.push(op->name);
+        }
+    }
+
+    if (!on_stack) {
+        ostringstream check;
+        if (is_const_zero(op->condition)) {
+            // Assertion always succeeds here, since allocation is never used
+            check << print_expr(const_true());
+        } else {
+            // Assert that the allocation worked....
+            check << "((" << op_name << " != nullptr) || (" << size_id << " == 0))";
+            if (!is_const_one(op->condition)) {
+                // ...but if the condition is false, it's OK for the new_expr to be null.
+                string op_condition = print_assignment(Bool(), print_expr(op->condition));
+                check << " || (!" << op_condition << ")";
+            }
+        }
+        create_assertion(check.str(), Call::make(Int(32), "halide_error_out_of_memory", {}, Call::Extern));
+
+        string free_function = op->free_function.empty() ?
+                                   (op->memory_type != MemoryType::VTCM ? "halide_free" : "halide_tcm_free") :
+                                   op->free_function;
+
+        emit_halide_free_helper(op_name, free_function);
+    }
+
+    op->body.accept(this);
+
+    // Free the memory if it was allocated on the heap and there is no matching
+    // Free node.
+    print_heap_free(op->name);
+    if (allocations.contains(op->name)) {
+        allocations.pop(op->name);
+    }
+
+    close_scope("alloc " + print_name(op->name));
+}
+
+void CodeGen_Xtensa::visit(const Let *op) {
+    const auto *call = op->value.as<Call>();
+    if (call && (call->name == "clamped_dense_ramp")) {
+        Expr body = substitute(op->name, call, op->body);
+        body.accept(this);
+        return;
+    }
+    return CodeGen_C::visit(op);
+}
+
+void CodeGen_Xtensa::visit(const LetStmt *op) {
+    const auto *call = op->value.as<Call>();
+    if (call && (call->name == "clamped_dense_ramp")) {
+        Stmt body = substitute(op->name, call, op->body);
+        body.accept(this);
+        return;
+    }
+    return CodeGen_C::visit(op);
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/src/CodeGen_Xtensa.h
+++ b/src/CodeGen_Xtensa.h
@@ -1,0 +1,67 @@
+#ifndef HALIDE_CODEGEN_XTENSA_H
+#define HALIDE_CODEGEN_XTENSA_H
+
+/** \file
+ * Defines the code-generator for producing Xtensa code
+ */
+
+#include "CodeGen_C.h"
+
+namespace Halide {
+namespace Internal {
+
+class CodeGen_Xtensa : public CodeGen_C {
+public:
+    using CodeGen_C::CodeGen_C;
+
+protected:
+    Stmt preprocess_function_body(const Stmt &stmt) override;
+
+    using CodeGen_C::visit;
+
+    std::string print_assignment(Type t, const std::string &rhs) override;
+    std::string print_type(Type t, CodeGen_C::AppendSpaceIfNeeded space_option = DoNotAppendSpace) override;
+    std::string print_xtensa_call(const Call *op);
+
+    void add_platform_prologue() override;
+    void add_vector_typedefs(const std::set<Type> &vector_types) override;
+
+    void visit(const Mul *) override;
+    void visit(const Div *) override;
+    void visit(const Mod *) override;
+
+    void visit(const Allocate *) override;
+    void visit(const For *) override;
+    void visit(const Ramp *op) override;
+    void visit(const Broadcast *op) override;
+    void visit(const Call *op) override;
+    void visit(const Cast *op) override;
+    void visit(const Load *op) override;
+    void visit(const EQ *op) override;
+    void visit(const LE *op) override;
+    void visit(const LT *op) override;
+    void visit(const GE *op) override;
+    void visit(const GT *op) override;
+    void visit(const Or *op) override;
+    void visit(const Reinterpret *op) override;
+    void visit(const Store *op) override;
+    void visit(const Select *op) override;
+    void visit(const Shuffle *op) override;
+    void visit(const Min *op) override;
+    void visit(const Max *op) override;
+    void visit(const IntImm *op) override;
+    void visit(const Let *op) override;
+    void visit(const LetStmt *op) override;
+
+    bool is_stack_private_to_thread() const override;
+
+    int current_loop_level = 0;
+    std::vector<std::string> global_static_allocations;
+
+    std::set<std::string> external_buffers;
+};
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/src/ConciseCasts.h
+++ b/src/ConciseCasts.h
@@ -40,8 +40,18 @@ inline Expr i64(Expr e) {
     return cast(t, std::move(e));
 }
 
+inline Expr i48(Expr e) {
+    Type t = Int(48, e.type().lanes());
+    return cast(t, std::move(e));
+}
+
 inline Expr i32(Expr e) {
     Type t = Int(32, e.type().lanes());
+    return cast(t, std::move(e));
+}
+
+inline Expr i24(Expr e) {
+    Type t = Int(24, e.type().lanes());
     return cast(t, std::move(e));
 }
 

--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -15,7 +15,7 @@ namespace {
 
 bool find_intrinsics_for_type(const Type &t) {
     // Currently, we only try to find and replace intrinsics for vector types that aren't bools.
-    return t.is_vector() && t.bits() >= 8;
+    return t.is_vector() && (t.bits() >= 8) && (t.bits() != 24) && (t.bits() != 48);
 }
 
 Expr widen(Expr a) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2226,6 +2226,12 @@ Func &Func::async() {
     return *this;
 }
 
+Func &Func::dma() {
+    invalidate_cache();
+    func.schedule().dma() = true;
+    return *this;
+}
+
 Stage Func::specialize(const Expr &c) {
     invalidate_cache();
     return Stage(func, func.definition(), 0).specialize(c);

--- a/src/Func.h
+++ b/src/Func.h
@@ -2256,6 +2256,9 @@ public:
      */
     Func &async();
 
+    /** TODO: document me */
+    Func &dma();
+
     /** Bound the extent of a Func's storage, but not extent of its
      * compute. This can be useful for forcing a function's allocation
      * to be a fixed size, which often means it can go on the stack.

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2283,6 +2283,7 @@ public:
     HALIDE_FORWARD_METHOD(Func, define_extern)
     HALIDE_FORWARD_METHOD_CONST(Func, defined)
     HALIDE_FORWARD_METHOD_CONST(Func, dimensions)
+    HALIDE_FORWARD_METHOD(Func, dma)
     HALIDE_FORWARD_METHOD(Func, fold_storage)
     HALIDE_FORWARD_METHOD(Func, fuse)
     HALIDE_FORWARD_METHOD(Func, gpu)

--- a/src/IRMatch.cpp
+++ b/src/IRMatch.cpp
@@ -267,6 +267,18 @@ public:
         }
     }
 
+    void visit(const Shuffle *op) override {
+        const Shuffle *e = expr.as<Shuffle>();
+        if (result && e && types_match(op->type, e->type) && op->vectors.size() == e->vectors.size() && op->indices == e->indices) {
+            for (size_t ix = 0; ix < op->vectors.size(); ix++) {
+                expr = e->vectors[ix];
+                op->vectors[ix].accept(this);
+            }
+        } else {
+            result = false;
+        }
+    }
+
     void visit(const Call *op) override {
         const Call *e = expr.as<Call>();
         if (result && e &&

--- a/src/InjectDmaTransfer.cpp
+++ b/src/InjectDmaTransfer.cpp
@@ -1,0 +1,417 @@
+#include "InjectDmaTransfer.h"
+#include "CSE.h"
+#include "ExprUsesVar.h"
+#include "Function.h"
+#include "IREquality.h"
+#include "IRMutator.h"
+#include "IROperator.h"
+#include "Simplify.h"
+#include "Substitute.h"
+
+namespace Halide {
+namespace Internal {
+
+using std::set;
+using std::string;
+using std::vector;
+
+/** If an integer expression varies linearly with the variables in the
+ * scope, return the linear term. Otherwise return an undefined
+ * Expr. */
+Expr is_linear(const Expr &e, const Scope<Expr> &linear) {
+    if (e.type() != Int(32)) {
+        return Expr();
+    }
+    if (const Variable *v = e.as<Variable>()) {
+        if (linear.contains(v->name)) {
+            return linear.get(v->name);
+        } else {
+            return make_zero(v->type);
+        }
+    } else if (const IntImm *op = e.as<IntImm>()) {
+        return make_zero(op->type);
+    } else if (const Add *add = e.as<Add>()) {
+        Expr la = is_linear(add->a, linear);
+        Expr lb = is_linear(add->b, linear);
+        if (is_const_zero(lb)) {
+            return la;
+        } else if (is_const_zero(la)) {
+            return lb;
+        } else if (la.defined() && lb.defined()) {
+            return la + lb;
+        } else {
+            return Expr();
+        }
+    } else if (const Sub *sub = e.as<Sub>()) {
+        Expr la = is_linear(sub->a, linear);
+        Expr lb = is_linear(sub->b, linear);
+        if (is_const_zero(lb)) {
+            return la;
+        } else if (la.defined() && lb.defined()) {
+            return la - lb;
+        } else {
+            return Expr();
+        }
+    } else if (const Mul *mul = e.as<Mul>()) {
+        Expr la = is_linear(mul->a, linear);
+        Expr lb = is_linear(mul->b, linear);
+        if (is_const_zero(la) && is_const_zero(lb)) {
+            return la;
+        } else if (is_const_zero(la) && lb.defined()) {
+            return mul->a * lb;
+        } else if (la.defined() && is_const_zero(lb)) {
+            return la * mul->b;
+        } else {
+            return Expr();
+        }
+    } else if (const Div *div = e.as<Div>()) {
+        Expr la = is_linear(div->a, linear);
+        if (is_const_zero(la)) {
+            return la;
+        } else {
+            return Expr();
+        }
+    } else if (const Mod *mod = e.as<Mod>()) {
+        Expr la = is_linear(mod->a, linear);
+        if (is_const_zero(la)) {
+            return la;
+        } else {
+            return Expr();
+        }
+    } else if (const Ramp *r = e.as<Ramp>()) {
+        Expr la = is_linear(r->base, linear);
+        Expr lb = is_linear(r->stride, linear);
+        if (is_const_zero(lb)) {
+            return la;
+        } else {
+            return Expr();
+        }
+    } else if (const Broadcast *b = e.as<Broadcast>()) {
+        return is_linear(b->value, linear);
+    } else if (const Min *m = e.as<Min>()) {
+        Expr la = is_linear(m->a, linear);
+        Expr lb = is_linear(m->b, linear);
+        if (is_const_zero(la) && is_const_zero(lb)) {
+            return la;
+        } else {
+            return Expr();
+        }
+    } else if (const Max *m = e.as<Max>()) {
+        Expr la = is_linear(m->a, linear);
+        Expr lb = is_linear(m->b, linear);
+        if (is_const_zero(la) && is_const_zero(lb)) {
+            return la;
+        } else {
+            return Expr();
+        }
+    } else {
+        return Expr();
+    }
+}
+
+namespace {
+// The maximum total number of DMA channels allowed.
+const int kMaxNumberOfDmaChannels = 4;
+// We want to use a separate channel(s) for the output copies, so it can be
+// overlapped with input copies and the rest of the processing.
+const int kNumberOfChannelsForOutputs = 1;
+// Start channel indexing for input copies from this channel.
+const int kOffsetOfChannelForInputs = kNumberOfChannelsForOutputs;
+// Use remaining channels for input copies.
+const int kNumberOfChannelsForInputs = kMaxNumberOfDmaChannels - kNumberOfChannelsForOutputs;
+}  // namespace
+
+// Replace indirect loads with dma_transfer intrinsics where
+// possible.
+class InjectDmaTransferIntoProducer : public IRMutator {
+    using IRMutator::visit;
+
+    struct LoopVar {
+        std::string name;
+        Expr min;
+        Expr extent;
+        bool body_is_also_loop;
+    };
+
+    std::string producer_name;
+    std::vector<LoopVar> loop_vars;
+    std::set<std::string> loops_to_be_removed;
+    std::map<string, Expr> containing_lets;
+    // Index of the current DMA channel.
+    int index;
+
+    Stmt visit(const For *op) override {
+        debug(3) << "InjectDmaTransfer::for " << op->name << "\n";
+        // Check if the body is also a loop.
+        bool is_body_a_single_for_loop = op->body.as<For>() != nullptr;
+        // Maybe a loop, but with lets in front of it.
+        if (const LetStmt *let = op->body.as<LetStmt>()) {
+            Stmt let_body = let->body;
+            while (let_body.node_type() == IRNodeType::LetStmt) {
+                let_body = let_body.as<LetStmt>()->body;
+            }
+            is_body_a_single_for_loop = let_body.as<For>() != nullptr;
+        }
+        loop_vars.push_back({op->name, op->min, op->extent, is_body_a_single_for_loop});
+        Stmt mutated = IRMutator::visit(op);
+        loop_vars.pop_back();
+        if (loops_to_be_removed.count(op->name) > 0) {
+            loops_to_be_removed.erase(op->name);
+            return mutated.as<For>()->body;
+        }
+        return mutated;
+    }
+
+    Stmt visit(const LetStmt *op) override {
+        // TODO: Not really correct, but probably want to skip lets which
+        // don't depend on loop vars.
+        if (loop_vars.empty()) {
+            return IRMutator::visit(op);
+        }
+        containing_lets[op->name] = op->value;
+
+        Stmt stmt;
+        Stmt body = mutate(op->body);
+        if (body.same_as(op->body)) {
+            stmt = op;
+        } else {
+            stmt = LetStmt::make(op->name, op->value, body);
+        }
+
+        containing_lets.erase(op->name);
+        return stmt;
+    }
+
+    Stmt visit(const Store *op) override {
+        if (op->name != producer_name) {
+            return IRMutator::visit(op);
+        }
+
+        // Check if the destination is an output buffer in which case we can
+        // do a wait for completion later.
+        is_output_dma = op->param.defined();
+        debug(3) << "InjectDmaTransfer::store " << op->name << "\n";
+        debug(3) << loop_vars.size() << "\n";
+
+        const Load *maybe_load = op->value.as<Load>();
+        if (const Call *maybe_call = op->value.as<Call>()) {
+            if (maybe_call->is_intrinsic(Call::IntrinsicOp::strict_float)) {
+                maybe_load = maybe_call->args[0].as<Load>();
+            }
+        }
+        // Has to be a direct load-to-store for now.
+        user_assert(maybe_load) << "Only direct load-to-stores are supported in dma()";
+
+        debug(3) << "InjectDmaTransfer::" << op->name << " " << maybe_load->name << "\n";
+        debug(3) << op->index << "\n";
+        debug(3) << maybe_load->index << "\n";
+
+        // Substitute in lets into indices of load and store to simplify a further
+        // analysis.
+        Expr op_index = op->index;
+        op_index = substitute_in_all_lets(op_index);
+        op_index = substitute(containing_lets, op_index);
+
+        Expr value_index = maybe_load->index;
+        value_index = substitute_in_all_lets(value_index);
+        value_index = substitute(containing_lets, value_index);
+
+        // A vector to hold DMA extents.
+        std::vector<Expr> dma_extents;
+
+        vector<Expr> store_strides;
+        vector<Expr> value_strides;
+
+        // Compute strides for each of the loop vars.
+        for (const auto &v : loop_vars) {
+            Scope<Expr> local_scope;
+            local_scope.push(v.name, 1);
+            Expr is_linear_store = is_linear(op_index, local_scope);
+            Expr is_linear_value = is_linear(value_index, local_scope);
+            debug(3) << "is_linear (stride) store: " << v.name << " " << is_linear_store << "\n";
+            debug(3) << "is_linear (stride) load: " << v.name << " " << is_linear_value << "\n";
+            store_strides.push_back(is_linear_store);
+            value_strides.push_back(is_linear_value);
+        }
+
+        // Use innermost loop var first.
+        const auto &v_inner = loop_vars.back();
+        Expr var = Variable::make(op->index.type(), v_inner.name);
+        // Use extent of the loop as one of the extents of DMA transactions.
+        dma_extents.push_back(v_inner.extent);
+        // This loop was replaced by DMA transfer, so remove the loop itself.
+        loops_to_be_removed.insert(v_inner.name);
+        // Substitute the min into the store/load base address.
+        Expr store_base = substitute(var, v_inner.min, op_index);
+        Expr value_base = substitute(var, v_inner.min, value_index);
+
+        Expr store_stride;
+        Expr value_stride;
+        // Hardware supports 2D transactions, so try to see if we can replace
+        // the next loop var. We only can do it if there are at least two loops
+        // and we were able to find the strides for corresponding loop var.
+        if ((loop_vars.size() > 1) && store_strides[loop_vars.size() - 2].defined() && value_strides[loop_vars.size() - 2].defined() && loop_vars[loop_vars.size() - 2].body_is_also_loop) {
+            const auto &v_outer = loop_vars[loop_vars.size() - 2];
+            Expr var_outer = Variable::make(op->index.type(), v_outer.name);
+            // Remove the second loop as well.
+            loops_to_be_removed.insert(v_outer.name);
+
+            // Substitute another min.
+            store_base = substitute(var_outer, v_outer.min, store_base);
+            value_base = substitute(var_outer, v_outer.min, value_base);
+
+            dma_extents.push_back(v_outer.extent);
+
+            // Use the strides we computed before.
+            store_stride = store_strides[loop_vars.size() - 2];
+            value_stride = value_strides[loop_vars.size() - 2];
+        } else {
+            // If we couldn't compute the strides, we still will do a 2D
+            // transaction, but set one of the extents to 1. This simplifies
+            // runtime a lot.
+            dma_extents.emplace_back(1);
+            store_stride = 1;
+            value_stride = 1;
+        }
+
+        // Try to simplify the base adresses after substitions.
+        store_base = simplify(store_base);
+        value_base = simplify(value_base);
+        debug(3) << ">>> " << store_base << "\n>>> "
+                 << value_base << "\n>>>" << v_inner.extent << "\n";
+
+        Expr copy_call = Call::make(Int(32), "halide_xtensa_copy_2d",
+                                    {is_output_dma ?
+                                         (index % kNumberOfChannelsForOutputs) :
+                                         ((index % kNumberOfChannelsForInputs) + kOffsetOfChannelForInputs),
+                                     Variable::make(type_of<void *>(), op->name), store_base, store_stride,
+                                     Variable::make(type_of<void *>(), maybe_load->name), value_base, value_stride,
+                                     dma_extents[0], dma_extents[1], op->value.type().bytes()},
+                                    Call::Intrinsic);
+
+        if (is_output_dma) {
+            source_name = maybe_load->name;
+        }
+
+        Stmt call_result_assert = AssertStmt::make(copy_call > 0, -1);
+
+        return call_result_assert;
+    }
+
+public:
+    InjectDmaTransferIntoProducer(const string &pn, int i)
+        : producer_name(pn), index(i) {
+    }
+
+    // Are we writing to the output buffer?
+    bool is_output_dma = false;
+    // If yes store the name of the source.
+    std::string source_name;
+};
+
+class InjectDmaTransfer : public IRMutator {
+    using IRMutator::visit;
+    const std::map<std::string, Function> &env;
+    // Index to track current DMA channel to use.
+    int index = 0;
+    // Mapping from the function name to the assigned DMA channel.
+    std::map<std::string, int> function_name_to_index;
+
+    Stmt visit(const ProducerConsumer *op) override {
+        if (op->is_producer) {
+            auto it = env.find(op->name);
+            if (it != env.end()) {
+                Function f = it->second;
+                if (f.schedule().dma()) {
+                    Stmt body = mutate(op->body);
+                    // Assign a separate DMA channel for each of the buffers.
+                    if (function_name_to_index.find(op->name) == function_name_to_index.end()) {
+                        function_name_to_index[op->name] = index;
+                        index++;
+                    }
+                    auto injector = InjectDmaTransferIntoProducer(op->name, function_name_to_index[op->name]);
+                    body = injector.mutate(body);
+                    if (!injector.is_output_dma) {
+                        // Add a wait in the *end* of the producer node for the
+                        // case when there any outstanding DMA transactions.
+                        Expr wait_result = Call::make(Int(32), "halide_xtensa_wait_for_copy",
+                                                      {(function_name_to_index[op->name] % kNumberOfChannelsForInputs) + kOffsetOfChannelForInputs}, Call::Intrinsic);
+                        Stmt wait_is_done = AssertStmt::make(wait_result == 0, -1);
+                        body = Block::make(body, wait_is_done);
+                    } else {
+                        // For the output nodes collect all of the corresponding
+                        // producers, so we can add required waits in a separate
+                        // pass later.
+                        producers_to_wait[injector.source_name] = function_name_to_index[op->name] % kNumberOfChannelsForOutputs;
+                    }
+                    return ProducerConsumer::make_produce(op->name, body);
+                }
+            }
+        }
+        return IRMutator::visit(op);
+    }
+
+public:
+    InjectDmaTransfer(const std::map<std::string, Function> &e)
+        : env(e) {
+    }
+
+    std::map<std::string, int> producers_to_wait;
+};
+
+class InjectWaitsInProducers : public IRMutator {
+    using IRMutator::visit;
+    const std::map<std::string, int> &producers_to_wait;
+
+    Stmt visit(const ProducerConsumer *op) override {
+        if (op->is_producer) {
+            auto it = producers_to_wait.find(op->name);
+            if (it != producers_to_wait.end()) {
+                // Add a wait in the *beginning* of the producer node to make
+                // sure that everything is copied before starting production of
+                // the new lines.
+                Expr wait_result = Call::make(Int(32), "halide_xtensa_wait_for_copy", {it->second}, Call::Intrinsic);
+                Stmt wait_is_done = AssertStmt::make(wait_result == 0, -1);
+                Stmt body = mutate(op->body);
+                body = Block::make(wait_is_done, body);
+
+                return ProducerConsumer::make_produce(op->name, body);
+            }
+        }
+        return IRMutator::visit(op);
+    }
+
+    Stmt visit(const Allocate *op) override {
+        auto it = producers_to_wait.find(op->name);
+        if (it != producers_to_wait.end()) {
+            // Add a wait in the end of the allocate node to make sure that
+            // everything is copied before de-allocation.
+            Expr wait_result = Call::make(Int(32), "halide_xtensa_wait_for_copy", {it->second}, Call::Intrinsic);
+            Stmt wait_is_done = AssertStmt::make(wait_result == 0, -1);
+            Stmt body = mutate(op->body);
+            body = Block::make(body, wait_is_done);
+
+            return Allocate::make(op->name, op->type, op->memory_type,
+                                  op->extents, op->condition, body,
+                                  op->new_expr, op->free_function);
+        }
+
+        return IRMutator::visit(op);
+    }
+
+public:
+    InjectWaitsInProducers(const std::map<std::string, int> &pr)
+        : producers_to_wait(pr){}
+
+          ;
+};
+
+Stmt inject_dma_transfer(Stmt s, const std::map<std::string, Function> &env) {
+    auto inject_dma = InjectDmaTransfer(env);
+    s = inject_dma.mutate(s);
+    s = InjectWaitsInProducers(inject_dma.producers_to_wait).mutate(s);
+    return s;
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/src/InjectDmaTransfer.h
+++ b/src/InjectDmaTransfer.h
@@ -1,0 +1,22 @@
+#ifndef HALIDE_INJECT_DMA_TRANSFER_H
+#define HALIDE_INJECT_DMA_TRANSFER_H
+
+/** \file
+ * Defines the lowering pass that injects Xtensa's DMA transfers.
+ */
+#include <map>
+#include <string>
+
+#include "Expr.h"
+
+namespace Halide {
+namespace Internal {
+
+class Function;
+
+Stmt inject_dma_transfer(Stmt s, const std::map<std::string, Function> &env);
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -36,6 +36,7 @@
 #include "IROperator.h"
 #include "IRPrinter.h"
 #include "InferArguments.h"
+#include "InjectDmaTransfer.h"
 #include "InjectHostDevBufferCopies.h"
 #include "Inline.h"
 #include "LICM.h"
@@ -400,6 +401,8 @@ void lower_impl(const vector<Function> &output_funcs,
     debug(1) << "Flattening nested ramps...\n";
     s = flatten_nested_ramps(s);
     log("Lowering after flattening nested ramps:", s);
+
+    s = inject_dma_transfer(s, env);
 
     debug(1) << "Removing dead allocations and moving loop invariant code...\n";
     s = remove_dead_allocations(s);

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -9,6 +9,7 @@
 #include "CodeGen_C.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_PyTorch.h"
+#include "CodeGen_Xtensa.h"
 #include "CompilerLogger.h"
 #include "Debug.h"
 #include "HexagonOffload.h"
@@ -631,10 +632,17 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
     if (contains(output_files, OutputFileType::c_source)) {
         debug(1) << "Module.compile(): c_source " << output_files.at(OutputFileType::c_source) << "\n";
         std::ofstream file(output_files.at(OutputFileType::c_source));
-        Internal::CodeGen_C cg(file,
-                               target(),
-                               target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusImplementation : Internal::CodeGen_C::CImplementation);
-        cg.compile(*this);
+        if (target().has_feature(Target::Xtensa)) {
+            Internal::CodeGen_Xtensa cg(file,
+                                        target(),
+                                        target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusImplementation : Internal::CodeGen_C::CImplementation);
+            cg.compile(*this);
+        } else {
+            Internal::CodeGen_C cg(file,
+                                   target(),
+                                   target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusImplementation : Internal::CodeGen_C::CImplementation);
+            cg.compile(*this);
+        }
     }
     if (contains(output_files, OutputFileType::python_extension)) {
         debug(1) << "Module.compile(): python_extension " << output_files.at(OutputFileType::python_extension) << "\n";

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -221,6 +221,7 @@ struct FuncScheduleContents {
     MemoryType memory_type = MemoryType::Auto;
     bool memoized = false;
     bool async = false;
+    bool dma = false;
     Expr memoize_eviction_key;
 
     FuncScheduleContents()
@@ -341,6 +342,7 @@ FuncSchedule FuncSchedule::deep_copy(
     copy.contents->memoized = contents->memoized;
     copy.contents->memoize_eviction_key = contents->memoize_eviction_key;
     copy.contents->async = contents->async;
+    copy.contents->dma = contents->dma;
 
     // Deep-copy wrapper functions.
     for (const auto &iter : contents->wrappers) {
@@ -382,6 +384,14 @@ bool &FuncSchedule::async() {
 
 bool FuncSchedule::async() const {
     return contents->async;
+}
+
+bool &FuncSchedule::dma() {
+    return contents->dma;
+}
+
+bool FuncSchedule::dma() const {
+    return contents->dma;
 }
 
 std::vector<StorageDim> &FuncSchedule::storage_dims() {

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -577,6 +577,9 @@ public:
     bool &async();
     bool async() const;
 
+    bool &dma();
+    bool dma() const;
+
     /** The list and order of dimensions used to store this
      * function. The first dimension in the vector corresponds to the
      * innermost dimension for storage (i.e. which dimension is

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -513,6 +513,8 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sve2", Target::SVE2},
     {"arm_dot_prod", Target::ARMDotProd},
     {"arm_fp16", Target::ARMFp16},
+    {"xtensa", Target::Xtensa},
+    {"xtensa_q8", Target::XtensaQ8},
     {"llvm_large_code_model", Target::LLVMLargeCodeModel},
     {"rvv", Target::RVV},
     {"armv81a", Target::ARMv81a},
@@ -1088,7 +1090,12 @@ int Target::natural_vector_size(const Halide::Type &t) const {
     const bool is_integer = t.is_int() || t.is_uint();
     const int data_size = t.bytes();
 
-    if (arch == Target::ARM) {
+    if (has_feature(Halide::Target::Xtensa)) {
+        if (has_feature(Halide::Target::XtensaQ8)) {
+            return 128 / data_size;
+        }
+        return 64 / data_size;
+    } else if (arch == Target::ARM) {
         if (vector_bits != 0 &&
             (has_feature(Halide::Target::SVE2) ||
              (t.is_float() && has_feature(Halide::Target::SVE)))) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -151,6 +151,8 @@ struct Target {
         SVE2 = halide_target_feature_sve2,
         ARMDotProd = halide_target_feature_arm_dot_prod,
         ARMFp16 = halide_target_feature_arm_fp16,
+        Xtensa = halide_target_feature_xtensa,
+        XtensaQ8 = halide_target_feature_xtensa_q8,
         LLVMLargeCodeModel = halide_llvm_large_code_model,
         RVV = halide_target_feature_rvv,
         ARMv81a = halide_target_feature_armv81a,

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -1072,7 +1072,7 @@ private:
             // Replace widening left shift with multiplication.
             const uint64_t *c = as_const_uint(op->args[1]);
             if (c && op->args[1].type().can_represent((uint64_t)1 << *c)) {
-                if (op->args[0].type().is_int() && (*c < op->args[0].type().bits() - 1)) {
+                if (op->args[0].type().is_int() && (*c < (uint64_t)op->args[0].type().bits() - 1)) {
                     return mutate(widening_mul(op->args[0], bc(IntImm::make(op->args[1].type().with_code(halide_type_int).with_lanes(1), (int64_t)1 << *c), op->args[1].type().lanes())));
                 } else {
                     return mutate(widening_mul(op->args[0], bc(UIntImm::make(op->args[1].type().with_lanes(1), (uint64_t)1 << *c), op->args[1].type().lanes())));

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -1,0 +1,2331 @@
+#include "XtensaOptimize.h"
+
+#include "AlignLoads.h"
+#include "Bounds.h"
+#include "CSE.h"
+#include "ConciseCasts.h"
+#include "Expr.h"
+#include "ExprUsesVar.h"
+#include "FindIntrinsics.h"
+#include "IREquality.h"
+#include "IRMatch.h"
+#include "IRMutator.h"
+#include "IROperator.h"
+#include "Lerp.h"
+#include "LoopCarry.h"
+#include "Simplify.h"
+#include "Substitute.h"
+#include <utility>
+
+namespace Halide {
+namespace Internal {
+
+using std::string;
+using std::vector;
+
+using namespace Halide::ConciseCasts;
+
+template<>
+bool is_native_xtensa_vector<int8_t>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<int8_t>();
+    return t.is_int() && (t.bits() == 8) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<uint8_t>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<uint8_t>();
+    return t.is_uint() && (t.bits() == 8) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<int16_t>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<int16_t>();
+    return t.is_int() && (t.bits() == 16) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<uint16_t>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<uint16_t>();
+    return t.is_uint() && (t.bits() == 16) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<int32_t>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<int32_t>();
+    return t.is_int() && (t.bits() == 32) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<int64_t>(const Type &t, const Target &target) {
+    // On Xtensa int64 vectors are *wide* vectors, so the number of lanes match
+    // the number of lanes for 32-bit vectors.
+    int vector_size = target.natural_vector_size<int32_t>();
+    return t.is_int() && (t.bits() == 64) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<uint32_t>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<uint32_t>();
+    return t.is_uint() && (t.bits() == 32) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<float16_t>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<float16_t>();
+    return t.is_float() && (t.bits() == 16) && (t.lanes() == vector_size);
+}
+
+template<>
+bool is_native_xtensa_vector<float>(const Type &t, const Target &target) {
+    int vector_size = target.natural_vector_size<float>();
+    return t.is_float() && (t.bits() == 32) && (t.lanes() == vector_size);
+}
+
+bool is_native_vector_type(const Type &t, const Target &target) {
+    int native_lanes = target.natural_vector_size<uint8_t>();
+
+    if (t.is_int_or_uint() && (t.lanes() == native_lanes) && (t.bits() == 8)) {
+        return true;
+    }
+
+    if (t.is_int_or_uint() && (t.lanes() == native_lanes) && (t.bits() == 24)) {
+        return true;
+    }
+
+    if (t.is_int_or_uint() && (t.lanes() == native_lanes / 2) && (t.bits() == 16)) {
+        return true;
+    }
+
+    if (t.is_int_or_uint() && (t.lanes() == native_lanes / 2) && (t.bits() == 48)) {
+        return true;
+    }
+
+    if (t.is_int_or_uint() && (t.lanes() == native_lanes / 4) && (t.bits() == 32)) {
+        return true;
+    }
+
+    if (t.is_float() && (t.lanes() == native_lanes / 4) && (t.bits() == 32)) {
+        return true;
+    }
+
+    return false;
+}
+
+bool is_double_native_vector_type(const Type &t, const Target &target) {
+    int single_vector_bitwidth = 8 * target.natural_vector_size<uint8_t>();
+
+    int double_vector_bitwidth = single_vector_bitwidth * 2;
+    return (t.bits() % 8 == 0) && (double_vector_bitwidth % t.bits() == 0) && (double_vector_bitwidth / t.bits() == t.lanes());
+}
+
+Type get_native_xtensa_vector(const Type &t, const Target &target) {
+    int vector_bitwidth = target.has_feature(Target::Feature::XtensaQ8) ? 1024 : 512;
+    int wide_vector_bitwidth = target.has_feature(Target::Feature::XtensaQ8) ? 4096 : 1536;
+
+    if (t.bits() == 64) {
+        return t.with_lanes(vector_bitwidth / 32);
+    }
+
+    if (t.bits() == 24 || t.bits() == 48) {
+        return t.with_lanes(wide_vector_bitwidth / t.bits());
+    }
+    return t.with_lanes(vector_bitwidth / t.bits());
+}
+
+std::string suffix_for_type(Type t) {
+    if (t.is_bool()) {
+        return "_u1";
+    } else if (t.is_int() && (t.bits() == 8)) {
+        return "_i8";
+    } else if (t.is_uint() && (t.bits() == 8)) {
+        return "_u8";
+    } else if (t.is_int() && (t.bits() == 16)) {
+        return "_i16";
+    } else if (t.is_uint() && (t.bits() == 16)) {
+        return "_u16";
+    } else if (t.is_int() && (t.bits() == 32)) {
+        return "_i32";
+    } else if (t.is_uint() && (t.bits() == 32)) {
+        return "_u32";
+    } else if (t.is_float() && (t.bits() == 32)) {
+        return "_f32";
+    } else if (t.is_float() && (t.bits() == 16)) {
+        return "_f16";
+    }
+
+    return "";
+}
+
+struct Pattern {
+    enum Flags {
+        InterleaveResult = 1 << 0,  // After evaluating the pattern, interleave native vectors of the result.
+        SwapOps01 = 1 << 1,         // Swap operands 0 and 1 prior to substitution.
+        SwapOps12 = 1 << 2,         // Swap operands 1 and 2 prior to substitution.
+        ExactLog2Op1 = 1 << 3,      // Replace operand 1 with its log base 2, if the log base 2 is exact.
+        ExactLog2Op2 = 1 << 4,      // Save as above, but for operand 2.
+
+        BeginExactLog2Op = 1,  // BeginExactLog2Op and EndExactLog2Op ensure that we check only op1 and op2
+        EndExactLog2Op = 3,    // for ExactLog2Op
+
+        NarrowOp0 = 1 << 10,  // Replace operand 0 with its half-width equivalent.
+        NarrowOp1 = 1 << 11,  // Same as above, but for operand 1.
+        NarrowOp2 = 1 << 12,
+        NarrowOp3 = 1 << 13,
+        NarrowOp4 = 1 << 14,
+        NarrowOps = NarrowOp0 | NarrowOp1 | NarrowOp2 | NarrowOp3 | NarrowOp4,
+
+        NarrowUnsignedOp0 = 1 << 15,  // Similar to the above, but narrow to an unsigned half width type.
+        NarrowUnsignedOp1 = 1 << 16,
+        NarrowUnsignedOp2 = 1 << 17,
+        NarrowUnsignedOp3 = 1 << 18,
+        NarrowUnsignedOp4 = 1 << 19,
+
+        NarrowUnsignedOps = NarrowUnsignedOp0 | NarrowUnsignedOp1 | NarrowUnsignedOp2 | NarrowUnsignedOp3 | NarrowUnsignedOp4,
+
+        AccumulatorOutput24 = 1 << 20,
+        AccumulatorOutput48 = 1 << 21,
+        AccumulatorOutput64 = 1 << 22,
+
+        PassOnlyOp0 = 1 << 23,
+        PassOnlyOp1 = 1 << 24,
+        PassOnlyOp2 = 1 << 25,
+        PassOnlyOp3 = 1 << 26,
+
+        PassOps = PassOnlyOp0 | PassOnlyOp1 | PassOnlyOp2 | PassOnlyOp3,
+        BeginPassOnlyOp = 0,  // BeginPassOnlyOp and EndPassOnlyOp ensure that we check only
+        EndPassOnlyOp = 4,    // PassOps[0|1|2|3].
+
+        SameOp01 = 1 << 27,
+        SameOp12 = 1 << 28,
+    };
+
+    std::string intrin;  // Name of the intrinsic
+    Expr pattern;        // The pattern to match against
+    int flags;
+
+    Pattern() = default;
+    Pattern(const std::string &intrin, Expr p, int flags = 0)
+        : intrin(intrin), pattern(std::move(p)), flags(flags) {
+    }
+};
+
+Expr wild_u8 = Variable::make(UInt(8), "*");
+Expr wild_u16 = Variable::make(UInt(16), "*");
+Expr wild_u32 = Variable::make(UInt(32), "*");
+Expr wild_u64 = Variable::make(UInt(64), "*");
+Expr wild_i8 = Variable::make(Int(8), "*");
+Expr wild_i16 = Variable::make(Int(16), "*");
+Expr wild_i24 = Variable::make(Int(24), "*");
+Expr wild_i32 = Variable::make(Int(32), "*");
+Expr wild_i64 = Variable::make(Int(64), "*");
+Expr wild_f32 = Variable::make(Float(32), "*");
+
+Expr wild_u1x = Variable::make(Type(Type::UInt, 1, 0), "*");
+Expr wild_u8x = Variable::make(Type(Type::UInt, 8, 0), "*");
+Expr wild_u16x = Variable::make(Type(Type::UInt, 16, 0), "*");
+Expr wild_u32x = Variable::make(Type(Type::UInt, 32, 0), "*");
+Expr wild_u64x = Variable::make(Type(Type::UInt, 64, 0), "*");
+Expr wild_i8x = Variable::make(Type(Type::Int, 8, 0), "*");
+Expr wild_i8x4 = Variable::make(Type(Type::Int, 8, 4), "*");
+Expr wild_i8x64 = Variable::make(Type(Type::Int, 8, 64), "*");
+Expr wild_i8x256 = Variable::make(Type(Type::Int, 8, 256), "*");
+Expr wild_u8x4 = Variable::make(Type(Type::UInt, 8, 4), "*");
+Expr wild_u8x64 = Variable::make(Type(Type::UInt, 8, 64), "*");
+Expr wild_u8x256 = Variable::make(Type(Type::UInt, 8, 256), "*");
+
+Expr wild_i16x = Variable::make(Type(Type::Int, 16, 0), "*");
+Expr wild_i24x = Variable::make(Type(Type::Int, 24, 0), "*");
+Expr wild_i24x64 = Variable::make(Type(Type::Int, 24, 64), "*");
+Expr wild_i24x128 = Variable::make(Type(Type::Int, 24, 128), "*");
+Expr wild_i24x256 = Variable::make(Type(Type::Int, 24, 256), "*");
+Expr wild_i32x = Variable::make(Type(Type::Int, 32, 0), "*");
+Expr wild_i48x = Variable::make(Type(Type::Int, 48, 0), "*");
+Expr wild_i64x = Variable::make(Type(Type::Int, 64, 0), "*");
+Expr wild_f32x = Variable::make(Type(Type::Float, 32, 0), "*");
+
+inline Expr i24(Expr e) {
+    Type t = Int(24, e.type().lanes());
+    return cast(t, std::move(e));
+}
+
+inline Expr i48(Expr e) {
+    Type t = Int(48, e.type().lanes());
+    return cast(t, std::move(e));
+}
+
+// Broadcast to an unknown number of lanes, for making patterns.
+Expr bc(Expr x, int lanes = 0) {
+    return Broadcast::make(std::move(x), lanes);
+}
+
+Expr ramp(Expr base, Expr stride, int lanes = 0) {
+    return Ramp::make(std::move(base), std::move(stride), lanes);
+}
+
+Expr vector_reduce(VectorReduce::Operator op, Expr x) {
+    return VectorReduce::make(op, std::move(x), 0);
+}
+
+Expr call(const string &name, const Expr &return_type, const vector<Expr> &args) {
+    return Call::make(return_type.type(), name, args, Call::PureExtern);
+}
+
+Expr concat(const vector<Expr> &x) {
+    return Shuffle::make_concat(x);
+}
+
+Expr repeat_each_element(Expr x, int times) {
+    vector<int> indices;
+    for (int ix = 0; ix < x.type().lanes(); ix++) {
+        for (int iy = 0; iy < times; iy++) {
+            indices.push_back(ix);
+        }
+    }
+    return Shuffle::make({std::move(x)}, indices);
+}
+
+Expr slice(Expr x, int begin, int stride, int size) {
+    return Shuffle::make_slice(std::move(x), begin, stride, size);
+}
+
+Expr load(const Type &type, const string &name, Expr index, ModulusRemainder alignment) {
+    return Load::make(type, name, std::move(index), Buffer<>(), Parameter(), const_true(), alignment);
+}
+
+// Check if the matches satisfy the given pattern flags, and mutate the matches
+// as specified by the flags.
+bool process_match_flags(vector<Expr> &matches, int flags) {
+    // The Pattern::Narrow*Op* flags are ordered such that the operand
+    // corresponds to the bit (with operand 0 corresponding to the least
+    // significant bit), so we can check for them all in a loop.
+    for (size_t i = 0; i < matches.size(); i++) {
+        Type t = matches[i].type();
+        Type target_t = t.with_bits(t.bits() / 2);
+        if (flags & (Pattern::NarrowOp0 << i)) {
+            matches[i] = lossless_cast(target_t, matches[i]);
+        } else if (flags & (Pattern::NarrowUnsignedOp0 << i)) {
+            matches[i] = lossless_cast(target_t.with_code(Type::UInt), matches[i]);
+        }
+        if (!matches[i].defined()) {
+            return false;
+        }
+    }
+
+    for (size_t i = Pattern::BeginExactLog2Op; i < Pattern::EndExactLog2Op; i++) {
+        // This flag is mainly to capture shifts. When the operand of a div or
+        // mul is a power of 2, we can use a shift instead.
+        if (flags & (Pattern::ExactLog2Op1 << (i - Pattern::BeginExactLog2Op))) {
+            int pow;
+            if (is_const_power_of_two_integer(matches[i], &pow)) {
+                matches[i] = cast(matches[i].type().with_lanes(1), pow);
+            } else {
+                return false;
+            }
+        }
+    }
+
+    if (flags & Pattern::PassOps) {
+        vector<Expr> new_matches;
+        for (size_t i = Pattern::BeginPassOnlyOp; i < Pattern::EndPassOnlyOp; i++) {
+            if (flags & (Pattern::PassOnlyOp0 << (i - Pattern::BeginPassOnlyOp))) {
+                new_matches.push_back(matches[i]);
+            }
+        }
+        matches.swap(new_matches);
+    }
+
+    if (flags & Pattern::SwapOps01) {
+        internal_assert(matches.size() >= 2);
+        std::swap(matches[0], matches[1]);
+    }
+    if (flags & Pattern::SwapOps12) {
+        internal_assert(matches.size() >= 3);
+        std::swap(matches[1], matches[2]);
+    }
+
+    if (flags & Pattern::SameOp01) {
+        internal_assert(matches.size() == 2);
+        if (!graph_equal(matches[0], matches[1])) {
+            return false;
+        }
+        matches = {matches[0]};
+    }
+
+    if (flags & Pattern::SameOp12) {
+        internal_assert(matches.size() == 3);
+        if (!graph_equal(matches[1], matches[2])) {
+            return false;
+        }
+        matches = {matches[0], matches[1]};
+    }
+
+    return true;
+}
+
+// Replace an expression with the one specified by a pattern.
+Expr replace_pattern(Expr x, const vector<Expr> &matches, const Pattern &p) {
+    x = Call::make(x.type(), p.intrin, matches, Call::PureExtern);
+    return x;
+}
+// Attempt to apply one of the patterns to x. If a match is
+// successful, the expression is replaced with a call using the
+// matched operands. Prior to substitution, the matches are mutated
+// with op_mutator.
+Expr apply_patterns(Expr x, const vector<Pattern> &patterns, IRMutator *op_mutator) {
+    debug(3) << "apply_patterns " << x << "\n";
+    vector<Expr> matches;
+    for (const Pattern &p : patterns) {
+        if (expr_match(p.pattern, x, matches)) {
+            debug(3) << "matched " << p.pattern << "\n";
+            debug(3) << "to " << x << "\n";
+            debug(3) << "matches:\n";
+            for (const Expr &i : matches) {
+                debug(3) << i << "\n";
+            }
+
+            if (!process_match_flags(matches, p.flags)) {
+                continue;
+            }
+
+            // Mutate the operands with the given mutator.
+            for (Expr &op : matches) {
+                op = op_mutator->mutate(op);
+            }
+
+            Type old_type = x.type();
+            if (p.flags & Pattern::AccumulatorOutput24) {
+                x = cast(Type(Type::Int, 24, x.type().lanes()), x);
+            } else if (p.flags & Pattern::AccumulatorOutput48) {
+                x = cast(Type(Type::Int, 48, x.type().lanes()), x);
+            } else if (p.flags & Pattern::AccumulatorOutput64) {
+                x = cast(Type(Type::Int, 64, x.type().lanes()), x);
+            }
+            x = replace_pattern(x, matches, p);
+            if ((p.flags & Pattern::AccumulatorOutput24) || (p.flags & Pattern::AccumulatorOutput48) || (p.flags & Pattern::AccumulatorOutput64)) {
+                x = cast(old_type, x);
+            }
+
+            debug(3) << "rewrote to: " << x << "\n";
+            return x;
+        }
+    }
+    return x;
+}
+
+template<typename T>
+Expr apply_commutative_patterns(const T *op, const vector<Pattern> &patterns, IRMutator *mutator) {
+    Expr ret = apply_patterns(op, patterns, mutator);
+    if (!ret.same_as(op)) {
+        return ret;
+    }
+
+    // Try commuting the op
+    Expr commuted = T::make(op->b, op->a);
+    ret = apply_patterns(commuted, patterns, mutator);
+    if (!ret.same_as(commuted)) {
+        return ret;
+    }
+
+    return op;
+}
+
+/** A helper for block_to_vector below. */
+void block_to_vector(const Stmt &s, vector<Stmt> &v) {
+    const Block *b = s.as<Block>();
+    if (!b) {
+        v.push_back(s);
+    } else {
+        block_to_vector(b->first, v);
+        block_to_vector(b->rest, v);
+    }
+}
+
+/** Unpack a block into its component Stmts. */
+vector<Stmt> block_to_vector(const Stmt &s) {
+    vector<Stmt> result;
+    block_to_vector(s, result);
+    return result;
+}
+
+class DualQuadMulMutator : public IRGraphMutator {
+private:
+    using IRGraphMutator::visit;
+
+    Expr visit(const Shuffle *op) override {
+
+        // Merge concat extract i32 calls into one dual call
+        if (op->is_concat() && op->vectors.size() == 2) {
+            const Call *call0 = op->vectors[0].as<Call>();
+            const Call *call1 = op->vectors[1].as<Call>();
+            if (call0 && call0->name == "halide_xtensa_extract_u32" &&
+                call1 && call1->name == "halide_xtensa_extract_u32") {
+                vector<Expr> dual_args = {
+                    call1->args[0],  // vector1
+                    call0->args[0],  // vector0
+                    call1->args[1],  // index1
+                    call0->args[1]   // index0
+                };
+                return Call::make(Int(8, 8), "halide_xtensa_dual_extract_i32",
+                                  dual_args, Call::PureExtern);
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    };
+
+    Stmt visit(const Block *op) override {
+        vector<Stmt> new_stmts;
+
+        vector<Stmt> stmts = block_to_vector(op);
+        int quad_mul_expr_count = 0;
+        // Check if all statements in the block are stores of quad-muls.
+        for (auto &stmt : stmts) {
+            // quad_mul is a call contained in store
+            const Store *store1 = stmt.as<Store>();
+            const Call *call1 = store1 ? store1->value.as<Call>() : nullptr;
+            if (!call1 || call1->name != "halide_xtensa_widen_quad_mul_add_u24") {
+                break;
+            }
+            quad_mul_expr_count++;
+        }
+
+        if (quad_mul_expr_count > 1) {
+            // Try to find pairs of quad-muls which have matching second argument.
+            // Track which statements have been used so far.
+            vector<bool> used(stmts.size(), false);
+            for (int first = 0; first < quad_mul_expr_count; first++) {
+                for (int second = first + 1; second < quad_mul_expr_count; second++) {
+                    if (used[first] || used[second]) {
+                        continue;
+                    }
+
+                    const Store *store1 = stmts[first].as<Store>();
+                    const Call *call1 = store1->value.as<Call>();
+
+                    const Store *store2 = stmts[second].as<Store>();
+                    const Call *call2 = store2->value.as<Call>();
+
+                    // Check if two quad-muls have the same operand.
+                    if ((call1->args.size() != 3) || (call2->args.size() != 3) || !equal(call1->args[1], call2->args[1])) {
+                        continue;
+                    }
+
+                    used[first] = true;
+                    used[second] = true;
+
+                    // Update stores to take from dual call result
+                    std::string dual_name = unique_name("_");
+                    Expr dual_24x64 = Variable::make(Type(Type::Int, 24, call1->type.lanes() + call2->type.lanes()),
+                                                     dual_name);
+                    Expr slice0 = Shuffle::make_slice(dual_24x64, 0, 1, call1->type.lanes());
+                    Expr slice1 = Shuffle::make_slice(dual_24x64, call1->type.lanes(), 1, call2->type.lanes());
+                    Stmt new_store0 = Store::make(store1->name, slice0, store1->index,
+                                                  store1->param, store1->predicate, store1->alignment);
+                    Stmt new_store1 = Store::make(store2->name, slice1, store2->index,
+                                                  store2->param, store2->predicate, store2->alignment);
+                    Stmt stores = Block::make(new_store0, new_store1);
+
+                    // Collect inputs for dual call
+                    std::vector<Expr> dual_qm_args = {
+                        concat({call1->args[0], call2->args[0]}),
+                        call1->args[1],
+                        // two of uint8x4_t multipliers.
+                        concat({call1->args[2], call2->args[2]})};
+
+                    // Insert LetStmt with dual call with store scope
+                    new_stmts.push_back(
+                        LetStmt::make(
+                            dual_name,
+                            call("halide_xtensa_dual_widen_quad_mul_add_u24", dual_24x64, dual_qm_args),
+                            stores));
+                }
+            }
+
+            // In the case we haven't used all statements (for example, couldn't find a pair)
+            // just add remaining quad muls to the list of statements.
+            for (int ix = 0; ix < (int)stmts.size(); ix++) {
+                if (!used[ix]) {
+                    new_stmts.push_back(stmts[ix]);
+                }
+            }
+        } else {
+            // Not all statements are stores of quad-muls, so just use the old ones.
+            new_stmts = stmts;
+        }
+
+        // Recursively mutate and check size to see if there is any merge
+        for (Stmt &i : new_stmts) {
+            i = mutate(i);
+        }
+        bool unchanged = new_stmts.size() == stmts.size();
+        if (unchanged) {
+            for (int i = 0; i < (int)new_stmts.size(); ++i) {
+                unchanged = unchanged && new_stmts[i].same_as(stmts[i]);
+            }
+        }
+
+        if (unchanged) {
+            return op;
+        } else {
+            return Block::make(new_stmts);
+        }
+    }
+};
+
+class MatchXtensaPatterns : public IRGraphMutator {
+private:
+    using IRGraphMutator::visit;
+
+    const Target target;
+
+    static Expr halide_xtensa_widen_mul_u24(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i24x.type(), "halide_xtensa_widen_mul_u24", {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_widen_mul_by_diff_u24(Expr v0, Expr v1, Expr v2) {
+        Expr call = Call::make(wild_i24x.type(), "halide_xtensa_widen_mul_by_diff_u24", {std::move(v0), std::move(v1), std::move(v2)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_widen_mul_i48(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i48x.type(), "halide_xtensa_widen_mul_i48", {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_widen_mul_add_i48(Expr v0, Expr v1, Expr v2) {
+        Expr call = Call::make(wild_i48x.type(), "halide_xtensa_widen_mul_add_i48", {std::move(v0), std::move(v1), std::move(v2)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_widen_add_i48(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i48x.type(), "halide_xtensa_widen_add_i48", {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_widen_add_u48(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i48x.type(), "halide_xtensa_widen_add_u48", {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_widen_pair_mul_i48(Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_i48x.type(), "halide_xtensa_widen_pair_mul_i48",
+                               {std::move(v0), std::move(v1), std::move(v2), std::move(v3)},
+                               Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_widen_pair_mul_add_i48(Expr w, Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_i48x.type(), "halide_xtensa_widen_pair_mul_add_i48",
+                               {std::move(w), std::move(v0), std::move(v1), std::move(v2), std::move(v3)},
+                               Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_slice_to_native_i32(Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_i32x.type(), "halide_xtensa_slice_to_native",
+                               {std::move(v0), std::move(v1), std::move(v2), std::move(v3)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_slice_to_native_u32(Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_u32x.type(), "halide_xtensa_slice_to_native",
+                               {std::move(v0), std::move(v1), std::move(v2), std::move(v3)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_slice_to_native_i16(Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_i16x.type(), "halide_xtensa_slice_to_native",
+                               {std::move(v0), std::move(v1), std::move(v2), std::move(v3)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_slice_to_native_u16(Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_u16x.type(), "halide_xtensa_slice_to_native",
+                               {std::move(v0), std::move(v1), std::move(v2), std::move(v3)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_i16(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i16x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_u16(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_u16x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_i24(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i24x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_i32(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i32x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_i32(Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_i32x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1), std::move(v2), std::move(v3)},
+                               Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_u32(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_u32x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_u1(Expr v0, Expr v1, Expr v2, Expr v3) {
+        Expr call = Call::make(wild_u1x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1), std::move(v2), std::move(v3)}, Call::PureExtern);
+        return call;
+    }
+
+    static Expr halide_xtensa_concat_from_native_i48(Expr v0, Expr v1) {
+        Expr call = Call::make(wild_i48x.type(), "halide_xtensa_concat_from_native",
+                               {std::move(v0), std::move(v1)}, Call::PureExtern);
+        return call;
+    }
+
+    Expr visit(const Add *op) override {
+        if (op->type.is_vector()) {
+            static const std::vector<Pattern> adds = {
+                // Predicated addition
+                // NOTE(vksnk): patterns below are for predicated instructions and look like they may
+                // be more efficient, but they are not according to simulator. We will need to check with
+                // Cadence about this.
+                // {"halide_xtensa_pred_add_i8", wild_i8x + select(wild_u1x, wild_i8x, wild_i8x)},
+                // {"halide_xtensa_pred_add_i16", wild_i16x + select(wild_u1x, wild_i16x, wild_i16x)},
+                // {"halide_xtensa_pred_add_i32", wild_i32x + select(wild_u1x, wild_i32x, wild_i32x)},
+
+                {"halide_xtensa_qqqq", slice(wild_i24x256, 0, 1, 128) + slice(wild_i24x256, 128, 1, 128), Pattern::SameOp01},
+                {"halide_xtensa_yyyy", (call("halide_xtensa_xxxx", wild_i24x64, {wild_i24x64, wild_i24x128}) + slice(wild_i24x128, 64, 1, 64)), Pattern::SameOp12},
+                {"halide_xtensa_xxxx", (wild_i24x64 + slice(wild_i24x128, 0, 1, 64))},
+
+                {"halide_xtensa_widen_quad_add_i48", widening_add(wild_i16x, wild_i16x) + widening_add(wild_i16x, wild_i16x), Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_quad_add_i48", i32(halide_xtensa_widen_add_i48(wild_i16x, wild_i16x)) + i32(halide_xtensa_widen_add_i48(wild_i16x, wild_i16x)), Pattern::AccumulatorOutput48},
+
+                {"halide_xtensa_widen_pair_mul_i48", widening_mul(wild_i16x, wild_i16x) + widening_mul(wild_i16x, wild_i16x), Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_pair_mul_u48", widening_mul(wild_u16x, wild_u16x) + widening_mul(wild_u16x, wild_u16x), Pattern::AccumulatorOutput48},
+
+                {"halide_xtensa_widen_pair_mul_i48", i48(wild_i16x) * i48(wild_i16x) + i48(wild_i16x) * i48(wild_i16x)},
+                {"halide_xtensa_widen_pair_mul_u48", i48(wild_u16x) * i48(wild_u16x) + i48(wild_u16x) * i48(wild_u16x)},
+
+                {"halide_xtensa_widen_pair_mul_i24", i24(wild_i8x) * i24(wild_i8x) + i24(wild_i8x) * i24(wild_i8x)},
+                {"halide_xtensa_widen_pair_mul_u24", i24(wild_u8x) * i24(wild_u8x) + i24(wild_u8x) * i24(wild_u8x)},
+
+                // Multiply-add to accumulator type.
+                {"halide_xtensa_widen_pair_mul_add_i48", i32(halide_xtensa_widen_mul_add_i48(wild_i48x, wild_i16x, wild_i16x)) + i32(halide_xtensa_widen_mul_i48(wild_i16x, wild_i16x)), Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_pair_mul_add_i48", halide_xtensa_widen_mul_add_i48(wild_i48x, wild_i16x, wild_i16x) + halide_xtensa_widen_mul_i48(wild_i16x, wild_i16x)},
+
+                {"halide_xtensa_widen_mul_add_i48", i32(wild_i48x) + i32(halide_xtensa_widen_mul_i48(wild_i16x, wild_i16x)), Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_mul_add_i48", wild_i48x + halide_xtensa_widen_mul_i48(wild_i16x, wild_i16x)},
+
+                {"halide_xtensa_widen_mul_add_u24", wild_i24x + halide_xtensa_widen_mul_u24(wild_u8x, wild_u8x)},
+                {"halide_xtensa_widen_mul_add_by_diff_u24", wild_i24x + halide_xtensa_widen_mul_by_diff_u24(wild_u8x, wild_u8, wild_u8x)},
+
+                {"halide_xtensa_widen_mul_add_i24",
+                 wild_i24x + call("halide_xtensa_widen_mul_i24", wild_i24x, {wild_i8x, wild_i8x})},
+
+                {"halide_xtensa_widen_quad_mul_add_i24",
+                 wild_i24x + call("halide_xtensa_widen_quad_mul_i24", wild_i24x, {wild_i8x, wild_i8x, wild_i8x, wild_i8x, wild_i8x})},
+
+                // Add to accumulator type.
+                // Paired add.
+                {"halide_xtensa_widen_pair_add_i48", i32(halide_xtensa_widen_add_i48(wild_i48x, wild_i16x)) + wild_i16x, Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_pair_add_i48", i32(halide_xtensa_widen_add_i48(wild_i48x, wild_i16x)) + wild_i32x, Pattern::AccumulatorOutput48 | Pattern::NarrowOp2},
+                {"halide_xtensa_widen_pair_add_u48", u32(halide_xtensa_widen_add_u48(wild_i48x, wild_u16x)) + wild_u16x, Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_pair_add_u48", u32(halide_xtensa_widen_add_u48(wild_i48x, wild_u16x)) + wild_u32x, Pattern::AccumulatorOutput48 | Pattern::NarrowUnsignedOp2},
+                // Single add.
+                {"halide_xtensa_widen_add_i48", i32(wild_i48x) + wild_i16x, Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_add_i48", i32(wild_i48x) + wild_i32x, Pattern::AccumulatorOutput48 | Pattern::NarrowOp1},
+                {"halide_xtensa_widen_add_u48", u32(wild_i48x) + wild_u16x, Pattern::AccumulatorOutput48},
+                {"halide_xtensa_widen_add_u48", u32(wild_i48x) + wild_u32x, Pattern::AccumulatorOutput48 | Pattern::NarrowUnsignedOp1},
+
+                {"halide_xtensa_widen_add_i24", i16(wild_i24x) + wild_i8x, Pattern::AccumulatorOutput24},
+                {"halide_xtensa_widen_add_i24", i16(wild_i24x) + wild_i16x, Pattern::AccumulatorOutput24 | Pattern::NarrowOp1},
+
+                {"halide_xtensa_widen_mul_add_i64", widening_mul(wild_i32x, wild_i32x) + bc(wild_i64), Pattern::NarrowOp2 | Pattern::AccumulatorOutput64},
+                {"halide_xtensa_widen_mul_add_i64", widening_mul(wild_i32x, wild_i32x) + wild_i64x, Pattern::NarrowOp2 | Pattern::AccumulatorOutput64},
+                {"halide_xtensa_widen_mul_add_i64", i32(wild_i64x) + i32(call("halide_xtensa_mul_i32", wild_i64x, {wild_i32x, wild_i32x})), Pattern::AccumulatorOutput64},
+            };
+
+            Expr new_expr = apply_commutative_patterns(op, adds, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Sub *op) override {
+        if (op->type.is_vector()) {
+            static const std::vector<Pattern> subs = {
+                // Predicated sub.
+                // NOTE(vksnk): patterns below are for predicated instructions and look like they may
+                // be more efficient, but they are not according to simulator. We will need to check with
+                // Cadence about this.
+                // {"halide_xtensa_pred_sub_i8", wild_i8x - select(wild_u1x, wild_i8x, wild_i8x)},
+                // {"halide_xtensa_pred_sub_i16", wild_i16x - select(wild_u1x, wild_i16x, wild_i16x)},
+                // {"halide_xtensa_pred_sub_i32", wild_i32x - select(wild_u1x, wild_i32x, wild_i32x)},
+                {"halide_xtensa_widen_mul_sub_u24", wild_i24x - halide_xtensa_widen_mul_u24(wild_u8x, wild_u8x)},
+            };
+
+            Expr new_expr = apply_patterns(op, subs, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Mul *op) override {
+        if (op->type.is_vector()) {
+            static const std::vector<Pattern> scalar_muls = {};
+
+            static const std::vector<Pattern> muls = {
+                {"halide_xtensa_widen_mul_i24", i24(wild_i8x) * bc(i24(wild_i8))},
+                {"halide_xtensa_widen_mul_u24", i24(wild_u8x) * bc(i24(wild_u8))},
+
+                {"halide_xtensa_widen_mul_i24", i24(wild_i8x) * i24(wild_i8x)},
+                {"halide_xtensa_widen_mul_u24", i24(wild_u8x) * i24(wild_u8x)},
+
+                {"halide_xtensa_widen_mul_by_diff_u24", (i24(wild_u8x) - bc(i24(wild_u8))) * bc(i24(wild_u8))},
+                {"halide_xtensa_widen_mul_by_diff_u24", (i24(wild_u8x) - bc(i24(wild_u8))) * i24(wild_u8x)},
+
+                {"halide_xtensa_widen_mul_i48", i48(wild_i16x) * i48(wild_i16x)},
+
+                {"halide_xtensa_mul_i32", wild_i32x * wild_i32x, Pattern::AccumulatorOutput64},
+
+                {"halide_xtensa_widen_zzzzz", i24(concat({wild_i8x64, wild_i8x64, wild_i8x64, wild_i8x64})) * i24(repeat_each_element(wild_i8x4, 64))},
+                {"halide_xtensa_widen_zzzzz", i24(wild_i8x256) * i24(repeat_each_element(wild_i8x4, 64))},
+                {"halide_xtensa_widen_zzzzz", i24(wild_u8x256) * bc(i24(wild_u8), 256)},
+                {"halide_xtensa_widen_zzzzz", i24(concat({wild_u8x64, wild_u8x64, wild_u8x64, wild_u8x64})) * i24(repeat_each_element(wild_u8x4, 64))},
+                {"halide_xtensa_widen_zzzzz", i24(wild_u8x256) * i24(repeat_each_element(wild_u8x4, 64))},
+
+                // Widening multiplication
+                // NOTE(vksnk): looked like a good idea, but seems to be slower. Need to double-check.
+                // {"halide_xtensa_widen_sqr_i48", wild_i32x * wild_i32x, Pattern::SameOp01 | Pattern::NarrowOps | Pattern::AccumulatorOutput48},
+            };
+
+            Expr new_expr = apply_commutative_patterns(op, scalar_muls, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+
+            new_expr = apply_commutative_patterns(op, muls, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Div *op) override {
+        if (op->type.is_vector()) {
+            Expr div = op;
+            static const std::vector<Pattern> divs = {
+                // TODO(vksnk): Before enabling it add a check for ExactLogOp
+                // {"halide_xtensa_div_i32_i16", wild_i32x / wild_i32x, Pattern::NarrowOp1}
+                {"halide_xtensa_narrow_i48_with_shift_i32", i32(wild_i48x) / wild_i32, Pattern::ExactLog2Op1},
+                {"halide_xtensa_narrow_i48_with_shift_u32", u32(wild_i48x) / wild_u32, Pattern::ExactLog2Op1},
+            };
+
+            Expr new_expr = apply_patterns(div, divs, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Max *op) override {
+        if (op->type.is_vector()) {
+            static const std::vector<Pattern> maxes = {
+                // NOTE(vksnk): patterns below are for predicated instructions and look like they may
+                // be more efficient, but they are not according to simulator. We will need to check with
+                // Cadence about this.
+                // {"halide_xtensa_pred_max_i16", max(wild_i16x, select(wild_u1x, wild_i16x, wild_i16x))}
+            };
+
+            Expr new_expr = apply_commutative_patterns(op, maxes, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Min *op) override {
+        if (op->type.is_vector()) {
+            static const std::vector<Pattern> maxes = {
+                // NOTE(vksnk): patterns below are for predicated instructions and look like they may
+                // be more efficient, but they are not according to simulator. We will need to check with
+                // Cadence about this.
+                // {"halide_xtensa_pred_min_i16", max(wild_i16x, select(wild_u1x, wild_i16x, wild_i16x))}
+            };
+
+            Expr new_expr = apply_commutative_patterns(op, maxes, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Cast *op) override {
+        // TODO(vksnk): disable widening_load until correctness issue is fixed.
+        // // Try to look for widening loads.
+        // if (const Load *load = op->value.as<Load>()) {
+        //     Expr dense_ramp_base = strided_ramp_base(load->index, 1);
+        //     if (dense_ramp_base.defined() && is_const_one(load->predicate) && (op->type.is_int_or_uint()) && ((op->type.bits() == 16) || (op->type.bits() == 32)) && (load->type.is_int_or_uint()) && (2 * load->type.bits() == op->type.bits())) {
+        //         // The third argument is just to pass the type of load.
+        //         return Call::make(op->type, "halide_xtensa_widening_load", {Variable::make(type_of<void *>(), load->name), dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern);
+        //     }
+        // }
+
+        // if (const Shuffle *concat = op->value.as<Shuffle>()) {
+        //     if (concat->is_concat()) {
+        //         std::vector<Expr> widened_loads;
+        //         for (const Expr &v : concat->vectors) {
+        //             if (const Load *load = v.as<Load>()) {
+        //                 Expr dense_ramp_base = strided_ramp_base(load->index, 1);
+        //                 if (dense_ramp_base.defined() && is_const_one(load->predicate) && (op->type.is_int_or_uint()) && ((op->type.bits() == 16) || (op->type.bits() == 32)) && (load->type.is_int_or_uint()) && (2 * load->type.bits() == op->type.bits())) {
+        //                     // The third argument is just to pass the type of load.
+        //                     widened_loads.push_back(Call::make(op->type.with_lanes(v.type().lanes()), "halide_xtensa_widening_load", {Variable::make(type_of<void *>(), load->name), dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern));
+        //                 }
+        //             }
+        //         }
+
+        //         if (widened_loads.size() == concat->vectors.size()) {
+        //             return Shuffle::make_concat(widened_loads);
+        //         }
+        //     }
+        // }
+
+        static const std::vector<Pattern> casts = {
+            // Narrowing multiply with shift.
+            // {"halide_xtensa_sat_mul_with_shift_i32", i32(wild_i64x * wild_i64x / wild_i64), Pattern::NarrowOp0 | Pattern::NarrowUnsignedOp1 | Pattern::ExactLog2Op2},
+
+            // Casts from bool.
+            {"halide_xtensa_convert_u1_to_i16", i16(i8(wild_u1x))},
+
+            // Narrowing with shifting.
+            {"halide_xtensa_narrow_i48_with_shift_i16", i16(i32(wild_i48x) >> wild_i32)},
+            {"halide_xtensa_narrow_i48_with_shift_i16", i16(i32(wild_i48x) / wild_i32), Pattern::ExactLog2Op1},
+            {"halide_xtensa_narrow_i48_with_shift_u16", u16(u32(wild_i48x) >> wild_u32)},
+            {"halide_xtensa_narrow_i48_with_shift_u16", u16(u32(wild_i48x) / wild_u32), Pattern::ExactLog2Op1},
+
+            {"halide_xtensa_narrow_i48_with_shift_i16", i16(wild_i48x >> wild_i32)},
+            {"halide_xtensa_narrow_i48_with_shift_i16", i16(wild_i48x / wild_i32), Pattern::ExactLog2Op1},
+            {"halide_xtensa_narrow_i48_with_shift_u16", u16(wild_i48x >> wild_u32)},
+            {"halide_xtensa_narrow_i48_with_shift_u16", u16(wild_i48x / wild_u32), Pattern::ExactLog2Op1},
+
+            {"halide_xtensa_narrow_i48_with_rounding_shift_i16", i16(rounding_shift_right(i32(wild_i48x), wild_i32))},
+            {"halide_xtensa_narrow_i48_with_rounding_shift_u16", u16(rounding_shift_right(u32(wild_i48x), wild_u32))},
+
+            {"halide_xtensa_narrow_with_shift_i16", i16(wild_i32x >> wild_i32)},
+            {"halide_xtensa_narrow_with_shift_i16", i16(wild_i32x / wild_i32), Pattern::ExactLog2Op1},
+            {"halide_xtensa_narrow_with_shift_u16", u16(wild_i32x >> wild_i32)},
+            {"halide_xtensa_narrow_with_shift_u16", u16(wild_i32x / wild_i32), Pattern::ExactLog2Op1},
+
+            {"halide_xtensa_narrow_with_rounding_shift_i8", i8(rounding_shift_right(wild_i16x, bc(wild_u16)))},
+            {"halide_xtensa_narrow_with_rounding_shift_u8", u8(rounding_shift_right(wild_i16x, bc(wild_u16)))},
+            {"halide_xtensa_narrow_with_rounding_shift_i16", i16(rounding_shift_right(wild_i32x, bc(wild_u32)))},
+
+            // Looks like there is no such instruction.
+            // {"halide_xtensa_sat_narrow_with_rounding_shift_u16", u16_sat(rounding_shift_right(wild_i32x, wild_u32))},
+
+            {"halide_xtensa_narrow_i24_with_shift_i16", i16(wild_i24x >> wild_i24)},
+            {"halide_xtensa_narrow_i24_with_shift_i16", i16(wild_i24x / wild_i24), Pattern::ExactLog2Op1},
+
+            {"halide_xtensa_narrow_i24_with_shift_i8", i8(wild_i24x >> wild_i24)},
+            {"halide_xtensa_narrow_i24_with_shift_i8", i8(wild_i24x / wild_i24), Pattern::ExactLog2Op1},
+            {"halide_xtensa_narrow_i24_with_shift_u8", u8(wild_i24x >> wild_i24)},
+            {"halide_xtensa_narrow_i24_with_shift_u8", u8(wild_i24x / wild_i24), Pattern::ExactLog2Op1},
+
+            {"halide_xtensa_narrow_high_i32", i32(wild_i64x >> 32)},
+            {"halide_xtensa_narrow_high_i32", i32(wild_i64x / IntImm::make(Int(64), 4294967296ll))},
+
+            {"halide_xtensa_narrow_shift_i32", i32(wild_i64x >> bc(wild_i64))},
+            {"halide_xtensa_narrow_shift_i32", i32(wild_i64x / bc(wild_i64)), Pattern::ExactLog2Op1},
+            {"halide_xtensa_narrow_shift_i32", i32(wild_i64x >> bc(wild_u64))},
+            {"halide_xtensa_narrow_shift_i32", i32(wild_i64x / bc(wild_u64)), Pattern::ExactLog2Op1},
+
+            // Concat and cast.
+            {"halide_xtensa_convert_concat_i16_to_i8", i8(halide_xtensa_concat_from_native_i16(wild_i16x, wild_i16x))},
+            {"halide_xtensa_convert_concat_i16_to_u8", u8(halide_xtensa_concat_from_native_i16(wild_i16x, wild_i16x))},
+            {"halide_xtensa_convert_concat_u16_to_i8", i8(halide_xtensa_concat_from_native_u16(wild_u16x, wild_u16x))},
+            {"halide_xtensa_convert_concat_u16_to_u8", u8(halide_xtensa_concat_from_native_u16(wild_u16x, wild_u16x))},
+            {"halide_xtensa_convert_concat_i32_to_i16", i16(halide_xtensa_concat_from_native_i32(wild_i32x, wild_i32x))},
+            {"halide_xtensa_convert_concat_i32_to_u16", u16(halide_xtensa_concat_from_native_i32(wild_i32x, wild_i32x))},
+            {"halide_xtensa_convert_concat_u32_to_i16", i16(halide_xtensa_concat_from_native_u32(wild_u32x, wild_u32x))},
+            {"halide_xtensa_convert_concat_u32_to_u16", u16(halide_xtensa_concat_from_native_u32(wild_u32x, wild_u32x))},
+
+            // NOTE(vksnk): looked like a good idea, but seems to be slower. Need to double-check.
+            // {"halide_xtensa_narrow_clz_i16", i16(count_leading_zeros(wild_u32x))},
+            // {"halide_xtensa_narrow_clz_i16", i16(count_leading_zeros(wild_i32x))},
+        };
+        if (op->type.is_vector()) {
+            Expr cast = op;
+
+            std::vector<Expr> matches;
+
+            Expr new_expr = apply_patterns(cast, casts, this);
+            if (!new_expr.same_as(cast)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Shuffle *op) override {
+        if (op->is_slice() && (op->slice_stride() == 1) && (op->slice_begin() % 4 == 0) && op->type.is_int_or_uint() && (op->type.bits() == 8) && (op->type.lanes() == 4)) {
+
+            return Call::make(op->type, std::string("halide_xtensa_extract_") + (op->type.is_int() ? "i32" : "u32"),
+                              {mutate(op->vectors[0]), op->slice_begin() / 4}, Call::PureExtern);
+        } else if (op->type.is_int_or_uint() && (op->type.bits() == 8) && (op->type.lanes() == 64)) {
+            if ((op->vectors.size() == 1) && (op->vectors[0].type().lanes() == 192)) {
+                bool is_extract_0_of_3 = true;
+                for (int ix = 0; ix < (int)op->indices.size(); ix++) {
+                    is_extract_0_of_3 = is_extract_0_of_3 && (op->indices[ix] == 3 * ix);
+                }
+
+                if (is_extract_0_of_3) {
+                    Expr op_vector = mutate(op->vectors[0]);
+                    vector<Expr> args = {op_vector};
+                    const Shuffle *maybe_shuffle = op_vector.as<Shuffle>();
+                    if (maybe_shuffle && maybe_shuffle->is_concat()) {
+                        args = maybe_shuffle->vectors;
+                    }
+                    if (op->type.is_int()) {
+                        return Call::make(op->type, "halide_xtensa_extract_0_of_3_i8",
+                                          args, Call::PureExtern);
+                    } else if (op->type.is_uint()) {
+                        return Call::make(op->type, "halide_xtensa_extract_0_of_3_u8",
+                                          args, Call::PureExtern);
+                    }
+                }
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Call *op) override {
+        // TODO(vksnk): disable widening_load until correctness issue is fixed.
+        // if (op->name == "halide_xtensa_slice_to_native") {
+        //     if (const Cast *cast = op->args[0].as<Cast>()) {
+        //         internal_assert(op->args.size() == 4);
+        //         if (const Load *load = cast->value.as<Load>()) {
+        //             Expr dense_ramp_base = strided_ramp_base(load->index, 1);
+
+        //             if (dense_ramp_base.defined() && is_const_one(load->predicate) && (cast->type.is_int_or_uint()) && ((cast->type.bits() == 16) || (cast->type.bits() == 32)) && (load->type.is_int_or_uint()) && (2 * load->type.bits() == cast->type.bits())) {
+        //                 // arg1 is an index and arg2 is a native vector size.
+        //                 dense_ramp_base = dense_ramp_base + op->args[1] * op->args[2];
+        //                 // The third argument is just to pass the type of load.
+        //                 return Call::make(op->type, "halide_xtensa_widening_load", {Variable::make(type_of<void *>(), load->name), dense_ramp_base, make_one(load->type.element_of())}, Call::PureExtern);
+        //             }
+        //         }
+        //     }
+        // }
+
+        // NOTE(vksnk): there seems to be a single instructions which could do lerp-like compute,
+        // but documentation is confusing and I couldn't get it right, so need to revisit at some point.
+        // if (op->is_intrinsic(Call::lerp) && op->type.is_int() && (op->type.bits() == 16) && (op->type.lanes() == 32)) {
+        //   internal_assert(op->args.size() == 3);
+        //   Expr weight = mutate(op->args[2]);
+        //   const Broadcast* maybe_bc = weight.as<Broadcast>();
+        //   if (maybe_bc) {
+        //     weight = maybe_bc->value;
+        //   }
+        //   return Call::make(op->type, "halide_xtensa_lerp_i16",
+        //                     {mutate(op->args[0]), mutate(op->args[1]), weight},
+        //                     Call::PureExtern);
+        // } else
+        if (op->is_intrinsic(Call::lerp)) {
+            // We need to lower lerps now to optimize the arithmetic
+            // that they generate.
+            internal_assert(op->args.size() == 3);
+            return mutate(lower_lerp(op->type, op->args[0], op->args[1], op->args[2], target));
+        } else if (op->is_intrinsic(Call::absd) && op->type.is_vector() && op->type.is_uint() && (op->type.bits() == 16)) {
+            internal_assert(op->args.size() == 2);
+            return Call::make(op->type, "halide_xtensa_absd_i16",
+                              {mutate(op->args[0]), mutate(op->args[1])},
+                              Call::PureExtern);
+        } else if (op->is_intrinsic(Call::widening_shift_left)) {
+            // Replace widening left shift with multiplication.
+            const uint64_t *c = as_const_uint(op->args[1]);
+            if (c && op->args[1].type().can_represent((uint64_t)1 << *c)) {
+                if (op->args[0].type().is_int() && (*c < op->args[0].type().bits() - 1)) {
+                    return mutate(widening_mul(op->args[0], bc(IntImm::make(op->args[1].type().with_code(halide_type_int).with_lanes(1), (int64_t)1 << *c), op->args[1].type().lanes())));
+                } else {
+                    return mutate(widening_mul(op->args[0], bc(UIntImm::make(op->args[1].type().with_lanes(1), (uint64_t)1 << *c), op->args[1].type().lanes())));
+                }
+            }
+        }
+
+        int slice_width_i16 = target.natural_vector_size<int16_t>();
+        int slice_width_i32 = target.natural_vector_size<int32_t>();
+
+        static const std::vector<Pattern> calls = {
+            {"halide_xtensa_abs_i8", abs(wild_i8x)},
+            {"halide_xtensa_abs_i16", abs(wild_i16x)},
+            {"halide_xtensa_abs_i32", abs(wild_i32x)},
+            {"halide_xtensa_abs_f32", abs(wild_f32x)},
+
+            {"halide_xtensa_avg_u8", halving_add(wild_u8x, wild_u8x)},
+            {"halide_xtensa_avg_i8", halving_add(wild_i8x, wild_i8x)},
+
+            {"halide_xtensa_avg_u16", halving_add(wild_u16x, wild_u16x)},
+            {"halide_xtensa_avg_i16", halving_add(wild_i16x, wild_i16x)},
+
+            // {"halide_xtensa_avg_u32", halving_add(wild_u32x, wild_u32x)},
+            // {"halide_xtensa_avg_i32", halving_add(wild_i32x, wild_i32x)},
+
+            {"halide_xtensa_avg_round_u8", rounding_halving_add(wild_u8x, wild_u8x)},
+            {"halide_xtensa_avg_round_i8", rounding_halving_add(wild_i8x, wild_i8x)},
+
+            {"halide_xtensa_avg_round_u16", rounding_halving_add(wild_u16x, wild_u16x)},
+            {"halide_xtensa_avg_round_i16", rounding_halving_add(wild_i16x, wild_i16x)},
+
+            // {"halide_xtensa_avg_round_u32", rounding_halving_add(wild_u32x, wild_u32x)},
+            // {"halide_xtensa_avg_round_i32", rounding_halving_add(wild_i32x, wild_i32x)},
+
+            {"halide_xtensa_sat_add_i16", saturating_add(wild_i16x, wild_i16x)},
+            {"halide_xtensa_sat_add_i32", saturating_add(wild_i32x, wild_i32x)},
+            {"halide_xtensa_sat_sub_i16", saturating_sub(wild_i16x, wild_i16x)},
+
+            {"halide_xtensa_widen_mul_i24", widening_mul(wild_i8x, wild_i8x), Pattern::AccumulatorOutput24},
+            {"halide_xtensa_widen_mul_u24", widening_mul(wild_u8x, wild_u8x), Pattern::AccumulatorOutput24},
+
+            {"halide_xtensa_widen_mul_i48", widening_mul(wild_i16x, wild_i16x), Pattern::AccumulatorOutput48},
+            {"halide_xtensa_widen_mul_ui48", widening_mul(wild_u16x, wild_i16x), Pattern::AccumulatorOutput48},
+            {"halide_xtensa_widen_mul_ui48", widening_mul(wild_i16x, wild_u16x), Pattern::AccumulatorOutput48 | Pattern::SwapOps01},
+            {"halide_xtensa_widen_mul_u48", widening_mul(wild_u16x, wild_u16x), Pattern::AccumulatorOutput48},
+            {"halide_xtensa_widen_mul_i64", widening_mul(wild_i32x, wild_i32x), Pattern::AccumulatorOutput64},
+            {"halide_xtensa_widen_mul_u64", widening_mul(wild_u32x, wild_u32x), Pattern::AccumulatorOutput64},
+
+            {"halide_xtensa_widen_add_u48", widening_add(wild_u16x, wild_u16x), Pattern::AccumulatorOutput48},
+            {"halide_xtensa_widen_add_i48", widening_add(wild_i16x, wild_i16x), Pattern::AccumulatorOutput48},
+
+            {"halide_xtensa_widen_right_mul_u64", widen_right_mul(wild_u32x, wild_u16x), Pattern::AccumulatorOutput64},
+
+            {"halide_xtensa_widen_zzzzz", halide_xtensa_widen_mul_u24(wild_u8x256, wild_u8)},
+            {"halide_xtensa_widen_zzzzz", halide_xtensa_widen_mul_u24(concat({wild_u8x64, wild_u8x64, wild_u8x64, wild_u8x64}), repeat_each_element(wild_u8x4, 64))},
+            {"halide_xtensa_widen_zzzzz", halide_xtensa_widen_mul_u24(repeat_each_element(wild_u8x4, 64), wild_u8x256), Pattern::SwapOps01},
+
+            // {"halide_xtensa_rounding_mul_shift_right_i8", rounding_mul_shift_right(wild_i8x, wild_i8x, bc(wild_u8))},
+            // {"halide_xtensa_rounding_mul_shift_right_i16", rounding_mul_shift_right(wild_i16x, wild_i16x, bc(wild_u16))},
+            // {"halide_xtensa_rounding_mul_shift_right_i32", rounding_mul_shift_right(wild_i32x, wild_i32x, bc(wild_u32))},
+
+            {"halide_xtensa_sat_narrow_with_rounding_shift_i8", i8_sat(rounding_shift_right(wild_i16x, wild_u16))},
+            {"halide_xtensa_sat_narrow_with_rounding_shift_u8", u8_sat(rounding_shift_right(wild_i16x, wild_u16))},
+            {"halide_xtensa_sat_narrow_with_rounding_shift_i16", i16_sat(rounding_shift_right(wild_i32x, wild_u32))},
+            {"halide_xtensa_sat_narrow_with_rounding_shift_i32", i32_sat(rounding_shift_right(wild_i64x, wild_u64))},
+
+            {"halide_xtensa_sat_narrow_with_signed_rounding_shift_i8", i8_sat(rounding_shift_right(wild_i16x, wild_i16))},
+            {"halide_xtensa_sat_narrow_with_signed_rounding_shift_u8", u8_sat(rounding_shift_right(wild_i16x, wild_i16))},
+            {"halide_xtensa_sat_narrow_with_signed_rounding_shift_i16", i16_sat(rounding_shift_right(wild_i32x, wild_i32))},
+            {"halide_xtensa_sat_narrow_with_signed_rounding_shift_i32", i32_sat(rounding_shift_right(wild_i64x, wild_i64))},
+
+            {"halide_xtensa_sat_left_shift_i16", i16_sat(widening_shift_left(wild_i16x, wild_i16x))},
+            {"halide_xtensa_sat_left_shift_i16", i16_sat(widening_shift_left(wild_i16x, wild_u16x))},
+
+            {"halide_xtensa_sat_left_shift_i32", i32_sat(widening_shift_left(wild_i32x, wild_i32x))},
+            {"halide_xtensa_sat_left_shift_i32", i32_sat(widening_shift_left(wild_i32x, wild_u32x))},
+
+            {"halide_xtensa_sat_narrow_shift_i32", i32_sat(wild_i64x >> bc(wild_i64))},
+            {"halide_xtensa_sat_narrow_shift_i32", i32_sat(wild_i64x / bc(wild_i64)), Pattern::ExactLog2Op1},
+            {"halide_xtensa_sat_narrow_shift_i32", i32_sat(wild_i64x >> bc(wild_u64))},
+            {"halide_xtensa_sat_narrow_shift_i32", i32_sat(wild_i64x / bc(wild_u64)), Pattern::ExactLog2Op1},
+
+            {"halide_xtensa_sat_narrow_i24x_with_shift_u8", u8_sat(i16(wild_i24x) >> bc(wild_i16))},
+            {"halide_xtensa_sat_narrow_i24x_with_shift_u8", u8_sat(i16(wild_i24x) / bc(wild_i16)), Pattern::ExactLog2Op1},
+
+            {"halide_xtensa_sat_narrow_i8", i8_sat(wild_i16x)},
+            {"halide_xtensa_sat_narrow_u8", u8_sat(wild_i16x)},
+            {"halide_xtensa_sat_narrow_i16", i16_sat(wild_i32x)},
+
+            {"halide_xtensa_rounding_shift_right_i8", rounding_shift_right(wild_i8x, bc(wild_u8))},
+            // {"halide_xtensa_rounding_shift_right_u8", rounding_shift_right(wild_u8x, bc(wild_u8))},
+            {"halide_xtensa_rounding_shift_right_i16", rounding_shift_right(wild_i16x, bc(wild_u16))},
+            // {"halide_xtensa_rounding_shift_right_u16", rounding_shift_right(wild_u16x, bc(wild_u16))},
+            {"halide_xtensa_rounding_shift_right_i32", rounding_shift_right(wild_i32x, bc(wild_u32))},
+            // {"halide_xtensa_rounding_shift_right_u32", rounding_shift_right(wild_u32x, bc(wild_u32))},
+
+            {"halide_xtensa_narrow_i48_with_shift_i16", call("halide_xtensa_narrow_with_shift_i16", wild_i16x, {i32(wild_i48x), wild_i32})},
+            {"halide_xtensa_narrow_i48_with_rounding_shift_i16", call("halide_xtensa_narrow_with_rounding_shift_i16", wild_i16x, {i32(wild_i48x), wild_u32})},
+
+            {"halide_xtensa_widen_pair_mul_add_u24",
+             call("halide_xtensa_yyyy", wild_i24x, {wild_i24x, halide_xtensa_concat_from_native_i24(halide_xtensa_widen_mul_u24(wild_u8x, wild_u8x), halide_xtensa_widen_mul_u24(wild_u8x, wild_u8x))})},
+
+            {"halide_xtensa_widen_quad_mul_add_i24",
+             call("halide_xtensa_yyyy", wild_i24x, {wild_i24x, call("halide_xtensa_qqqq", wild_i24x, {call("halide_xtensa_widen_zzzzz", wild_i24x, {wild_i8x, wild_i8x, wild_i8x, wild_i8x, wild_i8x})})})},
+
+            {"halide_xtensa_widen_quad_mul_add_i24",
+             call("halide_xtensa_yyyy", wild_i24x, {wild_i24x, call("halide_xtensa_qqqq", wild_i24x, {call("halide_xtensa_widen_zzzzz", wild_i24x, {wild_i8x256, wild_i8x4})})})},
+
+            {"halide_xtensa_widen_quad_mul_add_u24",
+             call("halide_xtensa_yyyy", wild_i24x, {wild_i24x, call("halide_xtensa_qqqq", wild_i24x, {call("halide_xtensa_widen_zzzzz", wild_i24x, {wild_u8x, wild_u8x, wild_u8x, wild_u8x, wild_u8x})})})},
+
+            {"halide_xtensa_widen_quad_mul_add_u24",
+             call("halide_xtensa_yyyy", wild_i24x, {wild_i24x, call("halide_xtensa_qqqq", wild_i24x, {call("halide_xtensa_widen_zzzzz", wild_i24x, {wild_u8x256, wild_u8x4})})})},
+
+            {"halide_xtensa_widen_quad_mul_add_by_scalar_u24",
+             call("halide_xtensa_yyyy", wild_i24x, {wild_i24x, call("halide_xtensa_qqqq", wild_i24x, {call("halide_xtensa_widen_zzzzz", wild_i24x, {wild_u8x256, wild_u8})})})},
+
+            {"halide_xtensa_widen_quad_mul_add_i24",
+             call("halide_xtensa_widen_pair_mul_add_i24", wild_i24x, {call("halide_xtensa_widen_pair_mul_add_i24", wild_i24x, {wild_i24x, wild_i8x, wild_i8, wild_i8x, wild_i8}), wild_i8x, wild_i8, wild_i8x, wild_i8})},
+            {"halide_xtensa_widen_pair_mul_add_i24",
+             call("halide_xtensa_widen_mul_add_i24", wild_i24x, {call("halide_xtensa_widen_mul_add_i24", wild_i24x, {wild_i24x, wild_i8x, wild_i8}), wild_i8x, wild_i8})},
+
+            {"halide_xtensa_widen_pair_mul_add_i48",
+             call("halide_xtensa_widen_mul_add_i48", wild_i48x,
+                  {call("halide_xtensa_widen_mul_add_i48", wild_i48x, {wild_i48x, wild_i16x, wild_i16x}), wild_i16x, wild_i16x})},
+
+            {"halide_xtensa_sat_narrow_i48_with_shift_i16", call("halide_xtensa_sat_narrow_with_rounding_shift_i16", wild_i16x, {i32(wild_i48x), wild_u32})},
+            // NOTE(vksnk): looked like a good idea, but seems to be slower. Need to double-check.
+            // {"halide_xtensa_i48x_clz_i16", halide_xtensa_narrow_clz_i16(i32(wild_i48x))},
+            // {"halide_xtensa_i48x_clz_i16", halide_xtensa_narrow_clz_i16(u32(wild_i48x))},
+            // Slice and convert
+            {"halide_xtensa_convert_u8_low_u16", halide_xtensa_slice_to_native_u16(u16(wild_u8x), 0, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_u8_high_u16", halide_xtensa_slice_to_native_u16(u16(wild_u8x), 1, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_u8_low_i16", halide_xtensa_slice_to_native_i16(i16(wild_u8x), 0, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_u8_high_i16", halide_xtensa_slice_to_native_i16(i16(wild_u8x), 1, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_i8_low_u16", halide_xtensa_slice_to_native_u16(u16(wild_i8x), 0, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_i8_high_u16", halide_xtensa_slice_to_native_u16(u16(wild_i8x), 1, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_i8_low_i16", halide_xtensa_slice_to_native_i16(i16(wild_i8x), 0, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_i8_high_i16", halide_xtensa_slice_to_native_i16(i16(wild_i8x), 1, wild_i32, wild_i32)},
+            {"halide_xtensa_convert_i32_u16", halide_xtensa_slice_to_native_u16(u16(halide_xtensa_concat_from_native_i32(wild_i32x, wild_i32x, wild_i32x, wild_i32x)), 0, slice_width_i16, slice_width_i16 * 2), Pattern::PassOnlyOp0 | Pattern::PassOnlyOp1},
+            {"halide_xtensa_convert_i32_u16", halide_xtensa_slice_to_native_u16(u16(halide_xtensa_concat_from_native_i32(wild_i32x, wild_i32x, wild_i32x, wild_i32x)), 1, slice_width_i16, slice_width_i16 * 2), Pattern::PassOnlyOp2 | Pattern::PassOnlyOp3},
+
+            {"halide_xtensa_convert_i48_low_i32", halide_xtensa_slice_to_native_i32(i32(wild_i48x), 0, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_i48_high_i32", halide_xtensa_slice_to_native_i32(i32(wild_i48x), 1, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_i48_low_i32", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_i48(wild_i48x, wild_i48x)), 0, slice_width_i32, slice_width_i32 * 4), Pattern::PassOnlyOp0},
+            {"halide_xtensa_convert_i48_high_i32", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_i48(wild_i48x, wild_i48x)), 1, slice_width_i32, slice_width_i32 * 4), Pattern::PassOnlyOp0},
+            {"halide_xtensa_convert_i48_low_i32", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_i48(wild_i48x, wild_i48x)), 2, slice_width_i32, slice_width_i32 * 4), Pattern::PassOnlyOp1},
+            {"halide_xtensa_convert_i48_high_i32", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_i48(wild_i48x, wild_i48x)), 3, slice_width_i32, slice_width_i32 * 4), Pattern::PassOnlyOp1},
+            {"halide_xtensa_convert_i48_low_u32", halide_xtensa_slice_to_native_u32(u32(wild_i48x), 0, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_i48_high_u32", halide_xtensa_slice_to_native_u32(u32(wild_i48x), 1, slice_width_i32, slice_width_i32 * 2)},
+
+            {"halide_xtensa_convert_u16_low_u32", halide_xtensa_slice_to_native_u32(u32(wild_u16x), 0, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_u16_high_u32", halide_xtensa_slice_to_native_u32(u32(wild_u16x), 1, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_u16_low_i32", halide_xtensa_slice_to_native_i32(i32(wild_u16x), 0, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_u16_high_i32", halide_xtensa_slice_to_native_i32(i32(wild_u16x), 1, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_i16_low_u32", halide_xtensa_slice_to_native_u32(u32(wild_i16x), 0, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_i16_high_u32", halide_xtensa_slice_to_native_u32(u32(wild_i16x), 1, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_i16_low_i32", halide_xtensa_slice_to_native_i32(i32(wild_i16x), 0, slice_width_i32, slice_width_i32 * 2)},
+            {"halide_xtensa_convert_i16_high_i32", halide_xtensa_slice_to_native_i32(i32(wild_i16x), 1, slice_width_i32, slice_width_i32 * 2)},
+
+            {"halide_xtensa_convert_to_int32x16_t_from_uint1x16_t", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_u1(wild_u1x, wild_u1x, wild_u1x, wild_u1x)), 0, 16, 64), Pattern::PassOnlyOp0},
+            {"halide_xtensa_convert_to_int32x16_t_from_uint1x16_t", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_u1(wild_u1x, wild_u1x, wild_u1x, wild_u1x)), 1, 16, 64), Pattern::PassOnlyOp1},
+            {"halide_xtensa_convert_to_int32x16_t_from_uint1x16_t", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_u1(wild_u1x, wild_u1x, wild_u1x, wild_u1x)), 2, 16, 64), Pattern::PassOnlyOp2},
+            {"halide_xtensa_convert_to_int32x16_t_from_uint1x16_t", halide_xtensa_slice_to_native_i32(i32(halide_xtensa_concat_from_native_u1(wild_u1x, wild_u1x, wild_u1x, wild_u1x)), 3, 16, 64), Pattern::PassOnlyOp3},
+
+            {"halide_xtensa_narrow_i48_with_shift_i32", i32(wild_i48x) >> wild_i32},
+            {"halide_xtensa_narrow_i48_with_shift_u32", u32(wild_i48x) >> wild_u32},
+
+            // Predicated saturated add/sub.
+            // NOTE(vksnk): patterns below are for predicated instructions and look like they may
+            // be more efficient, but they are not according to simulator. We will need to check with
+            // Cadence about this.
+            // {"halide_xtensa_pred_sat_add_i16", halide_xtensa_sat_add_i16(wild_i16x, select(wild_u1x, wild_i16x, wild_i16x))},
+            // {"halide_xtensa_pred_sat_sub_i16", halide_xtensa_sat_sub_i16(wild_i16x, select(wild_u1x, wild_i16x, wild_i16x))},
+        };
+        if (op->type.is_vector()) {
+            Expr call = op;
+
+            std::vector<Expr> matches;
+
+            Expr new_expr = apply_patterns(call, calls, this);
+            if (!new_expr.same_as(call)) {
+                return new_expr;
+            }
+        }
+
+        if (op->is_intrinsic()) {
+            Expr lowered = lower_intrinsic(op);
+            if (lowered.defined()) {
+                debug(1) << "Lowered intrinsic - " << op->name << "\n";
+                // lowered = simplify(lowered);
+                return mutate(lowered);
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const VectorReduce *op) override {
+        if (op->value.type().lanes() == op->type.lanes() * 2) {
+            static const std::vector<Pattern> reduces_2x = {
+                {"halide_xtensa_reduce_add_x2_i8", vector_reduce(VectorReduce::Add, wild_i16x), Pattern::NarrowOps},
+                {"halide_xtensa_reduce_add_x2_i16", vector_reduce(VectorReduce::Add, wild_i32x), Pattern::NarrowOps},
+                {"halide_xtensa_reduce_add_x2_i32", vector_reduce(VectorReduce::Add, wild_i32x)},
+            };
+
+            Expr new_expr = apply_patterns(op, reduces_2x, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        if (op->value.type().lanes() == op->type.lanes() * 4) {
+            static const std::vector<Pattern> reduces_4x = {
+                {"halide_xtensa_reduce_add_x4_i8", vector_reduce(VectorReduce::Add, wild_i16x), Pattern::NarrowOps},
+                {"halide_xtensa_reduce_add_x4_i16", vector_reduce(VectorReduce::Add, wild_i32x), Pattern::NarrowOps},
+                {"halide_xtensa_reduce_add_x4_i32", vector_reduce(VectorReduce::Add, wild_i32x)},
+            };
+
+            Expr new_expr = apply_patterns(op, reduces_4x, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        // Full reduction.
+        if (op->type.is_scalar()) {
+            static const std::vector<Pattern> full_reduces = {
+                // TODO(vksnk): should be a better way to do the cast in the end.
+                {"halide_xtensa_full_reduce_add_u8_to_i32", vector_reduce(VectorReduce::Add, i32(wild_u8x))},
+
+                {"halide_xtensa_full_reduce_add_i8", vector_reduce(VectorReduce::Add, wild_i16x), Pattern::NarrowOps},
+                {"halide_xtensa_full_reduce_add_i16", vector_reduce(VectorReduce::Add, wild_i32x), Pattern::NarrowOps},
+                {"halide_xtensa_full_reduce_add_i32", vector_reduce(VectorReduce::Add, wild_i32x)},
+
+                // Min reduction.
+                {"halide_xtensa_full_reduce_min_u8", vector_reduce(VectorReduce::Min, wild_u8x)},
+                {"halide_xtensa_full_reduce_min_u16", vector_reduce(VectorReduce::Min, wild_u16x)},
+                {"halide_xtensa_full_reduce_min_u32", vector_reduce(VectorReduce::Min, wild_u32x)},
+                {"halide_xtensa_full_reduce_min_i8", vector_reduce(VectorReduce::Min, wild_i8x)},
+                {"halide_xtensa_full_reduce_min_i16", vector_reduce(VectorReduce::Min, wild_i16x)},
+                {"halide_xtensa_full_reduce_min_i32", vector_reduce(VectorReduce::Min, wild_i32x)},
+
+                // Max reduction.
+                {"halide_xtensa_full_reduce_max_u8", vector_reduce(VectorReduce::Max, wild_u8x)},
+                {"halide_xtensa_full_reduce_max_u16", vector_reduce(VectorReduce::Max, wild_u16x)},
+                {"halide_xtensa_full_reduce_max_u32", vector_reduce(VectorReduce::Max, wild_u32x)},
+                {"halide_xtensa_full_reduce_max_i8", vector_reduce(VectorReduce::Max, wild_i8x)},
+                {"halide_xtensa_full_reduce_max_i16", vector_reduce(VectorReduce::Max, wild_i16x)},
+                {"halide_xtensa_full_reduce_max_i32", vector_reduce(VectorReduce::Max, wild_i32x)},
+            };
+
+            Expr new_expr = apply_patterns(op, full_reduces, this);
+            if (!new_expr.same_as(op)) {
+                return new_expr;
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    int loop_depth_ = 0;
+
+    Stmt visit(const For *op) override {
+        loop_depth_++;
+        Stmt body = IRGraphMutator::visit(op);
+        loop_depth_--;
+        return body;
+    }
+
+    Stmt visit(const LetStmt *op) override {
+        if (loop_depth_ < 1) {
+            return IRGraphMutator::visit(op);
+        }
+
+        if (op->value.type().is_handle()) {
+            return IRGraphMutator::visit(op);
+        }
+
+        if (op->value.type().is_scalar()) {
+            return IRGraphMutator::visit(op);
+        }
+        Stmt body = op->body;
+        body = substitute(op->name, op->value, body);
+        return mutate(body);
+    }
+
+    Expr match_clamped_dense_ramp(const Expr &index, const Expr &pred) {
+        Expr dense_ramp_base = strided_ramp_base(index, 1);
+        if (!dense_ramp_base.defined()) {
+            return Expr();
+        }
+
+        const std::vector<Expr> patterns = {
+            ramp(wild_i32, 1, pred.type().lanes()) <= bc(wild_i32, pred.type().lanes())};
+
+        vector<Expr> matches;
+        Expr new_pred;
+        for (const Expr &p : patterns) {
+            if (expr_match(p, pred, matches)) {
+                for (auto &m : matches) {
+                    m = mutate(m);
+                }
+                new_pred = Call::make(pred.type(), "clamped_dense_ramp", matches, Call::PureExtern);
+                break;
+            }
+        }
+        return new_pred;
+    }
+
+    Expr visit(const Load *op) override {
+        if (!is_const_one(op->predicate)) {
+            Expr new_pred = match_clamped_dense_ramp(op->index, op->predicate);
+
+            if (new_pred.defined()) {
+                return Load::make(op->type, op->name,
+                                  mutate(op->index), op->image,
+                                  op->param,
+                                  new_pred,
+                                  op->alignment);
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+    Stmt visit(const Store *op) override {
+        if (!is_const_one(op->predicate)) {
+            Expr new_pred = match_clamped_dense_ramp(op->index, op->predicate);
+
+            if (new_pred.defined()) {
+                return Store::make(op->name, mutate(op->value), mutate(op->index),
+                                   op->param, new_pred, op->alignment);
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+public:
+    MatchXtensaPatterns(const Target &target)
+        : target(target) {
+    }
+};
+
+// Find an upper bound of bounds.max - bounds.min.
+Expr span_of_bounds(const Interval &bounds) {
+    internal_assert(bounds.is_bounded());
+
+    const Min *min_min = bounds.min.as<Min>();
+    const Max *min_max = bounds.min.as<Max>();
+    const Min *max_min = bounds.max.as<Min>();
+    const Max *max_max = bounds.max.as<Max>();
+    const Add *min_add = bounds.min.as<Add>();
+    const Add *max_add = bounds.max.as<Add>();
+    const Sub *min_sub = bounds.min.as<Sub>();
+    const Sub *max_sub = bounds.max.as<Sub>();
+
+    if (min_min && max_min && equal(min_min->b, max_min->b)) {
+        return span_of_bounds({min_min->a, max_min->a});
+    } else if (min_max && max_max && equal(min_max->b, max_max->b)) {
+        return span_of_bounds({min_max->a, max_max->a});
+    } else if (min_add && max_add && equal(min_add->b, max_add->b)) {
+        return span_of_bounds({min_add->a, max_add->a});
+    } else if (min_sub && max_sub && equal(min_sub->b, max_sub->b)) {
+        return span_of_bounds({min_sub->a, max_sub->a});
+    } else {
+        return bounds.max - bounds.min;
+    }
+}
+
+// NOTE(vksnk): this is borrowed from HexagonOptimize.cpp, so
+// eventually need to generalize and share across two places.
+// Replace indirect loads with dynamic_shuffle intrinsics where
+// possible.
+class OptimizeShuffles : public IRMutator {
+    int lut_alignment;
+    int lut_size_in_bytes;
+    Scope<Interval> bounds;
+    std::vector<std::pair<std::string, Expr>> lets;
+
+    using IRMutator::visit;
+
+    template<typename NodeType, typename T>
+    NodeType visit_let(const T *op) {
+        // We only care about vector lets.
+        if (op->value.type().is_vector()) {
+            bounds.push(op->name, bounds_of_expr_in_scope(op->value, bounds));
+        }
+        NodeType node = IRMutator::visit(op);
+        if (op->value.type().is_vector()) {
+            bounds.pop(op->name);
+        }
+        return node;
+    }
+
+    Expr visit(const Let *op) override {
+        lets.emplace_back(op->name, op->value);
+        Expr expr = visit_let<Expr>(op);
+        lets.pop_back();
+        return expr;
+    }
+    Stmt visit(const LetStmt *op) override {
+        return visit_let<Stmt>(op);
+    }
+
+    Expr visit(const Load *op) override {
+        if (!is_const_one(op->predicate)) {
+            // TODO(psuriana): We shouldn't mess with predicated load for now.
+            return IRMutator::visit(op);
+        }
+        if (!op->type.is_vector() || op->index.as<Ramp>()) {
+            // Don't handle scalar or simple vector loads.
+            return IRMutator::visit(op);
+        }
+
+        Expr index = mutate(op->index);
+        Interval unaligned_index_bounds = bounds_of_expr_in_scope(index, bounds);
+        if (unaligned_index_bounds.is_bounded()) {
+            // We want to try both the unaligned and aligned
+            // bounds. The unaligned bounds might fit in 64 elements,
+            // while the aligned bounds do not.
+            int align = lut_alignment / op->type.bytes();
+            Interval aligned_index_bounds = {
+                (unaligned_index_bounds.min / align) * align,
+                ((unaligned_index_bounds.max + align) / align) * align - 1};
+            ModulusRemainder alignment(align, 0);
+
+            for (const Interval &index_bounds : {aligned_index_bounds, unaligned_index_bounds}) {
+                Expr index_span = span_of_bounds(index_bounds);
+                index_span = common_subexpression_elimination(index_span);
+                index_span = simplify(index_span);
+
+                // The hardware supports shuffle/select out of two native vectors,
+                // so we set to the double of native vector width in bytes.
+                // TODO(vksnk): in some cases it might be possible to prove that
+                // all indices span only a single vector (instead of two which is
+                // assumed here, which may help to save one vector load.
+                int lut_size = lut_size_in_bytes / op->type.element_of().bytes();
+                if (can_prove(index_span < lut_size)) {
+                    // This is a lookup within an up to 64 element array. We
+                    // can use dynamic_shuffle for this.
+                    // TODO(vksnk): original code doesn't align/pad here, why?
+                    int const_extent = as_const_int(index_span) ? (((*as_const_int(index_span) + align) / align) * align) : lut_size;
+                    Expr base = simplify(index_bounds.min);
+
+                    // Load all of the possible indices loaded from the
+                    // LUT. Note that for clamped ramps, this loads up to 1
+                    // vector past the max. CodeGen_Hexagon::allocation_padding
+                    // returns a native vector size to account for this.
+                    Expr lut = Load::make(op->type.with_lanes(const_extent), op->name,
+                                          Ramp::make(base, 1, const_extent),
+                                          op->image, op->param, const_true(const_extent), alignment);
+
+                    // We know the size of the LUT is not more than 64, so we
+                    // can safely cast the index to 16 bit, which
+                    // dynamic_shuffle requires.
+                    index = simplify(cast(Int(op->type.bits()).with_lanes(op->type.lanes()), index - base));
+                    return Call::make(op->type, "halide_xtensa_dynamic_shuffle", {lut, index /*, 0, const_extent - 1*/}, Call::PureExtern);
+                }
+                // Only the first iteration of this loop is aligned.
+                alignment = ModulusRemainder();
+            }
+        }
+        if (!index.same_as(op->index)) {
+            return Load::make(op->type, op->name, index, op->image, op->param, op->predicate, op->alignment);
+        } else {
+            return op;
+        }
+    }
+
+public:
+    OptimizeShuffles(int alignment, int size_in_bytes)
+        : lut_alignment(alignment), lut_size_in_bytes(size_in_bytes) {
+    }
+};
+
+class SplitVectorsToNativeSizes : public IRMutator {
+private:
+    std::vector<Type> native_vector_types;
+
+    using IRMutator::visit;
+
+    // Checks the list of native_vector_types and returns native vector width if the given type
+    // is multiple of it.
+    int get_native_vector_lanes_num(const Type &type) {
+        for (const auto &t : native_vector_types) {
+            if ((t.code() == type.code()) && (t.bits() == type.bits()) && (type.lanes() > t.lanes()) && (type.lanes() % t.lanes() == 0)) {
+                return t.lanes();
+            }
+        }
+        return 0;
+    }
+
+    int get_width_to_extend(const Type &type) {
+        if (!type.is_vector()) {
+            return 0;
+        }
+
+        for (const auto &t : native_vector_types) {
+            if ((t.code() == type.code()) && (t.bits() == type.bits()) && (type.lanes() < t.lanes())) {
+                return t.lanes();
+            }
+        }
+        return 0;
+    }
+
+    Expr pad(const Expr &e, int old_lanes, int new_lanes) {
+        return Call::make(e.type().with_lanes(new_lanes),
+                          "halide_xtensa_pad_to_native",
+                          {e, old_lanes},
+                          Call::PureExtern);
+        // TODO(vksnk): we should be able to use regular concats and slices
+        // but codegen support of non-uniform shuffles is limited right now.
+        // return Shuffle::make_concat({e, make_one(e.type().with_lanes(new_lanes - old_lanes))});
+    }
+
+    Expr slice(Expr e, Type t, int lanes) {
+        return Call::make(t, "halide_xtensa_slice_from_padded",
+                          {std::move(e), lanes}, Call::PureExtern);
+        // return Shuffle::make_slice(e, 0, 1, lanes);
+    }
+
+    Expr visit(const Broadcast *op) override {
+        int native_lanes = get_native_vector_lanes_num(op->type);
+        if (native_lanes > 0) {
+            int split_to = op->type.lanes() / native_lanes;
+            Expr value = mutate(op->value);
+
+            std::vector<Expr> concat_args;
+            for (int ix = 0; ix < split_to; ix++) {
+                Expr r = Broadcast::make(value, native_lanes);
+                concat_args.push_back(std::move(r));
+            }
+            return Call::make(op->type,
+                              "halide_xtensa_concat_from_native",
+                              concat_args, Call::PureExtern);
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const Select *op) override {
+        int native_lanes = get_native_vector_lanes_num(op->type);
+        if (native_lanes > 0) {
+            const int total_lanes = op->type.lanes();
+            int split_to = op->type.lanes() / native_lanes;
+            Expr cond = mutate(op->condition);
+            Expr t = mutate(op->true_value);
+            Expr f = mutate(op->false_value);
+
+            std::vector<Expr> concat_args;
+            for (int ix = 0; ix < split_to; ix++) {
+                Expr sliced_cond = Call::make(cond.type().with_lanes(native_lanes),
+                                              "halide_xtensa_slice_to_native",
+                                              {cond, ix, native_lanes, total_lanes},
+                                              Call::PureExtern);
+                Expr sliced_t = Call::make(t.type().with_lanes(native_lanes),
+                                           "halide_xtensa_slice_to_native",
+                                           {t, ix, native_lanes, total_lanes},
+                                           Call::PureExtern);
+                Expr sliced_f = Call::make(f.type().with_lanes(native_lanes),
+                                           "halide_xtensa_slice_to_native",
+                                           {f, ix, native_lanes, total_lanes},
+                                           Call::PureExtern);
+                Expr r = Select::make(sliced_cond, sliced_t, sliced_f);
+                concat_args.push_back(std::move(r));
+            }
+            return Call::make(op->type,
+                              "halide_xtensa_concat_from_native",
+                              concat_args, Call::PureExtern);
+        }
+
+        int width_to_extend = get_width_to_extend(op->type);
+        if (width_to_extend > 0) {
+            const int lanes = op->type.lanes();
+
+            Expr cond = mutate(op->condition);
+            Expr t = mutate(op->true_value);
+            Expr f = mutate(op->false_value);
+
+            Expr padded_cond = pad(cond, lanes, width_to_extend);
+            Expr padded_t = pad(t, lanes, width_to_extend);
+            Expr padded_f = pad(f, lanes, width_to_extend);
+
+            Expr r = Select::make(padded_cond, padded_t, padded_f);
+
+            return slice(r, op->type, lanes);
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    // NOTE(vksnk): not very clear if it's a good idea to slice loads/stores.
+    // Expr visit(const Load* op) override {
+    //     debug(0) << "maybe slicing load" << op->index << "\n";
+    //     Expr dense_ramp_base = strided_ramp_base(op->index, 1);
+    //     if (dense_ramp_base.defined()) {
+    //         const int64_t *const_base_ptr = as_const_int(dense_ramp_base);
+    //         if (const_base_ptr && is_const_one(op->predicate)) {
+    //             int native_lanes = get_native_vector_lanes_num(op->type);
+    //             int split_to = op->type.lanes() / native_lanes;
+    //             // Expr predicate = mutate(op->predicate);
+    //             // Expr ramp_base = mutate(op->index.as<Ramp>()->base);
+    //             // Expr index = Ramp::make(ramp_base, 1, op->index.type().lanes());
+    //             int64_t const_base = *const_base_ptr;
+    //             std::vector<Expr> concat_args;
+    //             for (int ix = 0; ix < split_to; ix++) {
+    //                 concat_args.push_back(
+    //                     Load::make(op->type.with_lanes(native_lanes),  op->name,
+    //                             Ramp::make(Expr((int32_t)const_base + ix * native_lanes), Expr(1), native_lanes),
+    //                             op->image, op->param, make_one(op->predicate.type().with_lanes(native_lanes)),
+    //                             op->alignment + native_lanes));
+    //             }
+
+    //             return Call::make(op->type,
+    //                         "halide_xtensa_concat_from_native",
+    //                         concat_args, Call::PureExtern);
+    //         }
+    //     }
+    //     return IRMutator::visit(op);
+    // }
+
+    //     Stmt visit(const Store* op) {
+    //         Expr dense_ramp_base = strided_ramp_base(op->index, 1);
+    //         if (dense_ramp_base.defined()) {
+    //             Expr predicate = mutate(op->predicate);
+    //             Expr value = mutate(op->value);
+    //             Expr ramp_base = mutate(op->index.as<Ramp>()->base);
+    //             Expr index = Ramp::make(ramp_base, 1, op->index.type().lanes());
+    //             return Store::make(op->name, std::move(value), std::move(index), op->param, std::move(predicate), op->alignment);
+    //         }
+    //         return IRMutator::visit(op);
+    //     }
+
+    // Expr visit(const Ramp *op) override {
+    //     int native_lanes = get_native_vector_lanes_num(op->type);
+    //     if (native_lanes > 0) {
+    //         int split_to = op->type.lanes() / native_lanes;
+    //         Expr base = mutate(op->base);
+    //         Expr stride = mutate(op->stride);
+
+    //         std::vector<Expr> concat_args;
+    //         for (int ix = 0; ix < split_to; ix++) {
+    //             Expr r = Ramp::make(base + stride * (native_lanes * ix), stride, native_lanes);
+    //             concat_args.push_back(std::move(r));
+    //         }
+    //         return Call::make(op->type,
+    //                             "halide_xtensa_concat_from_native",
+    //                             concat_args, Call::PureExtern);
+    //     }
+    //     int width_to_extend = get_width_to_extend(op->type);
+    //     if (width_to_extend > 0) {
+    //         Expr base = mutate(op->base);
+    //         Expr stride = mutate(op->stride);
+
+    //         const int lanes = op->type.lanes();
+    //         Expr r = Ramp::make(base, stride, width_to_extend);
+
+    //         return slice(r, op->type, lanes);
+    //     }
+
+    //     return IRMutator::visit(op);
+    // }
+
+    Expr visit(const Cast *op) override {
+        int to_native_lanes = get_native_vector_lanes_num(op->type);
+        int from_native_lanes = get_native_vector_lanes_num(op->value.type());
+        int native_lanes = std::max(to_native_lanes, from_native_lanes);
+
+        if ((to_native_lanes > 0) && (from_native_lanes > 0) && (native_lanes < op->type.lanes())) {
+            const int total_lanes = op->type.lanes();
+            int split_to = op->type.lanes() / native_lanes;
+
+            Expr value = mutate(op->value);
+
+            std::vector<Expr> concat_args;
+            for (int ix = 0; ix < split_to; ix++) {
+                Expr sliced = Call::make(value.type().with_lanes(native_lanes),
+                                         "halide_xtensa_slice_to_native",
+                                         {value, ix, native_lanes, total_lanes},
+                                         Call::PureExtern);
+                Expr r = Cast::make(op->type.with_lanes(native_lanes), sliced);
+                concat_args.push_back(std::move(r));
+            }
+            return Call::make(op->type,
+                              "halide_xtensa_concat_from_native",
+                              concat_args, Call::PureExtern);
+        }
+
+        int width_to_extend = std::max(get_width_to_extend(op->type), get_width_to_extend(op->value.type()));
+        if (width_to_extend > 0) {
+            Expr value = mutate(op->value);
+
+            const int lanes = op->type.lanes();
+            Expr padded = pad(value, lanes, width_to_extend);
+            Expr r = Cast::make(op->type.with_lanes(width_to_extend), padded);
+
+            return slice(r, op->type, lanes);
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const Reinterpret *op) override {
+        int to_native_lanes = get_native_vector_lanes_num(op->type);
+        int from_native_lanes = get_native_vector_lanes_num(op->value.type());
+        int native_lanes = std::max(to_native_lanes, from_native_lanes);
+
+        if ((to_native_lanes > 0) && (from_native_lanes > 0) && (native_lanes < op->type.lanes())) {
+            const int total_lanes = op->type.lanes();
+            int split_to = op->type.lanes() / native_lanes;
+
+            Expr value = mutate(op->value);
+
+            std::vector<Expr> concat_args;
+            for (int ix = 0; ix < split_to; ix++) {
+                Expr sliced = Call::make(value.type().with_lanes(native_lanes),
+                                         "halide_xtensa_slice_to_native",
+                                         {value, ix, native_lanes, total_lanes},
+                                         Call::PureExtern);
+                Expr r = Reinterpret::make(op->type.with_lanes(native_lanes), sliced);
+                concat_args.push_back(std::move(r));
+            }
+            return Call::make(op->type,
+                              "halide_xtensa_concat_from_native",
+                              concat_args, Call::PureExtern);
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    template<typename Op>
+    Expr visit_binop(const Op *op) {
+        int native_lanes = get_native_vector_lanes_num(op->a.type());
+        if (native_lanes > 0) {
+            const int total_lanes = op->type.lanes();
+            int split_to = op->type.lanes() / native_lanes;
+            Expr a = mutate(op->a);
+            Expr b = mutate(op->b);
+
+            std::vector<Expr> concat_args;
+            for (int ix = 0; ix < split_to; ix++) {
+                Expr sliced_a = Call::make(a.type().with_lanes(native_lanes),
+                                           "halide_xtensa_slice_to_native",
+                                           {a, ix, native_lanes, total_lanes},
+                                           Call::PureExtern);
+                Expr sliced_b = Call::make(b.type().with_lanes(native_lanes),
+                                           "halide_xtensa_slice_to_native",
+                                           {b, ix, native_lanes, total_lanes},
+                                           Call::PureExtern);
+                Expr r = Op::make(sliced_a, sliced_b);
+                concat_args.push_back(std::move(r));
+            }
+            return Call::make(op->type,
+                              "halide_xtensa_concat_from_native",
+                              concat_args, Call::PureExtern);
+        }
+
+        // TODO(vksnk): bool handling is maybe sketchy.
+        int width_to_extend = op->type.is_bool() ? get_width_to_extend(op->a.type()) : get_width_to_extend(op->type);
+        if (width_to_extend > 0) {
+            Expr a = mutate(op->a);
+            Expr b = mutate(op->b);
+
+            const int lanes = op->type.lanes();
+
+            Expr padded_a = pad(a, lanes, width_to_extend);
+            Expr padded_b = pad(b, lanes, width_to_extend);
+            Expr r = Op::make(padded_a, padded_b);
+
+            return slice(r, op->type, lanes);
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const Add *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Sub *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Mul *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Div *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Mod *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Min *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Max *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const EQ *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const NE *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const LT *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const LE *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const GT *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const GE *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Or *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const And *op) override {
+        return visit_binop(op);
+    }
+
+    Expr visit(const Call *op) override {
+        if (op->name.find("halide_xtensa_full_reduce_add") == 0) {
+            int native_lanes = get_native_vector_lanes_num(op->args[0].type());
+            if (native_lanes > 0) {
+                const int total_lanes = op->args[0].type().lanes();
+                int split_to = total_lanes / native_lanes;
+                Expr arg = mutate(op->args[0]);
+                Expr partial_sum;
+                for (int ix = 0; ix < split_to; ix++) {
+                    Expr sliced_arg = Call::make(arg.type().with_lanes(native_lanes),
+                                                 "halide_xtensa_slice_to_native",
+                                                 {arg, ix, native_lanes, total_lanes},
+                                                 Call::PureExtern);
+                    sliced_arg = Call::make(op->type, op->name, {sliced_arg}, op->call_type);
+                    if (!partial_sum.defined()) {
+                        partial_sum = sliced_arg;
+                    } else {
+                        partial_sum = Add::make(partial_sum, sliced_arg);
+                    }
+                }
+
+                return partial_sum;
+            }
+        }
+
+        if (op->name == "halide_xtensa_widening_load") {
+            int native_lanes = get_native_vector_lanes_num(op->type);
+
+            if ((native_lanes > 0) && (2 * native_lanes < op->type.lanes())) {
+                const int total_lanes = op->type.lanes();
+                int split_to = total_lanes / (2 * native_lanes);
+                std::vector<Expr> sliced_loads;
+
+                for (int ix = 0; ix < split_to; ix++) {
+                    Expr sliced_load = Call::make(op->type.with_lanes(2 * native_lanes), op->name, {op->args[0], op->args[1] + 2 * native_lanes * ix, op->args[2]}, Call::PureExtern);
+                    sliced_loads.push_back(sliced_load);
+                }
+                return Call::make(op->type,
+                                  "halide_xtensa_concat_from_native",
+                                  sliced_loads, Call::PureExtern);
+            }
+        }
+
+        const int total_lanes = op->type.lanes();
+        int native_lanes = get_native_vector_lanes_num(op->type);
+        std::set<std::string> skip_slicing = {"halide_xtensa_widening_load", "halide_xtensa_interleave_i16",
+                                              "halide_xtensa_narrow_i24_with_shift_i16",
+                                              // TODO(vksnk): ugly to list them all.
+                                              "halide_xtensa_reduce_add_x2_i8",
+                                              "halide_xtensa_reduce_add_x2_i16",
+                                              "halide_xtensa_reduce_add_x2_i32",
+                                              "halide_xtensa_reduce_add_x4_i8",
+                                              "halide_xtensa_reduce_add_x4_i16",
+                                              "halide_xtensa_reduce_add_x4_i32",
+                                              "reinterpret"};
+        // For some of the ops, it's better to slice into larger chunks.
+        std::map<std::string, int> slicing_multipliers = {
+            // There is only interleaved version of this intrinsic, so 2x vectors are required.
+            {"halide_xtensa_narrow_i48_with_shift_i32", 2},
+            {"halide_xtensa_narrow_i48_with_shift_u32", 2},
+            {"halide_xtensa_widen_right_mul_i64", 2},
+            {"halide_xtensa_widen_right_mul_u64", 2}};
+        int slicing_multiplier = 1;
+        if (slicing_multipliers.count(op->name) > 0) {
+            slicing_multiplier = slicing_multipliers[op->name];
+        }
+
+        if ((native_lanes > 0) && (native_lanes * slicing_multiplier < total_lanes) && (skip_slicing.count(op->name) == 0)) {
+            int split_to = op->type.lanes() / (native_lanes * slicing_multiplier);
+            vector<Expr> args;
+            for (const auto &arg : op->args) {
+                args.push_back(mutate(arg));
+            }
+
+            std::vector<Expr> concat_args;
+            for (int ix = 0; ix < split_to; ix++) {
+                std::vector<Expr> sliced_args;
+                for (size_t arg_index = 0; arg_index < op->args.size(); arg_index++) {
+                    Expr sliced_arg;
+                    if (args[arg_index].type().is_scalar()) {
+                        sliced_arg = args[arg_index];
+                        // dynamic_shuffle is tricky, we can actually slice an index,
+                        // but not the actual data vector.
+                    } else if ((op->name == "halide_xtensa_dynamic_shuffle") && arg_index == 0) {
+                        sliced_arg = args[arg_index];
+                    } else {
+                        sliced_arg = Call::make(args[arg_index].type().with_lanes(native_lanes * slicing_multiplier),
+                                                "halide_xtensa_slice_to_native",
+                                                {args[arg_index], ix, native_lanes * slicing_multiplier, total_lanes},
+                                                Call::PureExtern);
+                    }
+                    sliced_args.push_back(sliced_arg);
+                }
+
+                Expr r = Call::make(op->type.with_lanes(native_lanes * slicing_multiplier), op->name, sliced_args, op->call_type);
+                concat_args.push_back(std::move(r));
+            }
+
+            return Call::make(op->type,
+                              "halide_xtensa_concat_from_native",
+                              concat_args, Call::PureExtern);
+        }
+
+        // TODO(vksnk): need to be careful here, because not everything can be
+        // padded safely.
+        int width_to_extend = get_width_to_extend(op->type);
+        bool is_safe_to_pad = true;
+        for (const auto &arg : op->args) {
+            is_safe_to_pad = is_safe_to_pad && (arg.type().is_scalar() || (op->type.lanes() == arg.type().lanes()));
+        }
+        std::set<std::string> safe_to_pad = {"halide_xtensa_dynamic_shuffle"};
+        is_safe_to_pad = is_safe_to_pad || (safe_to_pad.count(op->name) > 0);
+        std::set<std::string> skip_padding = {"halide_xtensa_widening_load"};
+        is_safe_to_pad = is_safe_to_pad && (skip_padding.count(op->name) == 0);
+        if (width_to_extend > 0 && is_safe_to_pad) {
+            vector<Expr> args;
+            const int lanes = op->type.lanes();
+
+            for (const auto &arg : op->args) {
+                Expr padded_arg;
+                if (arg.type().is_scalar()) {
+                    padded_arg = arg;
+                } else {
+                    Expr mutated_arg = mutate(arg);
+                    padded_arg = pad(mutated_arg, lanes, width_to_extend);
+                }
+
+                args.push_back(padded_arg);
+            }
+
+            Expr r = Call::make(op->type.with_lanes(width_to_extend), op->name, args, op->call_type);
+
+            return slice(r, op->type, lanes);
+        }
+
+        return IRMutator::visit(op);
+    }
+
+    Expr visit(const VectorReduce *op) override {
+        // TODO(vksnk): Factor it out.
+        Expr (*binop)(Expr, Expr) = nullptr;
+        switch (op->op) {
+        case VectorReduce::Add:
+            binop = Add::make;
+            break;
+        case VectorReduce::Mul:
+            binop = Mul::make;
+            break;
+        case VectorReduce::Min:
+            binop = Min::make;
+            break;
+        case VectorReduce::Max:
+            binop = Max::make;
+            break;
+        case VectorReduce::And:
+            binop = And::make;
+            break;
+        case VectorReduce::Or:
+            binop = Or::make;
+            break;
+        case VectorReduce::SaturatingAdd:
+            binop = saturating_add;
+            break;
+        }
+
+        int native_lanes = get_native_vector_lanes_num(op->value.type());
+        // Only support full reductions for now.
+        if (native_lanes > 0 && op->type.is_scalar()) {
+            const int total_lanes = op->type.lanes();
+            int split_to = op->value.type().lanes() / native_lanes;
+            Expr v = mutate(op->value);
+
+            Expr partial_reduction;
+            for (int ix = 0; ix < split_to; ix++) {
+                Expr sliced_v = Call::make(v.type().with_lanes(native_lanes),
+                                           "halide_xtensa_slice_to_native",
+                                           {v, ix, native_lanes, total_lanes},
+                                           Call::PureExtern);
+                sliced_v = VectorReduce::make(op->op, sliced_v, 1);
+                if (!partial_reduction.defined()) {
+                    partial_reduction = sliced_v;
+                } else {
+                    partial_reduction = binop(partial_reduction, sliced_v);
+                }
+            }
+
+            return partial_reduction;
+        }
+
+        return IRMutator::visit(op);
+    }
+
+public:
+    SplitVectorsToNativeSizes(const Target &target) {
+        if (target.has_feature(Target::Feature::XtensaQ8)) {
+            native_vector_types = {
+                {Type(Type::Int, 8, 128)},
+                {Type(Type::UInt, 8, 128)},
+                {Type(Type::Int, 16, 64)},
+                {Type(Type::UInt, 16, 64)},
+                {Type(Type::Int, 32, 32)},
+                {Type(Type::UInt, 32, 32)},
+                {Type(Type::Int, 24, 128)},
+                {Type(Type::Int, 48, 64)},
+                {Type(Type::Int, 64, 32)},
+                {Type(Type::Float, 16, 64)},
+                {Type(Type::Float, 32, 32)},
+            };
+        } else {
+            native_vector_types = {
+                {Type(Type::Int, 8, 64)},
+                {Type(Type::UInt, 8, 64)},
+                {Type(Type::Int, 16, 32)},
+                {Type(Type::UInt, 16, 32)},
+                {Type(Type::Int, 32, 16)},
+                {Type(Type::UInt, 32, 16)},
+                {Type(Type::Int, 24, 64)},
+                {Type(Type::Int, 48, 32)},
+                {Type(Type::Int, 64, 16)},
+                {Type(Type::Float, 16, 32)},
+                {Type(Type::Float, 32, 16)},
+            };
+        }
+    }
+};
+
+class SimplifySliceConcat : public IRGraphMutator {
+private:
+    using IRGraphMutator::visit;
+
+    Expr visit(const Call *op) override {
+        if (op->name == "halide_xtensa_concat_from_native") {
+            if (op->args.size() == 1) {
+                return mutate(op->args[0]);
+            }
+        }
+
+        if (op->name == "halide_xtensa_slice_from_padded") {
+            if (const Broadcast *broadcast = op->args[0].as<Broadcast>()) {
+                return Broadcast::make(broadcast->value, op->type.lanes());
+            }
+            if (const Cast *cast = op->args[0].as<Cast>()) {
+                if (const Broadcast *broadcast = cast->value.as<Broadcast>()) {
+                    return Broadcast::make(Cast::make(cast->type.with_lanes(broadcast->value.type().lanes()), broadcast->value), op->type.lanes());
+                }
+            }
+        }
+
+        if (op->name == "halide_xtensa_slice_to_native") {
+            Expr first_arg = mutate(op->args[0]);
+            const Call *maybe_concat_call = first_arg.as<Call>();
+            int slice_index = op->args[1].as<IntImm>()->value;
+            int native_lanes = op->args[2].as<IntImm>()->value;
+            int total_lanes = op->args[3].as<IntImm>()->value;
+            if (maybe_concat_call && (maybe_concat_call->name == "halide_xtensa_concat_from_native") && (maybe_concat_call->type.lanes() == total_lanes) && ((int)maybe_concat_call->args.size() == total_lanes / native_lanes)) {
+                return maybe_concat_call->args[slice_index];
+            }
+
+            if (maybe_concat_call && (maybe_concat_call->name == "halide_xtensa_concat_from_native") && (maybe_concat_call->type.lanes() == total_lanes) && (maybe_concat_call->args[0].type().lanes() % native_lanes == 0)) {
+                int concat_group_size = maybe_concat_call->args[0].type().lanes() / native_lanes;
+                int new_index = slice_index % concat_group_size;
+                int concat_arg_index = slice_index / concat_group_size;
+
+                return Call::make(op->type,
+                                  "halide_xtensa_slice_to_native",
+                                  {maybe_concat_call->args[concat_arg_index], new_index, native_lanes,
+                                   maybe_concat_call->args[concat_arg_index].type().lanes()},
+                                  Call::PureExtern);
+            }
+
+            const Shuffle *maybe_concat_shuffle = first_arg.as<Shuffle>();
+            if (maybe_concat_shuffle && maybe_concat_shuffle->is_concat() && ((int)maybe_concat_shuffle->vectors.size() == total_lanes / native_lanes) && ((int)maybe_concat_shuffle->vectors[slice_index].type().lanes() == native_lanes)) {
+                return maybe_concat_shuffle->vectors[slice_index];
+            }
+
+            // TODO(vksnk): this looks very similar to above, maybe it's time to move to Shuffle::concat everywhere.
+            if (maybe_concat_shuffle && maybe_concat_shuffle->is_concat() && (maybe_concat_shuffle->vectors[0].type().lanes() % native_lanes == 0)) {
+                internal_assert(total_lanes == maybe_concat_shuffle->type.lanes());
+                int concat_group_size = maybe_concat_shuffle->vectors[0].type().lanes() / native_lanes;
+                int new_index = slice_index % concat_group_size;
+                int concat_arg_index = slice_index / concat_group_size;
+
+                return Call::make(op->type,
+                                  "halide_xtensa_slice_to_native",
+                                  {maybe_concat_shuffle->vectors[concat_arg_index], new_index, native_lanes,
+                                   maybe_concat_shuffle->vectors[concat_arg_index].type().lanes()},
+                                  Call::PureExtern);
+            }
+
+            if (first_arg.type().is_bool() && first_arg.type().is_scalar()) {
+                return first_arg;
+            }
+
+            const Broadcast *maybe_broadcast = first_arg.as<Broadcast>();
+            if (maybe_broadcast) {
+                return Broadcast::make(maybe_broadcast->value, op->type.lanes());
+            }
+
+            return Call::make(op->type, op->name,
+                              {first_arg, op->args[1], op->args[2], op->args[3]},
+                              Call::PureExtern);
+        }
+
+        if (op->name == "halide_xtensa_pad_to_native") {
+            Expr first_arg = mutate(op->args[0]);
+            const Call *maybe_slice_call = first_arg.as<Call>();
+            int lanes_before_padding = op->args[1].as<IntImm>()->value;
+            if (maybe_slice_call &&
+                (maybe_slice_call->name == "halide_xtensa_slice_from_padded") && (maybe_slice_call->type.lanes() == lanes_before_padding) && (op->type.lanes() == maybe_slice_call->args[0].type().lanes())) {
+                return maybe_slice_call->args[0];
+            }
+
+            if (maybe_slice_call &&
+                (maybe_slice_call->name == "halide_xtensa_slice_from_padded") && (maybe_slice_call->type.lanes() == lanes_before_padding) && (op->type.lanes() > maybe_slice_call->args[0].type().lanes())) {
+                return Call::make(op->type,
+                                  "halide_xtensa_pad_to_native",
+                                  {maybe_slice_call->args[0], op->args[1]},
+                                  Call::PureExtern);
+            }
+
+            const Shuffle *maybe_shuffle = first_arg.as<Shuffle>();
+            if (maybe_shuffle && maybe_shuffle->is_slice() && (maybe_shuffle->slice_begin() == 0) && (maybe_shuffle->slice_stride() == 1) && (maybe_shuffle->vectors.size() == 1) && ((int)maybe_shuffle->indices.size() == lanes_before_padding) && (op->type.lanes() == maybe_shuffle->vectors[0].type().lanes())) {
+                return maybe_shuffle->vectors[0];
+            }
+            const Broadcast *maybe_broadcast = first_arg.as<Broadcast>();
+            if (maybe_broadcast) {
+                return Broadcast::make(maybe_broadcast->value, op->type.lanes());
+            }
+
+            const Ramp *maybe_ramp = first_arg.as<Ramp>();
+            if (maybe_ramp) {
+                return Ramp::make(maybe_ramp->base, maybe_ramp->stride, op->type.lanes());
+            }
+
+            if (first_arg.type().is_bool() && first_arg.type().is_scalar()) {
+                return first_arg;
+            }
+
+            return Call::make(op->type, op->name,
+                              {first_arg, op->args[1]},
+                              Call::PureExtern);
+        }
+        return IRGraphMutator::visit(op);
+    }
+
+    Expr visit(const Shuffle *op) override {
+        if (op->is_slice() && op->slice_stride() == 1 && op->vectors.size() == 1) {
+            Expr mutated = mutate(op->vectors[0]);
+            const Call *maybe_call = mutated.as<Call>();
+            if (maybe_call && maybe_call->name == "halide_xtensa_concat_from_native") {
+                int offset = 0;
+                for (int ix = 0; ix < (int)maybe_call->args.size(); ix++) {
+                    if (offset == op->slice_begin()) {
+                        std::vector<Expr> new_args;
+                        int count = 0;
+                        while (count < op->type.lanes()) {
+                            new_args.push_back(maybe_call->args[ix]);
+                            count += maybe_call->args[ix].type().lanes();
+                            ix++;
+                        }
+                        if (count == op->type.lanes()) {
+                            return Call::make(op->type,
+                                              "halide_xtensa_concat_from_native",
+                                              new_args, Call::PureExtern);
+                        }
+                        break;
+                    }
+                    offset += maybe_call->args[ix].type().lanes();
+                }
+            }
+        }
+
+        return IRGraphMutator::visit(op);
+    }
+
+public:
+    SimplifySliceConcat() = default;
+};
+
+Stmt match_xtensa_patterns(const Stmt &stmt, const Target &target) {
+    const int alignment = target.natural_vector_size<uint8_t>();
+    const int lut_size_in_bytes = 2 * target.natural_vector_size<uint8_t>();
+    Stmt s = OptimizeShuffles(alignment, lut_size_in_bytes).mutate(stmt);
+    s = align_loads(s, alignment, 1);
+    // NOTE(vksnk): CSE seemed to break loop carry
+    // s = common_subexpression_elimination(s);
+
+    // Use at most 16 vector registers for carrying values.
+    // NOTE(vksnk): loop_carry seems to be a little finicky right now
+    // but looks like something we'd definitely want to have, so
+    // need to figure out where it goes wrong.
+    s = loop_carry(s, 16);
+    s = simplify(s);
+    for (int ix = 0; ix < 10; ix++) {
+        s = MatchXtensaPatterns(target).mutate(s);
+    }
+
+    // Split to the native vectors sizes.
+    s = substitute_in_all_lets(s);
+    s = SplitVectorsToNativeSizes(target).mutate(s);
+    for (int ix = 0; ix < 3; ix++) {
+        s = SimplifySliceConcat().mutate(s);
+    }
+
+    // Extra run to replace cast + concat, etc.
+    for (int ix = 0; ix < 10; ix++) {
+        s = MatchXtensaPatterns(target).mutate(s);
+    }
+    // NOTE(vksnk): looks like we shouldn't do simplification in the end.
+    // s = simplify(common_subexpression_elimination(s));
+    s = DualQuadMulMutator().mutate(s);
+    s = common_subexpression_elimination(s);
+
+    // debug(0) << s << "\n";
+    return s;
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/src/XtensaOptimize.h
+++ b/src/XtensaOptimize.h
@@ -1,0 +1,56 @@
+#ifndef HALIDE_XTENSA_OPTIMIZE_H
+#define HALIDE_XTENSA_OPTIMIZE_H
+
+#include "Expr.h"
+
+namespace Halide {
+
+struct Target;
+
+namespace Internal {
+
+template<typename T>
+bool is_native_xtensa_vector(const Type &t, const Target &target) {
+    return false;
+}
+
+template<>
+bool is_native_xtensa_vector<int8_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<uint8_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<int16_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<uint16_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<int32_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<int64_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<uint32_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<float16_t>(const Type &t, const Target &target);
+
+template<>
+bool is_native_xtensa_vector<float>(const Type &t, const Target &target);
+
+bool is_native_vector_type(const Type &t, const Target &target);
+bool is_double_native_vector_type(const Type &t, const Target &target);
+
+Type get_native_xtensa_vector(const Type &t, const Target &target);
+
+std::string suffix_for_type(Type t);
+
+Stmt match_xtensa_patterns(const Stmt &s, const Target &target);
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1384,6 +1384,8 @@ typedef enum halide_target_feature_t {
     halide_target_feature_egl,                    ///< Force use of EGL support.
     halide_target_feature_arm_dot_prod,           ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
     halide_target_feature_arm_fp16,               ///< Enable ARMv8.2-a half-precision floating point data processing
+    halide_target_feature_xtensa,                 ///< Enable Xtensa code generation.
+    halide_target_feature_xtensa_q8,              ///< Enable Xtensa for Q8 code generation. This should be set in *adidtion* to feature_xtensa.
     halide_llvm_large_code_model,                 ///< Use the LLVM large code model to compile
     halide_target_feature_rvv,                    ///< Enable RISCV "V" Vector Extension
     halide_target_feature_armv81a,                ///< Enable ARMv8.1-a instructions

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -49,13 +49,16 @@ typedef ptrdiff_t ssize_t;
 // for a few places in the runtime where we can't inline in the traditional
 // way.
 
+#ifdef __XTENSA__
+#define WEAK
+#define WEAK_INLINE __attribute__((always_inline))  // Note that WEAK_INLINE should *not* also be `inline`
+#else
 #define WEAK __attribute__((weak))
+#define WEAK_INLINE __attribute__((weak, always_inline))  // Note that WEAK_INLINE should *not* also be `inline`
+#endif
 
 // Note that ALWAYS_INLINE should *always* also be `inline`.
 #define ALWAYS_INLINE inline __attribute__((always_inline))
-
-// Note that WEAK_INLINE should *not* also be `inline`
-#define WEAK_INLINE __attribute__((weak, always_inline))
 
 // --------------
 

--- a/src/runtime/xtensa_dma.cpp
+++ b/src/runtime/xtensa_dma.cpp
@@ -1,0 +1,183 @@
+#include "HalideRuntime.h"
+#include "runtime_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void *tcm_alloc_on_bank(size_t size, unsigned char alignment,
+                               unsigned char bank);
+extern void tcm_free(void *ptr);
+
+void *halide_tcm_malloc(void *user_context, unsigned int x) {
+    const size_t alignment = ::halide_internal_malloc_alignment();
+    void *ptr = tcm_alloc_on_bank(x, alignment, /*bank=*/0);
+    // Try to allocate on the second bank.
+    if (!ptr) {
+        ptr = tcm_alloc_on_bank(x, alignment, /*bank=*/1);
+    }
+    return ptr;
+}
+
+void halide_tcm_free(void *user_context, void *ptr) {
+    tcm_free(ptr);
+}
+
+struct idma_buffer_t;
+
+typedef enum {
+    IDMA_1D_DESC = 1,
+    IDMA_2D_DESC = 2,
+    IDMA_64B_DESC = 4
+} idma_type_t;
+
+typedef enum {
+    IDMA_ERR_NO_BUF = -40,      /* No valid ring buffer */
+    IDMA_ERR_BAD_DESC = -20,    /* Descriptor not correct */
+    IDMA_ERR_BAD_CHAN,          /* Invalid channel number */
+    IDMA_ERR_NOT_INIT,          /* iDMAlib and HW not initialized  */
+    IDMA_ERR_TASK_NOT_INIT,     /* Cannot scheduled uninitialized task  */
+    IDMA_ERR_BAD_TASK,          /* Task not correct  */
+    IDMA_ERR_BUSY,              /* iDMA busy when not expected */
+    IDMA_ERR_IN_SPEC_MODE,      /* iDMAlib in unexpected mode */
+    IDMA_ERR_NOT_SPEC_MODE,     /* iDMAlib in unexpected mode */
+    IDMA_ERR_TASK_EMPTY,        /* No descs in the task/buffer */
+    IDMA_ERR_TASK_OUTSTAND_NEG, /* Number of outstanding descs is a negative value
+                                 */
+    IDMA_ERR_TASK_IN_ERROR,     /* Task in error */
+    IDMA_ERR_BUFFER_IN_ERROR,   /* Buffer in error */
+    IDMA_ERR_NO_NEXT_TASK,      /* Next task to process is missing  */
+    IDMA_ERR_BUF_OVFL,          /* Attempt to schedule too many descriptors */
+    IDMA_ERR_HW_ERROR,          /* HW error detected */
+    IDMA_ERR_BAD_INIT,          /* Bad idma_init args */
+    IDMA_OK = 0,                /* No error */
+    IDMA_CANT_SLEEP = 1,        /* Cannot sleep (no pending descriptors) */
+} idma_status_t;
+
+typedef void (*idma_callback_fn)(void *arg);
+
+#define DESC_IDMA_PRIOR_H 0x08000    /* QoS high */
+#define DESC_NOTIFY_W_INT 0x80000000 /* trigger interrupt on completion */
+
+idma_status_t halide_idma_init_loop(int32_t ch, idma_buffer_t *bufh,
+                                    idma_type_t type, int32_t ndescs,
+                                    void *cb_data,
+                                    idma_callback_fn cb_func);
+
+int32_t halide_idma_copy_desc(int32_t ch, void *dst, void *src, size_t size,
+                              uint32_t flags);
+
+int32_t idma_copy_2d_desc(int32_t ch, void *dst, void *src, size_t size,
+                          uint32_t flags, uint32_t nrows,
+                          uint32_t src_pitch, uint32_t dst_pitch);
+
+int32_t halide_idma_buffer_status(int32_t ch);
+
+idma_status_t halide_idma_sleep(int32_t ch);
+
+idma_buffer_t *idma_descriptor_alloc(idma_type_t type, int count);
+void idma_descriptor_free(idma_buffer_t *buffer);
+
+int32_t halide_idma_desc_done(int32_t ch, int32_t index);
+
+static const int kMaxChannelCount = 8;
+static const int kMaxRequestCount = 4;
+
+namespace {
+void cleanup_on_init_failure(int32_t channel_count, void **dma_desc) {
+    if (!dma_desc) {
+        return;
+    }
+    for (int ix = 0; ix < channel_count; ix++) {
+        if (dma_desc[ix] != nullptr) {
+            idma_descriptor_free((idma_buffer_t *)dma_desc[ix]);
+        }
+    }
+    halide_tcm_free(nullptr, dma_desc);
+}
+}  // namespace
+
+void **halide_init_dma(int32_t channel_count) {
+    if (channel_count > kMaxChannelCount) {
+        return nullptr;
+    }
+
+    // Allocate storage for DMA buffers/descriptors.
+    void **dma_desc = (void **)halide_tcm_malloc(nullptr, sizeof(void *) * kMaxChannelCount);
+
+    if (!dma_desc) {
+        return nullptr;
+    }
+
+    // Reset pointers to DMA buffers/descriptors.
+    for (int ix = 0; ix < kMaxChannelCount; ix++) {
+        dma_desc[ix] = nullptr;
+    }
+
+    // Allocate DMA descriptors and initialize DMA loop.
+    for (int ix = 0; ix < channel_count; ix++) {
+        dma_desc[ix] =
+            idma_descriptor_alloc(IDMA_2D_DESC, /*count=*/kMaxRequestCount);
+        if (!dma_desc[ix]) {
+            cleanup_on_init_failure(channel_count, dma_desc);
+            return nullptr;
+        }
+
+        idma_status_t init_status = halide_idma_init_loop(
+            ix, (idma_buffer_t *)dma_desc[ix], IDMA_2D_DESC, kMaxRequestCount, nullptr, nullptr);
+
+        if (init_status != IDMA_OK) {
+            cleanup_on_init_failure(channel_count, dma_desc);
+            return nullptr;
+        }
+    }
+
+    return dma_desc;
+}
+
+int32_t halide_xtensa_copy_1d(int channel, void *dst, int32_t dst_base,
+                              void *src, int32_t src_base, int extent,
+                              int item_size) {
+    while (halide_idma_buffer_status(channel) == kMaxRequestCount) {
+    }
+    int32_t id =
+        halide_idma_copy_desc(channel, (uint8_t *)dst + dst_base * item_size,
+                              (uint8_t *)src + src_base * item_size,
+                              extent * item_size, DESC_IDMA_PRIOR_H);
+    return id;
+}
+
+int32_t halide_xtensa_copy_2d(int channel, void *dst, int32_t dst_base,
+                              int32_t dst_stride, void *src, int32_t src_base,
+                              int32_t src_stride, int extent0, int extent1,
+                              int item_size) {
+    while (halide_idma_buffer_status(channel) == kMaxRequestCount) {
+    }
+    int32_t id =
+        idma_copy_2d_desc(channel, (uint8_t *)dst + dst_base * item_size,
+                          (uint8_t *)src + src_base * item_size,
+                          extent0 * item_size, DESC_IDMA_PRIOR_H, extent1,
+                          src_stride * item_size, dst_stride * item_size);
+
+    return id;
+}
+
+int32_t halide_xtensa_wait_for_copy(int32_t channel) {
+    while (halide_idma_buffer_status(channel) > 0) {
+    }
+
+    return 0;
+}
+
+void halide_release_dma(int32_t channel_count, void **dma_desc) {
+    for (int ix = 0; ix < channel_count; ix++) {
+        halide_xtensa_wait_for_copy(ix);
+        idma_descriptor_free((idma_buffer_t *)dma_desc[ix]);
+    }
+
+    halide_tcm_free(nullptr, dma_desc);
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/src/runtime/xtensa_dma_stubs.cpp
+++ b/src/runtime/xtensa_dma_stubs.cpp
@@ -1,0 +1,41 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef unsigned char uint8_t;
+typedef int int32_t;
+typedef unsigned int uint32_t;
+typedef __SIZE_TYPE__ size_t;
+
+void *memcpy(void *destination, const void *source, size_t num);
+
+void *halide_malloc(void *user_context, size_t x);
+void halide_free(void *user_context, void *ptr);
+
+void *halide_tcm_malloc(void *user_context, unsigned int x) {
+    return halide_malloc(user_context, x);
+}
+
+void halide_tcm_free(void *user_context, void *ptr) {
+    halide_free(user_context, ptr);
+}
+
+int halide_init_dma() {
+    return 0;
+}
+
+void halide_release_dma() {
+}
+
+int32_t halide_xtensa_copy_1d(void *dst, int32_t dst_base, void *src, int32_t src_base, int extent, int item_size) {
+    memcpy((uint8_t *)dst + dst_base * item_size, (uint8_t *)src + src_base * item_size, extent * item_size);
+    return 0;
+}
+
+int32_t halide_xtensa_wait_for_copy(int32_t id) {
+    return 0;
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif

--- a/src/runtime/xtensa_io.cpp
+++ b/src/runtime/xtensa_io.cpp
@@ -1,0 +1,10 @@
+#include "HalideRuntime.h"
+
+extern "C" {
+
+extern int printf(const char *format, ...);
+
+WEAK void halide_default_print(void *user_context, const char *str) {
+    printf("%s", str);
+}
+}

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -272,6 +272,7 @@ tests(GROUPS correctness
       simd_op_check_riscv.cpp
       simd_op_check_wasm.cpp
       simd_op_check_x86.cpp
+      simd_op_check_xtensa.cpp
       simplified_away_embedded_image.cpp
       simplify.cpp
       skip_stages.cpp

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -311,12 +311,18 @@ public:
         return {op, error_msg.str()};
     }
 
+    std::string sanitize(const std::string &s) {
+        std::string s_copy = s;
+        for (size_t i = 0; i < s.size(); i++) {
+            if (!isalnum(s[i])) s_copy[i] = '_';
+        }
+        return s_copy;
+    }
+
     void check(std::string op, int vector_width, Expr e) {
         // Make a name for the test by uniquing then sanitizing the op name
         std::string name = "op_" + op;
-        for (size_t i = 0; i < name.size(); i++) {
-            if (!isalnum(name[i])) name[i] = '_';
-        }
+        name = sanitize(name);
 
         name += "_" + std::to_string(tasks.size());
 

--- a/test/correctness/simd_op_check_xtensa.cpp
+++ b/test/correctness/simd_op_check_xtensa.cpp
@@ -1,0 +1,197 @@
+#include "Halide.h"
+#include "simd_op_check.h"
+
+using namespace Halide;
+using namespace Halide::ConciseCasts;
+
+class SimdOpCheckXtensa : public SimdOpCheckTest {
+public:
+    SimdOpCheckXtensa(Target t, int w = 768 /*256*3*/, int h = 128)
+        : SimdOpCheckTest(t, w, h) {
+    }
+    void setup_images() override {
+        for (auto p : image_params) {
+            p.reset();
+        }
+    }
+
+    bool can_run_code() const override {
+        return false;
+    }
+
+    void compile_and_check(Func error, const std::string &op, const std::string &name, int vector_width, std::ostringstream &error_msg) override {
+        // Compile just the vector Func to assembly.
+        std::string cpp_filename = output_directory + "check_" + name + ".cpp";
+        error.compile_to_c(cpp_filename, arg_types, "", target);
+        std::ifstream cpp_file;
+        cpp_file.open(cpp_filename);
+
+        bool found_it = false;
+
+        std::ostringstream msg;
+        msg << op << " did not generate for target=" << target.to_string() << " vector_width=" << vector_width << ". Instead we got:\n";
+
+        std::string line;
+        // We are going to print only main function.
+        msg << "Skipping non-main function definitions..."
+            << "\n";
+        std::string sanitized_op = sanitize(op);
+        bool inside_the_function = false;
+        while (getline(cpp_file, line)) {
+            if (!inside_the_function && ((line.find("int _op_" + op) != std::string::npos) || (line.find("int _op_" + sanitized_op) != std::string::npos))) {
+                inside_the_function = true;
+            }
+            if (!inside_the_function) {
+                continue;
+            }
+
+            msg << line << "\n";
+            // Check for the op in question
+            found_it |= wildcard_search(op, line) && !wildcard_search("_" + op, line);
+        }
+
+        if (!found_it) {
+            error_msg << "Failed: " << msg.str() << "\n";
+        }
+
+        cpp_file.close();
+
+        // Also compile the error checking Func (to be sure it compiles without error)
+        std::string fn_name = "test_" + name;
+        std::string fn_cpp_name = fn_name + ".cpp";
+        std::string fn_h_name = fn_name + +".h";
+        error.compile_to_c(output_directory + fn_cpp_name, arg_types, fn_name, target);
+        error.compile_to_header(output_directory + fn_h_name, arg_types, fn_name, target);
+    }
+
+    void add_tests() override {
+        Expr f16_1 = cast<Halide::float16_t>(in_f16(x));
+        Expr f32_1 = in_f32(x), f32_2 = in_f32(x + 16), f32_3 = in_f32(x + 32);
+        Expr f64_1 = in_f64(x), f64_2 = in_f64(x + 16), f64_3 = in_f64(x + 32);
+        Expr i8_1 = in_i8(x), i8_2 = in_i8(x + 16), i8_3 = in_i8(x + 32), i8_4 = in_i8(x + 48);
+        Expr u8_1 = in_u8(x), u8_2 = in_u8(x + 16), u8_3 = in_u8(x + 32), u8_4 = in_u8(x + 48);
+        Expr u8_even = in_u8(2 * x), u8_odd = in_u8(2 * x + 1);
+        Expr i16_1 = in_i16(x), i16_2 = in_i16(x + 16), i16_3 = in_i16(x + 32), i16_4 = in_i16(x + 48);
+        Expr u16_1 = in_u16(x), u16_2 = in_u16(x + 16), u16_3 = in_u16(x + 32), u16_4 = in_u16(x + 48);
+        Expr i32_1 = in_i32(x), i32_2 = in_i32(x + 16), i32_3 = in_i32(x + 32);
+        Expr u32_1 = in_u32(x), u32_2 = in_u32(x + 16), u32_3 = in_u32(x + 32);
+        Expr i64_1 = in_i64(x), i64_2 = in_i64(x + 16), i64_3 = in_i64(x + 32);
+        Expr u64_1 = in_u64(x), u64_2 = in_u64(x + 16), u64_3 = in_u64(x + 32);
+        Expr bool_1 = (f32_1 > 0.3f), bool_2 = (f32_1 < -0.3f), bool_3 = (f32_1 != -0.34f);
+
+        int vector_width = 64;
+
+        // 48-bit math
+        check("IVP_MULNX16", vector_width / 2, i32(i16_1) * i32(i16_2));
+        check("IVP_MULUUNX16", vector_width / 2, u32(u16_1) * u32(u16_2));
+        check("IVP_MULUUPNX16", vector_width / 2, u32(u16_1) * u32(u16_2) + u32(u16_3) * u32(u16_4));
+
+        check("halide_xtensa_widen_add_i48", vector_width / 2, i32(i16_1) + i32(i16_2));
+        check("halide_xtensa_widen_add_u48", vector_width / 2, u32(u16_1) + u32(u16_2));
+
+        // Multiplications.
+        check("IVP_MULNX16PACKL", vector_width / 2, i16_1 * i16_2);
+        check("IVP_MULN_2X32", vector_width / 2, i32_1 * i32_2);
+
+        // Shifts.
+        check("IVP_SRLNX16", vector_width / 2, u16_1 >> u16_2);
+        check("IVP_SRLINX16U", vector_width / 2, u16_1 / 4);
+        check("IVP_SRLN_2X32", vector_width / 4, u32_1 >> u32_2);
+        check("IVP_SRLIN_2X32", vector_width / 4, u32_1 / 4);
+        check("IVP_SLLNX16U", vector_width / 2, u16_1 << u16_2);
+        check("IVP_SLLINX16U", vector_width / 2, u16_1 * 4);
+        check("IVP_SLLN_2X32", vector_width / 4, u32_1 << u32_2);
+        check("IVP_SLLIN_2X32", vector_width / 4, u32_1 * 4);
+
+        // Casts.
+        check("convert<int32x32_t,int16x32_t>", vector_width / 2, i32(i16_1));
+        check("convert<float16x32_t,float32x32_t>", vector_width / 2, f16(f32_1));
+        check("convert<float32x32_t, float16x32_t>", vector_width / 2, f32(f16_1));
+        check("convert<float32x32_t, int16x32_t>", vector_width / 2, f32(i16_1));
+        check("convert<float32x32_t, uint16x32_t>", vector_width / 2, f32(u16_1));
+        check("convert<uint32x32_t, uint16x32_t>", vector_width / 2, u32(u16_1));
+        check("store_narrowing<int32x16_t, int16_t, 16>", vector_width / 4, i16(i32_1));
+        check("store_narrowing<uint32x16_t, uint16_t, 16>", vector_width / 4, u16(u32_1));
+        check("store_narrowing<int16x32_t, int8_t, 32>", vector_width / 2, i8(i16_1));
+        check("store_narrowing<uint16x32_t, uint8_t, 32>", vector_width / 2, u8(u16_1));
+
+        // Averaging instructions.
+        check("IVP_AVGUNX16", vector_width / 2, u16((u32(u16_1) + u32(u16_2)) / 2));
+        check("IVP_AVGNX16", vector_width / 2, i16((i32(i16_1) + i32(i16_2)) / 2));
+        check("IVP_AVGRUNX16", vector_width / 2, u16((u32(u16_1) + u32(u16_2) + 1) / 2));
+        check("IVP_AVGRNX16", vector_width / 2, i16((i32(i16_1) + i32(i16_2) + 1) / 2));
+
+        // Saturating arithmetic
+        check("IVP_ADDSNX16", vector_width / 2, i16_sat(i32(i16_1) + i32(i16_2)));
+        check("halide_xtensa_sat_add_i32", vector_width / 4, i32_sat(i64(i32_1) + i64(i32_2)));
+        check("IVP_SUBSNX16", vector_width / 2, i16_sat(i32(i16_1) - i32(i16_2)));
+        check("IVP_ABSSUBNX16", vector_width / 2, absd(u16_1, u16_2));
+        check("IVP_ABSSUBNX16", vector_width / 2, absd(i16_1, i16_2));
+
+        // Min/max
+        check("IVP_MAXUNX16", vector_width / 2, max(u16_1, u16_2));
+        check("IVP_MAXNX16", vector_width / 2, max(i16_1, i16_2));
+        check("IVP_MINUNX16", vector_width / 2, min(u16_1, u16_2));
+        check("IVP_MINNX16", vector_width / 2, min(i16_1, i16_2));
+        check("IVP_MAXUN_2X32", vector_width / 4, max(u32_1, u32_2));
+        check("IVP_MAXN_2X32", vector_width / 4, max(i32_1, i32_2));
+        check("IVP_MINUN_2X32", vector_width / 4, min(u32_1, u32_2));
+        check("IVP_MINN_2X32", vector_width / 4, min(i32_1, i32_2));
+
+        // Count_leading_zeros
+        check("IVP_NSAUNX16", vector_width / 2, count_leading_zeros(u16_1));
+        check("IVP_NSAUNX16", vector_width / 2, count_leading_zeros(i16_1));
+        check("IVP_NSAUN_2X32", vector_width / 4, count_leading_zeros(u32_1));
+        check("IVP_NSAUN_2X32", vector_width / 4, count_leading_zeros(i32_1));
+
+        //  Shifts
+        check("IVP_PACKVRNRNX48", vector_width / 2, i16(widening_mul(i16_1, i16_2) >> 4));
+
+        // These are not generated right now, because vectors are split now, so comment out for now.
+        // Narrowing with shifting.
+        // check("halide_xtensa_narrow_with_shift_i16", vector_width / 2, i16(i32_1 >> i32_2));
+        check("halide_xtensa_narrow_with_shift_i16", vector_width / 2, i16(i32_1 / 4));
+        // check("halide_xtensa_narrow_with_shift_u16", vector_width / 2, u16(i32_1 >> i32_2));
+        check("halide_xtensa_narrow_with_shift_u16", vector_width / 2, u16(i32_1 / 4));
+
+        check("IVP_AVGRNX16", vector_width / 2, i16((i32(i16_1) + i32(i16_2) + 1) / 2));
+    }
+
+private:
+    const Var x{"x"}, y{"y"};
+};
+
+int main(int argc, char **argv) {
+    Target host = get_host_target();
+    Target hl_target = get_target_from_environment();
+    printf("host is:      %s\n", host.to_string().c_str());
+    printf("HL_TARGET is: %s\n", hl_target.to_string().c_str());
+
+    if (!hl_target.has_feature(Target::Xtensa)) {
+        printf("[SKIP] Skipping the simd_op_check_xtensa test, because target doesn't have xtensa feature flag enabled\n");
+        return 0;
+    }
+    SimdOpCheckXtensa test_xtensa(hl_target);
+
+    if (argc > 1) {
+        test_xtensa.filter = argv[1];
+    }
+
+    if (argc > 2) {
+        // Don't forget: if you want to run the standard tests to a specific output
+        // directory, you'll need to invoke with the first arg enclosed
+        // in quotes (to avoid it being wildcard-expanded by the shell):
+        //
+        //    correctness_simd_op_check "*" /path/to/output
+        //
+        test_xtensa.output_directory = argv[2];
+    }
+    bool success = test_xtensa.test_all();
+
+    if (!success) {
+        return -1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
This backports the branch for Xtensa codegen into main. Note that it deliberately ignores changes to apps/ (which had grown stale); those changes may or may not be backported at a later date.

Aside from `simd_op_check_xtensa`, there are few tests for the new codegen paths; the next step to remedy that will be updating the buildbots to add code coverage for the existing test suite to the extent that is possible via AOT only (since the Xtensa codegen does not support JIT).