### PR TITLE
Move Xtensa from Feature to Arch

### DIFF
--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -88,7 +88,8 @@ void define_enums(py::module &m) {
         .value("Hexagon", Target::Arch::Hexagon)
         .value("POWERPC", Target::Arch::POWERPC)
         .value("RISCV", Target::Arch::RISCV)
-        .value("WebAssembly", Target::Arch::WebAssembly);
+        .value("WebAssembly", Target::Arch::WebAssembly)
+        .value("Xtensa", Target::Arch::Xtensa);
 
     // Please keep sorted.
     py::enum_<Target::Processor>(m, "TargetProcessorTune")
@@ -172,7 +173,6 @@ void define_enums(py::module &m) {
         .value("SVE2", Target::Feature::SVE2)
         .value("ARMDotProd", Target::Feature::ARMDotProd)
         .value("ARMFp16", Target::Feature::ARMFp16)
-        .value("Xtensa", Target::Feature::Xtensa)
         .value("XtensaQ8", Target::Feature::XtensaQ8)
         .value("LLVMLargeCodeModel", Target::Feature::LLVMLargeCodeModel)
         .value("RVV", Target::Feature::RVV)

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -632,7 +632,7 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
     if (contains(output_files, OutputFileType::c_source)) {
         debug(1) << "Module.compile(): c_source " << output_files.at(OutputFileType::c_source) << "\n";
         std::ofstream file(output_files.at(OutputFileType::c_source));
-        if (target().has_feature(Target::Xtensa)) {
+        if (target().arch == Target::Xtensa) {
             Internal::CodeGen_Xtensa cg(file,
                                         target(),
                                         target().has_feature(Target::CPlusPlusMangling) ? Internal::CodeGen_C::CPlusPlusImplementation : Internal::CodeGen_C::CImplementation);

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -398,6 +398,7 @@ const std::map<std::string, Target::Arch> arch_name_map = {
     {"hexagon", Target::Hexagon},
     {"wasm", Target::WebAssembly},
     {"riscv", Target::RISCV},
+    {"xtensa", Target::Xtensa},
 };
 
 bool lookup_arch(const std::string &tok, Target::Arch &result) {
@@ -513,7 +514,6 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"sve2", Target::SVE2},
     {"arm_dot_prod", Target::ARMDotProd},
     {"arm_fp16", Target::ARMFp16},
-    {"xtensa", Target::Xtensa},
     {"xtensa_q8", Target::XtensaQ8},
     {"llvm_large_code_model", Target::LLVMLargeCodeModel},
     {"rvv", Target::RVV},
@@ -1090,7 +1090,7 @@ int Target::natural_vector_size(const Halide::Type &t) const {
     const bool is_integer = t.is_int() || t.is_uint();
     const int data_size = t.bytes();
 
-    if (has_feature(Halide::Target::Xtensa)) {
+    if (arch == Target::Xtensa) {
         if (has_feature(Halide::Target::XtensaQ8)) {
             return 128 / data_size;
         }

--- a/src/Target.h
+++ b/src/Target.h
@@ -43,7 +43,8 @@ struct Target {
         Hexagon,
         POWERPC,
         WebAssembly,
-        RISCV
+        RISCV,
+        Xtensa
     } arch = ArchUnknown;
 
     /** The bit-width of the target machine. Must be 0 for unknown, or 32 or 64. */
@@ -151,7 +152,6 @@ struct Target {
         SVE2 = halide_target_feature_sve2,
         ARMDotProd = halide_target_feature_arm_dot_prod,
         ARMFp16 = halide_target_feature_arm_fp16,
-        Xtensa = halide_target_feature_xtensa,
         XtensaQ8 = halide_target_feature_xtensa_q8,
         LLVMLargeCodeModel = halide_llvm_large_code_model,
         RVV = halide_target_feature_rvv,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1387,8 +1387,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_egl,                    ///< Force use of EGL support.
     halide_target_feature_arm_dot_prod,           ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
     halide_target_feature_arm_fp16,               ///< Enable ARMv8.2-a half-precision floating point data processing
-    halide_target_feature_xtensa,                 ///< Enable Xtensa code generation.
-    halide_target_feature_xtensa_q8,              ///< Enable Xtensa for Q8 code generation. This should be set in *adidtion* to feature_xtensa.
+    halide_target_feature_xtensa_q8,              ///< Enable Xtensa for Q8 code generation. Ignored for non-Xtensa architectures.
     halide_llvm_large_code_model,                 ///< Use the LLVM large code model to compile
     halide_target_feature_rvv,                    ///< Enable RISCV "V" Vector Extension
     halide_target_feature_armv81a,                ///< Enable ARMv8.1-a instructions

--- a/test/correctness/simd_op_check_xtensa.cpp
+++ b/test/correctness/simd_op_check_xtensa.cpp
@@ -172,8 +172,8 @@ int main(int argc, char **argv) {
     printf("host is:      %s\n", host.to_string().c_str());
     printf("HL_TARGET is: %s\n", hl_target.to_string().c_str());
 
-    if (!hl_target.has_feature(Target::Xtensa)) {
-        printf("[SKIP] Skipping the simd_op_check_xtensa test, because target doesn't have xtensa feature flag enabled\n");
+    if (!hl_target.arch != Target::Xtensa) {
+        printf("[SKIP] Skipping the simd_op_check_xtensa test, because target is not Xtensa\n");
         return 0;
     }
     SimdOpCheckXtensa test_xtensa(hl_target);


### PR DESCRIPTION
From discussion on https://github.com/halide/Halide/pull/7464, it really makes more sense for Xtensa to be it's own Target::Arch, rather than a Feature, because we shouldn't ever consider other specific architectures in this case -- since (unlike eg GPU) we never generate any 'host' code for Xtensa, it's purely 100% C++ code to run on the DSP.

(attn @Aelphy)