### PR TITLE
Tighten Target parsing for Xtensa

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -714,7 +714,7 @@ bool merge_string(Target &t, const std::string &target) {
         }
     }
 
-    if (arch == Target::Xtensa) {
+    if (t.arch == Target::Xtensa) {
         // The only legal arch-bits-os for Xtensa is "xtensa-32-noos"
         if (t.bits != 32 || t.os != Target::NoOS) {
             return false;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -714,6 +714,13 @@ bool merge_string(Target &t, const std::string &target) {
         }
     }
 
+    if (arch == Target::Xtensa) {
+        // The only legal arch-bits-os for Xtensa is "xtensa-32-noos"
+        if (t.bits != 32 || t.os != Target::NoOS) {
+            return false;
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
only "xtensa-32-noos" allow for the base triple -- at present the bits and os are actually ignored, so let's constrain them to a single value rather than allowing random stuff to still work