### PR TITLE
Default RISCV backend to OFF for LLVM < 17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,11 @@ LLVM_CXX_FLAGS += -DLLVM_VERSION=$(LLVM_VERSION_TIMES_10)
 WITH_X86 ?= $(findstring x86, $(LLVM_COMPONENTS))
 WITH_ARM ?= $(findstring arm, $(LLVM_COMPONENTS))
 WITH_HEXAGON ?= $(findstring hexagon, $(LLVM_COMPONENTS))
+ifeq ($(shell test $(LLVM_VERSION_TIMES_10) -ge 170; echo $$?),0)
 WITH_RISCV ?= $(findstring riscv, $(LLVM_COMPONENTS))
+else
+# leave WITH_RISCV undefined
+endif
 WITH_AARCH64 ?= $(findstring aarch64, $(LLVM_COMPONENTS))
 WITH_POWERPC ?= $(findstring powerpc, $(LLVM_COMPONENTS))
 WITH_NVPTX ?= $(findstring nvptx, $(LLVM_COMPONENTS))

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -76,8 +76,18 @@ foreach (comp IN LISTS known_components)
     string(TOUPPER "TARGET_${comp}" OPTION)
     string(TOUPPER "WITH_${comp}" DEFINE)
 
-    cmake_dependent_option(${OPTION} "Include ${comp} target" ON
-                           "${comp} IN_LIST LLVM_TARGETS_TO_BUILD" OFF)
+    if (comp STREQUAL "RISCV" AND LLVM_PACKAGE_VERSION VERSION_LESS 17.0)
+        # We default the RISCV target to OFF for LLVM versions prior to 17.0;
+        # it's not clear how robust and well-tested Halide's RISCV codegen
+        # is with LLVM16, and a great deal of effort is being put into
+        # improving it in LLVM17... so default to off so that people won't
+        # hurt themselves too badly.
+        cmake_dependent_option(${OPTION} "Include ${comp} target" OFF
+                               "${comp} IN_LIST LLVM_TARGETS_TO_BUILD" OFF)
+    else ()
+        cmake_dependent_option(${OPTION} "Include ${comp} target" ON
+                               "${comp} IN_LIST LLVM_TARGETS_TO_BUILD" OFF)
+    endif ()
     if (${OPTION} OR Halide_SHARED_LLVM)
         message(STATUS "Enabling ${comp} backend")
         list(APPEND Halide_LLVM_DEFS $<BUILD_INTERFACE:${DEFINE}>)


### PR DESCRIPTION
LLVM17 is doing a lot of work on the RISCV backend, and the amount of testing done on Halide's LLVM16-based RISCV codegen is very light. It's been suggested that we should default to not enabling the RISCV backend for LLVM16 and earlier because of this (so that people attempting to use Halide for RISCV won't encounter a possible footgun).

This PR just adds the relevant mechanism; whether or not this is the correct decision is not clear. Discussion welcome.