### PR TITLE
Throw an erorr if split is called with the same older and inner var name

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1010,6 +1010,14 @@ void Stage::split(const string &old, const string &outer, const string &inner, c
 
     definition.schedule().touched() = true;
 
+    if (var_name_match(outer, inner)) {
+        user_error << "In schedule for " << name()
+                   << ", can't split " << old << " into "
+                   << outer << " and " << inner
+                   << " because the new var names are the same.\n"
+                   << dump_argument_list();
+    }
+
     // Check that the new names aren't already in the dims list.
     for (auto &dim : dims) {
         string new_names[2] = {inner, outer};

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1013,7 +1013,7 @@ void Stage::split(const string &old, const string &outer, const string &inner, c
     user_assert(inner != outer) << "In schedule for " << name()
                                 << ", can't split " << old << " into "
                                 << outer << " and " << inner
-                                << " because the new Var names are the same.\n"
+                                << " because the new Vars have the same name.\n"
                                 << dump_argument_list();
 
     // Check that the new names aren't already in the dims list.

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1013,7 +1013,7 @@ void Stage::split(const string &old, const string &outer, const string &inner, c
     user_assert(inner != outer) << "In schedule for " << name()
                                 << ", can't split " << old << " into "
                                 << outer << " and " << inner
-                                << " because the new var names are the same.\n"
+                                << " because the new Var names are the same.\n"
                                 << dump_argument_list();
 
     // Check that the new names aren't already in the dims list.

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1010,13 +1010,11 @@ void Stage::split(const string &old, const string &outer, const string &inner, c
 
     definition.schedule().touched() = true;
 
-    if (var_name_match(outer, inner)) {
-        user_error << "In schedule for " << name()
-                   << ", can't split " << old << " into "
-                   << outer << " and " << inner
-                   << " because the new var names are the same.\n"
-                   << dump_argument_list();
-    }
+    user_assert(inner != outer) << "In schedule for " << name()
+                                << ", can't split " << old << " into "
+                                << outer << " and " << inner
+                                << " because the new var names are the same.\n"
+                                << dump_argument_list();
 
     // Check that the new names aren't already in the dims list.
     for (auto &dim : dims) {

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -20,10 +20,8 @@ __attribute__((weak)) float __extendhfsf2(float actually_a_float16) {
 
 #else
 
-// We haven't tested this variant, so emit a warning if we ever compile for it.
-#pragma message "This variant of __extendhfsf2 has not been tested."
 __attribute__((weak)) float __extendhfsf2(uint16_t data) {
-    return Halide::float16_t::make_from_bits(data);
+    return (float)Halide::float16_t::make_from_bits(data);
 }
 
 #endif

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -91,6 +91,7 @@ tests(GROUPS error
       specialize_fail.cpp
       split_inner_wrong_tail_strategy.cpp
       split_non_innermost_predicated.cpp
+      split_same_var_names.cpp
       thread_id_outside_block_id.cpp
       too_many_args.cpp
       tuple_arg_select_undef.cpp

--- a/test/error/split_same_var_names.cpp
+++ b/test/error/split_same_var_names.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Var x;
+    Func f;
+    f(x) = x;
+    f.split(x, x, x, 16, TailStrategy::RoundUp);
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
fixes #7714 