### PR TITLE
Fix correctness_float16_t for ASAN builds

### DIFF
--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -2,6 +2,17 @@
 
 #include <limits>
 
+#ifdef __linux__
+// If LLVM was built with an older GCC but Halide is built with Clang,
+// we may be missing this symbol needed for float16 conversion.
+// Just insert a weak definition here as a workaround.
+extern "C" {
+__attribute__((weak)) float __extendhfsf2(uint16_t a) {
+    return (float)Halide::float16_t::make_from_bits(a);
+}
+}  // extern "C"
+#endif
+
 namespace {
 
 using namespace Halide;


### PR DESCRIPTION
This appears to be a glitch that has to do with changing ABI for float16 across versions of GCC; we build LLVM with gcc-9 on Linux, but the float16 ABI got changed (and unified in gcc12); since ASAN builds use Clang even on linux, there is a hiccup here.

This is an ugly monkey-patch to work around this issue.