### PR TITLE
Profiler should report Func count as well as time

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1777,6 +1777,9 @@ void halide_register_argv_and_metadata(
 
 /** Per-Func state tracked by the sampling profiler. */
 struct HALIDE_ATTRIBUTE_ALIGN(8) halide_profiler_func_stats {
+    /** Total number of times this Func was evaluated. */
+    uint64_t count;
+
     /** Total time taken evaluating this Func (in nanoseconds). */
     uint64_t time;
 

--- a/src/runtime/profiler_common.cpp
+++ b/src/runtime/profiler_common.cpp
@@ -468,8 +468,12 @@ WEAK void halide_profiler_report_unlocked(void *user_context, halide_profiler_st
                     sstr << " ";
                 }
 
-                sstr << " evals=" << fs->count;
-                cursor += 12;
+                sstr << " evals/run=";
+                float avg_runs = (float)fs->count / p->runs;
+                sstr << avg_runs;
+                // Only use one dec point here
+                sstr.erase(5);
+                cursor += 16;
                 while (sstr.size() < cursor) {
                     sstr << " ";
                 }


### PR DESCRIPTION
Sometimes it's useful to know how many times a Func is evaluated, independent of its time. This adds that to the profiler.