### PR TITLE
Experimenting with an ostringstream-like object that wraps around std::string

### DIFF
--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -10,7 +10,6 @@
 #include "Scope.h"
 #include "Target.h"
 
-#define SLOMP_INTERCEPT_CODEGEN_STREAMS (0)
 #define SLOMP_REPLACE_ISOLATED_STRINGSTREAMS (0)
 
 namespace Halide {
@@ -304,48 +303,6 @@ protected:
                                       const std::vector<LoweredArgument> &args,
                                       const MetadataNameMap &metadata_name_map);
     void emit_halide_free_helper(const std::string &alloc_name, const std::string &free_function);
-
-#if SLOMP_INTERCEPT_CODEGEN_STREAMS
-public:
-    std::string strstream;
-
-    CodeGen_C& stream;
-
-    template<typename T>
-    CodeGen_C& operator << (const T& t) {
-        strstream += std::to_string(t);
-        return *this;
-    }
-    CodeGen_C& operator << (const char* str) {
-        strstream += str;
-        return *this;
-    }
-    CodeGen_C& operator << (const std::string& str) {
-        strstream += str;
-        return *this;
-    }
-    CodeGen_C& write(const char* str, std::streamsize count) {
-        strstream.append(str, count);
-        return *this;
-    }
-    CodeGen_C& operator << (const unsigned char str[]) {
-        return *this << (const char*)str;
-    }
-    CodeGen_C& operator << (const Halide::Internal::Indentation& indent) {
-        strstream.append(indent.indent, ' ');
-        return *this;
-    }
-    CodeGen_C& operator << (const Halide::Expr& expr) {
-        if (!expr.defined()) {
-            strstream += "(undefined)";
-        }
-        else {
-            this->print(expr);
-        }
-        return *this;
-    }
-    const std::string& str() { return strstream; }
-#endif
 };
 
 }  // namespace Internal

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -10,6 +10,9 @@
 #include "Scope.h"
 #include "Target.h"
 
+#define SLOMP_INTERCEPT_CODEGEN_STREAMS (0)
+#define SLOMP_REPLACE_ISOLATED_STRINGSTREAMS (0)
+
 namespace Halide {
 
 struct Argument;
@@ -301,6 +304,48 @@ protected:
                                       const std::vector<LoweredArgument> &args,
                                       const MetadataNameMap &metadata_name_map);
     void emit_halide_free_helper(const std::string &alloc_name, const std::string &free_function);
