### PR TITLE
Mark all single-arg ctors in autoscheduler code as `explicit`

### DIFF
--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -287,7 +287,7 @@ class Featurizer : public IRVisitor {
                 // (e.g. a+a, where a is a trivial function),
                 // so we can't use std::move(matrix) here without making a copy
                 vector<vector<OptionalRational>> copy = matrix;
-                e->add_load_jacobian(std::move(copy));
+                e->add_load_jacobian(LoadJacobian(std::move(copy)));
             }
         }
     }
@@ -837,7 +837,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const Target &target) 
                 int leaves = 0;
                 Type narrowest_type;
                 map<string, int> calls;
-                CheckTypes(const Function &f)
+                explicit CheckTypes(const Function &f)
                     : func(f) {
                 }
             };

--- a/src/autoschedulers/adams2019/FunctionDAG.h
+++ b/src/autoschedulers/adams2019/FunctionDAG.h
@@ -129,7 +129,7 @@ class LoadJacobian {
     int64_t c;
 
 public:
-    LoadJacobian(vector<vector<OptionalRational>> &&matrix, int64_t c = 1)
+    explicit LoadJacobian(vector<vector<OptionalRational>> &&matrix, int64_t c = 1)
         : coeffs(matrix), c(c) {
     }
 
@@ -481,7 +481,7 @@ struct FunctionDAG {
                 return dependencies[n.id];
             };
 
-            Stage(Halide::Stage s)
+            explicit Stage(Halide::Stage s)
                 : stage(std::move(s)) {
             }
         };

--- a/src/autoschedulers/adams2019/Timer.h
+++ b/src/autoschedulers/adams2019/Timer.h
@@ -18,7 +18,7 @@ struct ScopedTimer {
     std::chrono::time_point<Clock> start = Clock::now();
     std::string msg;
 
-    ScopedTimer(const std::string &msg)
+    explicit ScopedTimer(const std::string &msg)
         : msg{msg} {
         aslog(0) << "Start: " << msg << "\n";
     }

--- a/src/autoschedulers/anderson2021/FunctionDAG.cpp
+++ b/src/autoschedulers/anderson2021/FunctionDAG.cpp
@@ -824,7 +824,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const Target &target) 
                 int leaves = 0;
                 Type narrowest_type;
                 map<string, int> calls;
-                CheckTypes(const Function &f)
+                explicit CheckTypes(const Function &f)
                     : func(f) {
                 }
             };

--- a/src/autoschedulers/anderson2021/FunctionDAG.h
+++ b/src/autoschedulers/anderson2021/FunctionDAG.h
@@ -507,7 +507,7 @@ struct FunctionDAG {
                 return dependencies[n.id];
             };
 
-            Stage(Halide::Stage s)
+            explicit Stage(Halide::Stage s)
                 : stage(std::move(s)) {
             }
 
@@ -674,7 +674,7 @@ public:
     int visit_binary(const Expr &a, const Expr &b);
     int visit_nary(const std::vector<Expr> &exprs);
 
-    ExprBranching(const NodeMap<int64_t> &inlined)
+    explicit ExprBranching(const NodeMap<int64_t> &inlined)
         : inlined{inlined} {
     }
 

