### PR TITLE
Fix a couple of clang-tidy errors

### DIFF
--- a/src/Dimension.cpp
+++ b/src/Dimension.cpp
@@ -1,5 +1,6 @@
 #include "Dimension.h"
 
+#include "Expr.h"
 #include "IR.h"
 #include "IROperator.h"
 #include <utility>

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -5,6 +5,7 @@
 #include "IR.h"
 #include "IRMutator.h"
 #include "IROperator.h"
+#include "Util.h"
 
 namespace Halide {
 namespace Internal {


### PR DESCRIPTION
Newer versions of clang-tidy can warn about things that are referenced only via transitive includes (e.g. "no header providing "Halide::Expr" is directly included"); this is not an error per se, but having everything referenced in a .cpp file directly included is good practice to avoid flaky include issues on different systems.