### PR TITLE
Revert #7446, #7457, #7458

### DIFF
--- a/apps/hannk/halide/common_halide.h
+++ b/apps/hannk/halide/common_halide.h
@@ -7,12 +7,12 @@
 
 namespace hannk {
 
-using Halide::rounding_shift_right;
-using Halide::saturating_add;
-using Halide::saturating_sub;
-using Halide::widening_add;
-using Halide::widening_mul;
-using Halide::widening_sub;
+using Halide::Internal::rounding_shift_right;
+using Halide::Internal::saturating_add;
+using Halide::Internal::saturating_sub;
+using Halide::Internal::widening_add;
+using Halide::Internal::widening_mul;
+using Halide::Internal::widening_sub;
 
 // Get the number of vector registers available on the target.
 int get_register_count(const Halide::Target &target);

--- a/apps/hannk/halide/pool_generator.cpp
+++ b/apps/hannk/halide/pool_generator.cpp
@@ -68,7 +68,7 @@ public:
         Expr inv_filter_count =
             u16_sat(((2 << log2_numerator) + filter_count) / (2 * filter_count));
         Expr average =
-            ::Halide::rounding_mul_shift_right(sum(c, x, y, b), inv_filter_count, log2_numerator);
+            rounding_mul_shift_right(sum(c, x, y, b), inv_filter_count, log2_numerator);
 
         output_(c, x, y, b) = clamp(u8_sat(average), output_min_, output_max_);
 

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2075,7 +2075,7 @@ Expr CodeGen_C::scalarize_vector_reduce(const VectorReduce *op) {
         binop = Or::make;
         break;
     case VectorReduce::SaturatingAdd:
-        binop = Halide::saturating_add;
+        binop = saturating_add;
         break;
     }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4188,7 +4188,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
         binop = Or::make;
         break;
     case VectorReduce::SaturatingAdd:
-        binop = Halide::saturating_add;
+        binop = saturating_add;
         break;
     }
 

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -14,8 +14,6 @@
 #include "Util.h"
 #include "Var.h"
 
-using namespace Halide::Internal;
-
 namespace Halide {
 
 // Evaluate a float polynomial efficiently, taking instruction latency
@@ -59,8 +57,8 @@ Expr stringify(const std::vector<Expr> &args) {
         return Expr("");
     }
 
-    return Call::make(type_of<const char *>(), Call::stringify,
-                      args, Call::PureIntrinsic);
+    return Internal::Call::make(type_of<const char *>(), Internal::Call::stringify,
+                                args, Internal::Call::PureIntrinsic);
 }
 
 Expr combine_strings(const std::vector<Expr> &args) {
@@ -83,10 +81,10 @@ Expr combine_strings(const std::vector<Expr> &args) {
     // useful to reduce emitted code size when printing
     size_t i = 0;
     while (i < strings.size() - 1) {
-        const auto *cur_str = strings[i].as<StringImm>();
-        const auto *next_str = strings[i + 1].as<StringImm>();
+        const auto *cur_str = strings[i].as<Internal::StringImm>();
+        const auto *next_str = strings[i + 1].as<Internal::StringImm>();
         if (cur_str && next_str) {
-            strings[i] = StringImm::make(cur_str->value + next_str->value);
+            strings[i] = Internal::StringImm::make(cur_str->value + next_str->value);
             strings.erase(strings.begin() + i + 1);
             continue;
         }
@@ -1091,10 +1089,10 @@ Expr unwrap_tags(const Expr &e) {
 }
 
 Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args) {
-    return Call::make(Int(32),
-                      "halide_error_requirement_failed",
-                      {stringify({std::move(condition)}), combine_strings(args)},
-                      Call::Extern);
+    return Internal::Call::make(Int(32),
+                                "halide_error_requirement_failed",
+                                {stringify({std::move(condition)}), combine_strings(args)},
+                                Internal::Call::Extern);
 }
 
 Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values) {
@@ -1102,11 +1100,9 @@ Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values) 
     std::vector<Expr> args;
     args.push_back(std::move(result));
     args.insert(args.end(), cache_key_values.begin(), cache_key_values.end());
-    return Call::make(t, Call::memoize_expr,
-                      args, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::memoize_expr,
+                                args, Internal::Call::PureIntrinsic);
 }
