### PR TITLE
Revert "Fix correctness_float16_t for ASAN builds"

### DIFF
--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -2,17 +2,6 @@
 
 #include <limits>
 
-#ifdef __linux__
-// If LLVM was built with an older GCC but Halide is built with Clang,
-// we may be missing this symbol needed for float16 conversion.
-// Just insert a weak definition here as a workaround.
-extern "C" {
-__attribute__((weak)) float __extendhfsf2(uint16_t a) {
-    return (float)Halide::float16_t::make_from_bits(a);
-}
-}  // extern "C"
-#endif
-
 namespace {
 
 using namespace Halide;


### PR DESCRIPTION
Reverts halide/Halide#7687

Local testing makes it appear this fix is (1) incorrect and (2) no longer needed, opening for retesting on the buildbots.