### PR TITLE
Try to fix remaining ASAN-reported leaks

### DIFF
--- a/cmake/toolchain.linux-x64-asan.cmake
+++ b/cmake/toolchain.linux-x64-asan.cmake
@@ -34,6 +34,10 @@ set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/env)
 # Can't mix -fsanitize=address with -fsanitize=fuzzer
 set(WITH_TEST_FUZZ OFF)
 
+# Sanitizer builds intermittently fail when using CCache for reasons that aren't
+# clear; default to turning it off
+set(Halide_CCACHE_BUILD OFF)
+
 if (NOT DEFINED Halide_SHARED_ASAN_RUNTIME_LIBRARY)
     execute_process(
         COMMAND ${CMAKE_CXX_COMPILER} "-print-file-name=libclang_rt.asan.so"
@@ -49,3 +53,4 @@ set(
     Halide_PYTHON_LAUNCHER
     ${CMAKE_COMMAND} -E env ASAN_OPTIONS=detect_leaks=0 LD_PRELOAD=${Halide_SHARED_ASAN_RUNTIME_LIBRARY}
 )
+

--- a/cmake/toolchain.linux-x64-fuzzer.cmake
+++ b/cmake/toolchain.linux-x64-fuzzer.cmake
@@ -30,3 +30,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/env)
+
+# Sanitizer builds intermittently fail when using CCache for reasons that aren't
+# clear; default to turning it off
+set(Halide_CCACHE_BUILD OFF)

--- a/test/correctness/skip_stages_memoize.cpp
+++ b/test/correctness/skip_stages_memoize.cpp
@@ -228,6 +228,8 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    Internal::JITSharedRuntime::release_all();
+
     printf("Success!\n");
     return 0;
 }

--- a/test/generator/error_codes_aottest.cpp
+++ b/test/generator/error_codes_aottest.cpp
@@ -126,6 +126,9 @@ int main(int argc, char **argv) {
     check(result, correct);
     in.dim = shape;
 
+    free(in.host);
+    free(out.host);
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
This fixes all but one of the known remaining ASAN-related leaks; the remaining is in `tutorial_lesson_19_wrapper_funcs`

I can't debug that one locally because the leaks are in OpenCL and I am temporarily relegated to using a 'cloud' machine with no real GPU for linux-x64 -- if someone with access to such a machine could take a look, I'd appreciate it (examples of leakage at https://buildbot.halide-lang.org/master/#/builders/154/builds/79/steps/12/logs/tutorial_lesson_19_wrapper_funcs)

Also, drive-by change to turn off CCache for sanitizer builds in the presets files -- we are already doing this on the buildbots via config script, but doing it in the presets is good too for people who want to use it locally (for reasons that aren't entirely clear, CCache and sanitizers don't like each other)