-
-}  // namespace Internal
 
 Expr widen_right_add(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "widen_right_add of undefined Expr\n"
@@ -1331,6 +1327,8 @@ Expr rounding_mul_shift_right(Expr a, Expr b, int q) {
     return rounding_mul_shift_right(std::move(a), std::move(b), make_const(qt, q));
 }
 
+}  // namespace Internal
+
 Expr fast_log(const Expr &x) {
     user_assert(x.type() == Float(32)) << "fast_log only works for Float(32)";
 
@@ -1440,22 +1438,22 @@ Expr print(const std::vector<Expr> &args) {
 
     // Call halide_print.
     Expr print_call =
-        Call::make(Int(32), "halide_print",
-                   {combined_string}, Call::Extern);
+        Internal::Call::make(Int(32), "halide_print",
+                             {combined_string}, Internal::Call::Extern);
 
     // Return the first argument.
     Expr result =
-        Call::make(args[0].type(), Call::return_second,
-                   {print_call, args[0]}, Call::PureIntrinsic);
+        Internal::Call::make(args[0].type(), Internal::Call::return_second,
+                             {print_call, args[0]}, Internal::Call::PureIntrinsic);
     return result;
 }
 
 Expr print_when(Expr condition, const std::vector<Expr> &args) {
     Expr p = print(args);
-    return Call::make(p.type(),
-                      Call::if_then_else,
-                      {std::move(condition), p, args[0]},
-                      Call::PureIntrinsic);
+    return Internal::Call::make(p.type(),
+                                Internal::Call::if_then_else,
+                                {std::move(condition), p, args[0]},
+                                Internal::Call::PureIntrinsic);
 }
 
 Expr require(Expr condition, const std::vector<Expr> &args) {
@@ -1465,14 +1463,14 @@ Expr require(Expr condition, const std::vector<Expr> &args) {
 
     Expr err = requirement_failed_error(condition, args);
 
-    return Call::make(args[0].type(),
-                      Call::require,
-                      {likely(std::move(condition)), args[0], std::move(err)},
-                      Call::Intrinsic);
+    return Internal::Call::make(args[0].type(),
+                                Internal::Call::require,
+                                {likely(std::move(condition)), args[0], std::move(err)},
+                                Internal::Call::Intrinsic);
 }
 
 Expr saturating_cast(Type t, Expr e) {
-    return Call::make(t, Call::saturating_cast, {std::move(e)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::saturating_cast, {std::move(e)}, Internal::Call::PureIntrinsic);
 }
 
 Expr select(Expr condition, Expr true_value, Expr false_value) {
@@ -1498,7 +1496,7 @@ Expr select(Expr condition, Expr true_value, Expr false_value) {
         << "  " << true_value << " has type " << true_value.type() << "\n"
         << "  " << false_value << " has type " << false_value.type() << "\n";
 
-    return Select::make(std::move(condition), std::move(true_value), std::move(false_value));
+    return Internal::Select::make(std::move(condition), std::move(true_value), std::move(false_value));
 }
 
 Tuple tuple_select(const Tuple &condition, const Tuple &true_value, const Tuple &false_value) {
@@ -1536,7 +1534,7 @@ Expr mux(const Expr &id, const std::vector<Expr> &values) {
     }
     std::vector<Expr> result{id};
     result.insert(result.end(), values.begin(), values.end());
-    return Call::make(t, Call::mux, result, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::mux, result, Internal::Call::PureIntrinsic);
 }
 
 Expr mux(const Expr &id, const Tuple &tup) {
@@ -1554,10 +1552,10 @@ Expr unsafe_promise_clamped(const Expr &value, const Expr &min, const Expr &max)
 
     // Min and max are allowed to be undefined with the meaning of no bound on that side.
 
-    return Call::make(value.type(),
-                      Call::unsafe_promise_clamped,
-                      {value, n_min_val, n_max_val},
-                      Call::PureIntrinsic);
+    return Internal::Call::make(value.type(),
+                                Internal::Call::unsafe_promise_clamped,
+                                {value, n_min_val, n_max_val},
+                                Internal::Call::PureIntrinsic);
 }
 
 namespace Internal {
@@ -1567,270 +1565,270 @@ Expr promise_clamped(const Expr &value, const Expr &min, const Expr &max) {
     Expr n_max_val = max.defined() ? lossless_cast(value.type(), max) : value.type().max();
 
     // Min and max are allowed to be undefined with the meaning of no bound on that side.
-    return Call::make(value.type(),
-                      Call::promise_clamped,
-                      {value, n_min_val, n_max_val},
-                      Call::PureIntrinsic);
+    return Internal::Call::make(value.type(),
+                                Internal::Call::promise_clamped,
+                                {value, n_min_val, n_max_val},
+                                Internal::Call::PureIntrinsic);
 }
 }  // namespace Internal
 
 Expr operator+(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator+ of undefined Expr\n";
-    match_types(a, b);
-    return Add::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Add::make(std::move(a), std::move(b));
 }
 
 Expr operator+(Expr a, int b) {
     user_assert(a.defined()) << "operator+ of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return Add::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::Add::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator+(int a, Expr b) {
     user_assert(b.defined()) << "operator+ of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return Add::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::Add::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr &operator+=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator+= of undefined Expr\n";
     Type t = a.type();
-    a = Add::make(std::move(a), cast(t, std::move(b)));
+    a = Internal::Add::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
 
 Expr operator-(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator- of undefined Expr\n";
-    match_types(a, b);
-    return Sub::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Sub::make(std::move(a), std::move(b));
 }
 
 Expr operator-(Expr a, int b) {
     user_assert(a.defined()) << "operator- of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return Sub::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::Sub::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator-(int a, Expr b) {
     user_assert(b.defined()) << "operator- of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return Sub::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::Sub::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator-(Expr a) {
     user_assert(a.defined()) << "operator- of undefined Expr\n";
     Type t = a.type();
-    return Sub::make(make_zero(t), std::move(a));
+    return Internal::Sub::make(Internal::make_zero(t), std::move(a));
 }
 
 Expr &operator-=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator-= of undefined Expr\n";
     Type t = a.type();
-    a = Sub::make(std::move(a), cast(t, std::move(b)));
+    a = Internal::Sub::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
 
 Expr operator*(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator* of undefined Expr\n";
-    match_types(a, b);
-    return Mul::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Mul::make(std::move(a), std::move(b));
 }
 
 Expr operator*(Expr a, int b) {
     user_assert(a.defined()) << "operator* of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return Mul::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::Mul::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator*(int a, Expr b) {
     user_assert(b.defined()) << "operator* of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return Mul::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::Mul::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr &operator*=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator*= of undefined Expr\n";
     Type t = a.type();
-    a = Mul::make(std::move(a), cast(t, std::move(b)));
+    a = Internal::Mul::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
 
 Expr operator/(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator/ of undefined Expr\n";
-    match_types(a, b);
-    return Div::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Div::make(std::move(a), std::move(b));
 }
 
 Expr &operator/=(Expr &a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator/= of undefined Expr\n";
     Type t = a.type();
-    a = Div::make(std::move(a), cast(t, std::move(b)));
+    a = Internal::Div::make(std::move(a), cast(t, std::move(b)));
     return a;
 }
 
 Expr operator/(Expr a, int b) {
     user_assert(a.defined()) << "operator/ of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return Div::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::Div::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator/(int a, Expr b) {
     user_assert(b.defined()) << "operator- of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return Div::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::Div::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator%(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator% of undefined Expr\n";
-    match_types(a, b);
-    return Mod::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Mod::make(std::move(a), std::move(b));
 }
 
 Expr operator%(Expr a, int b) {
     user_assert(a.defined()) << "operator% of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return Mod::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::Mod::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator%(int a, Expr b) {
     user_assert(b.defined()) << "operator% of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return Mod::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::Mod::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator>(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator> of undefined Expr\n";
-    match_types(a, b);
-    return GT::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::GT::make(std::move(a), std::move(b));
 }
 
 Expr operator>(Expr a, int b) {
     user_assert(a.defined()) << "operator> of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return GT::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::GT::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator>(int a, Expr b) {
     user_assert(b.defined()) << "operator> of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return GT::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::GT::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator<(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator< of undefined Expr\n";
-    match_types(a, b);
-    return LT::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::LT::make(std::move(a), std::move(b));
 }
 
 Expr operator<(Expr a, int b) {
     user_assert(a.defined()) << "operator< of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return LT::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::LT::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator<(int a, Expr b) {
     user_assert(b.defined()) << "operator< of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return LT::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::LT::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator<=(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator<= of undefined Expr\n";
-    match_types(a, b);
-    return LE::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::LE::make(std::move(a), std::move(b));
 }
 
 Expr operator<=(Expr a, int b) {
     user_assert(a.defined()) << "operator<= of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return LE::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::LE::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator<=(int a, Expr b) {
     user_assert(b.defined()) << "operator<= of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return LE::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::LE::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator>=(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator>= of undefined Expr\n";
-    match_types(a, b);
-    return GE::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::GE::make(std::move(a), std::move(b));
 }
 
 Expr operator>=(const Expr &a, int b) {
     user_assert(a.defined()) << "operator>= of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return GE::make(a, make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::GE::make(a, Internal::make_const(t, b));
 }
 
 Expr operator>=(int a, const Expr &b) {
     user_assert(b.defined()) << "operator>= of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return GE::make(make_const(t, a), b);
+    Internal::check_representable(t, a);
+    return Internal::GE::make(Internal::make_const(t, a), b);
 }
 
 Expr operator==(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator== of undefined Expr\n";
-    match_types(a, b);
-    return EQ::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::EQ::make(std::move(a), std::move(b));
 }
 
 Expr operator==(Expr a, int b) {
     user_assert(a.defined()) << "operator== of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return EQ::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::EQ::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator==(int a, Expr b) {
     user_assert(b.defined()) << "operator== of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return EQ::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::EQ::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator!=(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "operator!= of undefined Expr\n";
-    match_types(a, b);
-    return NE::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::NE::make(std::move(a), std::move(b));
 }
 
 Expr operator!=(Expr a, int b) {
     user_assert(a.defined()) << "operator!= of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return NE::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::NE::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr operator!=(int a, Expr b) {
     user_assert(b.defined()) << "operator!= of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return NE::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::NE::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr operator&&(Expr a, Expr b) {
-    match_types(a, b);
-    return And::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::And::make(std::move(a), std::move(b));
 }
 
 Expr operator&&(Expr a, bool b) {
@@ -1839,7 +1837,7 @@ Expr operator&&(Expr a, bool b) {
     if (b) {
         return a;
     } else {
-        return make_zero(a.type());
+        return Internal::make_zero(a.type());
     }
 }
 
@@ -1848,15 +1846,15 @@ Expr operator&&(bool a, Expr b) {
 }
 
 Expr operator||(Expr a, Expr b) {
-    match_types(a, b);
-    return Or::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Or::make(std::move(a), std::move(b));
 }
 
 Expr operator||(Expr a, bool b) {
     internal_assert(a.defined()) << "operator|| of undefined Expr\n";
     internal_assert(a.type().is_bool()) << "operator|| of Expr of type " << a.type() << "\n";
     if (b) {
-        return make_one(a.type());
+        return Internal::make_one(a.type());
     } else {
         return a;
     }
@@ -1867,49 +1865,49 @@ Expr operator||(bool a, Expr b) {
 }
 
 Expr operator!(Expr a) {
-    return Not::make(std::move(a));
+    return Internal::Not::make(std::move(a));
 }
 
 Expr max(Expr a, Expr b) {
     user_assert(a.defined() && b.defined())
         << "max of undefined Expr\n";
-    match_types(a, b);
-    return Max::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Max::make(std::move(a), std::move(b));
 }
 
 Expr max(Expr a, int b) {
     user_assert(a.defined()) << "max of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return Max::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::Max::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr max(int a, Expr b) {
     user_assert(b.defined()) << "max of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return Max::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::Max::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr min(Expr a, Expr b) {
     user_assert(a.defined() && b.defined())
         << "min of undefined Expr\n";
-    match_types(a, b);
-    return Min::make(std::move(a), std::move(b));
+    Internal::match_types(a, b);
+    return Internal::Min::make(std::move(a), std::move(b));
 }
 
 Expr min(Expr a, int b) {
     user_assert(a.defined()) << "max of undefined Expr\n";
     Type t = a.type();
-    check_representable(t, b);
-    return Min::make(std::move(a), make_const(t, b));
+    Internal::check_representable(t, b);
+    return Internal::Min::make(std::move(a), Internal::make_const(t, b));
 }
 
 Expr min(int a, Expr b) {
     user_assert(b.defined()) << "max of undefined Expr\n";
     Type t = b.type();
-    check_representable(t, a);
-    return Min::make(make_const(t, a), std::move(b));
+    Internal::check_representable(t, a);
+    return Internal::Min::make(Internal::make_const(t, a), std::move(b));
 }
 
 Expr cast(Type t, Expr a) {
@@ -1930,24 +1928,24 @@ Expr cast(Type t, Expr a) {
 
     // Fold constants early
     if (const int64_t *i = as_const_int(a)) {
-        return make_const(t, *i);
+        return Internal::make_const(t, *i);
     }
     if (const uint64_t *u = as_const_uint(a)) {
-        return make_const(t, *u);
+        return Internal::make_const(t, *u);
     }
     if (const double *f = as_const_float(a)) {
-        return make_const(t, *f);
+        return Internal::make_const(t, *f);
     }
 
     if (t.is_vector()) {
         if (a.type().is_scalar()) {
-            return Broadcast::make(cast(t.element_of(), std::move(a)), t.lanes());
-        } else if (const Broadcast *b = a.as<Broadcast>()) {
+            return Internal::Broadcast::make(cast(t.element_of(), std::move(a)), t.lanes());
+        } else if (const Internal::Broadcast *b = a.as<Internal::Broadcast>()) {
             internal_assert(b->lanes == t.lanes());
-            return Broadcast::make(cast(t.element_of(), b->value), t.lanes());
+            return Internal::Broadcast::make(cast(t.element_of(), b->value), t.lanes());
         }
     }
-    return Cast::make(t, std::move(a));
+    return Internal::Cast::make(t, std::move(a));
 }
 
 Expr clamp(Expr a, const Expr &min_val, const Expr &max_val) {
@@ -1963,7 +1961,7 @@ Expr clamp(Expr a, const Expr &min_val, const Expr &max_val) {
         << "Type mismatch in call to clamp. First argument ("
         << a << ") has type " << a.type() << ", but third argument ("
         << max_val << ") has type " << max_val.type() << ". Use an explicit cast.\n";
-    return Max::make(Min::make(std::move(a), std::move(n_max_val)), std::move(n_min_val));
+    return Internal::Max::make(Internal::Min::make(std::move(a), std::move(n_max_val)), std::move(n_min_val));
 }
 
 Expr abs(Expr a) {
@@ -1974,13 +1972,13 @@ Expr abs(Expr a) {
         user_warning << "Warning: abs of an unsigned type is a no-op\n";
         return a;
     }
-    return Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
-                      Call::abs, {std::move(a)}, Call::PureIntrinsic);
+    return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
+                                Internal::Call::abs, {std::move(a)}, Internal::Call::PureIntrinsic);
 }
 
 Expr absd(Expr a, Expr b) {
     user_assert(a.defined() && b.defined()) << "absd of undefined Expr\n";
-    match_types(a, b);
+    Internal::match_types(a, b);
     Type t = a.type();
 
     if (t.is_float()) {
@@ -1989,74 +1987,74 @@ Expr absd(Expr a, Expr b) {
     }
 
     // The argument may be signed, but the return type is unsigned.
-    return Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
-                      Call::absd, {std::move(a), std::move(b)},
-                      Call::PureIntrinsic);
+    return Internal::Call::make(t.with_code(t.is_int() ? Type::UInt : t.code()),
+                                Internal::Call::absd, {std::move(a), std::move(b)},
+                                Internal::Call::PureIntrinsic);
 }
 
 Expr sin(Expr x) {
     user_assert(x.defined()) << "sin of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "sin_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "sin_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "sin_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "sin_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "sin_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "sin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr asin(Expr x) {
     user_assert(x.defined()) << "asin of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "asin_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "asin_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "asin_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "asin_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "asin_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "asin_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr cos(Expr x) {
     user_assert(x.defined()) << "cos of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "cos_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "cos_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "cos_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "cos_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "cos_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "cos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr acos(Expr x) {
     user_assert(x.defined()) << "acos of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "acos_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "acos_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "acos_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "acos_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "acos_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "acos_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr tan(Expr x) {
     user_assert(x.defined()) << "tan of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "tan_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "tan_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "tan_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "tan_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "tan_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "tan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr atan(Expr x) {
     user_assert(x.defined()) << "atan of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "atan_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "atan_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "atan_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "atan_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "atan_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "atan_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2065,91 +2063,91 @@ Expr atan2(Expr y, Expr x) {
 
     if (y.type() == Float(64)) {
         x = cast<double>(x);
-        return Call::make(Float(64), "atan2_f64", {std::move(y), std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "atan2_f64", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
     } else if (y.type() == Float(16)) {
         x = cast<float16_t>(x);
-        return Call::make(Float(16), "atan2_f16", {std::move(y), std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "atan2_f16", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
     } else {
         y = cast<float>(y);
         x = cast<float>(x);
-        return Call::make(Float(32), "atan2_f32", {std::move(y), std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "atan2_f32", {std::move(y), std::move(x)}, Internal::Call::PureExtern);
     }
 }
 
 Expr sinh(Expr x) {
     user_assert(x.defined()) << "sinh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "sinh_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "sinh_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "sinh_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "sinh_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "sinh_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "sinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr asinh(Expr x) {
     user_assert(x.defined()) << "asinh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "asinh_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "asinh_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "asinh_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "asinh_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "asinh_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "asinh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr cosh(Expr x) {
     user_assert(x.defined()) << "cosh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "cosh_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "cosh_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "cosh_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "cosh_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "cosh_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "cosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr acosh(Expr x) {
     user_assert(x.defined()) << "acosh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "acosh_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "acosh_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "acosh_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "acosh_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "acosh_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "acosh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr tanh(Expr x) {
     user_assert(x.defined()) << "tanh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "tanh_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "tanh_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "tanh_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "tanh_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "tanh_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "tanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr atanh(Expr x) {
     user_assert(x.defined()) << "atanh of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "atanh_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "atanh_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "atanh_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "atanh_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "atanh_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "atanh_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr sqrt(Expr x) {
     user_assert(x.defined()) << "sqrt of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "sqrt_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "sqrt_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "sqrt_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "sqrt_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "sqrt_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "sqrt_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2160,22 +2158,22 @@ Expr hypot(const Expr &x, const Expr &y) {
 Expr exp(Expr x) {
     user_assert(x.defined()) << "exp of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "exp_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "exp_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "exp_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "exp_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "exp_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "exp_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
 Expr log(Expr x) {
     user_assert(x.defined()) << "log of undefined Expr\n";
     if (x.type() == Float(64)) {
-        return Call::make(Float(64), "log_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "log_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
-        return Call::make(Float(16), "log_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "log_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
-        return Call::make(Float(32), "log_f32", {cast<float>(std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "log_f32", {cast<float>(std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2188,21 +2186,21 @@ Expr pow(Expr x, Expr y) {
 
     if (x.type() == Float(64)) {
         y = cast<double>(std::move(y));
-        return Call::make(Float(64), "pow_f64", {std::move(x), std::move(y)}, Call::PureExtern);
+        return Internal::Call::make(Float(64), "pow_f64", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
     } else if (x.type() == Float(16)) {
         y = cast<float16_t>(std::move(y));
-        return Call::make(Float(16), "pow_f16", {std::move(x), std::move(y)}, Call::PureExtern);
+        return Internal::Call::make(Float(16), "pow_f16", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
     } else {
         x = cast<float>(std::move(x));
         y = cast<float>(std::move(y));
-        return Call::make(Float(32), "pow_f32", {std::move(x), std::move(y)}, Call::PureExtern);
+        return Internal::Call::make(Float(32), "pow_f32", {std::move(x), std::move(y)}, Internal::Call::PureExtern);
     }
 }
 
 Expr erf(const Expr &x) {
     user_assert(x.defined()) << "erf of undefined Expr\n";
     user_assert(x.type() == Float(32)) << "erf only takes float arguments\n";
-    return halide_erf(x);
+    return Internal::halide_erf(x);
 }
 
 Expr fast_pow(Expr x, Expr y) {
@@ -2219,9 +2217,9 @@ Expr fast_inverse(Expr x) {
     user_assert(x.defined()) << "fast_inverse of undefined Expr\n";
     Type t = x.type();
     if (t == Float(32)) {
-        return Call::make(t, "fast_inverse_f32", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "fast_inverse_f32", {std::move(x)}, Internal::Call::PureExtern);
     } else if (t == Float(16)) {
-        return Call::make(t, "fast_inverse_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "fast_inverse_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         user_error << "fast_inverse only takes float16 or float32 arguments\n";
         return Expr();
@@ -2232,9 +2230,9 @@ Expr fast_inverse_sqrt(Expr x) {
     user_assert(x.defined()) << "fast_inverse_sqrt of undefined Expr\n";
     Type t = x.type();
     if (t == Float(32)) {
-        return Call::make(t, "fast_inverse_sqrt_f32", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "fast_inverse_sqrt_f32", {std::move(x)}, Internal::Call::PureExtern);
     } else if (t == Float(16)) {
-        return Call::make(t, "fast_inverse_sqrt_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "fast_inverse_sqrt_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         user_error << "fast_inverse_sqrt only takes float16 or float32 arguments\n";
         return Expr();
@@ -2245,12 +2243,12 @@ Expr floor(Expr x) {
     user_assert(x.defined()) << "floor of undefined Expr\n";
     Type t = x.type();
     if (t.element_of() == Float(64)) {
-        return Call::make(t, "floor_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "floor_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (t.element_of() == Float(16)) {
-        return Call::make(t, "floor_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "floor_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         t = Float(32, t.lanes());
-        return Call::make(t, "floor_f32", {cast(t, std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(t, "floor_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2258,12 +2256,12 @@ Expr ceil(Expr x) {
     user_assert(x.defined()) << "ceil of undefined Expr\n";
     Type t = x.type();
     if (t.element_of() == Float(64)) {
-        return Call::make(t, "ceil_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "ceil_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
-        return Call::make(t, "ceil_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "ceil_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         t = Float(32, t.lanes());
-        return Call::make(t, "ceil_f32", {cast(t, std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(t, "ceil_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2274,19 +2272,19 @@ Expr round(Expr x) {
         x = cast<float>(x);
         t = x.type();
     }
-    return Call::make(t, Call::round, {std::move(x)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::round, {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 Expr trunc(Expr x) {
     user_assert(x.defined()) << "trunc of undefined Expr\n";
     Type t = x.type();
     if (t.element_of() == Float(64)) {
-        return Call::make(t, "trunc_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "trunc_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (t.element_of() == Float(16)) {
-        return Call::make(t, "trunc_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "trunc_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         t = Float(32, t.lanes());
-        return Call::make(t, "trunc_f32", {cast(t, std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(t, "trunc_f32", {cast(t, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2298,12 +2296,12 @@ Expr is_nan(Expr x) {
         x = strict_float(x);
     }
     if (x.type().element_of() == Float(64)) {
-        return Call::make(t, "is_nan_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "is_nan_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
-        return Call::make(t, "is_nan_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "is_nan_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         Type ft = Float(32, t.lanes());
-        return Call::make(t, "is_nan_f32", {cast(ft, std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(t, "is_nan_f32", {cast(ft, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2315,12 +2313,12 @@ Expr is_inf(Expr x) {
         x = strict_float(x);
     }
     if (x.type().element_of() == Float(64)) {
-        return Call::make(t, "is_inf_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "is_inf_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
-        return Call::make(t, "is_inf_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "is_inf_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         Type ft = Float(32, t.lanes());
-        return Call::make(t, "is_inf_f32", {cast(ft, std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(t, "is_inf_f32", {cast(ft, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2332,12 +2330,12 @@ Expr is_finite(Expr x) {
         x = strict_float(x);
     }
     if (x.type().element_of() == Float(64)) {
-        return Call::make(t, "is_finite_f64", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "is_finite_f64", {std::move(x)}, Internal::Call::PureExtern);
     } else if (x.type().element_of() == Float(16)) {
-        return Call::make(t, "is_finite_f16", {std::move(x)}, Call::PureExtern);
+        return Internal::Call::make(t, "is_finite_f16", {std::move(x)}, Internal::Call::PureExtern);
     } else {
         Type ft = Float(32, t.lanes());
-        return Call::make(t, "is_finite_f32", {cast(ft, std::move(x))}, Call::PureExtern);
+        return Internal::Call::make(t, "is_finite_f32", {cast(ft, std::move(x))}, Internal::Call::PureExtern);
     }
 }
 
@@ -2347,61 +2345,61 @@ Expr fract(const Expr &x) {
 }
 
 Expr reinterpret(Type t, Expr e) {
-    return Reinterpret::make(t, std::move(e));
+    return Internal::Reinterpret::make(t, std::move(e));
 }
 
 Expr operator&(Expr x, Expr y) {
     match_types_bitwise(x, y, "bitwise and");
     Type t = x.type();
-    return Call::make(t, Call::bitwise_and, {std::move(x), std::move(y)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator&(Expr x, int y) {
     Type t = x.type();
-    check_representable(t, y);
-    return Call::make(t, Call::bitwise_and, {std::move(x), make_const(t, y)}, Call::PureIntrinsic);
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator&(int x, Expr y) {
     Type t = y.type();
-    check_representable(t, x);
-    return Call::make(t, Call::bitwise_and, {make_const(t, x), std::move(y)}, Call::PureIntrinsic);
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_and, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator|(Expr x, Expr y) {
     match_types_bitwise(x, y, "bitwise or");
     Type t = x.type();
-    return Call::make(t, Call::bitwise_or, {std::move(x), std::move(y)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator|(Expr x, int y) {
     Type t = x.type();
-    check_representable(t, y);
-    return Call::make(t, Call::bitwise_or, {std::move(x), make_const(t, y)}, Call::PureIntrinsic);
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator|(int x, Expr y) {
     Type t = y.type();
-    check_representable(t, x);
-    return Call::make(t, Call::bitwise_or, {make_const(t, x), std::move(y)}, Call::PureIntrinsic);
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_or, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator^(Expr x, Expr y) {
     match_types_bitwise(x, y, "bitwise xor");
     Type t = x.type();
-    return Call::make(t, Call::bitwise_xor, {std::move(x), std::move(y)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator^(Expr x, int y) {
     Type t = x.type();
-    check_representable(t, y);
-    return Call::make(t, Call::bitwise_xor, {std::move(x), make_const(t, y)}, Call::PureIntrinsic);
+    Internal::check_representable(t, y);
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {std::move(x), Internal::make_const(t, y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator^(int x, Expr y) {
     Type t = y.type();
-    check_representable(t, x);
-    return Call::make(t, Call::bitwise_xor, {make_const(t, x), std::move(y)}, Call::PureIntrinsic);
+    Internal::check_representable(t, x);
+    return Internal::Call::make(t, Internal::Call::bitwise_xor, {Internal::make_const(t, x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator~(Expr x) {
@@ -2409,24 +2407,24 @@ Expr operator~(Expr x) {
     user_assert(x.type().is_int() || x.type().is_uint())
         << "Argument to bitwise not must be an integer or unsigned integer";
     Type t = x.type();
-    return Call::make(t, Call::bitwise_not, {std::move(x)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::bitwise_not, {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator<<(Expr x, Expr y) {
     match_lanes(x, y);
     match_bits(x, y);
     Type t = x.type();
-    return Call::make(t, Call::shift_left, {std::move(x), std::move(y)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::shift_left, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator<<(Expr x, int y) {
     Type t = x.type().with_code(halide_type_uint);
     if (y >= 0) {
-        check_representable(t, y);
-        return std::move(x) << make_const(t, y);
+        Internal::check_representable(t, y);
+        return std::move(x) << Internal::make_const(t, y);
     } else {
-        check_representable(t, -y);
-        return std::move(x) >> make_const(t, -y);
+        Internal::check_representable(t, -y);
+        return std::move(x) >> Internal::make_const(t, -y);
     }
 }
 
@@ -2434,17 +2432,17 @@ Expr operator>>(Expr x, Expr y) {
     match_lanes(x, y);
     match_bits(x, y);
     Type t = x.type();
-    return Call::make(t, Call::shift_right, {std::move(x), std::move(y)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::shift_right, {std::move(x), std::move(y)}, Internal::Call::PureIntrinsic);
 }
 
 Expr operator>>(Expr x, int y) {
     Type t = x.type().with_code(halide_type_uint);
     if (y >= 0) {
-        check_representable(t, y);
-        return std::move(x) >> make_const(t, y);
+        Internal::check_representable(t, y);
+        return std::move(x) >> Internal::make_const(t, y);
     } else {
-        check_representable(t, -y);
-        return std::move(x) << make_const(t, -y);
+        Internal::check_representable(t, -y);
+        return std::move(x) << Internal::make_const(t, -y);
     }
 }
 
@@ -2485,9 +2483,9 @@ Expr lerp(Expr zero_val, Expr one_val, Expr weight) {
         }
     }
     Type t = zero_val.type();
-    return Call::make(t, Call::lerp,
-                      {std::move(zero_val), std::move(one_val), std::move(weight)},
-                      Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::lerp,
+                                {std::move(zero_val), std::move(one_val), std::move(weight)},
+                                Internal::Call::PureIntrinsic);
 }
 
 Expr popcount(Expr x) {
@@ -2495,8 +2493,8 @@ Expr popcount(Expr x) {
     Type t = x.type();
     user_assert(t.is_uint() || t.is_int())
         << "Argument to popcount must be an integer\n";
-    return Call::make(t, Call::popcount,
-                      {std::move(x)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::popcount,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 Expr count_leading_zeros(Expr x) {
@@ -2504,8 +2502,8 @@ Expr count_leading_zeros(Expr x) {
     Type t = x.type();
     user_assert(t.is_uint() || t.is_int())
         << "Argument to count_leading_zeros must be an integer\n";
-    return Call::make(t, Call::count_leading_zeros,
-                      {std::move(x)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::count_leading_zeros,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 Expr count_trailing_zeros(Expr x) {
@@ -2513,38 +2511,38 @@ Expr count_trailing_zeros(Expr x) {
     Type t = x.type();
     user_assert(t.is_uint() || t.is_int())
         << "Argument to count_trailing_zeros must be an integer\n";
-    return Call::make(t, Call::count_trailing_zeros,
-                      {std::move(x)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::count_trailing_zeros,
+                                {std::move(x)}, Internal::Call::PureIntrinsic);
 }
 
 Expr div_round_to_zero(Expr x, Expr y) {
     user_assert(x.defined()) << "div_round_to_zero of undefined dividend\n";
     user_assert(y.defined()) << "div_round_to_zero of undefined divisor\n";
-    match_types(x, y);
+    Internal::match_types(x, y);
     if (x.type().is_uint()) {
         return std::move(x) / std::move(y);
     }
     user_assert(x.type().is_int()) << "First argument to div_round_to_zero is not an integer: " << x << "\n";
     user_assert(y.type().is_int()) << "Second argument to div_round_to_zero is not an integer: " << y << "\n";
     Type t = x.type();
-    return Call::make(t, Call::div_round_to_zero,
-                      {std::move(x), std::move(y)},
-                      Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::div_round_to_zero,
+                                {std::move(x), std::move(y)},
+                                Internal::Call::PureIntrinsic);
 }
 
 Expr mod_round_to_zero(Expr x, Expr y) {
     user_assert(x.defined()) << "mod_round_to_zero of undefined dividend\n";
     user_assert(y.defined()) << "mod_round_to_zero of undefined divisor\n";
-    match_types(x, y);
+    Internal::match_types(x, y);
     if (x.type().is_uint()) {
         return std::move(x) % std::move(y);
     }
     user_assert(x.type().is_int()) << "First argument to mod_round_to_zero is not an integer: " << x << "\n";
     user_assert(y.type().is_int()) << "Second argument to mod_round_to_zero is not an integer: " << y << "\n";
     Type t = x.type();
-    return Call::make(t, Call::mod_round_to_zero,
-                      {std::move(x), std::move(y)},
-                      Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::mod_round_to_zero,
+                                {std::move(x), std::move(y)},
+                                Internal::Call::PureIntrinsic);
 }
 
 Expr random_float(Expr seed) {
@@ -2563,8 +2561,8 @@ Expr random_float(Expr seed) {
 
     // This is (surprisingly) pure - it's a fixed psuedo-random
     // function of its inputs.
-    return Call::make(Float(32), Call::random,
-                      args, Call::PureIntrinsic);
+    return Internal::Call::make(Float(32), Internal::Call::random,
+                                args, Internal::Call::PureIntrinsic);
 }
 
 Expr random_uint(Expr seed) {
@@ -2581,8 +2579,8 @@ Expr random_uint(Expr seed) {
     }
     args.emplace_back(id);
 
-    return Call::make(UInt(32), Call::random,
-                      args, Call::PureIntrinsic);
+    return Internal::Call::make(UInt(32), Internal::Call::random,
+                                args, Internal::Call::PureIntrinsic);
 }
 
 Expr random_int(Expr seed) {
@@ -2591,33 +2589,33 @@ Expr random_int(Expr seed) {
 
 Expr likely(Expr e) {
     Type t = e.type();
-    return Call::make(t, Call::likely,
-                      {std::move(e)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::likely,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
 }
 
 Expr likely_if_innermost(Expr e) {
     Type t = e.type();
-    return Call::make(t, Call::likely_if_innermost,
-                      {std::move(e)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::likely_if_innermost,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
 }
 
 Expr strict_float(Expr e) {
     Type t = e.type();
-    return Call::make(t, Call::strict_float,
-                      {std::move(e)}, Call::PureIntrinsic);
+    return Internal::Call::make(t, Internal::Call::strict_float,
+                                {std::move(e)}, Internal::Call::PureIntrinsic);
 }
 
 Expr undef(Type t) {
-    return Call::make(t, Call::undef,
-                      std::vector<Expr>(),
-                      Call::Intrinsic);
+    return Internal::Call::make(t, Internal::Call::undef,
+                                std::vector<Expr>(),
+                                Internal::Call::Intrinsic);
 }
 
 namespace Internal {
 Expr unreachable(Type t) {
-    return Call::make(t, Call::unreachable,
-                      std::vector<Expr>(),
-                      Call::Intrinsic);
+    return Internal::Call::make(t, Internal::Call::unreachable,
+                                std::vector<Expr>(),
+                                Internal::Call::Intrinsic);
 }
 }  // namespace Internal
 
@@ -2625,7 +2623,10 @@ namespace {
 Expr make_scatter_gather(const std::vector<Expr> &args) {
     // There's currently no difference in the IR between a gather and
     // a scatter. They're distinct just to make code more readable.
-    return Call::make(args[0].type(), Call::scatter_gather, args, Call::Intrinsic);
+    return Halide::Internal::Call::make(args[0].type(),
+                                        Halide::Internal::Call::scatter_gather,
+                                        args,
+                                        Halide::Internal::Call::Intrinsic);
 }
 }  // namespace
 
@@ -2638,7 +2639,7 @@ Expr gather(const std::vector<Expr> &args) {
 }
 
 Expr extract_bits(Type t, const Expr &e, const Expr &lsb) {
-    return Call::make(t, Call::extract_bits, {e, lsb}, Call::Intrinsic);
+    return Internal::Call::make(t, Internal::Call::extract_bits, {e, lsb}, Internal::Call::Intrinsic);
 }
 
 Expr concat_bits(const std::vector<Expr> &e) {
@@ -2648,7 +2649,7 @@ Expr concat_bits(const std::vector<Expr> &e) {
     for (size_t i = 1; i < e.size(); i++) {
         user_assert(e[i].type() == t) << "All arguments to concat_bits must have the same type\n";
     }
-    return Call::make(t.with_bits(t.bits() * (int)e.size()), Call::concat_bits, e, Call::Intrinsic);
+    return Internal::Call::make(t.with_bits(t.bits() * (int)e.size()), Internal::Call::concat_bits, e, Internal::Call::Intrinsic);
 }
 
 }  // namespace Halide

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -351,6 +351,54 @@ Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args);
 
 Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
 
+/** Compute a + widen(b). */
+Expr widen_right_add(Expr a, Expr b);
+/** Compute a * widen(b). */
+Expr widen_right_mul(Expr a, Expr b);
+/** Compute a - widen(b). */
+Expr widen_right_sub(Expr a, Expr b);
+
+/** Compute widen(a) + widen(b). */
+Expr widening_add(Expr a, Expr b);
+/** Compute widen(a) * widen(b). a and b may have different signedness. */
+Expr widening_mul(Expr a, Expr b);
+/** Compute widen(a) - widen(b). The result is always signed. */
+Expr widening_sub(Expr a, Expr b);
+/** Compute widen(a) << b. */
+Expr widening_shift_left(Expr a, Expr b);
+Expr widening_shift_left(Expr a, int b);
+/** Compute widen(a) >> b. */
+Expr widening_shift_right(Expr a, Expr b);
+Expr widening_shift_right(Expr a, int b);
+
+/** Compute saturating_narrow(widening_add(a, (1 >> min(b, 0)) / 2) << b).
+ * When b is positive indicating a left shift, the rounding term is zero. */
+Expr rounding_shift_left(Expr a, Expr b);
+Expr rounding_shift_left(Expr a, int b);
+/** Compute saturating_narrow(widening_add(a, (1 << max(b, 0)) / 2) >> b).
+ * When b is negative indicating a left shift, the rounding term is zero. */
+Expr rounding_shift_right(Expr a, Expr b);
+Expr rounding_shift_right(Expr a, int b);
+
+/** Compute saturating_narrow(widen(a) + widen(b)) */
+Expr saturating_add(Expr a, Expr b);
+/** Compute saturating_narrow(widen(a) - widen(b)) */
+Expr saturating_sub(Expr a, Expr b);
+
+/** Compute narrow((widen(a) + widen(b)) / 2) */
+Expr halving_add(Expr a, Expr b);
+/** Compute narrow((widen(a) + widen(b) + 1) / 2) */
+Expr rounding_halving_add(Expr a, Expr b);
+/** Compute narrow((widen(a) - widen(b)) / 2) */
+Expr halving_sub(Expr a, Expr b);
+
+/** Compute saturating_narrow(shift_right(widening_mul(a, b), q)) */
+Expr mul_shift_right(Expr a, Expr b, Expr q);
+Expr mul_shift_right(Expr a, Expr b, int q);
+/** Compute saturating_narrow(rounding_shift_right(widening_mul(a, b), q)) */
+Expr rounding_mul_shift_right(Expr a, Expr b, Expr q);
+Expr rounding_mul_shift_right(Expr a, Expr b, int q);
+
 }  // namespace Internal
 
 /** Cast an expression to the halide type corresponding to the C++ type T. */
@@ -1578,197 +1626,6 @@ f32.vectorize(x, 8);
  * See test/correctness/extract_concat_bits.cpp for a complete example.
  */
 Expr concat_bits(const std::vector<Expr> &e);
-
-/** Below is a collection of intrinsics for fixed-point programming. Most of
- * them can be expressed via other means, but this is more natural for some, as
- * it avoids ghost widened intermediates that don't (or shouldn't) actually show
- * up in codegen, and doesn't rely on pattern-matching inside the compiler to
- * succeed to get good instruction selection.
- *
- * The semantics of each call are defined in terms of a non-existent 'widen' and
- * 'narrow' operators, which stand in for casts that double or halve the
- * bit-width of a type respectively.
- */
-
-/** Compute a + widen(b). */
-Expr widen_right_add(Expr a, Expr b);
-
-/** Compute a * widen(b). */
-Expr widen_right_mul(Expr a, Expr b);
-
-/** Compute a - widen(b). */
-Expr widen_right_sub(Expr a, Expr b);
-
-/** Compute widen(a) + widen(b). */
-Expr widening_add(Expr a, Expr b);
-
-/** Compute widen(a) * widen(b). a and b may have different signedness, in which
- * case the result is signed. */
-Expr widening_mul(Expr a, Expr b);
-
-/** Compute widen(a) - widen(b). The result is always signed. */
-Expr widening_sub(Expr a, Expr b);
-
-/** Compute widen(a) << b. */
-//@{
-Expr widening_shift_left(Expr a, Expr b);
-Expr widening_shift_left(Expr a, int b);
-//@}
-
-/** Compute widen(a) >> b. */
-//@{
-Expr widening_shift_right(Expr a, Expr b);
-Expr widening_shift_right(Expr a, int b);
-//@}
-
-/** Compute saturating_narrow(widening_add(a, (1 >> min(b, 0)) / 2) << b).
- * When b is positive indicating a left shift, the rounding term is zero. */
-//@{
-Expr rounding_shift_left(Expr a, Expr b);
-Expr rounding_shift_left(Expr a, int b);
-//@}
-
-/** Compute saturating_narrow(widening_add(a, (1 << max(b, 0)) / 2) >> b).
- * When b is negative indicating a left shift, the rounding term is zero. */
-//@{
-Expr rounding_shift_right(Expr a, Expr b);
-Expr rounding_shift_right(Expr a, int b);
-//@}
-
-/** Compute saturating_narrow(widen(a) + widen(b)) */
-Expr saturating_add(Expr a, Expr b);
-
-/** Compute saturating_narrow(widen(a) - widen(b)) */
-Expr saturating_sub(Expr a, Expr b);
-
-/** Compute narrow((widen(a) + widen(b)) / 2) */
-Expr halving_add(Expr a, Expr b);
-
-/** Compute narrow((widen(a) + widen(b) + 1) / 2) */
-Expr rounding_halving_add(Expr a, Expr b);
-
-/** Compute narrow((widen(a) - widen(b)) / 2) */
-Expr halving_sub(Expr a, Expr b);
-
-/** Compute saturating_narrow(shift_right(widening_mul(a, b), q)) */
-//@{
-Expr mul_shift_right(Expr a, Expr b, Expr q);
-Expr mul_shift_right(Expr a, Expr b, int q);
-//@}
-
-/** Compute saturating_narrow(rounding_shift_right(widening_mul(a, b), q)) */
-//@{
-Expr rounding_mul_shift_right(Expr a, Expr b, Expr q);
-Expr rounding_mul_shift_right(Expr a, Expr b, int q);
-//@}
-
-namespace Internal {
-// These deprecated versions of the functions take a type that can convert to
-// and from Expr instead of taking Exprs directly so that they'll be
-// lower-ranked in function resolution order.
-struct PseudoExpr {
-    Expr e;
-    PseudoExpr(const Expr &e)  // Intentionally implicit
-        : e(e) {
-    }
-    operator Expr() {
-        return e;
-    }
-};
-
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widen_right_add(PseudoExpr a, const Expr &b) {
-    return Halide::widen_right_add(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widen_right_mul(PseudoExpr a, const Expr &b) {
-    return Halide::widen_right_mul(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widen_right_sub(PseudoExpr a, const Expr &b) {
-    return Halide::widen_right_sub(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widening_add(PseudoExpr a, const Expr &b) {
-    return Halide::widening_add(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widening_mul(PseudoExpr a, const Expr &b) {
-    return Halide::widening_mul(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widening_sub(PseudoExpr a, const Expr &b) {
-    return Halide::widening_sub(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widening_shift_left(PseudoExpr a, const Expr &b) {
-    return Halide::widening_shift_left(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widening_shift_left(PseudoExpr a, int b) {
-    return Halide::widening_shift_left(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widening_shift_right(PseudoExpr a, const Expr &b) {
-    return Halide::widening_shift_right(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr widening_shift_right(PseudoExpr a, int b) {
-    return Halide::widening_shift_right(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr rounding_shift_left(PseudoExpr a, const Expr &b) {
-    return Halide::widening_shift_left(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr rounding_shift_left(PseudoExpr a, int b) {
-    return Halide::widening_shift_left(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr rounding_shift_right(PseudoExpr a, const Expr &b) {
-    return Halide::rounding_shift_right(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr rounding_shift_right(PseudoExpr a, int b) {
-    return Halide::rounding_shift_right(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr saturating_add(PseudoExpr a, const Expr &b) {
-    return Halide::saturating_add(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr saturating_sub(PseudoExpr a, const Expr &b) {
-    return Halide::saturating_sub(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr halving_add(PseudoExpr a, const Expr &b) {
-    return Halide::halving_add(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr rounding_halving_add(PseudoExpr a, const Expr &b) {
-    return Halide::rounding_halving_add(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr halving_sub(PseudoExpr a, const Expr &b) {
-    return Halide::halving_sub(a, b);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr mul_shift_right(PseudoExpr a, const Expr &b, const Expr &q) {
-    return Halide::mul_shift_right(a, b, q);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr mul_shift_right(PseudoExpr a, const Expr &b, int q) {
-    return Halide::mul_shift_right(a, b, q);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr rounding_mul_shift_right(PseudoExpr a, const Expr &b, const Expr &q) {
-    return Halide::rounding_mul_shift_right(a, b, q);
-}
-HALIDE_ATTRIBUTE_DEPRECATED("This function has been moved out of the Halide::Internal:: namespace into Halide::")
-inline Expr rounding_mul_shift_right(PseudoExpr a, const Expr &b, int q) {
-    return Halide::rounding_mul_shift_right(a, b, q);
-}
-}  // namespace Internal
 
 }  // namespace Halide
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -1668,10 +1668,8 @@ namespace Internal {
 // lower-ranked in function resolution order.
 struct PseudoExpr {
     Expr e;
-
-    template<typename T>
-    PseudoExpr(const T &t)  // Intentionally implicit
-        : e((Expr)t) {
+    PseudoExpr(const Expr &e)  // Intentionally implicit
+        : e(e) {
     }
     operator Expr() {
         return e;

--- a/src/InlineReductions.cpp
+++ b/src/InlineReductions.cpp
@@ -157,7 +157,7 @@ Expr saturating_sum(const RDom &r, Expr e, const Func &f) {
     user_assert(v.rdom.defined()) << "Expression passed to saturating_sum must reference a reduction domain";
 
     f(v.free_vars) = cast(e.type(), 0);
-    f(v.free_vars) = Halide::saturating_add(f(v.free_vars), e);
+    f(v.free_vars) = saturating_add(f(v.free_vars), e);
     return f(v.call_args);
 }
 

--- a/src/InlineReductions.cpp
+++ b/src/InlineReductions.cpp
@@ -157,7 +157,7 @@ Expr saturating_sum(const RDom &r, Expr e, const Func &f) {
     user_assert(v.rdom.defined()) << "Expression passed to saturating_sum must reference a reduction domain";
 
     f(v.free_vars) = cast(e.type(), 0);
-    f(v.free_vars) = saturating_add(f(v.free_vars), e);
+    f(v.free_vars) = Internal::saturating_add(f(v.free_vars), e);
     return f(v.call_args);
 }
 


### PR DESCRIPTION
Despite best efforts, these changes break existing downstream code; this temorarily reverts the changes to allow downstream merges. Once we find a better solution we should reapply these.