### PR TITLE
Use existing Halide Runtime atomic wrappers everywhere in the runtime

### DIFF
--- a/src/runtime/runtime_atomics.h
+++ b/src/runtime/runtime_atomics.h
@@ -1,0 +1,270 @@
+#ifndef HALIDE_RUNTIME_RUNTIME_ATOMICS_H
+#define HALIDE_RUNTIME_RUNTIME_ATOMICS_H
+
+#include "HalideRuntime.h"
+
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+namespace Synchronization {
+
+namespace {
+
+// TODO: most of these wrappers should do the remove_volatile for secondary arguments;
+// I've only put it in place for the locations necessary at this time.
+template<class T>
+struct remove_volatile { typedef T type; };
+template<class T>
+struct remove_volatile<volatile T> { typedef T type; };
+
+#ifdef BITS_32
+ALWAYS_INLINE uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
+    return __sync_and_and_fetch(addr, val);
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_fetch_add_acquire_release(T *addr, T val) {
+    return __sync_fetch_and_add(addr, val);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE T atomic_fetch_add_sequentially_consistent(T *addr, TV val) {
+    return __sync_fetch_and_add(addr, val);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE T atomic_fetch_sub_sequentially_consistent(T *addr, TV val) {
+    return __sync_fetch_and_sub(addr, val);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE T atomic_fetch_or_sequentially_consistent(T *addr, TV val) {
+    return __sync_fetch_and_or(addr, val);
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_add_fetch_sequentially_consistent(T *addr, T val) {
+    return __sync_add_and_fetch(addr, val);
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_sub_fetch_sequentially_consistent(T *addr, T val) {
+    return __sync_sub_and_fetch(addr, val);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE bool cas_strong_sequentially_consistent_helper(T *addr, TV *expected, TV *desired) {
+    TV oldval = *expected;
+    TV gotval = __sync_val_compare_and_swap(addr, oldval, *desired);
+    *expected = gotval;
+    return oldval == gotval;
+}
+
+ALWAYS_INLINE bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE bool atomic_cas_strong_sequentially_consistent(T *addr, TV *expected, TV *desired) {
+    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
+}
+
+ALWAYS_INLINE bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
+}
+
+template<typename T>
+ALWAYS_INLINE bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
+    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
+}
+
+ALWAYS_INLINE bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
+}
+
+ALWAYS_INLINE bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_fetch_and_release(T *addr, T val) {
+    return __sync_fetch_and_and(addr, val);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE T atomic_fetch_and_sequentially_consistent(T *addr, TV val) {
+    return __sync_fetch_and_and(addr, val);
+}
+
+template<typename T>
+ALWAYS_INLINE void atomic_load_relaxed(T *addr, T *val) {
+    *val = *addr;
+}
+
+template<typename T>
+ALWAYS_INLINE void atomic_load_acquire(T *addr, T *val) {
+    __sync_synchronize();
+    *val = *addr;
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_exchange_acquire(T *addr, T val) {
+    // Despite the name, this is really just an exchange operation with acquire ordering.
+    return __sync_lock_test_and_set(addr, val);
+}
+
+ALWAYS_INLINE uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
+    return __sync_or_and_fetch(addr, val);
+}
+
+ALWAYS_INLINE void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
+    *addr = *val;
+}
+
+template<typename T>
+ALWAYS_INLINE void atomic_store_release(T *addr, T *val) {
+    *addr = *val;
+    __sync_synchronize();
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE void atomic_store_sequentially_consistent(T *addr, TV *val) {
+    *addr = *val;
+    __sync_synchronize();
+}
+
+ALWAYS_INLINE void atomic_thread_fence_acquire() {
+    __sync_synchronize();
+}
+
+ALWAYS_INLINE void atomic_thread_fence_sequentially_consistent() {
+    __sync_synchronize();
+}
+
+#else
+
+ALWAYS_INLINE uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
+    return __atomic_and_fetch(addr, val, __ATOMIC_RELEASE);
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_fetch_add_acquire_release(T *addr, T val) {
+    return __atomic_fetch_add(addr, val, __ATOMIC_ACQ_REL);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE T atomic_fetch_add_sequentially_consistent(T *addr, TV val) {
+    return __atomic_fetch_add(addr, val, __ATOMIC_SEQ_CST);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE T atomic_fetch_sub_sequentially_consistent(T *addr, TV val) {
+    return __atomic_fetch_sub(addr, val, __ATOMIC_SEQ_CST);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE T atomic_fetch_or_sequentially_consistent(T *addr, TV val) {
+    return __atomic_fetch_or(addr, val, __ATOMIC_SEQ_CST);
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_add_fetch_sequentially_consistent(T *addr, T val) {
+    return __atomic_add_fetch(addr, val, __ATOMIC_SEQ_CST);
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_sub_fetch_sequentially_consistent(T *addr, T val) {
+    return __atomic_sub_fetch(addr, val, __ATOMIC_SEQ_CST);
+}
+
+ALWAYS_INLINE bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return __atomic_compare_exchange(addr, expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE bool atomic_cas_strong_sequentially_consistent(T *addr, TV *expected, TV *desired) {
+    return __atomic_compare_exchange(addr, expected, desired, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+}
+
+template<typename T>
+ALWAYS_INLINE bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
+    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
+}
+
+ALWAYS_INLINE bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
+}
+
+ALWAYS_INLINE bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
+}
+
+ALWAYS_INLINE bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
+    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+}
+
+template<typename T>
+ALWAYS_INLINE uintptr_t atomic_fetch_and_release(T *addr, T val) {
+    return __atomic_fetch_and(addr, val, __ATOMIC_RELEASE);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE uintptr_t atomic_fetch_and_sequentially_consistent(T *addr, TV val) {
+    return __atomic_fetch_and(addr, val, __ATOMIC_SEQ_CST);
+}
+
+template<typename T>
+ALWAYS_INLINE void atomic_load_relaxed(T *addr, T *val) {
+    __atomic_load(addr, val, __ATOMIC_RELAXED);
+}
+
+template<typename T>
+ALWAYS_INLINE void atomic_load_acquire(T *addr, T *val) {
+    __atomic_load(addr, val, __ATOMIC_ACQUIRE);
+    __sync_synchronize();
+    *val = *addr;
+}
+
+template<typename T>
+ALWAYS_INLINE T atomic_exchange_acquire(T *addr, T val) {
+    T result;
+    __atomic_exchange(addr, &val, &result, __ATOMIC_ACQUIRE);
+    return result;
+}
+
+ALWAYS_INLINE uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
+    return __atomic_or_fetch(addr, val, __ATOMIC_RELAXED);
+}
+
+ALWAYS_INLINE void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
+    __atomic_store(addr, val, __ATOMIC_RELAXED);
+}
+
+template<typename T>
+ALWAYS_INLINE void atomic_store_release(T *addr, T *val) {
+    __atomic_store(addr, val, __ATOMIC_RELEASE);
+}
+
+template<typename T, typename TV = typename remove_volatile<T>::type>
+ALWAYS_INLINE void atomic_store_sequentially_consistent(T *addr, TV *val) {
+    __atomic_store(addr, val, __ATOMIC_SEQ_CST);
+}
+
+ALWAYS_INLINE void atomic_thread_fence_acquire() {
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
+}
+
+ALWAYS_INLINE void atomic_thread_fence_sequentially_consistent() {
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+}
+
+#endif
+
+}  // namespace
+
+}  // namespace Synchronization
+}  // namespace Internal
+}  // namespace Runtime
+}  // namespace Halide
+
+#endif  // HALIDE_RUNTIME_RUNTIME_ATOMICS_H

--- a/src/runtime/runtime_atomics.h
+++ b/src/runtime/runtime_atomics.h
@@ -1,6 +1,13 @@
 #ifndef HALIDE_RUNTIME_RUNTIME_ATOMICS_H
 #define HALIDE_RUNTIME_RUNTIME_ATOMICS_H
 
+// This file provides an abstraction layer over the __sync/__atomic builtins
+// in Clang; for various reasons, we use __sync for 32-bit targets, and
+// __atomic for 64-bit. At some point it may be desirable/necessary to
+// migrate 32-bit to __atomic as well, at which time this file can
+// likely go away. See https://github.com/halide/Halide/issues/7431 for
+// a discussion of the history and issues as to why we work this way.
+
 #include "HalideRuntime.h"
 
 namespace Halide {

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -27,6 +27,8 @@
  *       be doable.
  */
 
+#include "runtime_atomics.h"
+
 // Copied from tsan_interface.h
 #ifndef TSAN_ANNOTATIONS
 #define TSAN_ANNOTATIONS 0
@@ -86,143 +88,6 @@ ALWAYS_INLINE void if_tsan_pre_signal(void *) {
 }
 ALWAYS_INLINE void if_tsan_post_signal(void *) {
 }
-#endif
-
-#ifdef BITS_32
-ALWAYS_INLINE uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
-    return __sync_and_and_fetch(addr, val);
-}
-
-template<typename T>
-ALWAYS_INLINE T atomic_fetch_add_acquire_release(T *addr, T val) {
-    return __sync_fetch_and_add(addr, val);
-}
-
-template<typename T>
-ALWAYS_INLINE bool cas_strong_sequentially_consistent_helper(T *addr, T *expected, T *desired) {
-    T oldval = *expected;
-    T gotval = __sync_val_compare_and_swap(addr, oldval, *desired);
-    *expected = gotval;
-    return oldval == gotval;
-}
-
-ALWAYS_INLINE bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
-}
-
-ALWAYS_INLINE bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
-}
-
-template<typename T>
-ALWAYS_INLINE bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
-    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
-}
-
-ALWAYS_INLINE bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
-}
-
-ALWAYS_INLINE bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return cas_strong_sequentially_consistent_helper(addr, expected, desired);
-}
-
-ALWAYS_INLINE uintptr_t atomic_fetch_and_release(uintptr_t *addr, uintptr_t val) {
-    return __sync_fetch_and_and(addr, val);
-}
-
-template<typename T>
-ALWAYS_INLINE void atomic_load_relaxed(T *addr, T *val) {
-    *val = *addr;
-}
-
-template<typename T>
-ALWAYS_INLINE void atomic_load_acquire(T *addr, T *val) {
-    __sync_synchronize();
-    *val = *addr;
-}
-
-ALWAYS_INLINE uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
-    return __sync_or_and_fetch(addr, val);
-}
-
-ALWAYS_INLINE void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
-    *addr = *val;
-}
-
-template<typename T>
-ALWAYS_INLINE void atomic_store_release(T *addr, T *val) {
-    *addr = *val;
-    __sync_synchronize();
-}
-
-ALWAYS_INLINE void atomic_thread_fence_acquire() {
-    __sync_synchronize();
-}
-
-#else
-
-ALWAYS_INLINE uintptr_t atomic_and_fetch_release(uintptr_t *addr, uintptr_t val) {
-    return __atomic_and_fetch(addr, val, __ATOMIC_RELEASE);
-}
-
-template<typename T>
-ALWAYS_INLINE T atomic_fetch_add_acquire_release(T *addr, T val) {
-    return __atomic_fetch_add(addr, val, __ATOMIC_ACQ_REL);
-}
-
-ALWAYS_INLINE bool atomic_cas_strong_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return __atomic_compare_exchange(addr, expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
-}
-
-template<typename T>
-ALWAYS_INLINE bool atomic_cas_weak_relacq_relaxed(T *addr, T *expected, T *desired) {
-    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED);
-}
-
-ALWAYS_INLINE bool atomic_cas_weak_release_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_RELEASE, __ATOMIC_RELAXED);
-}
-
-ALWAYS_INLINE bool atomic_cas_weak_relaxed_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_RELAXED, __ATOMIC_RELAXED);
-}
-
-ALWAYS_INLINE bool atomic_cas_weak_acquire_relaxed(uintptr_t *addr, uintptr_t *expected, uintptr_t *desired) {
-    return __atomic_compare_exchange(addr, expected, desired, true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
-}
-
-ALWAYS_INLINE uintptr_t atomic_fetch_and_release(uintptr_t *addr, uintptr_t val) {
-    return __atomic_fetch_and(addr, val, __ATOMIC_RELEASE);
-}
-
-template<typename T>
-ALWAYS_INLINE void atomic_load_relaxed(T *addr, T *val) {
-    __atomic_load(addr, val, __ATOMIC_RELAXED);
-}
-
-template<typename T>
-ALWAYS_INLINE void atomic_load_acquire(T *addr, T *val) {
-    __atomic_load(addr, val, __ATOMIC_ACQUIRE);
-}
-
-ALWAYS_INLINE uintptr_t atomic_or_fetch_relaxed(uintptr_t *addr, uintptr_t val) {
-    return __atomic_or_fetch(addr, val, __ATOMIC_RELAXED);
-}
-
-ALWAYS_INLINE void atomic_store_relaxed(uintptr_t *addr, uintptr_t *val) {
-    __atomic_store(addr, val, __ATOMIC_RELAXED);
-}
-
-template<typename T>
-ALWAYS_INLINE void atomic_store_release(T *addr, T *val) {
-    __atomic_store(addr, val, __ATOMIC_RELEASE);
-}
-
-ALWAYS_INLINE void atomic_thread_fence_acquire() {
-    __atomic_thread_fence(__ATOMIC_ACQUIRE);
-}
-
 #endif
 
 }  // namespace

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -1,5 +1,6 @@
 #include "HalideRuntime.h"
 #include "printer.h"
