### PR TITLE
Default WITH_TEST_FUZZ to OFF

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1053,7 +1053,9 @@ void CodeGen_ARM::visit(const Store *op) {
         std::ostringstream instr;
         vector<llvm::Type *> arg_types;
         llvm::Type *intrin_llvm_type = llvm_type_of(intrin_type);
-#if LLVM_VERSION >= 150
+#if LLVM_VERSION >= 170
+        const bool is_opaque = true;
+#elif LLVM_VERSION >= 150
         const bool is_opaque = llvm::PointerType::get(intrin_llvm_type, 0)->isOpaque();
 #else
         const bool is_opaque = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,8 +94,12 @@ else ()
     message(VERBOSE "Compiler supports libfuzzer sanitizer.")
 endif ()
 
+# Note that we want to default WITH_TEST_FUZZ to OFF, even if HAS_FUZZ_FLAGS
+# is true: just because our compiler supports fuzzing doesn't mean we want to
+# build the fuzz tests, because they won't really build properly without the
+# right preset specified.
 cmake_dependent_option(
-    WITH_TEST_FUZZ "Build fuzz tests" ON
+    WITH_TEST_FUZZ "Build fuzz tests" OFF
     HAS_FUZZ_FLAGS OFF
 )
 


### PR DESCRIPTION
Just because our compiler supports fuzzing doesn't mean we want to build the fuzz tests, because they won't really build properly without the right preset specified.

(This will be followed up with a change to the buildbot to set WITH_TEST_FUZZ to ON for fuzz tests)

attn: @TH3CHARLie