### PR TITLE
StmtViz: Search for tooltip only in the child node

### DIFF
--- a/src/StmtToViz.cpp
+++ b/src/StmtToViz.cpp
@@ -1260,14 +1260,14 @@ private:
         }
 
         stream << "<div id='" << id << "' class='cost-btn CostColor" << line_costc << "'"
-               << "   aria-describedby='tooltip-" << id << "'"
                << "   line-cost='" << line_cost << "' block-cost='" << block_cost << "'"
-               << "   line-cost-color='" << line_costc << "' block-cost-color='" << block_costc << "'>"
-               << "</div>";
+               << "   line-cost-color='" << line_costc << "' block-cost-color='" << block_costc << "'>";
 
         stream << "<span id='tooltip-" << id << "' class='tooltip cond-tooltop' role='tooltip-" << id << "'>"
                << prefix << line_cost
                << "</span>";
+
+        stream << "</div>";
     }
 
     /* Misc utility methods */
@@ -2367,14 +2367,14 @@ private:
         }
 
         stream << "<div id='" << id << "' class='cost-btn CostColor" << line_costc << "'"
-               << "   aria-describedby='tooltip-" << id << "'"
                << "   line-cost='" << line_cost << "' block-cost='" << block_cost << "'"
-               << "   line-cost-color='" << line_costc << "' block-cost-color='" << block_costc << "'>"
-               << "</div>";
+               << "   line-cost-color='" << line_costc << "' block-cost-color='" << block_costc << "'>";
 
         stream << "<span id='tooltip-" << id << "' class='tooltip cond-tooltop' role='tooltip-" << id << "'>"
                << prefix << line_cost
                << "</span>";
+
+        stream << "</div>";
     }
 
     // Prints the box .box-header within div.box
@@ -2439,14 +2439,15 @@ private:
         std::ostringstream ss;
 
         // Show condition expression button
-        ss << "<button title='Click to see path condition' id='cond-" << id << "' aria-describedby='cond-tooltip-" << id << "' class='trunc-cond' role='button'>"
-           << "..."
-           << "</button>";
+        ss << "<button title='Click to see path condition' id='cond-" << id << "' class='trunc-cond' role='button'>"
+           << "...";
 
         // Tooltip that shows condition expression
         ss << "<span id='cond-tooltip-" << id << "' class='tooltip cond-tooltop' role='cond-tooltip-" << id << "'>"
            << cond
            << "</span>";
+
+        ss << "</button>";
 
         return ss.str();
     }

--- a/src/irvisualizer/StmtToViz_javascript.template.html
+++ b/src/irvisualizer/StmtToViz_javascript.template.html
@@ -350,11 +350,9 @@
     }
 
     function init_tooltips(btns, prefix) {
-        var re = /(?:\-([^-]+))?$/;
         for (var i = 0; i < btns.size(); i++) {
             const button = btns[i];
-            //const tooltip = $(prefix + re.exec(button.id)[1])[0];
-            const tooltip = document.getElementById(prefix + re.exec(button.id)[1]);
+            const tooltip = button.firstElementChild;
             button.is_clicked = false;
             button.addEventListener('mouseenter', () => {
                 if (!button.is_clicked)


### PR DESCRIPTION
Further cut ~5 second of StmtVisualizer rendering by searching for the tooltip text-box in the child node of the current button. Previously, the script compose the global ID with regular expression, and then search the entire DOM causing delays.

Quoting the comments from #7713:
> ... It still is for like a second unresponsive every time you resize the panes, but I couldn't figure out how to fix that.

Resolves: https://github.com/halide/Halide/issues/7712 .
See also: #7713 .

cc'ed @maaz139  and @mcourteaux .