### PR TITLE
Making HLSL code-gen a couple orders of magnitude faster...

### DIFF
--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -947,7 +947,6 @@ string CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::print_cast(Type target_
 void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Cast *op) {
     Type target_type = op->type;
     Type source_type = op->value.type();
-    string value_expr = print_expr(op->value);
 
     string cast_expr = print_cast(target_type, source_type, print_expr(op->value));
 


### PR DESCRIPTION
Title says it all!

The redundant call to `print_expr()` ends up triggering an exponential chain of events that ultimately gets discarded.