### PR TITLE
Add/augment some runtime debug output

### DIFF
--- a/src/runtime/device_interface.cpp
+++ b/src/runtime/device_interface.cpp
@@ -96,15 +96,18 @@ ALWAYS_INLINE int debug_log_and_validate_buf(void *user_context, const halide_bu
     bool device_interface_set = (buf.device_interface != nullptr);
     bool device_set = (buf.device != 0);
     if (device_set && !device_interface_set) {
+        debug(user_context) << routine << " halide_error_no_device_interface for: " << buf << "\n";
         return halide_error_no_device_interface(user_context);
     }
     if (device_interface_set && !device_set) {
+        debug(user_context) << routine << " halide_error_device_interface_no_device for: " << buf << "\n";
         return halide_error_device_interface_no_device(user_context);
     }
 
     bool host_dirty = buf.host_dirty();
     bool device_dirty = buf.device_dirty();
     if (host_dirty && device_dirty) {
+        debug(user_context) << routine << " halide_error_host_and_device_dirty for: " << buf << "\n";
         return halide_error_host_and_device_dirty(user_context);
     }
     /* TODO: we could test:

--- a/src/runtime/to_string.cpp
+++ b/src/runtime/to_string.cpp
@@ -285,7 +285,8 @@ WEAK char *halide_buffer_to_string(char *dst, char *end, const halide_buffer_t *
     if (buf == nullptr) {
         return halide_string_to_string(dst, end, "nullptr");
     }
-    dst = halide_string_to_string(dst, end, "buffer(");
+    dst = halide_pointer_to_string(dst, end, buf);
+    dst = halide_string_to_string(dst, end, " -> buffer(");
     dst = halide_uint64_to_string(dst, end, buf->device, 1);
     dst = halide_string_to_string(dst, end, ", ");
     dst = halide_pointer_to_string(dst, end, buf->device_interface);


### PR DESCRIPTION
- in `halide_buffer_to_string()`, print the `halide_buffer_t*` pointer value as well
- in `debug_log_and_validate_buf()`, do debug logging for some failure modes that return errors