### PR TITLE
Upgrade Halide main branch for LLVM18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2258,6 +2258,10 @@ ifneq (,$(findstring clang version 17.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif
 
+ifneq (,$(findstring clang version 18.0,$(CLANG_VERSION)))
+CLANG_OK=yes
+endif
+
 ifneq (,$(findstring Apple LLVM version 5.0,$(CLANG_VERSION)))
 CLANG_OK=yes
 endif
@@ -2278,7 +2282,7 @@ $(BUILD_DIR)/clang_ok:
 	@exit 1
 endif
 
-ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 140 150 160 170))
+ifneq (,$(findstring $(LLVM_VERSION_TIMES_10), 160 170 180))
 LLVM_OK=yes
 endif
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ the repository (where this README is).
 
 At any point in time, building Halide requires either the latest stable version
 of LLVM, the previous stable version of LLVM, and trunk. At the time of writing,
-this means versions 17, 16, and 15 are supported, but 14 is not. The commands
+this means versions 18, 17, and 16 are supported, but 15 is not. The commands
 `llvm-config` and `clang` must be somewhere in the path.
 
 If your OS does not have packages for LLVM, you can find binaries for it at
@@ -127,10 +127,10 @@ works well on OS X and Ubuntu.)
 If you want to build it yourself, first check it out from GitHub:
 
 ```
-% git clone --depth 1 --branch llvmorg-16.0.0 https://github.com/llvm/llvm-project.git
+% git clone --depth 1 --branch llvmorg-16.0.6 https://github.com/llvm/llvm-project.git
 ```
 
-(If you want to build LLVM 16.x, use branch `release/16.x`; for current trunk,
+(If you want to build LLVM 17.x, use branch `release/17.x`; for current trunk,
 use `main`)
 
 Then build it like so:
@@ -287,10 +287,10 @@ Subsets of the tests can be selected with `-L` and include `correctness`,
 #### Building LLVM (optional)
 
 Follow these steps if you want to build LLVM yourself. First, download LLVM's
-sources (these instructions use the latest 16.0 release)
+sources (these instructions use the latest 17.0 release)
 
 ```
-D:\> git clone --depth 1 --branch llvmorg-16.0.0 https://github.com/llvm/llvm-project.git
+D:\> git clone --depth 1 --branch release/17.x https://github.com/llvm/llvm-project.git
 ```
 
 For a 64-bit build, run:

--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -20,12 +20,12 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 
-if (LLVM_PACKAGE_VERSION VERSION_LESS 15.0)
-    message(FATAL_ERROR "LLVM version must be 15.0 or newer")
+if (LLVM_PACKAGE_VERSION VERSION_LESS 16.0)
+    message(FATAL_ERROR "LLVM version must be 16.0 or newer")
 endif ()
 
-if (LLVM_PACKAGE_VERSION VERSION_GREATER 17.0)
-    message(WARNING "Halide is not tested on LLVM versions beyond 17.0")
+if (LLVM_PACKAGE_VERSION VERSION_GREATER 18.0)
+    message(WARNING "Halide is not tested on LLVM versions beyond 18.0")
 endif ()
 
 # LLVM_DEFINITIONS is a space-separated list instead of a more typical


### PR DESCRIPTION
LLVM just added `release/17.x` branch and now trunk is 18 -- update our build files and docs accordingly (see also https://github.com/halide/build_bot/pull/248, which needs to land first)