### PR TITLE
Pacify clang-tidy

### DIFF
--- a/test/correctness/lerp.cpp
+++ b/test/correctness/lerp.cpp
@@ -178,11 +178,11 @@ int main(int argc, char **argv) {
                                     std::numeric_limits<int32_t>::min(), 257, 255 * 65535, 1,
                                     "<uint16_t, uint8_t> zero, one uint32_t weight test");
     check_range<uint32_t, uint8_t>(0, 1, 0, 1,
-                                   1 << 31, 1, 0, 1,
+                                   0x80000000, 1, 0, 1,
                                    0, 255, 0, 1,
                                    "<uint32_t, uint8_t> weight test");
     check_range<uint32_t, uint16_t>(0, 1, 0, 1,
-                                    1 << 31, 1, 0, 1,
+                                    0x80000000, 1, 0, 1,
                                     0, 65535, 0, 1,
                                     "<uint32_t, uint16_t> weight test");
 
@@ -200,8 +200,8 @@ int main(int argc, char **argv) {
 #if 0  // takes too long, difficult to test with uint32_t
     // Check all delta values for 32-bit, do it in signed arithmetic
     check_range<int32_t, uint32_t>(std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max(), 0, 1,
-                                   1 << 31, 1, 0, 1,
-                                   0, 1, 1 << 31, 1,
+                                   0x80000000, 1, 0, 1,
+                                   0, 1, 0x80000000, 1,
                                     "<uint32_t, uint32_t> all zero starts");
 #endif
 


### PR DESCRIPTION
The code was constructing INT_MIN in a way that clang-tidy disapproved of.

Hopefully fixes #7497 