### PR TITLE
Fix various compilation errors with AppleClang 14.0.3

### DIFF
--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -270,7 +270,7 @@ IntrusivePtr<State> optimal_schedule_pass(FunctionDAG &dag,
 #endif
 
     // This loop is beam search over the sequence of decisions to make.
-    for (int i = 0;; i++) {
+    for (;;) {
         std::unordered_map<uint64_t, int> hashes;
         q.swap(pending);
 

--- a/src/autoschedulers/adams2019/retrain_cost_model.cpp
+++ b/src/autoschedulers/adams2019/retrain_cost_model.cpp
@@ -416,8 +416,6 @@ int main(int argc, char **argv) {
         float v_correct_ordering_rate_count[kModels] = {0};
 
         for (int e = 0; e < flags.epochs; e++) {
-            int counter = 0;
-
             float worst_miss = 0;
             uint64_t worst_miss_pipeline_id = 0;
             uint64_t worst_miss_schedule_id = 0;
@@ -536,8 +534,6 @@ int main(int argc, char **argv) {
                         }
                     }
                 }
-
-                counter++;
             }
 
             std::cout << "Loss: ";

--- a/test/correctness/float16_t_constants.cpp
+++ b/test/correctness/float16_t_constants.cpp
@@ -77,9 +77,9 @@ int main() {
         // Try converting to native float types
         float infinityPf = (float)infinityP;
         double infinityPd = (double)infinityP;
-        h_assert(std::isinf(infinityPf) & !std::signbit(infinityPf),
+        h_assert(std::isinf(infinityPf) && !std::signbit(infinityPf),
                  "positive infinity conversion to float invalid");
-        h_assert(std::isinf(infinityPd) & !std::signbit(infinityPd),
+        h_assert(std::isinf(infinityPd) && !std::signbit(infinityPd),
                  "positive infinity conversion to double invalid");
     }
 
@@ -101,9 +101,9 @@ int main() {
         // Try converting to native float types
         float infinityNf = (float)infinityN;
         double infinityNd = (double)infinityN;
-        h_assert(std::isinf(infinityNf) & std::signbit(infinityNf),
+        h_assert(std::isinf(infinityNf) && std::signbit(infinityNf),
                  "negative infinity conversion to float invalid");
-        h_assert(std::isinf(infinityNd) & std::signbit(infinityNd),
+        h_assert(std::isinf(infinityNd) && std::signbit(infinityNd),
                  "negative infinity conversion to double invalid");
     }
 


### PR DESCRIPTION
Newer versions of Xcode trigger `-Wbitwise-instead-of-logical` for this usage, which we treat as an error