### PR TITLE
Revert "[Hexagon] Fix compilation failures hexagon_remote"

### DIFF
--- a/src/runtime/hexagon_remote/Makefile
+++ b/src/runtime/hexagon_remote/Makefile
@@ -74,7 +74,7 @@ CCFLAGS-arm-32-android = -target armv7a-linux-androideabi21
 CCFLAGS-host := ${CCFLAGS} -I../ -I ${HEXAGON_TOOLS_ROOT}/Tools/include/iss/ -fPIC \
 	-L${HEXAGON_TOOLS_ROOT}/Tools/lib/iss/ -lwrapper
 
-CCFLAGS-v65 := $(CCFLAGS-v65) -I ${HEXAGON_SDK_LIBS}/common/rtld/ship/hexagon_Release_toolv83_v65 ${COMMON_CCFLAGS} -I ${HEXAGON_SDK_INCLUDES} -I ${HEXAGON_SDK_LIBS}/../rtos/qurt/computev65/include/qurt -I ${HEXAGON_SDK_LIBS}/../rtos/qurt/computev65/include/posix -mhvx -mhvx-length=128B -fno-exceptions -mv65
+CCFLAGS-v65 := $(CCFLAGS-v65) -I ${HEXAGON_SDK_LIBS}/common/rtld/ship/hexagon_Release_toolv83_v65 ${COMMON_CCFLAGS} -I ${HEXAGON_SDK_INCLUDES} -I ${HEXAGON_SDK_LIBS}/../rtos/qurt/computev65/include/qurt -mhvx -mhvx-length=128B -fno-exceptions -mv65
 
 CCFLAGS-arm-64-android := $(CCFLAGS-arm-64-android) ${COMMON_CCFLAGS} -llog -fPIE -pie -L${HEXAGON_SDK_LIBS}/../ipc/fastrpc/remote/ship/android_aarch64/
 CCFLAGS-arm-32-android := $(CCFLAGS-arm-32-android) ${COMMON_CCFLAGS} -llog -fPIE -pie -L${HEXAGON_SDK_LIBS}/../ipc/fastrpc/remote/ship/android

--- a/src/runtime/hexagon_remote/known_symbols.cpp
+++ b/src/runtime/hexagon_remote/known_symbols.cpp
@@ -20,7 +20,7 @@ void *lookup_symbol(const char *name, const known_symbol *map) {
 extern "C" {
 
 // More symbols we need to support.
-extern int qurt_hvx_lock(qurt_hvx_mode_t lock_mode);
+extern int qurt_hvx_lock();
 extern int qurt_hvx_unlock();
 extern int __hexagon_muldf3();
 extern int __hexagon_divdf3();


### PR DESCRIPTION
Reverts halide/Halide#7601

I'm reverting this because I can't see how the change to known_symbols.cpp could possibly compile anywhere (and it certainly doesn't for me); the `qurt_hvx_mode_t` enum type isn't defined and can't be forward-declared. 

@aankit-ca, please open a new PR with similar changes, but with instructions on how to properly build and test it so I can verify your fix.