### PR TITLE
Remove workaround for GCC 4.x.x in cpuid()

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -41,24 +41,12 @@ static void cpuid(int info[4], int infoType, int extra) {
 // CPU feature detection code taken from ispc
 // (https://github.com/ispc/ispc/blob/master/builtins/dispatch.ll)
 
-#ifdef _LP64
 void cpuid(int info[4], int infoType, int extra) {
     __asm__ __volatile__(
         "cpuid                 \n\t"
         : "=a"(info[0]), "=b"(info[1]), "=c"(info[2]), "=d"(info[3])
         : "0"(infoType), "2"(extra));
 }
-#else
-static void cpuid(int info[4], int infoType, int extra) {
-    // We save %ebx in case it's the PIC register
-    __asm__ __volatile__(
-        "mov{l}\t{%%}ebx, %1  \n\t"
-        "cpuid                 \n\t"
-        "xchg{l}\t{%%}ebx, %1  \n\t"
-        : "=a"(info[0]), "=r"(info[1]), "=c"(info[2]), "=d"(info[3])
-        : "0"(infoType), "2"(extra));
-}
-#endif
 #endif
 #endif
 


### PR DESCRIPTION
The PR removes the code with workaround for GCC 4.x.x. With later version of GCC (5 and later) and Clang the problem does not exist and "movl %ebx / xchgl %ebx" hack is not needed - the compiler correctly detects the use of `ebx` and stores/restores `ebx` register. The original problem was compiler error message when compiled with `-fPIC` and now it's safe to remove.

I have complete description of the problem here: https://github.com/ispc/ispc/issues/2504 and I've fixed ISPC code as well (it's the code where this snippet was originally borrowed from).
