### PR TITLE
Mark all single-arg ctors in src/runtime as explicit

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -162,7 +162,7 @@ struct AllocationHeader {
     std::atomic<int> ref_count;
 
     // Note that ref_count always starts at 1
-    AllocationHeader(void (*deallocate_fn)(void *))
+    explicit AllocationHeader(void (*deallocate_fn)(void *))
         : deallocate_fn(deallocate_fn), ref_count(1) {
     }
 };
@@ -298,7 +298,7 @@ private:
     // operation as well.
     struct DevRefCountCropped : DeviceRefCount {
         Buffer<T, Dims, InClassDimStorage> cropped_from;
-        DevRefCountCropped(const Buffer<T, Dims, InClassDimStorage> &cropped_from)
+        explicit DevRefCountCropped(const Buffer<T, Dims, InClassDimStorage> &cropped_from)
             : cropped_from(cropped_from) {
             ownership = BufferDeviceOwnership::Cropped;
         }
@@ -608,7 +608,7 @@ public:
             return {min() + extent()};
         }
 
-        Dimension(const halide_dimension_t &dim)
+        explicit Dimension(const halide_dimension_t &dim)
             : d(dim) {
         }
     };

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -272,7 +272,7 @@ public:
     CUcontext context = nullptr;
 
     // Constructor sets 'status' if any error occurs.
-    ALWAYS_INLINE Context(void *user_context)
+    ALWAYS_INLINE explicit Context(void *user_context)
         : user_context(user_context) {
 #ifdef DEBUG_RUNTIME
         halide_start_clock(user_context);

--- a/src/runtime/internal/memory_arena.h
+++ b/src/runtime/internal/memory_arena.h
@@ -30,8 +30,8 @@ public:
         uint32_t maximum_block_count = 0;
     };
 
-    MemoryArena(void *user_context, const Config &config = default_config(),
-                const SystemMemoryAllocatorFns &allocator = default_allocator());
+    explicit MemoryArena(void *user_context, const Config &config = default_config(),
+                         const SystemMemoryAllocatorFns &allocator = default_allocator());
 
     ~MemoryArena();
 

--- a/src/runtime/internal/pointer_table.h
+++ b/src/runtime/internal/pointer_table.h
@@ -15,7 +15,7 @@ class PointerTable {
 public:
     static constexpr size_t default_capacity = 32;  // smallish
 
-    PointerTable(void *user_context, size_t initial_capacity = 0, const SystemMemoryAllocatorFns &sma = default_allocator());
+    explicit PointerTable(void *user_context, size_t initial_capacity = 0, const SystemMemoryAllocatorFns &sma = default_allocator());
     PointerTable(const PointerTable &other);
     ~PointerTable();
 

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -83,7 +83,7 @@ struct StringUtils {
 //
 class StringStorage {
 public:
-    StringStorage(void *user_context = nullptr, uint32_t capacity = 0, const SystemMemoryAllocatorFns &sma = default_allocator());
+    explicit StringStorage(void *user_context = nullptr, uint32_t capacity = 0, const SystemMemoryAllocatorFns &sma = default_allocator());
     StringStorage(const StringStorage &other) = default;
     ~StringStorage();
 

--- a/src/runtime/internal/string_table.h
+++ b/src/runtime/internal/string_table.h
@@ -18,7 +18,7 @@ public:
     StringTable(const StringTable &) = delete;
     StringTable &operator=(const StringTable &) = delete;
 
-    StringTable(const SystemMemoryAllocatorFns &allocator = StringStorage::default_allocator());
+    explicit StringTable(const SystemMemoryAllocatorFns &allocator = StringStorage::default_allocator());
     StringTable(void *user_context, size_t capacity, const SystemMemoryAllocatorFns &allocator = StringStorage::default_allocator());
     StringTable(void *user_context, const char **array, size_t count, const SystemMemoryAllocatorFns &allocator = StringStorage::default_allocator());
     ~StringTable();

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -270,7 +270,7 @@ public:
     cl_command_queue cmd_queue = nullptr;
 
     // Constructor sets 'status' if any occurs.
-    ALWAYS_INLINE ClContext(void *user_context)
+    ALWAYS_INLINE explicit ClContext(void *user_context)
         : user_context(user_context) {
         if (clCreateContext == nullptr) {
             status = load_libopencl(user_context);

--- a/src/runtime/profiler_common.cpp
+++ b/src/runtime/profiler_common.cpp
@@ -29,7 +29,7 @@ class LockProfiler {
     halide_profiler_state *state;
 
 public:
-    LockProfiler(halide_profiler_state *s)
+    explicit LockProfiler(halide_profiler_state *s)
         : state(s) {
 #if TIMER_PROFILING
         halide_disable_timer_interrupt();

--- a/src/runtime/scoped_mutex_lock.h
+++ b/src/runtime/scoped_mutex_lock.h
@@ -11,7 +11,7 @@ namespace Internal {
 struct ScopedMutexLock {
     halide_mutex *mutex;
 
-    ALWAYS_INLINE ScopedMutexLock(halide_mutex *mutex)
+    ALWAYS_INLINE explicit ScopedMutexLock(halide_mutex *mutex)
         : mutex(mutex) {
         halide_mutex_lock(mutex);
     }

--- a/src/runtime/scoped_spin_lock.h
+++ b/src/runtime/scoped_spin_lock.h
@@ -12,7 +12,7 @@ struct ScopedSpinLock {
 
     volatile AtomicFlag *const flag;
 
-    ALWAYS_INLINE ScopedSpinLock(volatile AtomicFlag *flag)
+    ALWAYS_INLINE explicit ScopedSpinLock(volatile AtomicFlag *flag)
         : flag(flag) {
         while (__atomic_test_and_set(flag, __ATOMIC_ACQUIRE)) {
             // nothing

--- a/src/runtime/synchronization_common.h
+++ b/src/runtime/synchronization_common.h
@@ -603,7 +603,7 @@ WEAK int parking_control::unpark_requeue(uintptr_t addr_from, uintptr_t addr_to,
 struct mutex_parking_control final : public parking_control {
     uintptr_t *const lock_state;
 
-    ALWAYS_INLINE mutex_parking_control(uintptr_t *lock_state)
+    ALWAYS_INLINE explicit mutex_parking_control(uintptr_t *lock_state)
         : lock_state(lock_state) {
     }
 

--- a/src/runtime/vulkan_context.h
+++ b/src/runtime/vulkan_context.h
@@ -48,7 +48,7 @@ public:
     uint32_t queue_family_index = 0;  // used for operations requiring queue family
     halide_error_code_t error = halide_error_code_success;
 
-    HALIDE_ALWAYS_INLINE VulkanContext(void *user_context)
+    HALIDE_ALWAYS_INLINE explicit VulkanContext(void *user_context)
         : user_context(user_context) {
 
         int result = halide_vulkan_acquire_context(user_context,

--- a/src/runtime/webgpu.cpp
+++ b/src/runtime/webgpu.cpp
@@ -128,7 +128,7 @@ public:
 
     int error_code = 0;
 
-    ALWAYS_INLINE WgpuContext(void *user_context)
+    ALWAYS_INLINE explicit WgpuContext(void *user_context)
         : user_context(user_context) {
         error_code = halide_webgpu_acquire_context(
             user_context, &instance, &adapter, &device, &staging_buffer);


### PR DESCRIPTION
Minor code hygiene fix, done as byproduct of #7704