### PR TITLE
[vulkan] Fix SPIR-V IR references causing leaks

### DIFF
--- a/src/SpirvIR.cpp
+++ b/src/SpirvIR.cpp
@@ -357,12 +357,12 @@ SpvBlock::~SpvBlock() {
 
 void SpvBlock::add_instruction(SpvInstruction inst) {
     check_defined();
-    contents->instructions.push_back(inst);
+    contents->instructions.emplace_back(std::move(inst));
 }
 
 void SpvBlock::add_variable(SpvInstruction var) {
     check_defined();
-    contents->variables.push_back(var);
+    contents->variables.emplace_back(std::move(var));
 }
 
 const SpvBlock::Instructions &SpvBlock::instructions() const {
@@ -471,7 +471,7 @@ SpvBlock SpvFunction::create_block(SpvId block_id) {
     return block;
 }
 
-void SpvFunction::add_block(const SpvBlock &block) {
+void SpvFunction::add_block(SpvBlock block) {
     check_defined();
     if (!contents->blocks.empty()) {
         SpvBlock last_block = tail_block();
@@ -479,12 +479,12 @@ void SpvFunction::add_block(const SpvBlock &block) {
             last_block.add_instruction(SpvFactory::branch(block.id()));
         }
     }
-    contents->blocks.push_back(block);
+    contents->blocks.emplace_back(std::move(block));
 }
 
-void SpvFunction::add_parameter(const SpvInstruction &param) {
+void SpvFunction::add_parameter(SpvInstruction param) {
     check_defined();
-    contents->parameters.push_back(param);
+    contents->parameters.emplace_back(std::move(param));
 }
 
 uint32_t SpvFunction::parameter_count() const {
@@ -613,47 +613,49 @@ void SpvModule::clear() {
 
 void SpvModule::add_debug_string(SpvId result_id, const std::string &string) {
     check_defined();
-    contents->debug_source.push_back(SpvFactory::debug_string(result_id, string));
+    SpvInstruction inst = SpvFactory::debug_string(result_id, string);
+    contents->debug_source.emplace_back(std::move(inst));
 }
 
 void SpvModule::add_debug_symbol(SpvId id, const std::string &symbol) {
     check_defined();
-    contents->debug_symbols.push_back(SpvFactory::debug_symbol(id, symbol));
+    SpvInstruction inst = SpvFactory::debug_symbol(id, symbol);
+    contents->debug_symbols.emplace_back(std::move(inst));
 }
 
-void SpvModule::add_annotation(const SpvInstruction &val) {
+void SpvModule::add_annotation(SpvInstruction val) {
     check_defined();
-    contents->annotations.push_back(val);
+    contents->annotations.emplace_back(std::move(val));
 }
 
-void SpvModule::add_type(const SpvInstruction &val) {
+void SpvModule::add_type(SpvInstruction val) {
     check_defined();
-    contents->types.push_back(val);
+    contents->types.emplace_back(std::move(val));
 }
 
-void SpvModule::add_constant(const SpvInstruction &val) {
+void SpvModule::add_constant(SpvInstruction val) {
     check_defined();
-    contents->constants.push_back(val);
+    contents->constants.emplace_back(std::move(val));
 }
 
-void SpvModule::add_global(const SpvInstruction &val) {
+void SpvModule::add_global(SpvInstruction val) {
     check_defined();
-    contents->globals.push_back(val);
+    contents->globals.emplace_back(std::move(val));
 }
 
-void SpvModule::add_execution_mode(const SpvInstruction &val) {
+void SpvModule::add_execution_mode(SpvInstruction val) {
     check_defined();
-    contents->execution_modes.push_back(val);
+    contents->execution_modes.emplace_back(std::move(val));
 }
 
-void SpvModule::add_instruction(const SpvInstruction &val) {
+void SpvModule::add_instruction(SpvInstruction val) {
     check_defined();
-    contents->instructions.push_back(val);
+    contents->instructions.emplace_back(std::move(val));
 }
 
 void SpvModule::add_function(SpvFunction val) {
     check_defined();
-    contents->functions.emplace_back(val);
+    contents->functions.emplace_back(std::move(val));
 }
 
 void SpvModule::add_entry_point(const std::string &name, SpvInstruction inst) {

--- a/src/SpirvIR.h
+++ b/src/SpirvIR.h
@@ -230,8 +230,8 @@ public:
     SpvFunction &operator=(SpvFunction &&) = default;
 
     SpvBlock create_block(SpvId block_id);
-    void add_block(const SpvBlock &block);
-    void add_parameter(const SpvInstruction &param);
+    void add_block(SpvBlock block);
+    void add_parameter(SpvInstruction param);
     void set_return_precision(SpvPrecision precision);
     void set_parameter_precision(uint32_t index, SpvPrecision precision);
     bool is_defined() const;
@@ -281,13 +281,13 @@ public:
 
     void add_debug_string(SpvId result_id, const std::string &string);
     void add_debug_symbol(SpvId id, const std::string &symbol);
-    void add_annotation(const SpvInstruction &val);
-    void add_type(const SpvInstruction &val);
-    void add_constant(const SpvInstruction &val);
-    void add_global(const SpvInstruction &val);
-    void add_execution_mode(const SpvInstruction &val);
+    void add_annotation(SpvInstruction val);
+    void add_type(SpvInstruction val);
+    void add_constant(SpvInstruction val);
+    void add_global(SpvInstruction val);
+    void add_execution_mode(SpvInstruction val);
     void add_function(SpvFunction val);
-    void add_instruction(const SpvInstruction &val);
+    void add_instruction(SpvInstruction val);
     void add_entry_point(const std::string &name, SpvInstruction entry_point);
 
     void import_instruction_set(SpvId id, const std::string &instruction_set);

--- a/src/SpirvIR.h
+++ b/src/SpirvIR.h
@@ -113,6 +113,7 @@ class SpvFunction;
 class SpvBlock;
 class SpvInstruction;
 class SpvBuilder;
+class SpvContext;
 struct SpvFactory;
 
 /** Pre-declarations for SPIR-V IR data structures */
@@ -136,14 +137,13 @@ public:
     using ValueTypes = std::vector<SpvValueType>;
 
     SpvInstruction() = default;
-    ~SpvInstruction() = default;
+    ~SpvInstruction();
 
     SpvInstruction(const SpvInstruction &) = default;
     SpvInstruction &operator=(const SpvInstruction &) = default;
     SpvInstruction(SpvInstruction &&) = default;
     SpvInstruction &operator=(SpvInstruction &&) = default;
 
-    void set_block(SpvBlock block);
     void set_result_id(SpvId id);
     void set_type_id(SpvId id);
     void set_op_code(SpvOp opcode);
@@ -170,8 +170,8 @@ public:
     bool is_defined() const;
     bool is_immediate(uint32_t index) const;
     uint32_t length() const;
-    SpvBlock block() const;
     void check_defined() const;
+    void clear();
 
     void encode(SpvBinary &binary) const;
 
@@ -189,7 +189,7 @@ public:
     using Blocks = std::vector<SpvBlock>;
 
     SpvBlock() = default;
-    ~SpvBlock() = default;
+    ~SpvBlock();
 
     SpvBlock(const SpvBlock &) = default;
     SpvBlock &operator=(const SpvBlock &) = default;
@@ -198,19 +198,18 @@ public:
 
     void add_instruction(SpvInstruction inst);
     void add_variable(SpvInstruction var);
-    void set_function(SpvFunction func);
     const Instructions &instructions() const;
     const Variables &variables() const;
-    SpvFunction function() const;
     bool is_reachable() const;
     bool is_terminated() const;
     bool is_defined() const;
     SpvId id() const;
     void check_defined() const;
+    void clear();
 
     void encode(SpvBinary &binary) const;
 
-    static SpvBlock make(SpvFunction func, SpvId id);
+    static SpvBlock make(SpvId block_id);
 
 protected:
     SpvBlockContentsPtr contents;
@@ -223,7 +222,7 @@ public:
     using Parameters = std::vector<SpvInstruction>;
 
     SpvFunction() = default;
-    ~SpvFunction() = default;
+    ~SpvFunction();
 
     SpvFunction(const SpvFunction &) = default;
     SpvFunction &operator=(const SpvFunction &) = default;
@@ -233,10 +232,10 @@ public:
     SpvBlock create_block(SpvId block_id);
     void add_block(const SpvBlock &block);
     void add_parameter(const SpvInstruction &param);
-    void set_module(SpvModule module);
     void set_return_precision(SpvPrecision precision);
     void set_parameter_precision(uint32_t index, SpvPrecision precision);
     bool is_defined() const;
+    void clear();
 
     const Blocks &blocks() const;
     SpvBlock entry_block() const;
@@ -247,7 +246,6 @@ public:
     uint32_t parameter_count() const;
     uint32_t control_mask() const;
     SpvInstruction declaration() const;
-    SpvModule module() const;
     SpvId return_type_id() const;
     SpvId type_id() const;
     SpvId id() const;
@@ -274,7 +272,7 @@ public:
     using Imports = std::vector<ImportDefinition>;
 
     SpvModule() = default;
-    ~SpvModule() = default;
+    ~SpvModule();
 
     SpvModule(const SpvModule &) = default;
     SpvModule &operator=(const SpvModule &) = default;
@@ -334,6 +332,7 @@ public:
     bool is_defined() const;
     SpvId id() const;
     void check_defined() const;
+    void clear();
 
     void encode(SpvBinary &binary) const;
 
@@ -724,7 +723,6 @@ struct SpvInstructionContents {
     SpvId type_id = SpvNoType;
     Operands operands;
     ValueTypes value_types;
-    SpvBlock block;
 };
 
 /** Contents of a SPIR-V code block */
@@ -734,7 +732,6 @@ struct SpvBlockContents {
     using Blocks = std::vector<SpvBlock>;
     mutable RefCount ref_count;
     SpvId block_id = SpvInvalidId;
-    SpvFunction parent;
     Instructions instructions;
     Variables variables;
     Blocks before;
@@ -748,7 +745,6 @@ struct SpvFunctionContents {
     using Parameters = std::vector<SpvInstruction>;
     using Blocks = std::vector<SpvBlock>;
     mutable RefCount ref_count;
-    SpvModule parent;
     SpvId function_id;
     SpvId function_type_id;
     SpvId return_type_id;


### PR DESCRIPTION
Removed parent/owner back references (which weren't actually needed)
Fixed ownership transfers
Explicitly destruct and clear contents