### PR TITLE
Fix out of bounds access in anderson2021_test_apps_autoscheduler

### DIFF
--- a/src/autoschedulers/anderson2021/SearchSpace.cpp
+++ b/src/autoschedulers/anderson2021/SearchSpace.cpp
@@ -127,11 +127,11 @@ vector<SearchSpace::ParallelTileOption> SearchSpace::filter_parallel_tile_option
             if (c->node == node) {
                 int64_t total = 1;
                 int64_t max_available = 1;
-                for (const auto &l : c->stage->loop) {
+                for (size_t i = 0; i < c->stage->loop.size(); i++) {
+                    const auto& l = c->stage->loop[i];
                     if (!l.rvar) {
                         total *= o.outer_tiling[l.pure_dim];
-                        internal_assert(l.pure_dim < c->size.size()) << "l.pure_dim " << l.pure_dim << " c->size.size() " << c->size.size() << "\n";
-                        max_available *= c->size[l.pure_dim];
+                        max_available *= c->size[i];
                     }
                 }
                 max_total = std::max(max_total, total);

--- a/src/autoschedulers/anderson2021/SearchSpace.cpp
+++ b/src/autoschedulers/anderson2021/SearchSpace.cpp
@@ -128,7 +128,7 @@ vector<SearchSpace::ParallelTileOption> SearchSpace::filter_parallel_tile_option
                 int64_t total = 1;
                 int64_t max_available = 1;
                 for (size_t i = 0; i < c->stage->loop.size(); i++) {
-                    const auto& l = c->stage->loop[i];
+                    const auto &l = c->stage->loop[i];
                     if (!l.rvar) {
                         total *= o.outer_tiling[l.pure_dim];
                         max_available *= c->size[i];


### PR DESCRIPTION
This fixes https://github.com/halide/Halide/issues/7606. If an update stage has fewer pure vars than the pure definition, it can end up reading out of bounds. When reading the size of the update stage's loop, instead of using the corresponding pure dimension, it should just use its index within the update stage's loops.