### PR TITLE
Revise autoscheduler tool names to match those from #7483

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2381,12 +2381,12 @@ endif
 # Adams2019 also includes autotuning tools
 $(DISTRIB_DIR)/lib/libautoschedule_adams2019.$(PLUGIN_EXT): $(BIN_DIR)/libautoschedule_adams2019.$(PLUGIN_EXT)
 	@mkdir -p $(@D)
-	$(MAKE) -f $(SRC_DIR)/autoschedulers/adams2019/Makefile $(BIN_DIR)/retrain_cost_model $(BIN_DIR)/featurization_to_sample $(BIN_DIR)/get_host_target HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR)
+	$(MAKE) -f $(SRC_DIR)/autoschedulers/adams2019/Makefile $(BIN_DIR)/adams2019_retrain_cost_model $(BIN_DIR)/featurization_to_sample $(BIN_DIR)/get_host_target HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR)
 	cp $< $(DISTRIB_DIR)/lib/
-	for TOOL in retrain_cost_model featurization_to_sample get_host_target; do \
+	for TOOL in adams2019_retrain_cost_model featurization_to_sample get_host_target; do \
 		cp $(BIN_DIR)/$${TOOL} $(DISTRIB_DIR)/bin/;  \
 	done
-	cp $(SRC_DIR)/autoschedulers/adams2019/autotune_loop.sh $(DISTRIB_DIR)/tools/
+	cp $(SRC_DIR)/autoschedulers/adams2019/adams2019_autotune_loop.sh $(DISTRIB_DIR)/tools/
 ifeq ($(UNAME), Darwin)
 	install_name_tool -id @rpath/$(@F) $(CURDIR)/$@
 endif

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -79,7 +79,7 @@ else ()
     set(rbase $ORIGIN)
 endif ()
 
-foreach (util IN ITEMS adams2019_retrain_cost_model adams2019_featurization_to_sample adams2019_get_host_target adams2019_weightsdir_to_weightsfile)
+foreach (util IN ITEMS adams2019_retrain_cost_model featurization_to_sample get_host_target adams2019_weightsdir_to_weightsfile)
     if (TARGET ${util})
         if (NOT CMAKE_INSTALL_RPATH)
             set_target_properties(${util} PROPERTIES INSTALL_RPATH "${rbase};${rbase}/${lib_dir}")
@@ -121,7 +121,7 @@ install(DIRECTORY ${Halide_SOURCE_DIR}/tools/
         PATTERN "build_halide_h.cpp" EXCLUDE
         PATTERN "find_inverse.cpp" EXCLUDE)
 
-install(PROGRAMS ${Halide_SOURCE_DIR}/src/autoschedulers/adams2019/autotune_loop.sh
+install(PROGRAMS ${Halide_SOURCE_DIR}/src/autoschedulers/adams2019/adams2019_autotune_loop.sh
         DESTINATION ${Halide_INSTALL_TOOLSDIR}
         COMPONENT Halide_Development)
 

--- a/src/autoschedulers/adams2019/CMakeLists.txt
+++ b/src/autoschedulers/adams2019/CMakeLists.txt
@@ -71,7 +71,7 @@ if (APPLE AND num_archs GREATER 1)
     )
 endif ()
 
-# retrain_cost_model
+# adams2019_retrain_cost_model
 if (WITH_UTILS)
     add_executable(adams2019_retrain_cost_model
                    DefaultCostModel.cpp
@@ -106,10 +106,10 @@ target_link_libraries(Halide_Adams2019 PRIVATE ASLog ParamParser adams2019_cost_
 # TODO(#4053): implement auto-tuning support in CMake?
 
 if (WITH_UTILS)
-    add_executable(adams2019_featurization_to_sample featurization_to_sample.cpp)
+    add_executable(featurization_to_sample featurization_to_sample.cpp)
 
-    add_executable(adams2019_get_host_target get_host_target.cpp)
-    target_link_libraries(adams2019_get_host_target PRIVATE Halide::Halide)
+    add_executable(get_host_target get_host_target.cpp)
+    target_link_libraries(get_host_target PRIVATE Halide::Halide)
 
     add_executable(adams2019_weightsdir_to_weightsfile weightsdir_to_weightsfile.cpp Weights.cpp)
     target_link_libraries(adams2019_weightsdir_to_weightsfile PRIVATE Halide::Runtime)

--- a/src/autoschedulers/adams2019/Makefile
+++ b/src/autoschedulers/adams2019/Makefile
@@ -87,7 +87,7 @@ $(BIN)/libautoschedule_adams2019.$(PLUGIN_EXT): \
 	@mkdir -p $(@D)
 	$(CXX) -shared $(USE_EXPORT_DYNAMIC) -fPIC -fvisibility=hidden -fvisibility-inlines-hidden $(CXXFLAGS) $(OPTIMIZE) -I $(BIN)/cost_model $(filter-out %.h $(LIBHALIDE_LDFLAGS),$^) -o $@ $(HALIDE_SYSTEM_LIBS) $(HALIDE_RPATH_FOR_LIB)
 
-$(BIN)/retrain_cost_model: $(SRC)/retrain_cost_model.cpp \
+$(BIN)/adams2019_retrain_cost_model: $(SRC)/retrain_cost_model.cpp \
 				$(COMMON_DIR)/ASLog.cpp \
 				$(SRC)/DefaultCostModel.h \
 				$(SRC)/DefaultCostModel.cpp \
@@ -108,7 +108,7 @@ $(BIN)/featurization_to_sample: $(SRC)/featurization_to_sample.cpp
 $(BIN)/get_host_target: $(SRC)/get_host_target.cpp $(LIB_HALIDE) $(HALIDE_DISTRIB_PATH)/include/Halide.h
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $(filter %.cpp,$^) $(LIBHALIDE_LDFLAGS) $(OPTIMIZE) -o $@ $(HALIDE_RPATH_FOR_BIN)
-$(BIN)/weightsdir_to_weightsfile: $(SRC)/weightsdir_to_weightsfile.cpp $(SRC)/Weights.cpp
+$(BIN)/adams2019_weightsdir_to_weightsfile: $(SRC)/weightsdir_to_weightsfile.cpp $(SRC)/Weights.cpp
 	@mkdir -p $(@D)
 	$(CXX) $(CXXFLAGS) $^ $(OPTIMIZE) -o $@
 

--- a/src/autoschedulers/adams2019/adams2019_autotune_loop.sh
+++ b/src/autoschedulers/adams2019/adams2019_autotune_loop.sh
@@ -213,7 +213,7 @@ for ((BATCH_ID=$((FIRST+1));BATCH_ID<$((FIRST+1+NUM_BATCHES));BATCH_ID++)); do
         echo Retraining model...
 
         find ${SAMPLES} -name "*.sample" | \
-            ${AUTOSCHED_BIN}/retrain_cost_model \
+            ${AUTOSCHED_BIN}/adams2019_retrain_cost_model \
                 --epochs=${BATCH_SIZE} \
                 --rates="0.0001" \
                 --num_cores=32 \


### PR DESCRIPTION
The Halide 15.0.0 release inadvertently omitted all of these tools from the packaging. They are being re-added for 15.0.1. While we're doing this, let's go ahead and have the names match those proposed for Halide 16.