### PR TITLE
Fix handling of thread features for scalars in Anderson2021

### DIFF
--- a/src/autoschedulers/anderson2021/LoopNest.h
+++ b/src/autoschedulers/anderson2021/LoopNest.h
@@ -281,7 +281,7 @@ struct LoopNest {
     // index
     double storage_stride(const LoadJacobian &jac, int innermost_storage_dim, const FunctionDAG::Node *storage_node, const Bound &store_bounds, const LoopNest &root) const;
 
-    Strides compute_strides(const LoadJacobian &jac, int innermost_storage_dim, const FunctionDAG::Node *storage_node, const Bound &store_bounds, const ThreadInfo &thread_info, bool verbose = false) const;
+    Strides compute_strides(const LoadJacobian &jac, int innermost_storage_dim, const FunctionDAG::Node *storage_node, const Bound &store_bounds, const ThreadInfo *thread_info, bool verbose = false) const;
 
     bool all_strides_exist(const LoadJacobian &jac, const FunctionDAG::Node *storage_node, const LoopNest &root) const;
 
@@ -298,15 +298,15 @@ struct LoopNest {
     int vectorized_access_size(size_t loop_index, bool verbose = false) const;
 
     template<typename T>
-    void compute_num_mem_accesses_per_block(const LoadJacobian &jac, const FunctionDAG::Node *node, const Bound &store_bounds, const ThreadInfo &thread_info, int innermost_dim, double num_requests_per_warp, MemInfoType<T> &mem_info, bool verbose = false) const;
+    void compute_num_mem_accesses_per_block(const LoadJacobian &jac, const FunctionDAG::Node *node, const Bound &store_bounds, const ThreadInfo *thread_info, int innermost_dim, double num_requests_per_warp, MemInfoType<T> &mem_info, bool verbose = false) const;
 
     std::pair<double, double> compute_local_mem_store_features(const LoadJacobian &jac, int consumer_innermost_dim, const FunctionDAG::Node *node, const Bound &consumer_store_bounds, const LoopNest &root, double serial_loop_extents) const;
 
     template<typename T>
-    MemInfoType<T> compute_mem_store_info(const LoadJacobian &jac, int consumer_innermost_dim, const FunctionDAG::Node *node, const Bound &consumer_store_bounds, const ThreadInfo &thread_info, double serial_loop_extents, bool verbose) const;
+    MemInfoType<T> compute_mem_store_info(const LoadJacobian &jac, int consumer_innermost_dim, const FunctionDAG::Node *node, const Bound &consumer_store_bounds, const ThreadInfo *thread_info, double serial_loop_extents, bool verbose) const;
 
     template<typename T>
-    void compute_mem_load_features(const LoadJacobian &jac, int producer_innermost_dim, const FunctionDAG::Node *node, const Bound &producer_store_bounds, bool producer_has_been_scheduled, const ThreadInfo &thread_info, MemInfoType<T> &mem_info, double serial_loop_extents, bool verbose = false) const;
+    void compute_mem_load_features(const LoadJacobian &jac, int producer_innermost_dim, const FunctionDAG::Node *node, const Bound &producer_store_bounds, bool producer_has_been_scheduled, const ThreadInfo *thread_info, MemInfoType<T> &mem_info, double serial_loop_extents, bool verbose = false) const;
 
     double compute_local_mem_stride(double stride, double bytes) const;
 

--- a/src/autoschedulers/anderson2021/State.cpp
+++ b/src/autoschedulers/anderson2021/State.cpp
@@ -500,6 +500,7 @@ bool State::compute_featurization(const FunctionDAG &dag, const Anderson2021Para
     }
 
     Timer timer;
+    feature_root->dump();
     feature_root->compute_features(dag, params, target, sites, 1, 1, nullptr, nullptr, *feature_root, GPULoopInfo(feature_root.get()), true, total_shared_mem_alloc_sizes, nullptr, nullptr, nullptr, features, stats, verbose);
 
     stats.featurization_time += timer.elapsed();

--- a/src/autoschedulers/anderson2021/Tiling.cpp
+++ b/src/autoschedulers/anderson2021/Tiling.cpp
@@ -72,7 +72,7 @@ std::vector<std::vector<int64_t>> generate_serial_tilings(const std::vector<int6
                     continue;
                 }
                 t.back() = outer;
-                if (d == last_d && ((!allow_inner_ones && equal_to_existing_size(s, t)) || (all_ones(t) && !all_ones(s)))) {
+                if (d == last_d && ((!allow_inner_ones && equal_to_existing_size(s, t)) || all_ones(t))) {
                     continue;
                 }
                 result.push_back(t);

--- a/src/autoschedulers/anderson2021/Tiling.cpp
+++ b/src/autoschedulers/anderson2021/Tiling.cpp
@@ -72,7 +72,7 @@ std::vector<std::vector<int64_t>> generate_serial_tilings(const std::vector<int6
                     continue;
                 }
                 t.back() = outer;
-                if (d == last_d && ((!allow_inner_ones && equal_to_existing_size(s, t)) || all_ones(t))) {
+                if (d == last_d && ((!allow_inner_ones && equal_to_existing_size(s, t)) || (all_ones(t) && !all_ones(s)))) {
                     continue;
                 }
                 result.push_back(t);

--- a/src/autoschedulers/anderson2021/test/storage_strides.cpp
+++ b/src/autoschedulers/anderson2021/test/storage_strides.cpp
@@ -167,7 +167,7 @@ void test_bounds() {
         const auto &jac = node_f->outgoing_edges.front()->load_jacobians.front();
 
         const auto &thread = root->children[0]->children[0];
-        Strides strides = thread->compute_strides(jac, 0, node_f, root_bounds_f, thread_info, verbose);
+        Strides strides = thread->compute_strides(jac, 0, node_f, root_bounds_f, &thread_info, verbose);
 
         GlobalAccessAccumulator accumulator{bytes_per_point, 1, strides, verbose};
         thread_info.for_each_thread_id_in_first_warp(accumulator);
@@ -227,7 +227,7 @@ void test_bounds() {
         const auto &jac = node_f->outgoing_edges.front()->load_jacobians.front();
 
         const auto &thread = root->children[0]->children[0];
-        Strides strides = thread->compute_strides(jac, 0, node_f, root_bounds_f, thread_info, verbose);
+        Strides strides = thread->compute_strides(jac, 0, node_f, root_bounds_f, &thread_info, verbose);
 
         GlobalAccessAccumulator accumulator{bytes_per_point, 1, strides, verbose};
         thread_info.for_each_thread_id_in_first_warp(accumulator);
@@ -293,7 +293,7 @@ void test_bounds() {
         const auto &jac = node_f->outgoing_edges.front()->load_jacobians.front();
 
         const auto &thread = root->children[0]->children[0];
-        Strides strides = thread->compute_strides(jac, 0, node_f, root_bounds_f, thread_info, verbose);
+        Strides strides = thread->compute_strides(jac, 0, node_f, root_bounds_f, &thread_info, verbose);
         strides.dump(true);
 
         GlobalAccessAccumulator accumulator{bytes_per_point, 1, strides, verbose};
@@ -367,7 +367,7 @@ void test_bounds() {
 
         const auto &thread = root->children[0]->children[0];
         const auto &thread_bounds_g = thread->get_bounds(node_g);
-        Strides strides = thread->compute_strides(jac, 0, node_g, thread_bounds_g, thread_info, verbose);
+        Strides strides = thread->compute_strides(jac, 0, node_g, thread_bounds_g, &thread_info, verbose);
 
         GlobalAccessAccumulator accumulator{bytes_per_point, 1, strides, verbose};
         thread_info.for_each_thread_id_in_first_warp(accumulator);

--- a/test/autoschedulers/anderson2021/test.cpp
+++ b/test/autoschedulers/anderson2021/test.cpp
@@ -433,5 +433,17 @@ int main(int argc, char **argv) {
         Pipeline(output).apply_autoscheduler(target, params);
     }
 
+    // Scalars with a reduction
+    if (true) {
+        ImageParam im(Int(32), 2);
+
+        Func f("f"), output("output");
+        RDom r(0, 2000, 0, 2000);
+        f() = 5;
+        output() = sum(im, r) + f();
+
+        Pipeline(output).apply_autoscheduler(target, params);
+    }
+
     return 0;
 }


### PR DESCRIPTION
This fixes the issue in https://github.com/halide/Halide/pull/7699. The cause is that the autoscheduler assumes that every Func is surrounded by a block loop and a thread loop, which means it assumes there is always a non-null `ThreadInfo` object when the features are computed. But in this case, the output of the generator is a single number so the autoscheduler is currently not creating a block and thread loop for it, so the ThreadInfo object ends up being null.

The main thing this PR does is add some special cases to `compute_features` for handling scalars. It was also necessary to change some function signatures to accept a `ThreadInfo*` instead of a `ThreadInfo&` so that it can test whether the passed object is null or not.