+
+#if SLOMP_INTERCEPT_CODEGEN_STREAMS
+public:
+    std::string strstream;
+
+    CodeGen_C& stream;
+
+    template<typename T>
+    CodeGen_C& operator << (const T& t) {
+        strstream += std::to_string(t);
+        return *this;
+    }
+    CodeGen_C& operator << (const char* str) {
+        strstream += str;
+        return *this;
+    }
+    CodeGen_C& operator << (const std::string& str) {
+        strstream += str;
+        return *this;
+    }
+    CodeGen_C& write(const char* str, std::streamsize count) {
+        strstream.append(str, count);
+        return *this;
+    }
+    CodeGen_C& operator << (const unsigned char str[]) {
+        return *this << (const char*)str;
+    }
+    CodeGen_C& operator << (const Halide::Internal::Indentation& indent) {
+        strstream.append(indent.indent, ' ');
+        return *this;
+    }
+    CodeGen_C& operator << (const Halide::Expr& expr) {
+        if (!expr.defined()) {
+            strstream += "(undefined)";
+        }
+        else {
+            this->print(expr);
+        }
+        return *this;
+    }
+    const std::string& str() { return strstream; }
+#endif
 };
 
 }  // namespace Internal

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -12,25 +12,7 @@ namespace Halide {
 namespace Internal {
 
 #if SLOMP_REPLACE_ISOLATED_STRINGSTREAMS
-struct ostringstream {
-    std::string stream;
-
-    template<typename T>
-    ostringstream& operator << (const T& t) {
-        stream += std::to_string(t);
-        return *this;
-    }
-    ostringstream& operator << (const char* str) {
-        stream += str;
-        return *this;
-    }
-    ostringstream& operator << (const std::string& str) {
-        stream += str;
-        return *this;
-    }
-
-    const std::string& str() { return stream; }
-};
+using ostringstream = halide_stream;
 #else
 using std::ostringstream;
 #endif

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -15,25 +15,7 @@ namespace Halide {
 namespace Internal {
 
 #if SLOMP_REPLACE_ISOLATED_STRINGSTREAMS
-struct ostringstream {
-    std::string stream;
-
-    template<typename T>
-    ostringstream& operator << (const T& t) {
-        stream += std::to_string(t);
-        return *this;
-    }
-    ostringstream& operator << (const char* str) {
-        stream += str;
-        return *this;
-    }
-    ostringstream& operator << (const std::string& str) {
-        stream += str;
-        return *this;
-    }
-
-    const std::string& str() { return stream; }
-};
+using ostringstream = halide_stream;
 #else
 using std::ostringstream;
 #endif
@@ -43,8 +25,6 @@ using std::string;
 using std::vector;
 
 namespace {
-
-ostringstream nil;
 
 class CodeGen_Metal_Dev : public CodeGen_GPU_Dev {
 public:

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -39,7 +39,7 @@ void CodeGen_PyTorch::compile(const Module &module) {
     // and should be totally safe, since we are using the same codegen logic
     // that would be in the .h file anyway.
     {
-        CodeGen_C extern_decl_gen(stream, module.target(), CodeGen_C::CPlusPlusExternDecl);
+        CodeGen_C extern_decl_gen(stream.redirect, module.target(), CodeGen_C::CPlusPlusExternDecl);
         extern_decl_gen.compile(module);
     }
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -150,7 +150,7 @@ public:
     void emit();
 
 private:
-    std::ostream &stream;
+    halide_stream stream;
     const std::string generator_registered_name;
     const std::string generator_stub_name;
     std::string class_name;

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -41,8 +41,8 @@ halide_stream& halide_stream::operator << (const std::string& str) {
     redirect << str;
     return *this;
 }
-halide_stream& halide_stream::operator << (const unsigned char str[]) {
-    //ZoneScopedN("halide_stream::<<(unsigned char [])");
+halide_stream& halide_stream::operator << (const unsigned char (&str) []) {
+    //ZoneScopedN("halide_stream::<<(unsigned char & [])");
     redirect << str;
     return *this;
 }
@@ -84,7 +84,7 @@ halide_stream& halide_stream::operator << (const std::string& str) {
     strstream += str;
     return *this;
 }
-halide_stream& halide_stream::operator << (const unsigned char str[]) {
+halide_stream& halide_stream::operator << (const unsigned char (&str) []) {
     //ZoneScopedN("halide_stream::<<(unsigned char [])");
     return *this << (const char*)str;
 }
@@ -103,13 +103,14 @@ std::string halide_stream::str() { return strstream; }
 void halide_stream::setf(std::ios::fmtflags flags, std::ios::fmtflags mask) { };
 #endif
 
-void halide_stream_instantiate_templates() {
-    halide_stream s;
-    unsigned const int x = 0;
-    float y = 0.0f;
-    s << x;
-    s << y;
-}
+// explicit template instatiations
+template halide_stream& halide_stream::operator<< <char>          (const char&);
+template halide_stream& halide_stream::operator<< <int>           (const int&);
+template halide_stream& halide_stream::operator<< <unsigned int>  (const unsigned int&);
+template halide_stream& halide_stream::operator<< <long>          (const long&);
+template halide_stream& halide_stream::operator<< <unsigned long> (const unsigned long&);
+template halide_stream& halide_stream::operator<< <long long>     (const long long&);
+template halide_stream& halide_stream::operator<< <float>         (const float&);
 
 template<typename T>
 std::ostream &ostream_indirect(std::ostream &stream, const T &t) {

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -54,11 +54,11 @@ halide_stream& halide_stream::write(const char* str, std::streamsize count) {
 std::string halide_stream::str() { return private_oss.str(); }
 void halide_stream::setf(std::ios::fmtflags flags, std::ios::fmtflags mask) { ZoneScoped; redirect.setf(flags, mask); };
 #else
-std::ostringstream halide_stream::sentinel;
-halide_stream::halide_stream() : redirect(sentinel) { new(&strstream)std::string(); }
+std::ostream halide_stream::nil (nullptr);
+halide_stream::halide_stream() : redirect(nil) { new(&strstream)std::string(); }
 halide_stream::halide_stream(std::ostream& s) : redirect(s) { new(&strstream)std::string(); }
 halide_stream::~halide_stream() {
-    if (&redirect != &sentinel) {
+    if (&redirect != &nil) {
         //ZoneScopedN("halide_stream::~halide_stream::flush");
         redirect << strstream;
     }

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -14,7 +14,7 @@
  * These operators are implemented using \ref Halide::Internal::IRPrinter
  */
 
-#include <ostream>
+#include "halide_stream.hpp"
 
 #include "IRVisitor.h"
 #include "Module.h"
@@ -24,31 +24,33 @@ namespace Halide {
 
 /** Emit an expression on an output stream (such as std::cout) in
  * human-readable form */
-std::ostream &operator<<(std::ostream &stream, const Expr &);
+halide_stream &operator<<(halide_stream &stream, const Expr &);
 
 /** Emit a halide type on an output stream (such as std::cout) in
  * human-readable form */
-std::ostream &operator<<(std::ostream &stream, const Type &);
+halide_stream &operator<<(halide_stream &stream, const Type &);
 
 /** Emit a halide Module on an output stream (such as std::cout) in
  * human-readable form */
-std::ostream &operator<<(std::ostream &stream, const Module &);
+halide_stream &operator<<(halide_stream &stream, const Module &);
 
 /** Emit a halide device api type in human-readable form */
+halide_stream &operator<<(halide_stream &stream, const DeviceAPI &);
 std::ostream &operator<<(std::ostream &stream, const DeviceAPI &);
 
 /** Emit a halide memory type in human-readable form */
+halide_stream &operator<<(halide_stream &stream, const MemoryType &);
 std::ostream &operator<<(std::ostream &stream, const MemoryType &);
 
 /** Emit a halide tail strategy in human-readable form */
-std::ostream &operator<<(std::ostream &stream, const TailStrategy &t);
+halide_stream &operator<<(halide_stream &stream, const TailStrategy &t);
 
 /** Emit a halide LoopLevel in human-readable form */
-std::ostream &operator<<(std::ostream &stream, const LoopLevel &);
+halide_stream &operator<<(halide_stream &stream, const LoopLevel &);
 
 struct Target;
 /** Emit a halide Target in a human readable form */
-std::ostream &operator<<(std::ostream &stream, const Target &);
+halide_stream &operator<<(halide_stream &stream, const Target &);
 
 namespace Internal {
 
@@ -58,42 +60,47 @@ class Closure;
 
 /** Emit a halide associative pattern on an output stream (such as std::cout)
  * in a human-readable form */
+halide_stream &operator<<(halide_stream &stream, const AssociativePattern &);
 std::ostream &operator<<(std::ostream &stream, const AssociativePattern &);
 
 /** Emit a halide associative op on an output stream (such as std::cout) in a
  * human-readable form */
+halide_stream &operator<<(halide_stream &stream, const AssociativeOp &);
 std::ostream &operator<<(std::ostream &stream, const AssociativeOp &);
 
 /** Emit a halide statement on an output stream (such as std::cout) in
  * a human-readable form */
-std::ostream &operator<<(std::ostream &stream, const Stmt &);
+halide_stream &operator<<(halide_stream &stream, const Stmt &);
 
 /** Emit a halide for loop type (vectorized, serial, etc) in a human
  * readable form */
+halide_stream &operator<<(halide_stream &stream, const ForType &);
 std::ostream &operator<<(std::ostream &stream, const ForType &);
 
 /** Emit a horizontal vector reduction op in human-readable form. */
-std::ostream &operator<<(std::ostream &stream, const VectorReduce::Operator &);
+halide_stream &operator<<(halide_stream &stream, const VectorReduce::Operator &);
 
 /** Emit a halide name mangling value in a human readable format */
-std::ostream &operator<<(std::ostream &stream, const NameMangling &);
+halide_stream &operator<<(halide_stream &stream, const NameMangling &);
 
 /** Emit a halide LoweredFunc in a human readable format */
-std::ostream &operator<<(std::ostream &stream, const LoweredFunc &);
+halide_stream &operator<<(halide_stream &stream, const LoweredFunc &);
 
 /** Emit a halide linkage value in a human readable format */
-std::ostream &operator<<(std::ostream &stream, const LinkageType &);
+halide_stream &operator<<(halide_stream &stream, const LinkageType &);
 
 /** Emit a halide dimension type in human-readable format */
+halide_stream &operator<<(halide_stream &stream, const DimType &);
 std::ostream &operator<<(std::ostream &stream, const DimType &);
 
 /** Emit a Closure in human-readable format */
+halide_stream &operator<<(halide_stream &out, const Closure &);
 std::ostream &operator<<(std::ostream &out, const Closure &c);
 
 struct Indentation {
     int indent;
 };
-std::ostream &operator<<(std::ostream &stream, const Indentation &);
+halide_stream &operator<<(halide_stream &stream, const Indentation &);
 
 /** An IRVisitor that emits IR to the given output stream in a human
  * readable form. Can be subclassed if you want to modify the way in
@@ -104,6 +111,7 @@ public:
     /** Construct an IRPrinter pointed at a given output stream
      * (e.g. std::cout, or a std::ofstream) */
     explicit IRPrinter(std::ostream &);
+    explicit IRPrinter(halide_stream &);
 
     /** emit an expression on the output stream */
     void print(const Expr &);
@@ -126,7 +134,8 @@ protected:
     }
 
     /** The stream on which we're outputting */
-    std::ostream &stream;
+    halide_stream& stream;
+    halide_stream private_stream;
 
     /** The current indentation level, useful for pretty-printing
      * statements */

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -36,7 +36,7 @@ public:
     }
 
 private:
-    std::ostream &out;
+    halide_stream out;
     const map<string, Function> &env;
     int indent = 0;
 

--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -293,7 +293,7 @@ void PythonExtensionGen::compile(const Module &module) {
         // The CodeGen_C dtor must run to finish codegen correctly,
         // so wrap this in braces
         {
-            CodeGen_C extern_decl_gen(dest, module.target(), CodeGen_C::CPlusPlusExternDecl);
+            CodeGen_C extern_decl_gen(dest.redirect, module.target(), CodeGen_C::CPlusPlusExternDecl);
             extern_decl_gen.compile(module);
         }
 

--- a/src/PythonExtensionGen.h
+++ b/src/PythonExtensionGen.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "halide_stream.hpp"
+
 namespace Halide {
 
 class Module;
@@ -21,7 +23,7 @@ public:
     void compile(const Module &module);
 
 private:
-    std::ostream &dest;
+    halide_stream dest;
 
     void compile(const LoweredFunc &f);
 };

--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -251,13 +251,13 @@ void RDom::where(Expr predicate) {
 }
 
 /** Emit an RVar in a human-readable form */
-std::ostream &operator<<(std::ostream &stream, const RVar &v) {
+halide_stream &operator<<(halide_stream &stream, const RVar &v) {
     stream << v.name() << "(" << v.min() << ", " << v.extent() << ")";
     return stream;
 }
 
 /** Emit an RDom in a human-readable form. */
-std::ostream &operator<<(std::ostream &stream, const RDom &dom) {
+halide_stream &operator<<(halide_stream &stream, const RDom &dom) {
     stream << "RDom(\n";
     for (int i = 0; i < dom.dimensions(); i++) {
         stream << "  " << dom[i] << "\n";

--- a/src/RDom.h
+++ b/src/RDom.h
@@ -15,6 +15,8 @@
 #include "Reduction.h"
 #include "Util.h"
 
+#include "halide_stream.hpp"
+
 namespace Halide {
 
 template<typename T, int Dims>
@@ -341,10 +343,10 @@ public:
 };
 
 /** Emit an RVar in a human-readable form */
-std::ostream &operator<<(std::ostream &stream, const RVar &);
+halide_stream &operator<<(halide_stream &stream, const RVar &);
 
 /** Emit an RDom in a human-readable form. */
-std::ostream &operator<<(std::ostream &stream, const RDom &);
+halide_stream &operator<<(halide_stream &stream, const RDom &);
 }  // namespace Halide
 
 #endif

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1953,7 +1953,7 @@ class PrintUsesOfFunc : public IRVisitor {
     int indent = 1;
     string func, caller;
     bool last_print_was_ellipsis = false;
-    std::ostream &stream;
+    halide_stream stream;
 
     Indentation get_indent() const {
         return Indentation{indent};

--- a/src/StmtToViz.cpp
+++ b/src/StmtToViz.cpp
@@ -2145,7 +2145,7 @@ private:
  */
 class HTMLVisualizationPrinter : public IRVisitor {
 public:
-    HTMLVisualizationPrinter(std::ofstream &os, std::map<const IRNode *, int> &nids)
+    HTMLVisualizationPrinter(halide_stream &os, std::map<const IRNode *, int> &nids)
         : stream(os), node_ids(nids) {
     }
 
@@ -2166,7 +2166,7 @@ public:
 
 private:
     // Handle to output file stream
-    std::ofstream &stream;
+    halide_stream &stream;
 
     // Used to track the context within generated HTML
     std::vector<std::string> context_stack_tags;
@@ -2377,8 +2377,8 @@ private:
             return "Else";
         }
 
-        std::ostringstream ss;
-        HTMLCodePrinter<std::ostringstream> printer(ss, node_ids);
+        halide_stream ss;
+        HTMLCodePrinter<halide_stream> printer(ss, node_ids);
         e.accept(&printer);
         std::string html_e = ss.str();
 
@@ -2741,9 +2741,9 @@ public:
     explicit IRVisualizer(const std::string &html_output_filename,
                           const Module &m,
                           const std::string &assembly_input_filename)
-        : html_code_printer(stream, node_ids), html_viz_printer(stream, node_ids) {
+        : stream(outfile), html_code_printer(stream, node_ids), html_viz_printer(stream, node_ids) {
         // Open output file
-        stream.open(html_output_filename.c_str());
+        outfile.open(html_output_filename.c_str());
 
         // Load assembly code -- if not explicit specified, assume it will have matching pathname
         // as our output file, with a different extension.
@@ -2789,7 +2789,8 @@ public:
 
 private:
     // Handle to output file stream
-    std::ofstream stream;
+    std::ofstream outfile;
+    halide_stream stream;
 
     // Handle to assembly file stream
     std::ifstream assembly;
@@ -2801,7 +2802,7 @@ private:
     std::map<const IRNode *, int> node_ids;
 
     // Used to translate IR to code in HTML
-    HTMLCodePrinter<std::ofstream> html_code_printer;
+    HTMLCodePrinter<halide_stream> html_code_printer;
 
     // Used to translate IR to visualization in HTML
     HTMLVisualizationPrinter html_viz_printer;

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -3,6 +3,9 @@
 #include "IRMutator.h"
 #include "Scope.h"
 
+#define TRACY_GLUE_ENABLE (0)
+#include "debug/tracy_profiler_glue.hpp"
+
 namespace Halide {
 namespace Internal {
 
@@ -100,28 +103,30 @@ public:
 
 }  // namespace
 
-Expr substitute(const string &name, const Expr &replacement, const Expr &expr) {
-    map<string, Expr> m;
-    m[name] = replacement;
+Expr substitute(const map<string, Expr>& m, const Expr& expr) {
+    ZoneScoped;
     Substitute s(m);
     return s.mutate(expr);
+}
+
+Stmt substitute(const map<string, Expr>& m, const Stmt& stmt) {
+    ZoneScoped;
+    Substitute s(m);
+    return s.mutate(stmt);
+}
+
+Expr substitute(const string &name, const Expr &replacement, const Expr &expr) {
+    ZoneScoped;
+    map<string, Expr> m;
+    m[name] = replacement;
+    return substitute(m, expr);
 }
 
 Stmt substitute(const string &name, const Expr &replacement, const Stmt &stmt) {
+    ZoneScoped;
     map<string, Expr> m;
     m[name] = replacement;
-    Substitute s(m);
-    return s.mutate(stmt);
-}
-
-Expr substitute(const map<string, Expr> &m, const Expr &expr) {
-    Substitute s(m);
-    return s.mutate(expr);
-}
-
-Stmt substitute(const map<string, Expr> &m, const Stmt &stmt) {
-    Substitute s(m);
-    return s.mutate(stmt);
+    return substitute(m, stmt);
 }
 
 namespace {
@@ -144,6 +149,7 @@ public:
 }  // namespace
 
 Expr substitute(const Expr &find, const Expr &replacement, const Expr &expr) {
+    ZoneScoped;
     SubstituteExpr s;
     s.find = find;
     s.replacement = replacement;
@@ -151,6 +157,7 @@ Expr substitute(const Expr &find, const Expr &replacement, const Expr &expr) {
 }
 
 Stmt substitute(const Expr &find, const Expr &replacement, const Stmt &stmt) {
+    ZoneScoped;
     SubstituteExpr s;
     s.find = find;
     s.replacement = replacement;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -65,6 +65,8 @@
 #include <ucontext.h>
 #endif
 
+#include "halide_stream.hpp"
+
 #ifdef _WIN32
 namespace {
 
@@ -644,7 +646,7 @@ void halide_toc_impl(const char *file, int line) {
 
 std::string c_print_name(const std::string &name,
                          bool prefix_underscore) {
-    ostringstream oss;
+    halide_stream oss;
 
     // Prefix an underscore to avoid reserved words (e.g. a variable named "while")
     if (prefix_underscore && isalpha(name[0])) {

--- a/src/debug/tracy_profiler_glue.hpp
+++ b/src/debug/tracy_profiler_glue.hpp
@@ -1,0 +1,144 @@
+// Tracy glue -- Marcos Slomp (@slomp)
+
+#ifndef TRACY_PROFILER_GLUE_H
+#define TRACY_PROFILER_GLUE_H
+// clang-format off
+
+#if TRACY_GLUE_ENABLE
+    #ifndef TRACY_ENABLE
+    #define TRACY_ENABLE
+    #endif
+    // TRACY_GLUE_PATH:
+    // - must NOT be enclosed with quotes
+    // - must use only forward slashes
+    // - must end in a forward slash
+    #ifndef TRACY_GLUE_PATH
+    #define TRACY_GLUE_PATH <my-path-to-tracy>
+    #endif
+#else
+    #ifdef TRACY_ENABLE
+    #undef TRACY_ENABLE
+    #endif
+#endif
+
+#ifdef TRACY_ENABLE
+
+#ifndef TRACY_GLUE_PATH
+#define TRACY_GLUE_PATH
+#endif // TRACY_GLUE_PATH
+
+#define TRACY_GLUE_STRINGIFY(x) #x
+#define TRACY_GLUE_PARROT(...) __VA_ARGS__
+#define TRACY_GLUE_CONCAT(path,file) TRACY_GLUE_PARROT(path)TRACY_GLUE_PARROT(file)
+#define TRACY_GLUE_INCLUDE_STRING(file) TRACY_GLUE_STRINGIFY(file)
+#define TRACY_GLUE_INCLUDE(path, file) TRACY_GLUE_INCLUDE_STRING( TRACY_GLUE_CONCAT(path, file) )
+#define TRACY_GLUE_INCLUDE_FILE(file) TRACY_GLUE_INCLUDE(TRACY_GLUE_PATH, file)
+
+#include TRACY_GLUE_INCLUDE_FILE(public/tracy/Tracy.hpp)
+
+#ifdef TRACY_GLUE_ENABLE_VULKAN
+#include TRACY_GLUE_INCLUDE_FILE(TracyVulkan.hpp)
+#endif
+
+#ifdef TRACY_GLUE_ENABLE_D3D11
+#include TRACY_GLUE_INCLUDE_FILE(TracyD3D11.hpp)
+#endif
+
+#ifdef TRACY_GLUE_ENABLE_D3D12
+#include TRACY_GLUE_INCLUDE_FILE(TracyD3D12.hpp)
+#endif
+
+#ifdef TRACY_GLUE_ENABLE_OPENGL
+#include TRACY_GLUE_INCLUDE_FILE(TracyOpenGL.hpp)
+#endif
+
+#ifdef TRACY_GLUE_IMPLEMENTATION
+#include TRACY_GLUE_INCLUDE_FILE(public/TracyClient.cpp)
+#endif
+
+#undef TRACY_GLUE_INCLUDE_FILE
+#undef TRACY_GLUE_INCLUDE
+#undef TRACY_GLUE_INCLUDE_STRING
+#undef TRACY_GLUE_CONCAT
+#undef TRACY_GLUE_PARROT
+#undef TRACY_GLUE_STRINGIFY
+
+// NOTE(marcos): custom Tracy Zones (shortcuts)
+
+#define TracyThreadName(name) tracy::SetThreadName(name)
+
+#define ZoneString(s)                                      \
+    std::string tracy_zone_text_##__LINE__ = std::move(s); \
+    ZoneText((tracy_zone_text_##__LINE__).c_str(), (tracy_zone_text_##__LINE__).size())
+
+#define ZoneTextL(s) ZoneText(((s) ? (s) : ""), ((s) ? strlen(s) : 0))
+#define ZoneTextVL(z, s) ZoneTextV(z, ((s) ? (s) : ""), ((s) ? strlen(s) : 0))
+
+#define TracyPulse(name, baseline, pulse) \
+    TracyPlot(name, baseline);            \
+    TracyPlot(name, pulse);               \
+    TracyPlot(name, baseline);
+
+#define TracyTick(name, from, to) \
+    TracyPlot(name, from);        \
+    TracyPlot(name, to);
+
+#define TracyOnly(...) __VA_ARGS__
+
+#define ZoneTransientArgs(name, stackdepth, active) \
+    __LINE__, __FILE__, strlen(__FILE__), __FUNCTION__, strlen(__FUNCTION__), name, strlen(name), stackdepth, active
+
+#else // TRACY_ENABLE
+
+#define TracyNoOp ((void)0)
+
+#define ZoneScoped
+#define ZoneScopedS(...)
+#define ZoneScopedNC(...)
+#define ZoneScopedN(...)
+#define ZoneScopedC(...)
+#define ZoneNamedNC(...)
+#define ZoneNamedN(...)
+#define ZoneValue(...)
+#define ZoneColor(...)
+#define ZoneName(...)
+#define ZoneText(...)
+#define ZoneTransientN(...)
+#define ZoneColorV(...) TracyNoOp
+
+#define TracyPlot(...)
+#define TracyMessage(...) TracyNoOp
+#define TracyMessageC(...) TracyNoOp
+#define TracyMessageL(...) TracyNoOp
+#define TracyMessageLC(...) TracyNoOp
+
+#define FrameMark
+#define FrameMarkNamed(...)
+
+// Vulkan
+#define TracyVkZone(...)
+#define TracyVkZoneC(...)
+#define TracyVkCollect(...)
+
+// D3D11
+#define TracyD3D11Zone(...)
+#define TracyD3D11Collect(...)
+
+// OpenGL
+#define TracyGpuZone(...)
+#define TracyGpuCollect
+
+// Shortcuts
+#define TracyThreadName(...) TracyNoOp
+#define ZoneString(...)
+#define ZoneTextL(...)
+#define ZoneTextVL(...)
+#define TracyPulse(...)
+#define TracyTick(...)
+#define TracyOnly(...)
+#define ZoneTransientArgs(...)
+
+#endif // TRACY_ENABLE
+
+// clang-format on
+#endif // TRACY_PROFILER_GLUE_H

--- a/src/halide_stream.hpp
+++ b/src/halide_stream.hpp
@@ -25,10 +25,10 @@ struct halide_stream {
     halide_stream& operator << (const char* str);
     halide_stream& operator << (char* str);
     halide_stream& operator << (const std::string& str);
-    halide_stream& operator << (const unsigned char str[]);
+    halide_stream& operator << (const unsigned char (&str) []);
 
     template<size_t N>
-    halide_stream& operator << (const char(&str)[N]);
+    halide_stream& operator << (const char (&str) [N]);
 
     halide_stream& write(const char* str, std::streamsize count);
 

--- a/src/halide_stream.hpp
+++ b/src/halide_stream.hpp
@@ -1,0 +1,49 @@
+#ifndef HALIDE_STREAM_H
+#define HALIDE_STREAM_H
+
+#include <sstream>
+
+namespace Halide::Internal {
+    class CodeGen_C;
+    class CodeGen_PyTorch;
+    class PythonExtensionGen;
+}
+
+struct halide_stream {
+    union {
+        std::string strstream;
+        std::ostringstream private_oss;
+    };
+
+    halide_stream();
+    halide_stream(std::ostream& s);
+    ~halide_stream();
+
+    template<typename T>
+    halide_stream& operator << (const T& t);
+
+    halide_stream& operator << (const char* str);
+    halide_stream& operator << (char* str);
+    halide_stream& operator << (const std::string& str);
+    halide_stream& operator << (const unsigned char str[]);
+
+    template<size_t N>
+    halide_stream& operator << (const char(&str)[N]);
+
+    halide_stream& write(const char* str, std::streamsize count);
+
+    std::string str();
+
+    void setf(std::ios::fmtflags flags, std::ios::fmtflags mask);
+
+private:
+    static std::ostringstream sentinel;
+
+    std::ostream& redirect;
+
+    friend class Halide::Internal::CodeGen_C;
+    friend class Halide::Internal::CodeGen_PyTorch;
+    friend class Halide::Internal::PythonExtensionGen;
+};
+
+#endif//HALIDE_STREAM_H

--- a/src/halide_stream.hpp
+++ b/src/halide_stream.hpp
@@ -37,7 +37,7 @@ struct halide_stream {
     void setf(std::ios::fmtflags flags, std::ios::fmtflags mask);
 
 private:
-    static std::ostringstream sentinel;
+    static std::ostream nil;
 
     std::ostream& redirect;
 


### PR DESCRIPTION
This is a rough draft, not for merging.
The implementation is a bit messy, since I was trying to be quick and make as few changes as possible.
This is just to illustrate issue https://github.com/halide/Halide/issues/7724.

To get to the optimal path, enable `SLOMP_REPLACE_ISOLATED_STRINGSTREAMS` in `CodeGen_C.h` by setting it to `(1)`, and disable `SLOMP_HALIDE_STREAM_REDIRECT_TO_OSTREAM` in `IRPrinter.cpp` by setting it to `(0)`.

Across the board, on both MSVC and MacOS+clang+libc++, replacing `ostringstream` by `string` concatenation is anywhere from 1.5x to 10x faster. I'll post some profiling pictures soon. With the replacement, the various `print` routines move down the hot-spot list and things like cache insertions and such move to the top (as expected).

Is it really worth? Maybe. This is mostly for GPU code (and statement files). I am not sure about the overall impact on other code-gen paths. Moreover, the real bottlenecks are the various `substitute` routines. which dwarf the print routines anyway.

## MacOS + clang + libc++

before:
<img width="614" alt="Screenshot 2023-08-03 at 11 07 16 AM" src="https://github.com/halide/Halide/assets/526886/19ea8091-2855-4fc6-a375-adad83a97f79">

after:
<img width="615" alt="Screenshot 2023-08-03 at 11 06 39 AM" src="https://github.com/halide/Halide/assets/526886/4ab5ae04-5049-4bb1-a077-9282170a26c6">

## MSVC

before:
![image](https://github.com/halide/Halide/assets/526886/f9ecc17b-369e-4194-8414-ebd4aa1d9743)

after:
![image](https://github.com/halide/Halide/assets/526886/91879532-7233-4864-bc4c-b977f969972e)
