### PR TITLE
Update onnx app to Adams2019 autoscheduler and new autoscheduler API

### DIFF
--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -1,5 +1,11 @@
 include ../support/Makefile.inc
 
+ifneq (,$(findstring -m32,$(CXX) $(CC) $(CCFLAGS) $(CXXFLAGS)))
+build:
+	@echo "Not testing this app in a 32-bit build (-m32 found in flags)"
+test: build
+else
+
 PROTOC := $(shell which protoc)
 
 ifdef PROTOC
@@ -103,4 +109,5 @@ build:
 	@echo "No protoc in $(PATH), you need to install protocol buffers"
 test: build
 
+endif
 endif

--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -88,7 +88,7 @@ PYCXXFLAGS =  $(CXXFLAGS) $(PYBIND11_CFLAGS) -Wno-deprecated-register
 
 # Python extension for HalideModel
 $(BIN)/%/$(PY_MODEL_EXT): model.cpp $(BIN)/%/oclib.a
-	$(CXX) $(PYCXXFLAGS) -Wall -shared -fPIC -I$(BIN)/$* $^ $(LIBHALIDE_LDFLAGS) -o $@ $(LDFLAGS)
+	$(CXX) $(PYCXXFLAGS) -Wall -shared -fPIC -I$(BIN)/$* $^ $(LIBHALIDE_LDFLAGS) -Wl,--no-as-needed -lautoschedule_adams2019 -Wl,--as-needed -o $@ $(LDFLAGS)
 
 
 model_test: $(BIN)/$(HL_TARGET)/$(PY_MODEL_EXT)

--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -72,7 +72,7 @@ $(BIN)/%/onnx_converter_generator_test: onnx_converter_generator_test.cc $(BIN)/
 
 build: $(BIN)/$(HL_TARGET)/onnx_converter_test $(BIN)/$(HL_TARGET)/onnx_converter_generator_test
 
-test: build
+test: build model_test
 	LD_LIBRARY_PATH=$(BIN) $(BIN)/$(HL_TARGET)/onnx_converter_test
 	LD_LIBRARY_PATH=$(BIN) $(BIN)/$(HL_TARGET)/onnx_converter_generator_test
 

--- a/apps/onnx/model.cpp
+++ b/apps/onnx/model.cpp
@@ -65,7 +65,8 @@ HalideModel convert_onnx_model(
 std::string auto_schedule(const HalideModel &pipeline) {
     // Generate a schedule for the pipeline.
     Halide::Target tgt = Halide::get_host_target();
-    auto schedule = pipeline.rep->auto_schedule(tgt);
+    Halide::AutoschedulerParams autoscheduler_params = Halide::AutoschedulerParams("Adams2019");
+    auto schedule = pipeline.rep->apply_autoscheduler(tgt, autoscheduler_params);
     return schedule.schedule_source;
 }
 

--- a/apps/onnx/model.cpp
+++ b/apps/onnx/model.cpp
@@ -529,7 +529,8 @@ void print_loop_nest(const HalideModel &pipeline) {
 }
 
 void print_lowered_statement(const HalideModel &pipeline) {
-    std::string tmp_file = std::tmpnam(nullptr);
+    Halide::Internal::TemporaryFile f("model", ".stmt");
+    std::string tmp_file = f.pathname();
     pipeline.rep->compile_to_lowered_stmt(
         tmp_file, pipeline.rep->infer_arguments());
     std::ifstream is(tmp_file);
@@ -537,7 +538,6 @@ void print_lowered_statement(const HalideModel &pipeline) {
     while (std::getline(is, line)) {
         std::cout << line << "\n";
     }
-    std::remove(tmp_file.c_str());
 }
 
 }  // namespace

--- a/apps/onnx/model_test.py
+++ b/apps/onnx/model_test.py
@@ -35,10 +35,10 @@ class ModelTest(unittest.TestCase):
         model.BuildFromOnnxModel(onnx_model)
         schedule = model.OptimizeSchedule()
         schedule = schedule.replace('\n', ' ')
-        expected_schedule = r'// --- BEGIN machine-generated schedule // Target: .+// MachineParams: .+// Delete this line if not using Generator Pipeline pipeline = get_pipeline\(\);.+Func OUT = pipeline.get_func\(1\);.+{.+}.+'
+        expected_schedule = r'.*Func OUT = pipeline.get_func\(1\);.+'
         self.assertRegex(schedule, expected_schedule)
 
-        input = np.random.rand(2, 3) - 0.5
+        input = (np.random.rand(2, 3) - 0.5).astype('float32')
         outputs = model.run([input])
         self.assertEqual(1, len(outputs))
         output = outputs[0]
@@ -62,12 +62,12 @@ class ModelTest(unittest.TestCase):
         model = Model()
         model.BuildFromOnnxModel(onnx_model)
         schedule = model.OptimizeSchedule()
-        schedule = schedule.replace('\n', ' ')
-        expected_schedule = r'// --- BEGIN machine-generated schedule // Target: .+// MachineParams: .+// Delete this line if not using Generator Pipeline pipeline = get_pipeline\(\);.+Func C = pipeline.get_func\(2\);.+{.+}.+'
+        schedule = schedule.replace('\n', ' ')        
+        expected_schedule = r'.*Func C = pipeline.get_func\(2\);.+'
         self.assertRegex(schedule, expected_schedule)
 
-        input1 = np.random.randint(-10, 10, size=())
-        input2 = np.random.randint(-10, 10, size=())
+        input1 = np.random.randint(-10, 10, size=()).astype('int32')
+        input2 = np.random.randint(-10, 10, size=()).astype('int32')
         outputs = model.run([input1, input2])
         self.assertEqual(1, len(outputs))
         output = outputs[0]


### PR DESCRIPTION
Fixes #7670

This app had rotted, largely because the linux bots don't have the prereqs installed so they weren't testing it. Unfortunately one of the prereqs seems to be the package python3-onnx, which isn't available on the ubuntu distribution installed on the bots (focal fossa).