### PR TITLE
Improve assembly-file finding logic in StmtToViz

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -616,7 +616,7 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
 
     if (contains(output_files, OutputFileType::stmt_viz)) {
         debug(1) << "Module.compile(): stmt_viz " << output_files.at(OutputFileType::stmt_viz) << "\n";
-        Internal::print_to_viz(output_files.at(OutputFileType::stmt_viz), *this);
+        Internal::print_to_viz(output_files.at(OutputFileType::stmt_viz), *this, output_files.at(OutputFileType::assembly));
     }
     if (contains(output_files, OutputFileType::function_info_header)) {
         debug(1) << "Module.compile(): function_info_header " << output_files.at(OutputFileType::function_info_header) << "\n";

--- a/src/StmtToViz.h
+++ b/src/StmtToViz.h
@@ -15,8 +15,14 @@ namespace Internal {
 
 struct Stmt;
 
-/** Dump an HTML-formatted visualization of a Module to filename. */
-void print_to_viz(const std::string &filename, const Module &m);
+/** Dump an HTML-formatted visualization of a Module to filename.
+ * If assembly_input_filename is not empty, it is expected to be the path
+ * to assembly output. If empty, the code will attempt to find such a
+ * file based on output_filename (replacing ".stmt.html" with ".s"),
+ * and will assert-fail if no such file is found. */
+void print_to_viz(const std::string &html_output_filename,
+                  const Module &m,
+                  const std::string &assembly_input_filename = "");
 
 }  // namespace Internal
 }  // namespace Halide


### PR DESCRIPTION
(1) Avoid having to guess at location by just passing in the location, since we usually already know it. (2) If we don't know it, be more cautious when constructing it: the output html filename might not match our expectations, and all file extensions must use get_output_info() to work correctly on all platforms.