### PR TITLE
Don't introduce reinterprets in find/lower intrinsics

### DIFF
--- a/src/IR.h
+++ b/src/IR.h
@@ -32,6 +32,13 @@ struct Cast : public ExprNode<Cast> {
     static Expr make(Type t, Expr v);
 
     static const IRNodeType _node_type = IRNodeType::Cast;
+
+    /** Check if the cast is equivalent to a reinterpret. */
+    bool is_reinterpret() const {
+        return (type.is_int_or_uint() &&
+                value.type().is_int_or_uint() &&
+                type.bits() == value.type().bits());
+    }
 };
 
 /** Reinterpret value as another type, without affecting any of the bits


### PR DESCRIPTION
As discussed with @abadams , later lowering stages expect to see int/uint reinterprets to have been normalized to casts. This PR removes the places in `find_intrinsics` and `lower_intrinsics` that introduce `reinterpret`, and use `cast` instead.