### PR TITLE
Use static dimensions in autoscheduler test generators

### DIFF
--- a/test/autoschedulers/adams2019/demo_generator.cpp
+++ b/test/autoschedulers/adams2019/demo_generator.cpp
@@ -6,10 +6,10 @@ using namespace Halide;
 
 class ConvRelu : public Halide::Generator<ConvRelu> {
 public:
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 120, CO = 24, W = 100, H = 80;

--- a/test/autoschedulers/adams2019/included_schedule_file_generator.cpp
+++ b/test/autoschedulers/adams2019/included_schedule_file_generator.cpp
@@ -13,10 +13,10 @@ namespace {
 // demo_generator.cpp, but packaged separately to avoid confusion for
 // newcomers.
 struct IncludedScheduleFile : public Halide::Generator<IncludedScheduleFile> {
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 120, CO = 24, W = 100, H = 80;

--- a/test/autoschedulers/anderson2021/demo_generator.cpp
+++ b/test/autoschedulers/anderson2021/demo_generator.cpp
@@ -6,10 +6,10 @@ using namespace Halide;
 
 class ConvRelu : public Halide::Generator<ConvRelu> {
 public:
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 120, CO = 24, W = 100, H = 80;

--- a/test/autoschedulers/anderson2021/included_schedule_file_generator.cpp
+++ b/test/autoschedulers/anderson2021/included_schedule_file_generator.cpp
@@ -13,10 +13,10 @@ namespace {
 // demo_generator.cpp, but packaged separately to avoid confusion for
 // newcomers.
 struct IncludedScheduleFile : public Halide::Generator<IncludedScheduleFile> {
-    Input<Buffer<float>> input{"input", 4};
-    Input<Buffer<float>> filter{"filter", 4};
-    Input<Buffer<float>> bias{"bias", 1};
-    Output<Buffer<float>> relu{"relu", 4};
+    Input<Buffer<float, 4>> input{"input"};
+    Input<Buffer<float, 4>> filter{"filter"};
+    Input<Buffer<float, 1>> bias{"bias"};
+    Output<Buffer<float, 4>> relu{"relu"};
 
     void generate() {
         const int N = 5, CI = 120, CO = 24, W = 100, H = 80;


### PR DESCRIPTION
https://github.com/halide/Halide/pull/6856 unintentionally reverted some autoscheduler test generators to use non-static dimensions for their input/output buffers, and applied the same changes to some new generators. This changes them all to use static dimensions.