### PR TITLE
[vulkan] Change the feature version requirement to v1.3 for correctness_gpu_dynamic_shared

### DIFF
--- a/test/correctness/gpu_dynamic_shared.cpp
+++ b/test/correctness/gpu_dynamic_shared.cpp
@@ -20,8 +20,8 @@ int main(int argc, char **argv) {
         assert(interface->compute_capability != nullptr);
         int major, minor;
         int err = interface->compute_capability(nullptr, &major, &minor);
-        if (err != 0 || (major == 1 && minor < 2)) {
-            printf("[SKIP] Vulkan %d.%d is less than required 1.2.\n", major, minor);
+        if (err != 0 || (major == 1 && minor < 3)) {
+            printf("[SKIP] Vulkan %d.%d is less than required 1.3.\n", major, minor);
             return 0;
         }
         if ((t.os == Target::IOS) || (t.os == Target::OSX)) {


### PR DESCRIPTION
The linux-buildbot-4 machine only supports v1.2, and that isn't enough to run this test.

Change the feature detection to require v1.3, otherwise skip the test.