### PR TITLE
Fix leak on cloning functions with update defs

### DIFF
--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2022,6 +2022,8 @@ Func create_clone_wrapper(Function wrapped_fn, const string &wrapper_name) {
     // Fix up any self-references in the clone.
     FunctionPtr self_reference = wrapper.function().get_contents();
     self_reference.weaken();
+    // remapping might already contain a strong self-reference from the deep
+    // copy, so we want to use operator[], not emplace or insert.
     remapping[wrapped_fn.get_contents()] = self_reference;
     wrapper.function().substitute_calls(remapping);
     return wrapper;

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2022,7 +2022,7 @@ Func create_clone_wrapper(Function wrapped_fn, const string &wrapper_name) {
     // Fix up any self-references in the clone.
     FunctionPtr self_reference = wrapper.function().get_contents();
     self_reference.weaken();
-    remapping.emplace(wrapped_fn.get_contents(), self_reference);
+    remapping[wrapped_fn.get_contents()] = self_reference;
     wrapper.function().substitute_calls(remapping);
     return wrapper;
 }


### PR DESCRIPTION
When cloning a Func with an update def, the remapping map resulting from the deep copy may already contain a key for the wrapped function pointing to a strong reference to itself. The reasons are unclear to me, but it means that emplace silently does nothing and we get a memory leak because the cloned Func's update definition has a strong self-reference after the remapping is applied.

We want to replace it with a weak reference, so this PR changes things to use operator[] instead of emplace.