### PR TITLE
Experiment to improve code readability in CodegenXtensa

### DIFF
--- a/src/CodeGen_Xtensa.h
+++ b/src/CodeGen_Xtensa.h
@@ -7,6 +7,8 @@
 
 #include <set>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -17,7 +19,10 @@ namespace Internal {
 
 class CodeGen_Xtensa : public CodeGen_C {
 public:
-    using CodeGen_C::CodeGen_C;
+    CodeGen_Xtensa(std::ostream &dest,
+                   const Target &target,
+                   OutputKind output_kind = CImplementation,
+                   const std::string &include_guard = "");
 
 protected:
     Stmt preprocess_function_body(const Stmt &stmt) override;
@@ -59,7 +64,7 @@ protected:
     void visit(const LetStmt *op) override;
 
     template<typename ComparisonOp>
-    void visit_comparison_op(const ComparisonOp *op, const std::string &op_name);
+    void visit_comparison_op(const ComparisonOp *op, std::string_view op_name);
 
     bool is_stack_private_to_thread() const override;
 
@@ -70,6 +75,52 @@ protected:
 
     // TODO: this appears to be unused; we read from it but never write to it?
     std::set<std::string> external_buffers;
+
+    // ---------------------
+    // For most of our purposes, a halide_type_t is just as good as a Halide::Type,
+    // but notably smaller and more efficient (since it fits into a u32 and hashes well).
+    class HalideTypeHasher {
+    public:
+        size_t operator()(const halide_type_t &t) const;
+    };
+
+    using HalideTypeSet = std::unordered_set<halide_type_t, HalideTypeHasher>;
+
+    // A set of enums representing all possible 'xtensa native' vector types.
+    // Note that this is a subset of all the Halide scalar types, since Xtensa
+    // doesn't support all of these as vectors. The 'none' type is for cases
+    // in which the type we have doesn't match any of the Xtensa native vectors
+    // (ie, the 'default:' case).
+    //
+    // You'd normally use halide_type_to_xnv_type_map to map a specific `op->type`
+    // to one of these, and use these as the cases for a switch or similar.
+    // (Note that we can't use the expected u32 value of the op->type since
+    // those will have varying lanes depending on what our Target is set to.)
+    enum class XNVType {
+        none = 0,
+
+        float16,
+        float32,
+        int8,
+        int16,
+        int24,
+        int32,
+        int48,
+        int64,
+        uint8,
+        uint16,
+        uint24,
+        uint32,
+        uint48,
+    };
+
+    using HalideTypeToXNVMap = std::unordered_map<halide_type_t, XNVType, HalideTypeHasher>;
+    const HalideTypeToXNVMap halide_type_to_xnv_type_map;
+
+    // like `halide_type_to_xnv_type_map[op_type]`, but return XNVType::none if not found.
+    XNVType xnv_type(const halide_type_t &op_type) const;
+
+    void print_custom_binop(std::string_view name, const Type &t, const Expr &a, const Expr &b);
 
     template<typename T>
     bool is_native_xtensa_vector(halide_type_t op_type) const {
@@ -95,6 +146,8 @@ protected:
         const halide_type_t native_vector_type = get_native_xtensa_vector(t);
         return t == native_vector_type.with_lanes(2 * native_vector_type.lanes);
     }
+
+    const std::unordered_map<std::string, std::string> op_name_to_intrinsic;
 };
 
 }  // namespace Internal


### PR DESCRIPTION
This is just a draft because (1) it's not complete, and (2) I'm not 100% sure this is the best improvement to make.

The problem I wanted to solve here was that CodeGenXtensa currently has a pervasive pattern of repeated-if-else code to choose the right type, and repeated (redundant) code inside each else clause.

I was hoping that something enabling a more `switch`-like chunk of code would be smaller, easier to read and reason about, and have less redundant chunks (e.g. calls to `print_assignment()` for every type clause which are identical except for the instruction name).

This takes the approach that we can use a map to make `halide_type_t` -> a bespoke enum; if the type is in the map, it means it's equivalent to `is_native_xtensa_vector<>()` returning true. This allows us to use `switch` statements in many places with only a slight overhead, but (maybe?) simpler-to-read code; when combined with judicious use of lambdas, we (hopefully?) get less redundant code.

That said... this still isn't quite as elegant / easy to read as I'd like; whether or not this is enough of an improvement to be worth finishing is a matter I'd like some other folks thoughts on.

Alternately, if someone has an even-better idea for handling all this, I'd love to hear anout it :-)