### PR TITLE
[vulkan] Fix subregion memory offsets to respect buffer alignment 

### DIFF
--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -625,8 +625,8 @@ int VulkanMemoryAllocator::allocate_block(void *instance_ptr, MemoryBlock *block
         block->properties.alignment = instance->physical_device_limits.minStorageBufferOffsetAlignment;
     } else if (usage_flags & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) {
         block->properties.alignment = instance->physical_device_limits.minUniformBufferOffsetAlignment;
-    } 
-    // Some drivers appear to report a buffer alignment constraint (regardless of usage) that can be larger than either of the above 
+    }
+    // Some drivers appear to report a buffer alignment constraint (regardless of usage) that can be larger than either of the above
     if (memory_requirements.alignment > block->properties.alignment) {
         block->properties.alignment = memory_requirements.alignment;
     }

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -620,11 +620,14 @@ int VulkanMemoryAllocator::allocate_block(void *instance_ptr, MemoryBlock *block
                    << "dedicated=" << (block->dedicated ? "true" : "false") << ")\n";
 #endif
 
+    // Enforce any alignment constrainst reported by the device limits for each usage type
     if (usage_flags & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT) {
         block->properties.alignment = instance->physical_device_limits.minStorageBufferOffsetAlignment;
     } else if (usage_flags & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT) {
         block->properties.alignment = instance->physical_device_limits.minUniformBufferOffsetAlignment;
-    } else {
+    } 
+    // Some drivers appear to report a buffer alignment constraint (regardless of usage) that can be larger than either of the above 
+    if (memory_requirements.alignment > block->properties.alignment) {
         block->properties.alignment = memory_requirements.alignment;
     }
     block->handle = (void *)device_memory;


### PR DESCRIPTION
This appears to fix issues that were present on linux-buildbot-4 whereby the driver is reporting a buffer alignment constraint which is larger (??) than the offset alignment constraint for the buffer usage.  In this case, the validation layer reports that this buffer alignment constraint has to be applied to the byte offset for BindBufferMemory.

These changes fix this issue.