### PR TITLE
Avoiding having shader kernels depend on host arch/os by unsetting it

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -361,8 +361,8 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
 #endif
         }
     } else {
-        internal_error << "Bad target arch: " << target.arch << "\n";
-        return llvm::DataLayout("unreachable");
+        // Return empty data layout. Must be set later.
+        return llvm::DataLayout("");
     }
 }
 
@@ -497,7 +497,7 @@ llvm::Triple get_triple_for_target(const Target &target) {
             user_error << "No RISCV support for this OS\n";
         }
     } else {
-        internal_error << "Bad target arch: " << target.arch << "\n";
+        // Return default-constructed triple. Must be set later.
     }
 
     return triple;

--- a/src/OffloadGPULoops.cpp
+++ b/src/OffloadGPULoops.cpp
@@ -254,23 +254,29 @@ class InjectGpuOffload : public IRMutator {
 public:
     InjectGpuOffload(const Target &target)
         : target(target) {
+        Target device_target = target;
+        // For the GPU target we just want to pass the flags, to avoid the
+        // generated kernel code unintentionally having any dependence on the
+        // host arch or os.
+        device_target.os = Target::OSUnknown;
+        device_target.arch = Target::ArchUnknown;
         if (target.has_feature(Target::OpenGLCompute)) {
-            cgdev[DeviceAPI::OpenGLCompute] = new_CodeGen_OpenGLCompute_Dev(target);
+            cgdev[DeviceAPI::OpenGLCompute] = new_CodeGen_OpenGLCompute_Dev(device_target);
         }
         if (target.has_feature(Target::CUDA)) {
-            cgdev[DeviceAPI::CUDA] = new_CodeGen_PTX_Dev(target);
+            cgdev[DeviceAPI::CUDA] = new_CodeGen_PTX_Dev(device_target);
         }
         if (target.has_feature(Target::OpenCL)) {
-            cgdev[DeviceAPI::OpenCL] = new_CodeGen_OpenCL_Dev(target);
+            cgdev[DeviceAPI::OpenCL] = new_CodeGen_OpenCL_Dev(device_target);
         }
         if (target.has_feature(Target::Metal)) {
-            cgdev[DeviceAPI::Metal] = new_CodeGen_Metal_Dev(target);
+            cgdev[DeviceAPI::Metal] = new_CodeGen_Metal_Dev(device_target);
         }
         if (target.has_feature(Target::D3D12Compute)) {
-            cgdev[DeviceAPI::D3D12Compute] = new_CodeGen_D3D12Compute_Dev(target);
+            cgdev[DeviceAPI::D3D12Compute] = new_CodeGen_D3D12Compute_Dev(device_target);
         }
         if (target.has_feature(Target::WebGPU)) {
-            cgdev[DeviceAPI::WebGPU] = new_CodeGen_WebGPU_Dev(target);
+            cgdev[DeviceAPI::WebGPU] = new_CodeGen_WebGPU_Dev(device_target);
         }
 
         internal_assert(!cgdev.empty()) << "Requested unknown GPU target: " << target.to_string() << "\n";


### PR DESCRIPTION
Alternative to #7464 

Currently how lerp is lowered inside cuda kernels depends on the host architecture. This was unintentional. This PR nukes the host os and arch when compiling shader kernels so that this sort of accidental dependence doesn't occur in future. 