### PR TITLE
Enable Github depend bot to scan for Javascript vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,1 @@
+src/irvisualizer/package.json

--- a/src/irvisualizer/.eslintrc.js
+++ b/src/irvisualizer/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  "env": {
+      "browser": true,
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+      "ecmaVersion": "2017",
+      "sourceType": "module",
+  },
+  "rules": {
+      "comma-dangle": ["error", "only-multiline"]
+  }
+}

--- a/src/irvisualizer/.gitignore
+++ b/src/irvisualizer/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/irvisualizer/README.md
+++ b/src/irvisualizer/README.md
@@ -1,0 +1,58 @@
+# Javascript toolchain for IRVisualizer: the single page web application
+
+## Features:
+
+* To trigger Github's online Dependabot alerts for security vulnerabilities.
+
+* To enable static analyzer for the Javascript/ES6 language.
+
+* To visualize the Halide IR and the assembly code interactively
+with a web browser.
+
+## Usage:
+
+* Execute `yarn install` to scan for broken Javascript dependencies.
+
+* (To be completed) execute `yarn run lint` to scan the main script for potential syntax errors and
+  bugs.
+
+## Recommended Makefile build rules
+
+```make
+ESBUILD=node_modules/.bin/esbuild
+ESLINT=node_modules/.bin/eslint
+
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+all: depend build    ## Download dependencies and build everything
+
+depend:    ## Download Nodejs dependencies
+	yarn install
+
+watch:    ## Debug mode, monitor file changes and then compile automatically
+	yarn run watch
+
+build:   ## Release mode, optimize and minimize the Javascript file
+	yarn run build
+
+lint:    ## Run static analyzer on the main javascript
+	yarn run lint
+
+.PHONY: depend watch build lint
+```
+
+## Development roadmap
+
+* [ ] Rename the extensions from `*.template.html` to `template/*.[js|css|html]`.
+
+* [ ] Modernize the main script to ES6.
+
+* [ ] Import all dependencies with the `import` statement, not via the `<script>` tag.
+
+* [ ] Resolve all static analyzer warnings, e.g. "buttonHide" is already defined, "btns.size()" is undefined, etc.
+
+* [ ] Invoke `make build` to bundle all dependencies, stylesheets, and
+  javascripts from the `template/` folder to the output folder
+  `distribution/bundle.[js|css]`; to embed all bundled code into the single HTML
+  file, so that users can browse the IRVisualizer output without Internet access.

--- a/src/irvisualizer/StmtToViz_dependencies.template.html
+++ b/src/irvisualizer/StmtToViz_dependencies.template.html
@@ -10,7 +10,7 @@
 <!-- Expand Button links -->
 <link href='http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css' rel='stylesheet'>
 
-<script src='http://code.jquery.com/jquery-1.10.2.js'></script>
+<script src='http://code.jquery.com/jquery-3.7.0.js'></script>
 
 
 <!-- Assembly Code links (Speed Highlight) -->

--- a/src/irvisualizer/package.json
+++ b/src/irvisualizer/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "halide-irvisualizer",
+  "description": "Halide IRVisualizer web toolchain",
+  "author": "Halide IRVisualizer workgroup",
+  "version": "0.0.1",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
+  "scripts": {
+    "build": "esbuild StmtToViz_javascript.template.html --bundle --minify --sourcemap --outdir=build --target=es6",
+    "lint": "eslint StmtToViz_javascript.template.html",
+    "watch": "esbuild StmtToViz_javascript.template.html --bundle --watch --outdir=build"
+  },
+  "dependencies": {
+    "@speed-highlight/core": "speed-highlight/core",
+    "bootstrap": "5.2.0",
+    "bootstrap-icons": "1.5.0",
+    "font-awesome": "4.1.0",
+    "jquery": "3.7.0",
+    "treeflex": "^2.0.1"
+  },
+  "devDependencies": {
+    "esbuild": "^0.18.13",
+    "eslint": "^2.11.1",
+    "yarn": "^1.22.10"
+  }
+}


### PR DESCRIPTION
Add a dummy javascript library dependencies file "package.json" and the book-keeping file "yarn.lock" to monitor the IRVisualizer tool for outdated dependencies. Activate Github's Dependbot notification for any security vulnerabilities and virus.

Upgrade the JQuery library to v3.7.0 .

cc'ed @maaz139 and @mcourteaux .