### PR TITLE
[vulkan] Disable generator acquire_release test for Vulkan

### DIFF
--- a/test/generator/acquire_release_aottest.cpp
+++ b/test/generator/acquire_release_aottest.cpp
@@ -207,6 +207,9 @@ bool run_test() {
 }
 
 int main(int argc, char **argv) {
+#if defined(TEST_VULKAN)
+    printf("[SKIP] Vulkan doesn't implement a custom context for this test.\n");
+#else
     if (!run_test()) {
         return 1;
     }
@@ -214,7 +217,7 @@ int main(int argc, char **argv) {
     if (!run_test()) {
         return 1;
     }
-
+#endif
     return 0;
 }
 


### PR DESCRIPTION
There's really not an easy way to create a custom Vulkan context needed for this test.