### PR TITLE
[xtensa] fixed regression due to a new pattern for narrow_predicate

### DIFF
--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -1237,6 +1237,8 @@ private:
         }
 
         const std::vector<Expr> patterns = {
+            ramp(0, 1, pred.type().lanes()) <= bc(wild_i8, pred.type().lanes()),
+            ramp(0, 1, pred.type().lanes()) <= bc(wild_i16, pred.type().lanes()),
             ramp(wild_i32, 1, pred.type().lanes()) <= bc(wild_i32, pred.type().lanes())};
 
         vector<Expr> matches;


### PR DESCRIPTION
New rewrite rools for narrow_predicate in FindIntrinsics.cpp prevented Optimize to use "clamped_dense_ramp". New patterns compensate for that.