### PR TITLE
Rename `device_copy` -> `DeviceCopy`

### DIFF
--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -893,7 +893,7 @@ WEAK int halide_cuda_device_malloc(void *user_context, halide_buffer_t *buf) {
 }
 
 namespace {
-WEAK int cuda_do_multidimensional_copy(void *user_context, const device_copy &c,
+WEAK int cuda_do_multidimensional_copy(void *user_context, const DeviceCopy &c,
                                        uint64_t src, uint64_t dst, int d, bool from_host, bool to_host,
                                        CUstream stream) {
     if (d > MAX_COPY_DIMS) {
@@ -976,7 +976,7 @@ WEAK int halide_cuda_buffer_copy(void *user_context, struct halide_buffer_t *src
     halide_abort_if_false(user_context, from_host || src->device);
     halide_abort_if_false(user_context, to_host || dst->device);
 
-    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+    DeviceCopy c = make_buffer_copy(src, from_host, dst, to_host);
 
     {
         Context ctx(user_context);

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -2836,7 +2836,7 @@ WEAK int halide_d3d12compute_device_release(void *user_context) {
 
 namespace {
 
-void do_multidimensional_copy(d3d12_device *device, const device_copy &c,
+void do_multidimensional_copy(d3d12_device *device, const DeviceCopy &c,
                               uint64_t src_offset, uint64_t dst_offset, int dimensions) {
     TRACELOG;
 
@@ -2878,7 +2878,7 @@ WEAK int halide_d3d12compute_copy_to_device(void *user_context, halide_buffer_t 
     }
 
     // 1. memcpy from halide host memory to "upload" staging memory
-    device_copy c = make_host_to_device_copy(buffer);
+    DeviceCopy c = make_host_to_device_copy(buffer);
     halide_abort_if_false(user_context, (c.dst == buffer->device));
     d3d12_buffer *dev_buffer = peel_buffer(buffer);
     halide_abort_if_false(user_context, buffer->size_in_bytes() == dev_buffer->sizeInBytes);
@@ -2935,7 +2935,7 @@ WEAK int halide_d3d12compute_copy_to_host(void *user_context, halide_buffer_t *b
                              dev_byte_offset, staging_byte_offset, total_size);
 
     // 2. memcpy from "readback" staging memory to halide host memory
-    device_copy c = make_device_to_host_copy(buffer);
+    DeviceCopy c = make_device_to_host_copy(buffer);
     void *staging_data = buffer_contents(staging);
     c.src = reinterpret_cast<uint64_t>(staging_data) + staging_byte_offset;
     // the 'host' buffer already points to the beginning of the cropped region
@@ -3236,7 +3236,7 @@ WEAK int halide_d3d12compute_buffer_copy(void *user_context, struct halide_buffe
     halide_abort_if_false(user_context, from_host || src->device);
     halide_abort_if_false(user_context, to_host || dst->device);
 
-    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+    DeviceCopy c = make_buffer_copy(src, from_host, dst, to_host);
     MAYBE_UNUSED(c);
 
     {

--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -533,7 +533,7 @@ WEAK int halide_buffer_copy_already_locked(void *user_context, struct halide_buf
         }
 
         if (to_host && from_host_valid) {
-            device_copy c = make_buffer_copy(src, true, dst, true);
+            DeviceCopy c = make_buffer_copy(src, true, dst, true);
             copy_memory(c, user_context);
             result = halide_error_code_success;
         } else if (to_host && from_device_valid) {

--- a/src/runtime/hexagon_host.cpp
+++ b/src/runtime/hexagon_host.cpp
@@ -674,7 +674,7 @@ WEAK int halide_hexagon_copy_to_device(void *user_context, halide_buffer_t *buf)
 #endif
 
     halide_abort_if_false(user_context, buf->host && buf->device);
-    device_copy c = make_host_to_device_copy(buf);
+    DeviceCopy c = make_host_to_device_copy(buf);
 
     // Get the descriptor associated with the ion buffer.
     c.dst = ptr_to_uint64(halide_hexagon_get_device_handle(user_context, buf));
@@ -698,7 +698,7 @@ WEAK int halide_hexagon_copy_to_host(void *user_context, struct halide_buffer_t 
 #endif
 
     halide_abort_if_false(user_context, buf->host && buf->device);
-    device_copy c = make_device_to_host_copy(buf);
+    DeviceCopy c = make_device_to_host_copy(buf);
 
     // Get the descriptor associated with the ion buffer.
     c.src = ptr_to_uint64(halide_hexagon_get_device_handle(user_context, buf));
@@ -817,7 +817,7 @@ WEAK int halide_hexagon_buffer_copy(void *user_context, struct halide_buffer_t *
     uint64_t t_before = halide_current_time_ns(user_context);
 #endif
 
-    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+    DeviceCopy c = make_buffer_copy(src, from_host, dst, to_host);
 
     // Get the descriptor associated with the ion buffer.
     if (!from_host) {

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -298,7 +298,7 @@ WEAK mtl_device *metal_api_checked_device;
 
 namespace {
 void do_device_to_device_copy(void *user_context, mtl_blit_command_encoder *encoder,
-                              const device_copy &c, uint64_t src_offset, uint64_t dst_offset, int d) {
+                              const DeviceCopy &c, uint64_t src_offset, uint64_t dst_offset, int d) {
     if (d == 0) {
         buffer_to_buffer_1d_copy(encoder, ((device_handle *)c.src)->buf, c.src_begin + src_offset,
                                  ((device_handle *)c.dst)->buf, dst_offset, c.chunk_size);
@@ -660,7 +660,7 @@ WEAK int halide_metal_copy_to_device(void *user_context, halide_buffer_t *buffer
         return halide_error_code_generic_error;
     }
 
-    device_copy c = make_host_to_device_copy(buffer);
+    DeviceCopy c = make_host_to_device_copy(buffer);
     mtl_buffer *metal_buffer = ((device_handle *)c.dst)->buf;
     c.dst = (uint64_t)buffer_contents(metal_buffer) + ((device_handle *)c.dst)->offset;
 
@@ -711,7 +711,7 @@ WEAK int halide_metal_copy_to_host(void *user_context, halide_buffer_t *buffer) 
         return halide_error_code_generic_error;
     }
 
-    device_copy c = make_device_to_host_copy(buffer);
+    DeviceCopy c = make_device_to_host_copy(buffer);
     c.src = (uint64_t)buffer_contents(((device_handle *)c.src)->buf) + ((device_handle *)c.src)->offset;
 
     copy_memory(c, user_context);
@@ -952,7 +952,7 @@ WEAK int halide_metal_buffer_copy(void *user_context, struct halide_buffer_t *sr
         return halide_error_code_device_buffer_copy_failed;
     }
 
-    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+    DeviceCopy c = make_buffer_copy(src, from_host, dst, to_host);
 
     {
         MetalContextHolder metal_context(user_context, true);

--- a/src/runtime/msan.cpp
+++ b/src/runtime/msan.cpp
@@ -27,7 +27,7 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK void annotate_helper(void *uc, const device_copy &c, int d, int64_t off) {
+WEAK void annotate_helper(void *uc, const DeviceCopy &c, int d, int64_t off) {
     while (d >= 0 && c.extent[d] == 1) {
         d--;
     }
@@ -43,7 +43,7 @@ WEAK void annotate_helper(void *uc, const device_copy &c, int d, int64_t off) {
     }
 };
 
-WEAK void check_helper(void *uc, const device_copy &c, int d, int64_t off, const char *buf_name) {
+WEAK void check_helper(void *uc, const DeviceCopy &c, int d, int64_t off, const char *buf_name) {
     while (d >= 0 && c.extent[d] == 1) {
         d--;
     }
@@ -72,7 +72,7 @@ WEAK int halide_msan_annotate_buffer_is_initialized(void *user_context, halide_b
         return 0;
     }
 
-    Halide::Runtime::Internal::device_copy c = Halide::Runtime::Internal::make_host_to_device_copy(b);
+    Halide::Runtime::Internal::DeviceCopy c = Halide::Runtime::Internal::make_host_to_device_copy(b);
     if (c.chunk_size == 0) {
         return 0;
     }
@@ -100,7 +100,7 @@ WEAK int halide_msan_check_buffer_is_initialized(void *user_context, halide_buff
     (void)halide_msan_check_memory_is_initialized(user_context, (void *)b, sizeof(*b), buf_name);                              // ignore errors
     (void)halide_msan_check_memory_is_initialized(user_context, (void *)b->dim, b->dimensions * sizeof(b->dim[0]), buf_name);  // ignore errors
 
-    Halide::Runtime::Internal::device_copy c = Halide::Runtime::Internal::make_host_to_device_copy(b);
+    Halide::Runtime::Internal::DeviceCopy c = Halide::Runtime::Internal::make_host_to_device_copy(b);
     if (c.chunk_size == 0) {
         return 0;
     }

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -935,7 +935,7 @@ WEAK int halide_opencl_device_malloc(void *user_context, halide_buffer_t *buf) {
 
 namespace {
 WEAK int opencl_do_multidimensional_copy(void *user_context, ClContext &ctx,
-                                         const device_copy &c,
+                                         const DeviceCopy &c,
                                          int64_t src_idx, int64_t dst_idx,
                                          int d, bool from_host, bool to_host) {
     if (d > MAX_COPY_DIMS) {
@@ -1010,7 +1010,7 @@ WEAK int halide_opencl_buffer_copy(void *user_context, struct halide_buffer_t *s
     halide_abort_if_false(user_context, from_host || src->device);
     halide_abort_if_false(user_context, to_host || dst->device);
 
-    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+    DeviceCopy c = make_buffer_copy(src, from_host, dst, to_host);
 
     {
         ClContext ctx(user_context);
@@ -1728,7 +1728,7 @@ WEAK int halide_opencl_image_buffer_copy(void *user_context, struct halide_buffe
     halide_abort_if_false(user_context, from_host || src->device);
     halide_abort_if_false(user_context, to_host || dst->device);
 
-    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+    DeviceCopy c = make_buffer_copy(src, from_host, dst, to_host);
 
     int err = 0;
     {

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -377,7 +377,7 @@ WEAK int halide_openglcompute_device_free(void *user_context, halide_buffer_t *b
 namespace {
 
 template<typename Source, typename Dest>
-ALWAYS_INLINE void converting_copy_memory_helper(const device_copy &copy, int d, int64_t src_off, int64_t dst_off) {
+ALWAYS_INLINE void converting_copy_memory_helper(const DeviceCopy &copy, int d, int64_t src_off, int64_t dst_off) {
     // Skip size-1 dimensions
     while (d >= 0 && copy.extent[d] == 1) {
         d--;
@@ -440,7 +440,7 @@ WEAK int halide_openglcompute_copy_to_device(void *user_context, halide_buffer_t
     }
     halide_buffer_t buf_copy = *buf;
     buf_copy.device = (uint64_t)device_data;
-    device_copy dev_copy = make_host_to_device_copy(&buf_copy);
+    DeviceCopy dev_copy = make_host_to_device_copy(&buf_copy);
 
     if (buf->type.code == halide_type_int) {
         if (buf->type.bits == 8) {
@@ -532,7 +532,7 @@ WEAK int halide_openglcompute_copy_to_host(void *user_context, halide_buffer_t *
 
     halide_buffer_t buf_copy = *buf;
     buf_copy.device = (uint64_t)device_data;
-    device_copy dev_copy = make_device_to_host_copy(&buf_copy);
+    DeviceCopy dev_copy = make_device_to_host_copy(&buf_copy);
 
     if (buf->type.code == halide_type_int) {
         if (buf->type.bits == 8) {

--- a/src/runtime/webgpu.cpp
+++ b/src/runtime/webgpu.cpp
@@ -605,7 +605,7 @@ int do_copy_to_host(void *user_context, WgpuContext *context, uint8_t *dst,
 }
 
 int do_multidimensional_copy(void *user_context, WgpuContext *context,
-                             const device_copy &c,
+                             const DeviceCopy &c,
                              int64_t src_idx, int64_t dst_idx,
                              int d, bool from_host, bool to_host) {
     if (d > MAX_COPY_DIMS) {
@@ -704,7 +704,7 @@ WEAK int halide_webgpu_buffer_copy(void *user_context,
     halide_abort_if_false(user_context, from_host || src->device);
     halide_abort_if_false(user_context, to_host || dst->device);
 
-    device_copy c = make_buffer_copy(src, from_host, dst, to_host);
+    DeviceCopy c = make_buffer_copy(src, from_host, dst, to_host);
 
     int err = halide_error_code_success;
     {


### PR DESCRIPTION
This is 100% stylistic, but it's bothered me for years: the `device_copy` struct doesn't follow the usual Halide style for struct types, so every time I see it, I want to read it as a function name. Let's rename it to DeviceCopy to help keep me sane?

Also, drive-by change of #define to constexpr since we have C++17 in runtime.