### PR TITLE
Fix bugs in PyTorch codegen.

### DIFF
--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -25,6 +25,7 @@ void CodeGen_PyTorch::compile(const Module &module) {
                           "Please add \"-user_context\" to the generator's target options.\n";
         }
         stream << "#include \"ATen/cuda/CUDAContext.h\"\n";
+        stream << "#include \"HalidePyTorchCudaHelpers.h\"\n";
     }
     stream << "#include \"HalideBuffer.h\"\n";
     stream << "#include \"HalidePyTorchHelpers.h\"\n";
@@ -43,6 +44,11 @@ void CodeGen_PyTorch::compile(const Module &module) {
     }
 
     for (const auto &f : module.functions()) {
+        // Don't put non-external function declarations in headers.
+        // We need to be consistent with CodeGen_C::compile.
+        if (f.linkage == LinkageType::Internal) {
+            continue;
+        }
         if (target.has_feature(Target::CUDA)) {
             compile(f, true);
         } else {

--- a/src/runtime/HalidePyTorchHelpers.h
+++ b/src/runtime/HalidePyTorchHelpers.h
@@ -16,7 +16,7 @@
 #include "HalideBuffer.h"
 
 // Forward declare the cuda_device_interface, for tensor wrapper.
-const halide_device_interface_t *halide_cuda_device_interface();
+extern "C" const halide_device_interface_t *halide_cuda_device_interface();
 
 #define HLPT_CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
 #define HLPT_CHECK_CUDA(x) AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")


### PR DESCRIPTION
There are several problems with the current PyTorch CodeGen.
First, the emitted `.pytorch.h` file incorrectly exposes functions with internal linkage (which is inconsistent with the C codegen), and leads to compile errors when actually compiling the header file. I added a check for internal linkage to fix this.
Next is the problems when using CUDA. Currently when using the generated `.pytorch.h` file, the linker will complain that there is undefined reference to a symbol related to `halide_cuda_device_interface` (the name is mangled when reported by the linker). This is because the forward declaration was not in a `extern "C"` block.
Moreover, there is a really subtle problem when the generated pipeline is invoked by PyTorch (which I actually have described in Matrix). The Halide pipeline runs in a different CUDA stream than that of PyTorch kernels. Afterwards I discovered that `HalidePyTorchCudaHelpers.h` was not included as `apps/HelloPyTorch/setup.py` did, and weakly-linked CUDA handles are not overridden. I fix this by simply including this header in the codegen.