### PR TITLE
Mark the Halide pipeline structs as aligned(8)

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1764,7 +1764,7 @@ void halide_register_argv_and_metadata(
  * alongside the pipeline. */
 
 /** Per-Func state tracked by the sampling profiler. */
-struct halide_profiler_func_stats {
+struct HALIDE_ATTRIBUTE_ALIGN(8) halide_profiler_func_stats {
     /** Total time taken evaluating this Func (in nanoseconds). */
     uint64_t time;
 
@@ -1792,7 +1792,7 @@ struct halide_profiler_func_stats {
 
 /** Per-pipeline state tracked by the sampling profiler. These exist
  * in a linked list. */
-struct halide_profiler_pipeline_stats {
+struct HALIDE_ATTRIBUTE_ALIGN(8) halide_profiler_pipeline_stats {
     /** Total time spent inside this pipeline (in nanoseconds) */
     uint64_t time;
 


### PR DESCRIPTION
When compiling for 32-bit, LLVM assumes that these structs are only 4-aligned (since alignof(uint64_t) == 4 for x86-32), which means some atomic operations on these structs may require library calls. Since these structs are always malloc'ed, and malloc on all our platforms will return an 8-aligned pointer, we can improve this by telling Clang that the struct will always be at least 8-aligned.