### PR TITLE
Fix float16 warning for older clangs

### DIFF
--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -20,10 +20,8 @@ __attribute__((weak)) float __extendhfsf2(float actually_a_float16) {
 
 #else
 
-// We haven't tested this variant, so emit a warning if we ever compile for it.
-#pragma message "This variant of __extendhfsf2 has not been tested."
 __attribute__((weak)) float __extendhfsf2(uint16_t data) {
-    return Halide::float16_t::make_from_bits(data);
+    return (float)Halide::float16_t::make_from_bits(data);
 }
 
 #endif


### PR DESCRIPTION
This routine was missing a float cast when compiled with older clangs. Also removed the warning, because I have now tested it.