### PR TITLE
Change argument/type signature of Call::prefetch (Fixes #4211)

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1825,20 +1825,23 @@ void CodeGen_C::visit(const Call *op) {
     } else if (op->is_intrinsic(Call::undef)) {
         user_error << "undef not eliminated before code generation. Please report this as a Halide bug.\n";
     } else if (op->is_intrinsic(Call::prefetch)) {
-        user_assert((op->args.size() == 4) && is_const_one(op->args[2]))
+        internal_assert(op->type == Int(32));
+        user_assert((op->args.size() == 5) && is_const_one(op->args[3]))
             << "Only prefetch of 1 cache line is supported in C backend.\n";
 
-        const Expr &base_address = op->args[0];
-        const Expr &base_offset = op->args[1];
-        // const Expr &extent0 = op->args[2];  // unused
-        // const Expr &stride0 = op->args[3];  // unused
+        const Type prefetch_element_type = op->args[0].type();
+        const Expr &base_address = op->args[1];
+        const Expr &base_offset = op->args[2];
+        // const Expr &extent0 = op->args[3];  // unused
+        // const Expr &stride0 = op->args[4];  // unused
 
         const Variable *base = base_address.as<Variable>();
         internal_assert(base && base->type.is_handle());
         // TODO: provide some way to customize the rw and locality?
-        rhs << "__builtin_prefetch("
-            << "((" << print_type(op->type) << " *)" << print_name(base->name)
-            << " + " << print_expr(base_offset) << "), /*rw*/0, /*locality*/0)";
+        // __builtin_prefetch() returns void, so use comma operator to satisfy assignment
+        rhs << "(__builtin_prefetch("
+            << "((" << print_type(prefetch_element_type) << " *)" << print_name(base->name)
+            << " + " << print_expr(base_offset) << "), /*rw*/0, /*locality*/0), 0)";
     } else if (op->is_intrinsic(Call::size_of_halide_buffer_t)) {
         rhs << "(sizeof(halide_buffer_t))";
     } else if (op->is_intrinsic(Call::strict_float)) {

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -703,8 +703,11 @@ Expr Call::make(Type type, const std::string &name, const std::vector<Expr> &arg
                 FunctionPtr func, int value_index,
                 Buffer<> image, Parameter param) {
     if (name == intrinsic_op_names[Call::prefetch] && call_type == Call::Intrinsic) {
-        internal_assert(args.size() % 2 == 0)
-            << "Number of args to a prefetch call should be even: {base, offset, extent0, stride0, extent1, stride1, ...}\n";
+        internal_assert(type == Int(32))
+            << "The return type of a prefetch call must be Int(32)";
+        internal_assert(args.size() >= 5 && (args.size() % 2) == 1)  // Prefetch: {prefetch_element_type(0), base, offset, extent0, stride0, ...}
+            << "Number of args to a prefetch call should be even: {prefetch_element_type(0), base, offset, extent0, stride0, extent1, stride1, ...}\n";
+        internal_assert(is_const_zero(args[0])) << "The first arg to a prefetch call should be a constant zero of the type to prefetch";
     }
     for (size_t i = 0; i < args.size(); i++) {
         internal_assert(args[i].defined()) << "Call of " << name << " with argument " << i << " undefined.\n";

--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -422,7 +422,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         // Collapse the prefetched region into lower dimension whenever is possible.
         // TODO(psuriana): Deal with negative strides and overlaps.
 
-        internal_assert(op->args.size() % 2 == 0);  // Prefetch: {base, offset, extent0, stride0, ...}
+        internal_assert(op->args.size() >= 5 && (op->args.size() % 2) == 1);  // Prefetch: {prefetch_element_type(0), base, offset, extent0, stride0, ...}
 
         auto [args, changed] = mutate_with_changes(op->args, nullptr);
 
@@ -430,7 +430,7 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
         // based on the storage dimension in ascending order (i.e. innermost
         // first and outermost last), so, it is enough to check for the upper
         // triangular pairs to see if any contiguous addresses exist.
-        for (size_t i = 2; i < args.size(); i += 2) {
+        for (size_t i = 3; i < args.size(); i += 2) {
             Expr extent_0 = args[i];
             Expr stride_0 = args[i + 1];
             for (size_t j = i + 2; j < args.size(); j += 2) {

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -356,7 +356,7 @@ private:
 
         Expr base_offset = mutate(flatten_args(op->name, prefetch_min, Buffer<>(), op->prefetch.param));
         Expr base_address = Variable::make(Handle(), op->name);
-        vector<Expr> args = {base_address, base_offset};
+        vector<Expr> args = {make_zero(op->types[0]), base_address, base_offset};
 
         auto iter = env.find(op->name);
         if (iter != env.end()) {
@@ -391,7 +391,7 @@ private:
         }
 
         // TODO: Consider generating a prefetch call for each tuple element.
-        Stmt prefetch_call = Evaluate::make(Call::make(op->types[0], Call::prefetch, args, Call::Intrinsic));
+        Stmt prefetch_call = Evaluate::make(Call::make(Int(32), Call::prefetch, args, Call::Intrinsic));
         if (!is_const_one(condition)) {
             prefetch_call = IfThenElse::make(condition, prefetch_call);
         }

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -2160,8 +2160,8 @@ int main(int argc, char **argv) {
         // Check that contiguous prefetch call get collapsed
         Expr base = Variable::make(Handle(), "buf");
         Expr offset = x;
-        check(Call::make(Int(32), Call::prefetch, {base, offset, 4, 1, 64, 4, min(x + y, 128), 256}, Call::Intrinsic),
-              Call::make(Int(32), Call::prefetch, {base, offset, min(x + y, 128) * 256, 1}, Call::Intrinsic));
+        check(Call::make(Int(32), Call::prefetch, {make_zero(Int(32)), base, offset, 4, 1, 64, 4, min(x + y, 128), 256}, Call::Intrinsic),
+              Call::make(Int(32), Call::prefetch, {make_zero(Int(32)), base, offset, min(x + y, 128) * 256, 1}, Call::Intrinsic));
     }
 
     // This expression is a good stress-test. It caused exponential


### PR DESCRIPTION
As noted in the issue above, the return type of this Call was used weirdly and wrongly: it wasn't the return type of the intrinsic (which is always int32, and always ignored), but rather, the type of the elements to prefetch. This didn't seem to be causing any obvious errors, but it meant we needed some weird special cases in the code. We now insert another element in the args to carry the type needed (with a value of constant zero).