### PR TITLE
[Xtensa] Adds a pass to lift allocations out of the loop

### DIFF
--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -2344,6 +2344,14 @@ public:
     LiftAllocations() = default;
 };
 
+Stmt lift_stack_allocations(const Stmt &s) {
+    LiftAllocations lift_allocations;
+    Stmt stmt = lift_allocations.mutate(s);
+    lift_allocations.switch_to_second_pass();
+    stmt = lift_allocations.mutate(s);
+    return stmt;
+}
+
 Stmt match_xtensa_patterns(const Stmt &stmt, const Target &target) {
     const int alignment = target.natural_vector_size<uint8_t>();
     const int lut_size_in_bytes = 2 * target.natural_vector_size<uint8_t>();
@@ -2382,7 +2390,7 @@ Stmt match_xtensa_patterns(const Stmt &stmt, const Target &target) {
     }
 
     s = common_subexpression_elimination(s);
-    // debug(0) << s << "\n";
+    s = lift_stack_allocations(s);
     return s;
 }
 

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -2299,7 +2299,7 @@ class LiftAllocations : public IRMutator {
                     blocked_allocations[loops[ix].loop_index].insert(op->name);
                 }
             } else {
-                if (loop_to_lift_to < loops.size()) {
+                if (loop_to_lift_to < (int)loops.size()) {
                     // Combine extents, so we can take a maximum in case there are
                     // multiple allocations. There is an assumption that the
                     // allocation size fits into an int32. That should be true

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -2382,15 +2382,9 @@ Stmt match_xtensa_patterns(const Stmt &stmt, const Target &target) {
 
     s = DualQuadMulMutator().mutate(s);
 
-    {
-        LiftAllocations lift_stack_allocations;
-        s = lift_stack_allocations.mutate(s);
-        lift_stack_allocations.switch_to_second_pass();
-        s = lift_stack_allocations.mutate(s);
-    }
-
-    s = common_subexpression_elimination(s);
     s = lift_stack_allocations(s);
+    s = common_subexpression_elimination(s);
+
     return s;
 }
 


### PR DESCRIPTION
This pass is only called for Xtensa codegen and is only applied to stack or dynamic allocations in local on-chip memory. Potentially, it could be used on other platforms as well if needed (with hopefully only few adjustments).

This requires two traversals of the IR, which are implemented within a single pass, because they need to share a lot of code. Hopefully, the implementation is not too confusing.

I've tested it extensively on our internal pipelines and see significant performance gains in some cases. Ideally, I would like to add a separate test for it, but since this is Xtensa specific, it's going to be dependent on adding testing infrastructure for Xtensa first (I hope I can return to working on it very soon).