### PR TITLE
Upgrade our PyBind11 version to 2.10.4 (#7617)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools>=43",
   "wheel",
   "scikit-build",
-  "pybind11==2.6.2",
+  "pybind11==2.10.4",
   "cmake>=3.22",
   "ninja; platform_system!='Windows'"
 ]

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -25,7 +25,7 @@ cmake_dependent_option(
 
 # Set the expected (downloaded) version of pybind11
 option(PYBIND11_USE_FETCHCONTENT "Enable to download pybind11 via FetchContent" ON)
-set(PYBIND11_VER 2.6.2 CACHE STRING "The pybind11 version to use (or download)")
+set(PYBIND11_VER 2.10.4 CACHE STRING "The pybind11 version to use (or download)")
 
 ##
 # Dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ imageio
 ninja; platform_system!='Windows'
 numpy
 pillow
-pybind11==2.6.2
+pybind11==2.10.4
 scikit-build
 scipy
 setuptools>=43


### PR DESCRIPTION
(Note that PyBind11 2.10.x is the first version to properly support Python 3.11)