### PR TITLE
Fix operator/ on ModulusRemainder

### DIFF
--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -453,7 +453,9 @@ ModulusRemainder operator/(const ModulusRemainder &a, const ModulusRemainder &b)
 
     if (b.modulus == 0 && b.remainder != 0) {
         if (mod(a.modulus, b.remainder) == 0) {
-            return {a.modulus / b.remainder, div_imp(a.remainder, b.remainder)};
+            int64_t m = a.modulus / b.remainder;
+            int64_t r = mod(div_imp(a.remainder, b.remainder), m);
+            return {m, r};
         }
     }
 


### PR DESCRIPTION
It wasn't reducing the remainder modulo the modulus, which confused trim_bounds_using_alignment in the simplifier.

Fixes #7584 