### PR TITLE
[Help wanted] Emit stmt ahead of GPU/DSP/parfar offloading

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -79,9 +79,7 @@ ostream &operator<<(ostream &stream, const Module &m) {
     for (const auto &b : m.buffers()) {
         stream << b << "\n";
     }
-    for (const auto &f : m.functions()) {
-        stream << f << "\n";
-    }
+    stream << m.pseudoCode() << "\n";
     return stream;
 }
 

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -423,6 +423,8 @@ void lower_impl(const vector<Function> &output_funcs,
     debug(1) << "Lowering after final simplification:\n"
              << s << "\n\n";
 
+    const Stmt pseudo_code{s};
+
     if (!custom_passes.empty()) {
         for (size_t i = 0; i < custom_passes.size(); i++) {
             debug(1) << "Running custom lowering pass " << i << "...\n";
@@ -559,6 +561,8 @@ void lower_impl(const vector<Function> &output_funcs,
     }
 
     result_module.append(main_func);
+
+    result_module.stashPseudoCode(LoweredFunc{pipeline_name, public_args, pseudo_code, linkage_type});
 
     auto *logger = get_compiler_logger();
     if (logger) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -320,6 +320,7 @@ struct ModuleContents {
     Target target;
     std::vector<Buffer<>> buffers;
     std::vector<Internal::LoweredFunc> functions;
+    std::unique_ptr<Internal::LoweredFunc> pseudo_code;
     std::vector<Module> submodules;
     MetadataNameMap metadata_name_map;
     bool any_strict_float{false};
@@ -399,6 +400,9 @@ const std::vector<Internal::LoweredFunc> &Module::functions() const {
     return contents->functions;
 }
 
+const Internal::LoweredFunc &Module::pseudoCode() const {
+    return *(contents->pseudo_code);
+}
 std::vector<Internal::LoweredFunc> &Module::functions() {
     return contents->functions;
 }
@@ -423,6 +427,10 @@ void Module::append(const Buffer<> &buffer) {
 
 void Module::append(const Internal::LoweredFunc &function) {
     contents->functions.push_back(function);
+}
+
+void Module::stashPseudoCode(Internal::LoweredFunc &&function) {
+    contents->pseudo_code = std::make_unique<Internal::LoweredFunc>(function);
 }
 
 void Module::append(const Module &module) {

--- a/src/Module.h
+++ b/src/Module.h
@@ -161,6 +161,8 @@ public:
     const std::vector<Internal::LoweredFunc> &functions() const;
     std::vector<Internal::LoweredFunc> &functions();
     const std::vector<Module> &submodules() const;
+
+    const Internal::LoweredFunc &pseudoCode() const;
     // @}
 
     /** Return the function with the given name. If no such function
@@ -172,6 +174,7 @@ public:
     void append(const Buffer<void> &buffer);
     void append(const Internal::LoweredFunc &function);
     void append(const Module &module);
+    void stashPseudoCode(Internal::LoweredFunc &&function);
     // @}
 
     /** Compile a halide Module to variety of outputs, depending on

--- a/src/StmtToViz.cpp
+++ b/src/StmtToViz.cpp
@@ -46,9 +46,7 @@ public:
     // Pre-compute all costs to avoid repeated work
     void compute_all_costs(const Module &m) {
         // Compute all node costs
-        for (const auto &fn : m.functions()) {
-            fn.body.accept(this);
-        }
+        m.pseudoCode().body.accept(this);
 
         // Compute the max cost for each category
         max_compute_cost = -1;
@@ -526,9 +524,7 @@ public:
         // nodes we need to map and generate their assembly
         // markers (comments that appear in the assembly code
         // associating the code with this node)
-        for (const auto &fn : m.functions()) {
-            fn.body.accept(this);
-        }
+        m.pseudoCode().body.accept(this);
 
         // Find markers in asm code
         std::istringstream asm_stream(code);
@@ -672,9 +668,7 @@ public:
         }
 
         // Print module functions
-        for (const auto &fn : m.functions()) {
-            print(fn);
-        }
+        print(m.pseudoCode());
 
         // Close indented div holding body code
         print_closing_tag("div");
@@ -2190,9 +2184,7 @@ public:
 
     void print(const Module &m, AssemblyInfo asm_info) {
         assembly_info = std::move(asm_info);
-        for (const auto &fn : m.functions()) {
-            print(fn);
-        }
+        print(m.pseudoCode());
     }
 
 private:

--- a/src/StmtToViz.cpp
+++ b/src/StmtToViz.cpp
@@ -734,7 +734,7 @@ private:
             print_html_element("span", "matched", " {");
 
             // Open indented div to hold buffer data
-            print_opening_tag("div", "indent BufferData", id);
+            print_opening_tag("div", "indent BufferData collapsed-block", id);
 
             std::string str((const char *)buf.data(), buf.size_in_bytes());
             if (starts_with(buf.name(), "cuda_")) {


### PR DESCRIPTION
Stash the stmt right after the "final" (?) lowered form, ahead of DSP or GPU offloading. Also skipped the extraction of `parfor` into individual functions. The stmt is stored in `Halide::Module::contents->pseudo_code`. Modify IRPrinter to emit the pseudo-code as desired.

~Current status: the new code can emit stmt from the generator command-line argument `path/to/generator ... -e stmt`, but not `-e html`.~

Note: I have no idea how VizStmt estimate the compute and data movement costs for HVX/GPU `Stmt`. ~Help wanted to resolve the following bug:~



Resolves: #7519 . 

cc'ed @maaz139 .