+#include "runtime_atomics.h"
 #include "scoped_spin_lock.h"
 
 extern "C" {
@@ -14,8 +15,7 @@ namespace Internal {
 // A spinlock that allows for shared and exclusive access. It's
 // equivalent to a reader-writer lock, but in my case the "readers"
 // will actually be writing simultaneously to the trace buffer, so
-// that's a bad name. We use the __sync primitives used elsewhere in
-// the runtime for atomic work. They are well supported by clang.
+// that's a bad name.
 class SharedExclusiveSpinLock {
     volatile uint32_t lock = 0;
 
@@ -37,37 +37,51 @@ class SharedExclusiveSpinLock {
 
 public:
     ALWAYS_INLINE void acquire_shared() {
+        using namespace Halide::Runtime::Internal::Synchronization;
+
         while (true) {
-            uint32_t x = lock & shared_mask;
-            if (__sync_bool_compare_and_swap(&lock, x, x + 1)) {
+            uint32_t expected = lock & shared_mask;
+            uint32_t desired = expected + 1;
+            if (atomic_cas_strong_sequentially_consistent(&lock, &expected, &desired)) {
                 return;
             }
         }
     }
 
     ALWAYS_INLINE void release_shared() {
-        __sync_fetch_and_sub(&lock, 1);
+        using namespace Halide::Runtime::Internal::Synchronization;
+
+        atomic_fetch_sub_sequentially_consistent(&lock, (uint32_t)1);
     }
 
     ALWAYS_INLINE void acquire_exclusive() {
+        using namespace Halide::Runtime::Internal::Synchronization;
+
         while (true) {
             // If multiple threads are trying to acquire exclusive
             // ownership, we may need to rerequest exclusive waiting
             // while we spin, as it gets unset whenever a thread
             // acquires exclusive ownership.
-            __sync_fetch_and_or(&lock, exclusive_waiting_mask);
-            if (__sync_bool_compare_and_swap(&lock, exclusive_waiting_mask, exclusive_held_mask)) {
+            atomic_fetch_or_sequentially_consistent(&lock, exclusive_waiting_mask);
+            uint32_t expected = exclusive_waiting_mask;
+            uint32_t desired = exclusive_held_mask;
+            if (atomic_cas_strong_sequentially_consistent(&lock, &expected, &desired)) {
                 return;
             }
         }
     }
 
     ALWAYS_INLINE void release_exclusive() {
-        __sync_fetch_and_and(&lock, ~exclusive_held_mask);
+        using namespace Halide::Runtime::Internal::Synchronization;
+
+        atomic_fetch_and_sequentially_consistent(&lock, ~exclusive_held_mask);
     }
 
     ALWAYS_INLINE void init() {
-        lock = 0;
+        using namespace Halide::Runtime::Internal::Synchronization;
+
+        uint32_t value = 0;
+        atomic_store_sequentially_consistent(&lock, &value);
     }
 
     SharedExclusiveSpinLock() = default;
@@ -83,15 +97,17 @@ class TraceBuffer {
     // Attempt to atomically acquire space in the buffer to write a
     // packet. Returns nullptr if the buffer was full.
     ALWAYS_INLINE halide_trace_packet_t *try_acquire_packet(void *user_context, uint32_t size) {
+        using namespace Halide::Runtime::Internal::Synchronization;
+
         lock.acquire_shared();
         halide_abort_if_false(user_context, size <= buffer_size);
-        uint32_t my_cursor = __sync_fetch_and_add(&cursor, size);
+        uint32_t my_cursor = atomic_fetch_add_sequentially_consistent(&cursor, size);
         if (my_cursor + size > sizeof(buf)) {
             // Don't try to back it out: instead, just allow this request to fail
             // (along with all subsequent requests) and record the 'overage'
             // that was added and should be ignored; then, in the next flush,
             // remove the overage.
-            __sync_fetch_and_add(&overage, size);
+            atomic_fetch_add_sequentially_consistent(&overage, size);
             lock.release_shared();
             return nullptr;
         } else {
@@ -131,8 +147,10 @@ public:
 
     // Release a packet, allowing it to be written out with flush
     ALWAYS_INLINE void release_packet(halide_trace_packet_t *) {
+        using namespace Halide::Runtime::Internal::Synchronization;
+
         // Need a memory barrier to guarantee all the writes are done.
-        __sync_synchronize();
+        atomic_thread_fence_sequentially_consistent();
         lock.release_shared();
     }
 
@@ -158,9 +176,11 @@ WEAK void *halide_trace_file_internally_opened = nullptr;
 extern "C" {
 
 WEAK int32_t halide_default_trace(void *user_context, const halide_trace_event_t *e) {
+    using namespace Halide::Runtime::Internal::Synchronization;
+
     static int32_t ids = 1;
 
-    int32_t my_id = __sync_fetch_and_add(&ids, 1);
+    int32_t my_id = atomic_fetch_add_sequentially_consistent(&ids, 1);
 
     // If we're dumping to a file, use a binary format
     int fd = halide_get_trace_file(user_context);

--- a/src/runtime/webgpu.cpp
+++ b/src/runtime/webgpu.cpp
@@ -3,6 +3,7 @@
 #include "device_interface.h"
 #include "gpu_context_common.h"
 #include "printer.h"
+#include "runtime_atomics.h"
 #include "scoped_spin_lock.h"
 
 #include "mini_webgpu.h"
@@ -162,6 +163,8 @@ public:
     // Wait for all error callbacks in this scope to fire.
     // Returns the error code (or success).
     halide_error_code_t wait() {
+        using namespace Halide::Runtime::Internal::Synchronization;
+
         if (callbacks_remaining == 0) {
             error(user_context) << "no outstanding error scopes\n";
             return halide_error_code_internal_error;
@@ -172,7 +175,7 @@ public:
         wgpuDevicePopErrorScope(device, error_callback, this);
 
         // Wait for the error callbacks to fire.
-        while (__sync_fetch_and_or(&callbacks_remaining, 0) > 0) {
+        while (atomic_fetch_or_sequentially_consistent(&callbacks_remaining, 0) > 0) {
             wgpuDeviceTick(device);
         }
 
@@ -194,6 +197,8 @@ private:
     static void error_callback(WGPUErrorType type,
                                char const *message,
                                void *userdata) {
+        using namespace Halide::Runtime::Internal::Synchronization;
+
         ErrorScope *context = (ErrorScope *)userdata;
         switch (type) {
         case WGPUErrorType_NoError:
@@ -215,7 +220,7 @@ private:
             context->error_code = halide_error_code_generic_error;
         }
 
-        __sync_fetch_and_add(&context->callbacks_remaining, -1);
+        atomic_fetch_add_sequentially_consistent(&context->callbacks_remaining, -1);
     }
 };
 


### PR DESCRIPTION
We currently have a set of wrappers around the __atomic/__sync primitives used by our threading model; for various reasons, we desire to use the (deprecated) __sync primitives for 32-bit builds instead of the __atomic primitives (see https://github.com/halide/Halide/pull/7427 for some discussion).

This PR attempts to use these abstractions everywhere else in our runtime, for consistency, so that 64-bit builds consistent use the __atomic primitives for (e.g.) profiling and tracing too. This meant:
- Splitting the wrappers into a new header (runtime_atomics.h), as synchronization_common.h can't be included into arbitrary other files, for valid reasons
- Adding wrappers for the necessary primitives
- Modifying the code elsewhere in the runtime

Where new wrappers were needed, I generally defaulted to assuming that SEQ_CST was the safest memory order to use.

Not entirely sure if this is a worthwhile goal or not, but putting this out there for consideration and discussion.