### PR TITLE
Add build number to Python wheel before uploading

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -75,10 +75,13 @@ jobs:
             -DWITH_TUTORIALS=NO -DWITH_UTILS=NO -DWITH_PYTHON_STUBS=NO &&
             cmake --build build --target install
 
+      - name: Tag wheels
+        run: wheel tags --build=${{ github.run_id }} ./wheelhouse/*.whl
+
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse/*${{ github.run_id }}*.whl
 
   pip-other:
     name: Package Halide Python bindings
@@ -192,10 +195,13 @@ jobs:
           CIBW_CONFIG_SETTINGS: "--global-option=egg_info --global-option=-b.dev${{ needs.pip-labels.outputs.halide_pypi_label }}"
           CIBW_ARCHS_MACOS: "universal2"
 
+      - name: Tag wheels
+        run: wheel tags --build=${{ github.run_id }} ./wheelhouse/*.whl
+
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse/*${{ github.run_id }}*.whl
 
   pip-sdist:
     name: Make SDist

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: "${{ matrix.arch }}"
           CIBW_BUILD: "cp38-manylinux* cp39-manylinux* cp310-manylinux*"
-          CIBW_CONFIG_SETTINGS: "--global-option=egg_info --global-option=-b.dev${{ needs.pip-labels.outputs.halide_pypi_label }}"
+          CIBW_CONFIG_SETTINGS: "--global-option=egg_info --global-option=-b.dev${{ needs.pip-labels.outputs.halide_pypi_label }} --global-option=--build-number --global-option=${{github.run_id}}"
           CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/halide/manylinux2014_x86_64-llvm:${{ env.LLVM_VER }}
           # CIBW_MANYLINUX_I686_IMAGE: ghcr.io/halide/manylinux2014_i686-llvm:${{ env.LLVM_VER }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/halide/manylinux2014_aarch64-llvm:${{ env.LLVM_VER }}
@@ -75,13 +75,10 @@ jobs:
             -DWITH_TUTORIALS=NO -DWITH_UTILS=NO -DWITH_PYTHON_STUBS=NO &&
             cmake --build build --target install
 
-      - name: Tag wheels
-        run: wheel tags --build=${{ github.run_id }} ./wheelhouse/*.whl
-
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ./wheelhouse/*${{ github.run_id }}*.whl
+          path: ./wheelhouse/*.whl
 
   pip-other:
     name: Package Halide Python bindings
@@ -192,16 +189,13 @@ jobs:
         env:
           CMAKE_PREFIX_PATH: ${{ github.workspace }}/local-halide
           CIBW_BUILD: "cp38-${{ matrix.pytag }} cp39-${{ matrix.pytag }} cp310-${{ matrix.pytag }}"
-          CIBW_CONFIG_SETTINGS: "--global-option=egg_info --global-option=-b.dev${{ needs.pip-labels.outputs.halide_pypi_label }}"
+          CIBW_CONFIG_SETTINGS: "--global-option=egg_info --global-option=-b.dev${{ needs.pip-labels.outputs.halide_pypi_label }} --global-option=--build-number --global-option=${{github.run_id}}"
           CIBW_ARCHS_MACOS: "universal2"
-
-      - name: Tag wheels
-        run: wheel tags --build=${{ github.run_id }} ./wheelhouse/*.whl
 
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ./wheelhouse/*${{ github.run_id }}*.whl
+          path: ./wheelhouse/*.whl
 
   pip-sdist:
     name: Make SDist


### PR DESCRIPTION
This change adds a build number based on GitHub Actions' `github.run_id` to the Python wheel before uploading. This should work around the issue that causes the uploads to fail currently.

Fixes #7293