### PR TITLE
Add user_assert for zero vector width in CodegenRISCV

### DIFF
--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -141,6 +141,9 @@ private:
 CodeGen_RISCV::CodeGen_RISCV(const Target &t)
     : CodeGen_Posix(t) {
     use_llvm_vp_intrinsics = true;
+    user_assert(native_vector_bits() > 0) << "No vector_bits was specified for RISCV codegen; "
+        << "this is almost certainly a mistake. You should add -rvv-vector_bits_N "
+        << "to your Target string, where N is the SIMD width in bits (e.g. 128).";
 }
 
 string CodeGen_RISCV::mcpu_target() const {

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -142,8 +142,8 @@ CodeGen_RISCV::CodeGen_RISCV(const Target &t)
     : CodeGen_Posix(t) {
     use_llvm_vp_intrinsics = true;
     user_assert(native_vector_bits() > 0) << "No vector_bits was specified for RISCV codegen; "
-        << "this is almost certainly a mistake. You should add -rvv-vector_bits_N "
-        << "to your Target string, where N is the SIMD width in bits (e.g. 128).";
+                                          << "this is almost certainly a mistake. You should add -rvv-vector_bits_N "
+                                          << "to your Target string, where N is the SIMD width in bits (e.g. 128).";
 }
 
 string CodeGen_RISCV::mcpu_target() const {


### PR DESCRIPTION
If you forget to add `-rvv-vector_bits_N` to your Target string, we try to codegen with a vector width of 0, which (unsurprisingly) craters in many places which assume a nonzero value. It's pretty unlikely anyone wants to use Halide to codegen to a RISCV core that lacks SIMD, so let's add a more helpful failure message for this easy-to-make error (we can revisit this later if it actually is desirable for some reason.)

(I looked briefly at trying to clean up all the places in CodegenLLVM, etc, that make that assumption, but it quickly turned into a rat's nest; it's definitely fixable if we want to support this in the future, but, again, I suspect we don't.)