### PR TITLE
In fuzz/simplify, output errors to cerr, not cout

### DIFF
--- a/test/fuzz/simplify.cpp
+++ b/test/fuzz/simplify.cpp
@@ -224,14 +224,14 @@ bool test_simplification(Expr a, Expr b, Type t, const map<string, Expr> &vars) 
         }
         if (!equal(a_j_v, b_j_v)) {
             for (map<string, Expr>::const_iterator i = vars.begin(); i != vars.end(); i++) {
-                std::cout << i->first << " = " << i->second << "\n";
+                std::cerr << i->first << " = " << i->second << "\n";
             }
 
-            std::cout << a << "\n";
-            std::cout << b << "\n";
-            std::cout << "In vector lane " << j << ":\n";
-            std::cout << a_j << " -> " << a_j_v << "\n";
-            std::cout << b_j << " -> " << b_j_v << "\n";
+            std::cerr << a << "\n";
+            std::cerr << b << "\n";
+            std::cerr << "In vector lane " << j << ":\n";
+            std::cerr << a_j << " -> " << a_j_v << "\n";
+            std::cerr << b_j << " -> " << b_j_v << "\n";
             return false;
         }
     }


### PR DESCRIPTION
This makes it easier to capture error output in downstream test harnesses

attn @silvergasp 