### PR TITLE
[Hexagon] Remove v62 support

### DIFF
--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -142,8 +142,6 @@ void define_enums(py::module &m) {
         .value("LargeBuffers", Target::Feature::LargeBuffers)
         .value("HVX", Target::Feature::HVX)
         .value("HVX_128", Target::Feature::HVX_128)
-        .value("HVX_v62", Target::Feature::HVX_v62)
-        .value("HVX_v65", Target::Feature::HVX_v65)
         .value("HVX_v66", Target::Feature::HVX_v66)
         .value("FuzzFloatStores", Target::Feature::FuzzFloatStores)
         .value("SoftFloatABI", Target::Feature::SoftFloatABI)

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -39,8 +39,8 @@ enum {
     EF_HEXAGON_MACH_V5 = 0x4,
     EF_HEXAGON_MACH_V55 = 0x5,
     EF_HEXAGON_MACH_V60 = 0x60,  // Deprecated
-    EF_HEXAGON_MACH_V61 = 0x61,  // Deprecated?
-    EF_HEXAGON_MACH_V62 = 0x62,
+    EF_HEXAGON_MACH_V61 = 0x61,  // Deprecated
+    EF_HEXAGON_MACH_V62 = 0x62,  // Deprecated
     EF_HEXAGON_MACH_V65 = 0x65,
     EF_HEXAGON_MACH_V66 = 0x66,
 };
@@ -553,10 +553,8 @@ public:
     HexagonLinker(const Target &target) {
         if (target.has_feature(Target::HVX_v66)) {
             flags = Elf::EF_HEXAGON_MACH_V66;
-        } else if (target.has_feature(Target::HVX_v65)) {
-            flags = Elf::EF_HEXAGON_MACH_V65;
         } else {
-            flags = Elf::EF_HEXAGON_MACH_V62;
+            flags = Elf::EF_HEXAGON_MACH_V65;
         }
     }
 
@@ -980,8 +978,6 @@ Stmt inject_hexagon_rpc(Stmt s, const Target &host_target,
         Target::Profile,
         Target::NoAsserts,
         Target::HVX_128,
-        Target::HVX_v62,
-        Target::HVX_v65,
         Target::HVX_v66,
     };
     for (Target::Feature i : shared_features) {

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -1079,10 +1079,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             if (t.arch == Target::Hexagon) {
                 modules.push_back(get_initmod_qurt_hvx(c, bits_64, debug));
                 modules.push_back(get_initmod_hvx_128_ll(c));
-                if (t.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
-                    modules.push_back(get_initmod_qurt_hvx_vtcm(c, bits_64,
-                                                                debug));
-                }
+                modules.push_back(get_initmod_qurt_hvx_vtcm(c, bits_64, debug));
 
             } else {
                 modules.push_back(get_initmod_prefetch(c, bits_64, debug));

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -286,8 +286,6 @@ Target calculate_host_target() {
 
 bool is_using_hexagon(const Target &t) {
     return (t.has_feature(Target::HVX) ||
-            t.has_feature(Target::HVX_v62) ||
-            t.has_feature(Target::HVX_v65) ||
             t.has_feature(Target::HVX_v66) ||
             t.has_feature(Target::HexagonDma) ||
             t.arch == Target::Hexagon);
@@ -297,16 +295,10 @@ int get_hvx_lower_bound(const Target &t) {
     if (!is_using_hexagon(t)) {
         return -1;
     }
-    if (t.has_feature(Target::HVX_v62)) {
-        return 62;
-    }
-    if (t.has_feature(Target::HVX_v65)) {
-        return 65;
-    }
     if (t.has_feature(Target::HVX_v66)) {
         return 66;
     }
-    return 60;
+    return 65;
 }
 
 }  // namespace
@@ -491,8 +483,6 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"large_buffers", Target::LargeBuffers},
     {"hvx", Target::HVX_128},
     {"hvx_128", Target::HVX_128},
-    {"hvx_v62", Target::HVX_v62},
-    {"hvx_v65", Target::HVX_v65},
     {"hvx_v66", Target::HVX_v66},
     {"fuzz_float_stores", Target::FuzzFloatStores},
     {"soft_float_abi", Target::SoftFloatABI},
@@ -1248,8 +1238,6 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
         CUDACapability75,
         CUDACapability80,
         CUDACapability86,
-        HVX_v62,
-        HVX_v65,
         HVX_v66,
         VulkanV10,
         VulkanV12,
@@ -1385,12 +1373,6 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
 
     // Same trick as above for CUDA
     int hvx_version = std::min((unsigned)hvx_a, (unsigned)hvx_b);
-    if (hvx_version < 62) {
-        output.features.reset(HVX_v62);
-    }
-    if (hvx_version < 65) {
-        output.features.reset(HVX_v65);
-    }
     if (hvx_version < 66) {
         output.features.reset(HVX_v66);
     }
@@ -1422,10 +1404,9 @@ void target_test() {
         {{"x86-64-linux-vulkan", "x86-64-linux", "x86-64-linux-vulkan"}},
         {{"x86-64-linux-vulkan-vk_v13", "x86-64-linux-vulkan", "x86-64-linux-vulkan"}},
         {{"x86-64-linux-vulkan-vk_v13", "x86-64-linux-vulkan-vk_v10", "x86-64-linux-vulkan-vk_v10"}},
-        {{"hexagon-32-qurt-hvx_v65", "hexagon-32-qurt-hvx_v62", "hexagon-32-qurt-hvx_v62"}},
-        {{"hexagon-32-qurt-hvx_v62", "hexagon-32-qurt", "hexagon-32-qurt"}},
-        {{"hexagon-32-qurt-hvx_v62-hvx", "hexagon-32-qurt", ""}},
-        {{"hexagon-32-qurt-hvx_v62-hvx", "hexagon-32-qurt-hvx", "hexagon-32-qurt-hvx"}},
+        {{"hexagon-32-qurt-hvx_v66", "hexagon-32-qurt", "hexagon-32-qurt"}},
+        {{"hexagon-32-qurt-hvx_v66-hvx", "hexagon-32-qurt", ""}},
+        {{"hexagon-32-qurt-hvx_v66-hvx", "hexagon-32-qurt-hvx", "hexagon-32-qurt-hvx"}},
     };
 
     for (const auto &test : gcd_tests) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -119,8 +119,6 @@ struct Target {
         HexagonDma = halide_target_feature_hexagon_dma,
         HVX_128 = halide_target_feature_hvx_128,
         HVX = HVX_128,
-        HVX_v62 = halide_target_feature_hvx_v62,
-        HVX_v65 = halide_target_feature_hvx_v65,
         HVX_v66 = halide_target_feature_hvx_v66,
         FuzzFloatStores = halide_target_feature_fuzz_float_stores,
         SoftFloatABI = halide_target_feature_soft_float_abi,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1352,7 +1352,6 @@ typedef enum halide_target_feature_t {
     halide_target_feature_large_buffers,  ///< Enable 64-bit buffer indexing to support buffers > 2GB. Ignored if bits != 64.
 
     halide_target_feature_hvx_128,                ///< Enable HVX 128 byte mode.
-    halide_target_feature_hvx_v62,                ///< Enable Hexagon v62 architecture.
     halide_target_feature_fuzz_float_stores,      ///< On every floating point store, set the last bit of the mantissa to zero. Pipelines for which the output is very different with this feature enabled may also produce very different output on different processors.
     halide_target_feature_soft_float_abi,         ///< Enable soft float ABI. This only enables the soft float ABI calling convention, which does not necessarily use soft floats.
     halide_target_feature_msan,                   ///< Enable hooks for MSAN support.
@@ -1365,7 +1364,6 @@ typedef enum halide_target_feature_t {
     halide_target_feature_trace_stores,           ///< Trace all stores done by the pipeline. Equivalent to calling Func::trace_stores on every non-inlined Func.
     halide_target_feature_trace_realizations,     ///< Trace all realizations done by the pipeline. Equivalent to calling Func::trace_realizations on every non-inlined Func.
     halide_target_feature_trace_pipeline,         ///< Trace the pipeline.
-    halide_target_feature_hvx_v65,                ///< Enable Hexagon v65 architecture.
     halide_target_feature_hvx_v66,                ///< Enable Hexagon v66 architecture.
     halide_target_feature_cl_half,                ///< Enable half support on OpenCL targets
     halide_target_feature_strict_float,           ///< Turn off all non-IEEE floating-point optimization. Currently applies only to LLVM targets.

--- a/test/correctness/hexagon_scatter.cpp
+++ b/test/correctness/hexagon_scatter.cpp
@@ -76,9 +76,7 @@ int test() {
             .parallel(y)
             .vectorize(x, vector_size / 2);
 
-        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
-            f.store_in(MemoryType::VTCM);
-        }
+        f.store_in(MemoryType::VTCM);
     }
 
     Buffer<DTYPE> buf = g.realize({W, H});

--- a/test/correctness/histogram.cpp
+++ b/test/correctness/histogram.cpp
@@ -50,14 +50,12 @@ bool test() {
             .compute_at(g, Var::outermost())
             .vectorize(x, vector_size);
 
-        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
-            hist.store_in(MemoryType::VTCM);
+        hist.store_in(MemoryType::VTCM);
 
-            hist
-                .update(0)
-                .allow_race_conditions()
-                .vectorize(r.x, vector_size);
-        }
+        hist
+            .update(0)
+            .allow_race_conditions()
+            .vectorize(r.x, vector_size);
     } else {
         hist.compute_root();
     }


### PR DESCRIPTION
Remove v62 and make v65 as the default isa version for HVX.
@pranavb-ca @steven-johnson 