### PR TITLE
Allow autoconversion from `Buffer<T>` -> `Buffer<const T>&` and to `Buffer<void>&`

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1249,6 +1249,28 @@ public:
         return as_const();
     }
 
+    /** Add some syntactic sugar to allow autoconversion from Buffer<T> to Buffer<void>& when
+     * passing arguments */
+    template<typename TVoid,
+             typename T2 = T,
+             typename = typename std::enable_if<std::is_same<TVoid, void>::value &&
+                                                !std::is_void<T2>::value &&
+                                                !std::is_const<T2>::value>::type>
+    operator Buffer<TVoid, Dims, InClassDimStorage> &() & {
+        return as<TVoid, Dims>();
+    }
+
+    /** Add some syntactic sugar to allow autoconversion from Buffer<const T> to Buffer<const void>& when
+     * passing arguments */
+    template<typename TVoid,
+             typename T2 = T,
+             typename = typename std::enable_if<std::is_same<TVoid, void>::value &&
+                                                !std::is_void<T2>::value &&
+                                                std::is_const<T2>::value>::type>
+    operator Buffer<const TVoid, Dims, InClassDimStorage> &() & {
+        return as<const TVoid, Dims>();
+    }
+
     /** Conventional names for the first three dimensions. */
     // @{
     int width() const {

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1242,6 +1242,13 @@ public:
     }
     // @}
 
+    /** Add some syntactic sugar to allow autoconversion from Buffer<T> to Buffer<const T>& when
+     * passing arguments */
+    template<typename T2 = T, typename = typename std::enable_if<!std::is_const<T2>::value>::type>
+    operator Buffer<typename std::add_const<T2>::type, Dims, InClassDimStorage> &() & {
+        return as_const();
+    }
+
     /** Conventional names for the first three dimensions. */
     // @{
     int width() const {

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -221,6 +221,20 @@ int main(int argc, char **argv) {
     }
 
     {
+        // Check that Buffer<T> will autoconvert to Buffer<const T>&
+        Buffer<float> a(100, 80, 3);
+        a.for_each_element([&](int x, int y, int c) {
+            a(x, y, c) = x + 100.0f * y + 100000.0f * c;
+        });
+        Buffer<float> b(a);
+
+        const auto check_equal_non_const_ref = [](Buffer<const float> &a, Buffer<const float> &b) {
+            check_equal(a, b);
+        };
+        check_equal_non_const_ref(a, b);
+    }
+
+    {
         // Check lifting a function over scalars to a function over entire buffers.
         const int W = 5, H = 4, C = 3;
         Buffer<float> a(W, H, C);

--- a/test/correctness/halide_buffer.cpp
+++ b/test/correctness/halide_buffer.cpp
@@ -221,17 +221,31 @@ int main(int argc, char **argv) {
     }
 
     {
-        // Check that Buffer<T> will autoconvert to Buffer<const T>&
         Buffer<float> a(100, 80, 3);
         a.for_each_element([&](int x, int y, int c) {
             a(x, y, c) = x + 100.0f * y + 100000.0f * c;
         });
         Buffer<float> b(a);
 
+        // Check that Buffer<T> will autoconvert to Buffer<const T>&
         const auto check_equal_non_const_ref = [](Buffer<const float> &a, Buffer<const float> &b) {
             check_equal(a, b);
         };
         check_equal_non_const_ref(a, b);
+
+        // Check that Buffer<T> will autoconvert to Buffer<void>&
+        const auto check_equal_non_const_void_ref = [](Buffer<void> &a, Buffer<void> &b) {
+            check_equal(a.as<float>(), b.as<float>());
+        };
+        check_equal_non_const_void_ref(a, b);
+
+        // Check that Buffer<const T> will autoconvert to Buffer<const void>&
+        const auto check_equal_const_void_ref = [](Buffer<const void> &a, Buffer<const void> &b) {
+            check_equal(a.as<const float>(), b.as<const float>());
+        };
+        Buffer<const float> ac = a;
+        Buffer<const float> bc = b;
+        check_equal_const_void_ref(ac, bc);
     }
 
     {


### PR DESCRIPTION
When you are intermixing CPU and GPU calls in a single piece of code, it's preferable to pass `Buffer<>` by nonconst reference, so that lazy host<->device copies are done efficiently.

However, many callers prefer to define input Buffers as `Buffer<const T>` (as they should), but the fact that this form didn't easily allow autoconversion from caller (whihc may well have constructed the buffer as non-const) to callee (due to incompatible type references) led some users to just pass by a copy, since these autoconverted. This had a couple of undesirable effects:
- Making a copy cost a small but nonzero amount of code (managing refcounts, etc)
- More importantly, lazy copies in the callee got 'lost' to the caller, since the `halide_buffer_t` in the callee was a copy, thus any added `device` value or change in dirty bits was never seen.

This could previously be worked around by adding explicit calls to `.as_const()`, but that is ugly and awkward.

This change adds an ugly-but-safe implicit-conversion overload, to allow converting `Buffer<T>&` to `Buffer<const T>&`, iff T isn't already const. This will allow cleaning up downstream code to pass by references more consistently, without needing to add `.as_const()` warts.