### PR TITLE
fix(fuzz): Refactor fuzzers to fix off by 1 errors

### DIFF
--- a/test/fuzz/fuzz_helpers.h
+++ b/test/fuzz/fuzz_helpers.h
@@ -1,0 +1,15 @@
+#ifndef HALIDE_FUZZ_HELPERS_H_
+#define HALIDE_FUZZ_HELPERS_H_
+
+#include "fuzzer/FuzzedDataProvider.h"
+#include <vector>
+
+namespace Halide {
+
+template<typename T>
+inline T pick_value_in_vector(FuzzedDataProvider &fdp, std::vector<T> &vec) {
+    return vec[fdp.ConsumeIntegralInRange<size_t>(0, vec.size() - 1)];
+}
+}  // namespace Halide
+
+#endif  // HALIDE_FUZZ_HELPERS_H_


### PR DESCRIPTION
Cleanup the fuzzers making them more readable and fix off by one errors caused by incorrect usage of
FuzzedDataProvider::ConsumeIntegralInRange.

Closes: #7546