--- a/src/autoschedulers/anderson2021/GPULoopInfo.h
+++ b/src/autoschedulers/anderson2021/GPULoopInfo.h
@@ -19,7 +19,7 @@ namespace Autoscheduler {
 struct LoopNest;
 
 struct GPULoopInfo {
-    GPULoopInfo(const LoopNest *root)
+    explicit GPULoopInfo(const LoopNest *root)
         : root{root} {
     }
 

--- a/src/autoschedulers/anderson2021/GPUMemInfo.h
+++ b/src/autoschedulers/anderson2021/GPUMemInfo.h
@@ -114,7 +114,7 @@ using LocalMemInfo = MemInfoType<LocalMem>;
 
 struct Strides {
 public:
-    Strides(const std::vector<int64_t> &storage_strides)
+    explicit Strides(const std::vector<int64_t> &storage_strides)
         : storage_strides{storage_strides} {
     }
 

--- a/src/autoschedulers/anderson2021/LoopNest.h
+++ b/src/autoschedulers/anderson2021/LoopNest.h
@@ -576,7 +576,7 @@ struct Filter {
     const LoopNest *loop_nest;
     bool logging = false;
 
-    Filter(const LoopNest *loop_nest)
+    explicit Filter(const LoopNest *loop_nest)
         : loop_nest{loop_nest}, logging{enable_filter_printing()} {
         if (logging) {
             std::cerr << "\nState filtered: \n";

--- a/src/autoschedulers/anderson2021/LoopNestParser.h
+++ b/src/autoschedulers/anderson2021/LoopNestParser.h
@@ -100,7 +100,7 @@ class LoopNestParser {
     std::unordered_set<std::string> all_stages;
 
 public:
-    LoopNestParser(const std::vector<std::string> &loop_nest)
+    explicit LoopNestParser(const std::vector<std::string> &loop_nest)
         : loop_nest{loop_nest} {
         parse(loop_nest);
     }

--- a/src/autoschedulers/anderson2021/SearchSpace.cpp
+++ b/src/autoschedulers/anderson2021/SearchSpace.cpp
@@ -189,7 +189,7 @@ vector<ThreadTileOption> SearchSpace::filter_thread_tile_options(vector<Intrusiv
 
         ThreadTileOption o;
         o.loop_nest = loop_nest;
-        o.max_idle_lane_wastage = loop_nest->max_idle_lane_wastage(target, {loop_nest.get()});
+        o.max_idle_lane_wastage = loop_nest->max_idle_lane_wastage(target, GPULoopInfo(loop_nest.get()));
         options.emplace_back(std::move(o));
     }
 

--- a/src/autoschedulers/anderson2021/SearchSpaceOptions.h
+++ b/src/autoschedulers/anderson2021/SearchSpaceOptions.h
@@ -17,7 +17,7 @@ struct SearchSpaceOptions {
 
     std::bitset<4> options;
 
-    SearchSpaceOptions(const std::string &bit_str)
+    explicit SearchSpaceOptions(const std::string &bit_str)
         : options{bit_str} {
         aslog(1) << "Search space options:\n";
         aslog(1) << "Input string: " << bit_str << "\n";

--- a/src/autoschedulers/anderson2021/State.cpp
+++ b/src/autoschedulers/anderson2021/State.cpp
@@ -500,7 +500,7 @@ bool State::compute_featurization(const FunctionDAG &dag, const Anderson2021Para
     }
 
     Timer timer;
-    feature_root->compute_features(dag, params, target, sites, 1, 1, nullptr, nullptr, *feature_root, {feature_root.get()}, true, total_shared_mem_alloc_sizes, nullptr, nullptr, nullptr, features, stats, verbose);
+    feature_root->compute_features(dag, params, target, sites, 1, 1, nullptr, nullptr, *feature_root, GPULoopInfo(feature_root.get()), true, total_shared_mem_alloc_sizes, nullptr, nullptr, nullptr, features, stats, verbose);
 
     stats.featurization_time += timer.elapsed();
     ++stats.num_featurizations;

--- a/src/autoschedulers/anderson2021/Statistics.h
+++ b/src/autoschedulers/anderson2021/Statistics.h
@@ -32,7 +32,7 @@ struct ScopedTimer {
     std::chrono::time_point<Clock> start;
     std::string msg;
 
-    ScopedTimer(const std::string &msg)
+    explicit ScopedTimer(const std::string &msg)
         : start{Clock::now()}, msg{msg} {
         aslog(1) << "Start: " << msg << "\n";
     }

--- a/src/autoschedulers/anderson2021/test/thread_info.cpp
+++ b/src/autoschedulers/anderson2021/test/thread_info.cpp
@@ -18,8 +18,8 @@ void test_thread_info() {
         std::vector<int64_t> loop_extents;
         std::vector<int64_t> max_thread_counts;
 
-        loop.push_back({});
-        loop.push_back({});
+        loop.emplace_back();
+        loop.emplace_back();
 
         // 16x8
         size.push_back(16);
@@ -65,7 +65,7 @@ void test_thread_info() {
         max_thread_counts.push_back(16);
         max_thread_counts.push_back(16);
         max_thread_counts.push_back(2);
-        loop.push_back({});
+        loop.emplace_back();
 
         {
             ThreadInfo info{vectorized_loop_index, size, loop, max_thread_counts};

--- a/src/autoschedulers/common/ASLog.h
+++ b/src/autoschedulers/common/ASLog.h
@@ -17,7 +17,7 @@ class aslog {
     const bool logging;
 
 public:
-    aslog(int verbosity)
+    explicit aslog(int verbosity)
         : logging(verbosity <= aslog_level()) {
     }
 

--- a/src/autoschedulers/common/PerfectHashMap.h
+++ b/src/autoschedulers/common/PerfectHashMap.h
@@ -9,7 +9,7 @@
 struct PerfectHashMapAsserter {
     const bool c;
 
-    PerfectHashMapAsserter(bool c)
+    explicit PerfectHashMapAsserter(bool c)
         : c(c) {
     }
 

--- a/src/autoschedulers/common/cmdline.h
+++ b/src/autoschedulers/common/cmdline.h
@@ -189,7 +189,7 @@ inline std::string readable_typename<int>() {
 #ifdef HALIDE_WITH_EXCEPTIONS
 class cmdline_error : public std::exception {
 public:
-    cmdline_error(const std::string &msg)
+    explicit cmdline_error(const std::string &msg)
         : msg(msg) {
     }
     ~cmdline_error() throw() override = default;

--- a/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
+++ b/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
@@ -2615,7 +2615,7 @@ class FindVarsUsingVar : public IRVisitor {
 public:
     Scope<> vars;
 
-    FindVarsUsingVar(const string &var) {
+    explicit FindVarsUsingVar(const string &var) {
         vars.push(var);
     }
 };


### PR DESCRIPTION
Good code hygiene, noticed while working on Anderson2021 bugs. (Done via using clang-tidy-17, which has a new check to enforce this.) Note that this also converted a couple of `push_back()` -> `emplace_back()`.