### PR TITLE
Deprecate OpenGLCompute for Halide 16

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -762,7 +762,7 @@ enum RuntimeKind {
     OpenCL,
     Metal,
     CUDA,
-    OpenGLCompute,          // NOTE: this feature is deprecated and will be removed in Halide 17
+    OpenGLCompute,  // NOTE: this feature is deprecated and will be removed in Halide 17
     Hexagon,
     D3D12Compute,
     Vulkan,
@@ -770,7 +770,7 @@ enum RuntimeKind {
     OpenCLDebug,
     MetalDebug,
     CUDADebug,
-    OpenGLComputeDebug,     // NOTE: this feature is deprecated and will be removed in Halide 17
+    OpenGLComputeDebug,  // NOTE: this feature is deprecated and will be removed in Halide 17
     HexagonDebug,
     D3D12ComputeDebug,
     VulkanDebug,

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -762,7 +762,7 @@ enum RuntimeKind {
     OpenCL,
     Metal,
     CUDA,
-    OpenGLCompute,
+    OpenGLCompute,          // NOTE: this feature is deprecated and will be removed in Halide 17
     Hexagon,
     D3D12Compute,
     Vulkan,
@@ -770,7 +770,7 @@ enum RuntimeKind {
     OpenCLDebug,
     MetalDebug,
     CUDADebug,
-    OpenGLComputeDebug,
+    OpenGLComputeDebug,     // NOTE: this feature is deprecated and will be removed in Halide 17
     HexagonDebug,
     D3D12ComputeDebug,
     VulkanDebug,

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -520,6 +520,10 @@ MetadataNameMap Module::get_metadata_name_map() const {
 
 void Module::compile(const std::map<OutputFileType, std::string> &output_files) const {
     validate_outputs(output_files);
+    
+    if (target().has_feature(Target::OpenGLCompute)) {
+        user_warning << "WARNING: OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.\n";
+    }
 
     // Minor but worthwhile optimization: if all of the output files are of types that won't
     // ever rely on submodules (e.g.: toplevel declarations in C/C++), don't bother resolving

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -520,7 +520,7 @@ MetadataNameMap Module::get_metadata_name_map() const {
 
 void Module::compile(const std::map<OutputFileType, std::string> &output_files) const {
     validate_outputs(output_files);
-    
+
     if (target().has_feature(Target::OpenGLCompute)) {
         user_warning << "WARNING: OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.\n";
     }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -929,6 +929,10 @@ void Pipeline::realize(JITUserContext *context,
     Target target = t;
     user_assert(defined()) << "Can't realize an undefined Pipeline\n";
 
+    if (t.has_feature(Target::OpenGLCompute)) {
+        user_warning << "WARNING: OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.\n";
+    }
+
     debug(2) << "Realizing Pipeline for " << target << "\n";
 
     if (target.has_unknowns()) {

--- a/src/Target.h
+++ b/src/Target.h
@@ -108,7 +108,7 @@ struct Target {
         CLDoubles = halide_target_feature_cl_doubles,
         CLHalf = halide_target_feature_cl_half,
         CLAtomics64 = halide_target_feature_cl_atomic64,
-        OpenGLCompute = halide_target_feature_openglcompute,
+        OpenGLCompute = halide_target_feature_openglcompute, // NOTE: This feature is deprecated and will be removed in Halide 17.
         EGL = halide_target_feature_egl,
         UserContext = halide_target_feature_user_context,
         Profile = halide_target_feature_profile,

--- a/src/Target.h
+++ b/src/Target.h
@@ -108,7 +108,7 @@ struct Target {
         CLDoubles = halide_target_feature_cl_doubles,
         CLHalf = halide_target_feature_cl_half,
         CLAtomics64 = halide_target_feature_cl_atomic64,
-        OpenGLCompute = halide_target_feature_openglcompute, // NOTE: This feature is deprecated and will be removed in Halide 17.
+        OpenGLCompute = halide_target_feature_openglcompute,  // NOTE: This feature is deprecated and will be removed in Halide 17.
         EGL = halide_target_feature_egl,
         UserContext = halide_target_feature_user_context,
         Profile = halide_target_feature_profile,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1338,7 +1338,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_cl_doubles,   ///< Enable double support on OpenCL targets
     halide_target_feature_cl_atomic64,  ///< Enable 64-bit atomics operations on OpenCL targets
 
-    halide_target_feature_openglcompute,  ///< Enable OpenGL Compute runtime.
+    halide_target_feature_openglcompute,  ///< Enable OpenGL Compute runtime. NOTE: This feature is deprecated and will be removed in Halide 17.
 
     halide_target_feature_user_context,  ///< Generated code takes a user_context pointer as first argument
 

--- a/src/runtime/HalideRuntimeOpenGLCompute.h
+++ b/src/runtime/HalideRuntimeOpenGLCompute.h
@@ -18,6 +18,7 @@ extern "C" {
 
 #define HALIDE_RUNTIME_OPENGLCOMPUTE
 
+HALIDE_ATTRIBUTE_DEPRECATED("OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.")
 extern const struct halide_device_interface_t *halide_openglcompute_device_interface();
 
 /** These are forward declared here to allow clients to override the
@@ -27,6 +28,7 @@ extern const struct halide_device_interface_t *halide_openglcompute_device_inter
 /** This function sets up OpenGL context, loads relevant GL functions, then
  *  compiles src OpenGL compute shader into OpenGL program and stores it for future use.
  */
+HALIDE_ATTRIBUTE_DEPRECATED("OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.")
 extern int halide_openglcompute_initialize_kernels(void *user_context, void **state_ptr,
                                                    const char *src, int size);
 
@@ -36,6 +38,7 @@ extern int halide_openglcompute_initialize_kernels(void *user_context, void **st
  *  This function doesn't wait for the completion of the shader, but it sets memory
  *  barrier which forces successive retrieval of output data to wait until shader is done.
  */
+HALIDE_ATTRIBUTE_DEPRECATED("OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.")
 extern int halide_openglcompute_run(void *user_context,
                                     void *state_ptr,
                                     const char *entry_name,
@@ -46,6 +49,7 @@ extern int halide_openglcompute_run(void *user_context,
                                     void *args[],
                                     int8_t is_buffer[]);
 
+HALIDE_ATTRIBUTE_DEPRECATED("OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.")
 extern void halide_openglcompute_finalize_kernels(void *user_context, void *state_ptr);
 // @}
 
@@ -54,6 +58,7 @@ extern void halide_openglcompute_finalize_kernels(void *user_context, void *stat
  *  You may have to implement this yourself. Halide only provides implementations
  *  for some platforms."
  */
+HALIDE_ATTRIBUTE_DEPRECATED("OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.")
 extern void *halide_opengl_get_proc_address(void *user_context, const char *name);
 
 /** This function creates an OpenGL context for use by the OpenGL backend.
@@ -61,6 +66,7 @@ extern void *halide_opengl_get_proc_address(void *user_context, const char *name
  *  You may have to implement this yourself as well. Halide only provides
  *   implementations for some platforms."
  */
+HALIDE_ATTRIBUTE_DEPRECATED("OpenGLCompute is deprecated in Halide 16 and will be removed in Halide 17.")
 extern int halide_opengl_create_context(void *user_context);
 
 #ifdef __cplusplus

--- a/src/runtime/openglcompute.cpp
+++ b/src/runtime/openglcompute.cpp
@@ -1,3 +1,6 @@
+// Ignore deprecation warnings inside our own runtime
+#define HALIDE_ALLOW_DEPRECATED 1
+
 #include "HalideRuntimeOpenGLCompute.h"
 #include "device_buffer_utils.h"
 #include "device_interface.h"


### PR DESCRIPTION
This marks OpenGLCompute as deprecated, roughly modeled after the commit that did the same for OpenGL.