### PR TITLE
Backport #7472 to release/15.x

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -39,6 +39,7 @@ find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 if (Python3_VERSION VERSION_LESS "3.8")
     message(FATAL_ERROR "Halide requires Python v3.8 or later, but found ${Python3_VERSION}.")
 endif ()
+message(STATUS "Found Python ${Python3_VERSION} at ${Python3_EXECUTABLE}")
 
 if (PYBIND11_USE_FETCHCONTENT)
     include(FetchContent)


### PR DESCRIPTION
Same issue was present in the JIT wrappers for Python; this is the same fix, adapted for JIT.