### PR TITLE
[vulkan] Fix missing initializer for vulkan memory config 

### DIFF
--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -187,6 +187,7 @@ int VulkanMemoryAllocator::initialize(void *user_context,
     block_allocator_config.maximum_block_count = cfg.maximum_block_count;
     block_allocator_config.maximum_block_size = cfg.maximum_block_size;
     block_allocator_config.minimum_block_size = cfg.minimum_block_size;
+    block_allocator_config.nearest_multiple = cfg.nearest_multiple;
     block_allocator = BlockAllocator::create(user_context, block_allocator_config, allocators);
     if (block_allocator == nullptr) {
         error(user_context) << "VulkanMemoryAllocator: Failed to create BlockAllocator! Out of memory?!\n";


### PR DESCRIPTION
Looks like this line got munged in a previous merge. This gets the correctness_multiple_outputs test to pass.