### PR TITLE
Add a few missing support bits for StmtViz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1554,7 +1554,7 @@ $(FILTERS_DIR)/multitarget.a: $(BIN_DIR)/multitarget.generator
 	@mkdir -p $(@D)
 	$(CURDIR)/$< -g multitarget -f "HalideTest::multitarget" $(GEN_AOT_OUTPUTS) -o $(CURDIR)/$(FILTERS_DIR) \
 		target=$(TARGET)-no_bounds_query-no_runtime-c_plus_plus_name_mangling,$(TARGET)-no_runtime-c_plus_plus_name_mangling  \
-		-e assembly,bitcode,c_source,c_header,stmt_html,static_library,stmt
+        -e assembly,bitcode,c_source,c_header,stmt_html,static_library,stmt,stmt_viz
 
 $(FILTERS_DIR)/msan.a: $(BIN_DIR)/msan.generator
 	@mkdir -p $(@D)

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -819,7 +819,7 @@ add_halide_library(<target> FROM <generator-target>
 
 extra-output = ASSEMBLY | BITCODE | COMPILER_LOG | FEATURIZATION
              | LLVM_ASSEMBLY | PYTHON_EXTENSION
-             | PYTORCH_WRAPPER | SCHEDULE | STMT | STMT_HTML
+             | PYTORCH_WRAPPER | SCHEDULE | STMT | STMT_HTML | STMT_VIZ
 ```
 
 This function creates a called `<target>` corresponding to running the

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -195,7 +195,8 @@ function(add_halide_library TARGET)
         REGISTRATION
         SCHEDULE
         STMT
-        STMT_HTML)
+        STMT_HTML
+        STMT_VIZ)
 
     # "hash table" of extra outputs to extensions
     set(ASSEMBLY_extension ".s")
@@ -210,6 +211,7 @@ function(add_halide_library TARGET)
     set(SCHEDULE_extension ".schedule.h")
     set(STMT_extension ".stmt")
     set(STMT_HTML_extension ".stmt.html")
+    set(STMT_VIZ_extension ".stmt.viz.html")
 
     ##
     # Parse the arguments and set defaults for missing values.

--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -62,7 +62,8 @@ void define_enums(py::module &m) {
 
     py::enum_<StmtOutputFormat>(m, "StmtOutputFormat")
         .value("Text", StmtOutputFormat::Text)
-        .value("HTML", StmtOutputFormat::HTML);
+        .value("HTML", StmtOutputFormat::HTML)
+        .value("StmtViz", StmtOutputFormat::StmtViz);
 
     py::enum_<TailStrategy>(m, "TailStrategy")
         .value("RoundUp", TailStrategy::RoundUp)

--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -204,6 +204,7 @@ void define_enums(py::module &m) {
         .value("static_library", OutputFileType::static_library)
         .value("stmt", OutputFileType::stmt)
         .value("stmt_html", OutputFileType::stmt_html)
+        .value("stmt_viz", OutputFileType::stmt_viz)
         .value("compiler_log", OutputFileType::compiler_log);
 }
 

--- a/python_bindings/test/correctness/compile_to.py
+++ b/python_bindings/test/correctness/compile_to.py
@@ -43,8 +43,12 @@ def main():
         else:
             assert os.path.isfile(os.path.join(tmpdir, "f_all.o"))
 
-        p = os.path.join(tmpdir, "f.html")
+        p = os.path.join(tmpdir, "f.stmt.html")
         f.compile_to({hl.OutputFileType.stmt_html: p}, args, "f")
+        assert os.path.isfile(p)
+
+        p = os.path.join(tmpdir, "f.stmt.viz.html")
+        f.compile_to({hl.OutputFileType.stmt_viz: p}, args, "f")
         assert os.path.isfile(p)
 
     finally:

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -535,6 +535,10 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
         debug(1) << "Module.compile(): stmt_html " << output_files.at(OutputFileType::stmt_html) << "\n";
         Internal::print_to_html(output_files.at(OutputFileType::stmt_html), *this);
     }
+    if (contains(output_files, OutputFileType::stmt_viz)) {
+        debug(1) << "Module.compile(): stmt_viz " << output_files.at(OutputFileType::stmt_viz) << "\n";
+        Internal::print_to_viz(output_files.at(OutputFileType::stmt_viz), *this);
+    }
 
     // Minor but worthwhile optimization: if all of the output files are of types that won't
     // ever rely on submodules (e.g.: toplevel declarations in C/C++), don't bother resolving

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -340,7 +340,7 @@ void Pipeline::compile_to_lowered_stmt(const string &filename,
                                        StmtOutputFormat fmt,
                                        const Target &target) {
     Module m = compile_to_module(args, "", target);
-    m.compile(single_output(filename, m, fmt == HTML ? OutputFileType::stmt_html : OutputFileType::stmt));
+    m.compile(single_output(filename, m, fmt == HTML ? OutputFileType::stmt_html : (fmt == StmtViz ? OutputFileType::stmt_viz : OutputFileType::stmt)));
 }
 
 void Pipeline::compile_to_static_library(const string &filename_prefix,

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -72,7 +72,8 @@ struct JITCallArgs;
  * or as an HTML file which can be opened in a browerser and manipulated via JS and CSS.*/
 enum StmtOutputFormat {
     Text,
-    HTML
+    HTML,
+    StmtViz,
 };
 
 namespace {

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -293,6 +293,7 @@ tests(GROUPS correctness
       stage_strided_loads.cpp
       stencil_chain_in_update_definitions.cpp
       stmt_to_html.cpp
+      stmt_to_viz.cpp
       storage_folding.cpp
       store_in.cpp
       strict_float.cpp

--- a/test/correctness/stmt_to_viz.cpp
+++ b/test/correctness/stmt_to_viz.cpp
@@ -1,0 +1,49 @@
+#include "Halide.h"
+#include "halide_test_dirs.h"
+
+#include <cstdio>
+
+using namespace Halide;
+
+int main() {
+    Var x, y;
+
+    // The gradient function and schedule from tutorial lesson 5.
+    Func gradient_fast("gradient_fast");
+    gradient_fast(x, y) = x + y;
+
+    Var x_outer, y_outer, x_inner, y_inner, tile_index;
+    gradient_fast
+        .tile(x, y, x_outer, y_outer, x_inner, y_inner, 256, 256)
+        .fuse(x_outer, y_outer, tile_index)
+        .parallel(tile_index);
+
+    Var x_inner_outer, y_inner_outer, x_vectors, y_pairs;
+    gradient_fast
+        .tile(x_inner, y_inner, x_inner_outer, y_inner_outer, x_vectors, y_pairs, 4, 2)
+        .vectorize(x_vectors)
+        .unroll(y_pairs);
+
+    std::string result_file_1 = Internal::get_test_tmp_dir() + "stmt_to_viz_dump_1.stmt.viz.html";
+    Internal::ensure_no_file_exists(result_file_1);
+    gradient_fast.compile_to_lowered_stmt(result_file_1, {}, Halide::StmtViz);
+    Internal::assert_file_exists(result_file_1);
+
+    // Also check using an image.
+    std::string result_file_2 = Internal::get_test_tmp_dir() + "stmt_to_html_dump_2.stmt.viz.html";
+    Internal::ensure_no_file_exists(result_file_2);
+    Buffer<int> im(800, 600);
+    gradient_fast.compile_to_lowered_stmt(result_file_2, {im}, Halide::StmtViz);
+    Internal::assert_file_exists(result_file_2);
+
+    // Check a multi-output pipeline.
+    std::string result_file_3 = Internal::get_test_tmp_dir() + "stmt_to_html_dump_3.stmt.viz.html";
+    Internal::ensure_no_file_exists(result_file_3);
+    Func tuple_func;
+    tuple_func(x, y) = Tuple(x, y);
+    tuple_func.compile_to_lowered_stmt(result_file_3, {}, Halide::StmtViz);
+    Internal::assert_file_exists(result_file_3);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/tutorial/lesson_03_debugging_1.cpp
+++ b/tutorial/lesson_03_debugging_1.cpp
@@ -53,9 +53,9 @@ int main(int argc, char **argv) {
 
     // Halide will also output an HTML version of this output, which
     // supports syntax highlighting and code-folding, so it can be
-    // nicer to read for large pipelines. Open gradient.html with your
+    // nicer to read for large pipelines. Open gradient.stmt.viz.html with your
     // browser after running this tutorial.
-    gradient.compile_to_lowered_stmt("gradient.html", {}, HTML);
+    gradient.compile_to_lowered_stmt("gradient.stmt.viz.html", {}, StmtViz);
 
     // You can usually figure out what code Halide is generating using
     // this pseudocode. In the next lesson we'll see how to snoop on

--- a/tutorial/lesson_15_generators_usage.sh
+++ b/tutorial/lesson_15_generators_usage.sh
@@ -94,13 +94,15 @@ check_file_exists my_first_generator_win32.h
 # -n file_base_name : Specifies the basename of the generated file(s). If
 # you omit this, it defaults to the name of the generated function.
 
-# -e static_library,object,c_header,assembly,bitcode,stmt,stmt_html: A list of
+# -e static_library,object,c_header,assembly,bitcode,stmt,stmt_html,stmt_viz: A list of
 # comma-separated values specifying outputs to create. The default is
 # "static_library,c_header,registration". "assembly" generates assembly equivalent to the
 # generated object file. "bitcode" generates llvm bitcode for the pipeline.
 # "stmt" generates human-readable pseudocode for the pipeline (similar to
 # setting HL_DEBUG_CODEGEN). "stmt_html" generates an html version of the
 # pseudocode, which can be much nicer to read than the raw .stmt file.
+# "stmt_viz" produces a very detailed HTML output that includes information
+# about control flow, assembly output, cost indicators, and much more.
 
 # -r file_base_name : Specifies that the generator should create a
 # standalone file for just the runtime. For use when generating multiple


### PR DESCRIPTION
This is to augment #7421 and add some missing build-and-test support bits that got overlooked, including output from the CMake generator rules, some Python support issues, README, tutorial, and multitarget output.