### PR TITLE
Upgrade CMake to 3.24 and inject FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 3.24)
+
+# Use our dependency provider by default, but make it easy to
+# override
+
+if (NOT DEFINED CMAKE_PROJECT_TOP_LEVEL_INCLUDES)
+    set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES "${CMAKE_CURRENT_LIST_DIR}/cmake/dependencies.cmake")
+endif ()
+
 project(Halide
         VERSION 17.0.0
         DESCRIPTION "Halide compiler and libraries"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.23)
+cmake_minimum_required(VERSION 3.24)
 project(Halide
         VERSION 17.0.0
         DESCRIPTION "Halide compiler and libraries"

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -67,12 +67,11 @@ we strongly suggest reading through the [CMake documentation][cmake-docs] first.
 
 ## Installing CMake
 
-Halide requires at least version 3.22, which was released in November 2021.
-Fortunately, getting a recent version of CMake couldn't be easier, and there are
-multiple good options on any system to do so. Generally, one should always have
-the most recent version of CMake installed system-wide. CMake is committed to
-backwards compatibility and even the most recent release can build projects over
-a decade old.
+Halide requires at least version 3.24. Fortunately, getting a recent version of
+CMake couldn't be easier, and there are multiple good options on any system to do
+so. Generally, one should always have the most recent version of CMake installed
+system-wide. CMake is committed to backwards compatibility and even the most recent
+release can build projects over a decade old.
 
 ### Cross-platform
 
@@ -90,13 +89,14 @@ See the [PyPI website][pypi-cmake] for more details.
 
 On Windows, there are three primary methods for installing an up-to-date CMake:
 
-1. If you have Visual Studio 2019 installed, you can get CMake 3.17 through the
-   Visual Studio installer. This is the recommended way of getting CMake if you
-   are able to use Visual Studio 2019. See Microsoft's
-   [documentation][vs2019-cmake-docs] for more details.
-2. If you use [Chocolatey][chocolatey], its [CMake package][choco-cmake] is kept
+1. If you have Visual Studio installed, you can get a recent CMake version through
+   the Visual Studio installer. This is the recommended way of getting CMake if you
+   are able to use Visual Studio 2019. See Microsoft's [documentation][vs2019-cmake-docs]
+   for more details.
+2. On Windows 11 and newer, `winget install cmake` should work out of the box.
+3. If you use [Chocolatey][chocolatey], its [CMake package][choco-cmake] is kept
    up to date. It should be as simple as `choco install cmake`.
-3. Otherwise, you should install CMake from [Kitware's website][cmake-download].
+4. Otherwise, you should install CMake from [Kitware's website][cmake-download].
 
 ### macOS
 
@@ -116,18 +116,13 @@ is also a viable option.
 
 There are a few good ways to install a modern CMake on Ubuntu:
 
-1. If you're on Ubuntu Linux 22.04 (Jammy Jellyfish), then simply running
-   `sudo apt install cmake` will get you CMake 3.22.
-2. If you are on an older Ubuntu release or would like to use the newest CMake,
-   try installing via the snap store: `snap install cmake`. Be sure you do not
-   already have `cmake` installed via APT. The snap package automatically stays
-   up to date.
-3. For older versions of Debian, Ubuntu, Mint, and derivatives, Kitware provides
-   an [APT repository][cmake-apt] with up-to-date releases. Note that this is
-   still useful for Ubuntu 20.04 because it will remain up to date.
-4. If all else fails, you might need to build CMake from source (eg. on old
-   Ubuntu versions running on ARM). In that case, follow the directions posted
-   on [Kitware's website][cmake-from-source].
+1. On any Ubuntu release, you can get the newest CMake via the snap
+   store: `snap install cmake`. Be sure you do not already have `cmake` installed
+   via APT. The snap package automatically stays up to date.
+2. If you do not wish to use Snap, Kitware provides an [APT repository][cmake-apt]
+   with up-to-date releases. Compatible with Debian, Ubuntu, Mint, and derivatives.
+3. If all else fails, you might need to build CMake from source. In that case,
+   follow the directions posted on [Kitware's website][cmake-from-source].
 
 For other Linux distributions, check with your distribution's package manager or
 use pip as detailed above. Snap packages might also be available.
@@ -575,7 +570,7 @@ No matter how you intend to use Halide, you will need some basic CMake
 boilerplate.
 
 ```cmake
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(HalideExample)
 
 set(CMAKE_CXX_STANDARD 17)  # or newer

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Test apps from the perspective of a consuming project.
 ##
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(Halide_apps)
 
 enable_testing()

--- a/apps/HelloBaremetal/CMakeLists.txt
+++ b/apps/HelloBaremetal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 project(HelloBaremetal)
 

--- a/apps/HelloBaremetal/cmake-external_project/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-external_project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 # Enable assembly language (.s) support additionally
 project(HelloBaremetal LANGUAGES C CXX ASM)

--- a/apps/HelloBaremetal/cmake-external_project/generator/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-external_project/generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 project(HelloBaremetal-gen)
 

--- a/apps/HelloBaremetal/cmake-super_build/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-super_build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 project(HelloBaremetal-Super)
 

--- a/apps/HelloBaremetal/cmake-super_build/app/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-super_build/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 # Enable assembly language (.s) support additionally
 project(HelloBaremetal-app LANGUAGES C CXX ASM)

--- a/apps/HelloBaremetal/cmake-super_build/generator/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-super_build/generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 project(HelloBaremetal-gen)
 

--- a/apps/HelloBaremetal/cmake-twice/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-twice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 # Enable assembly language (.s) support additionally
 project(HelloBaremetal LANGUAGES C CXX ASM)

--- a/apps/HelloWasm/CMakeLists.txt
+++ b/apps/HelloWasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(HelloWasm)
 
 enable_testing()

--- a/apps/bgu/CMakeLists.txt
+++ b/apps/bgu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(bgu)
 
 enable_testing()

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(bilateral_grid)
 
 enable_testing()

--- a/apps/blur/CMakeLists.txt
+++ b/apps/blur/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(blur)
 
 enable_testing()

--- a/apps/c_backend/CMakeLists.txt
+++ b/apps/c_backend/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(c_backend)
 
 enable_testing()

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(camera_pipe)
 
 enable_testing()

--- a/apps/compositing/CMakeLists.txt
+++ b/apps/compositing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(compositing)
 
 enable_testing()

--- a/apps/conv_layer/CMakeLists.txt
+++ b/apps/conv_layer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(conv_layer)
 
 enable_testing()

--- a/apps/cuda_mat_mul/CMakeLists.txt
+++ b/apps/cuda_mat_mul/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(cuda_mat_mul)
 
 # This just checks whether CUDA is available ahead of time to allow

--- a/apps/depthwise_separable_conv/CMakeLists.txt
+++ b/apps/depthwise_separable_conv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(depthwise_separable_conv)
 
 enable_testing()

--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(fft)
 
 enable_testing()

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(hannk)
 
 # We need to set this for some of the subprojects pulled in by TFLite (eg flatbuffers)

--- a/apps/hannk/cmake/superbuild/CMakeLists.txt
+++ b/apps/hannk/cmake/superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.23)
+cmake_minimum_required(VERSION 3.24)
 project(hannk_superbuild LANGUAGES NONE)
 
 ##

--- a/apps/harris/CMakeLists.txt
+++ b/apps/harris/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(harris)
 
 enable_testing()

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(hist)
 
 enable_testing()

--- a/apps/iir_blur/CMakeLists.txt
+++ b/apps/iir_blur/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(iir_blur)
 
 enable_testing()

--- a/apps/interpolate/CMakeLists.txt
+++ b/apps/interpolate/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(interpolate)
 
 enable_testing()

--- a/apps/lens_blur/CMakeLists.txt
+++ b/apps/lens_blur/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(lens_blur)
 
 enable_testing()

--- a/apps/linear_algebra/CMakeLists.txt
+++ b/apps/linear_algebra/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(linear_algebra)
 
 enable_testing()

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(local_laplacian)
 
 enable_testing()

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(max_filter)
 
 enable_testing()

--- a/apps/nl_means/CMakeLists.txt
+++ b/apps/nl_means/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(nl_means)
 
 enable_testing()

--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(resize)
 
 enable_testing()

--- a/apps/stencil_chain/CMakeLists.txt
+++ b/apps/stencil_chain/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(stencil_chain)
 
 enable_testing()

--- a/apps/unsharp/CMakeLists.txt
+++ b/apps/unsharp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(unsharp)
 
 enable_testing()

--- a/apps/wavelet/CMakeLists.txt
+++ b/apps/wavelet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(wavelet)
 
 enable_testing()

--- a/cmake/BundleStatic.cmake
+++ b/cmake/BundleStatic.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 ##
 # This module provides a utility for bundling a set of IMPORTED

--- a/cmake/FindHalide_WebGPU.cmake
+++ b/cmake/FindHalide_WebGPU.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 # tip: uncomment this line to get better debugging information if find_library() fails
 # set(CMAKE_FIND_DEBUG_MODE TRUE)

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 option(Halide_NO_DEFAULT_FLAGS "When enabled, suppresses recommended flags in add_halide_generator" OFF)
 

--- a/cmake/HalideTargetHelpers.cmake
+++ b/cmake/HalideTargetHelpers.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 ##
 # Utilities for manipulating Halide target triples

--- a/cmake/TargetExportScript.cmake
+++ b/cmake/TargetExportScript.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 include(CheckLinkerFlag)
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.24)
+
+include(FetchContent)
+
+##
+# Flatbuffers
+
+FetchContent_Declare(
+    flatbuffers
+    GIT_REPOSITORY https://github.com/google/flatbuffers.git
+    GIT_TAG 0100f6a5779831fa7a651e4b67ef389a8752bd9b # 23.5.26
+    GIT_SHALLOW TRUE
+    OVERRIDE_FIND_PACKAGE
+)
+
+# Patch busted flatbuffers build that doesn't play nice with FetchContent
+if (NOT EXISTS "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/flatbuffers-extra.cmake")
+    file(WRITE "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/flatbuffers-extra.cmake" [=[
+add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
+if (BUILD_SHARED_LIBS)
+    set_property(TARGET flatbuffers PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif ()
+]=])
+endif ()

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
     flatbuffers
     GIT_REPOSITORY https://github.com/google/flatbuffers.git
-    GIT_TAG 0100f6a5779831fa7a651e4b67ef389a8752bd9b # 23.5.26
+    GIT_TAG 0100f6a5779831fa7a651e4b67ef389a8752bd9b # v23.5.26
     GIT_SHALLOW TRUE
     OVERRIDE_FIND_PACKAGE
 )
@@ -22,3 +22,14 @@ if (BUILD_SHARED_LIBS)
 endif ()
 ]=])
 endif ()
+
+##
+# pybind11
+
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG 5b0a6fc2017fcc176545afe3e09c9f9885283242 # v3.10.4
+    GIT_SHALLOW TRUE
+    OVERRIDE_FIND_PACKAGE
+)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -16,6 +16,8 @@ FetchContent_Declare(
 # Fix up the targets
 if (NOT EXISTS "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/flatbuffers-extra.cmake")
     file(WRITE "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/flatbuffers-extra.cmake" [=[
+add_executable(flatbuffers::flatc ALIAS flatc)
+
 add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
 if (BUILD_SHARED_LIBS)
     set_property(TARGET flatbuffers PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -16,40 +16,7 @@ if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
 endif ()
 
 if (WITH_WABT)
-    set(WABT_VER 1.0.33)
-
-    message(STATUS "Fetching WABT ${WABT_VER}...")
-    FetchContent_Declare(wabt
-                         GIT_REPOSITORY https://github.com/WebAssembly/wabt.git
-                         GIT_TAG ${WABT_VER}
-                         GIT_SHALLOW TRUE)
-
-    # configuration for wabt
-    set(WITH_EXCEPTIONS ${Halide_ENABLE_EXCEPTIONS})
-    set(BUILD_TESTS OFF)
-    set(BUILD_TOOLS OFF)
-    set(BUILD_LIBWASM OFF)
-    set(USE_INTERNAL_SHA256 ON)
-    FetchContent_MakeAvailable(wabt)
-
-    set_target_properties(wabt PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-    # Disable this very-noisy warning in GCC
-    target_compile_options(wabt
-                           PRIVATE
-                           $<$<CXX_COMPILER_ID:GNU>:-Wno-alloca-larger-than>)
-
-    # TODO: we want to require unique prefixes to include these files, to avoid ambiguity;
-    # this means we have to prefix with "wabt-src/...", which is less bad than other alternatives,
-    # but perhaps we could do better (esp. if wabt was smarter about what it exposed?)
-    add_library(Halide_wabt INTERFACE)
-    target_sources(Halide_wabt INTERFACE $<BUILD_INTERFACE:$<TARGET_OBJECTS:wabt>>)
-    target_include_directories(Halide_wabt
-                               SYSTEM # Use -isystem instead of -I; this is a trick so that clang-tidy won't analyze these includes
-                               INTERFACE
-                               $<BUILD_INTERFACE:${wabt_SOURCE_DIR}>/include
-                               $<BUILD_INTERFACE:${wabt_BINARY_DIR}>/include)
-    set_target_properties(Halide_wabt PROPERTIES EXPORT_NAME wabt)
+    find_package(wabt 1.0.33 REQUIRED)
 endif ()
 
 if (WITH_V8)

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -1,4 +1,3 @@
-include(FetchContent)
 include(CMakeDependentOption)
 
 cmake_dependent_option(WITH_WABT "Include WABT Interpreter for WASM testing" ON "TARGET_WEBASSEMBLY" OFF)

--- a/packaging/common/HalideConfig.cmake
+++ b/packaging/common/HalideConfig.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 macro(Halide_fail message)
     set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${message}")

--- a/packaging/common/HalideHelpersConfig.cmake
+++ b/packaging/common/HalideHelpersConfig.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 
 set(Halide_HOST_TARGET @Halide_HOST_TARGET@)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "wheel",
   "scikit-build",
   "pybind11==2.10.4",
-  "cmake>=3.22",
+  "cmake>=3.24",
   "ninja; platform_system!='Windows'"
 ]
 build-backend = "setuptools.build_meta"

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.23)
+cmake_minimum_required(VERSION 3.24)
 project(Halide_Python)
 
 include(CMakeDependentOption)

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -23,10 +23,6 @@ cmake_dependent_option(
     WITH_TESTS OFF
 )
 
-# Set the expected (downloaded) version of pybind11
-option(PYBIND11_USE_FETCHCONTENT "Enable to download pybind11 via FetchContent" ON)
-set(PYBIND11_VER 2.10.4 CACHE STRING "The pybind11 version to use (or download)")
-
 ##
 # Dependencies
 ##
@@ -35,23 +31,9 @@ set(PYBIND11_VER 2.10.4 CACHE STRING "The pybind11 version to use (or download)"
 # Development.Module and Development.Embed. We don't need the Embed
 # part, so only requesting Module avoids failures when Embed is not
 # available, as is the case in the manylinux Docker images.
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
-if (Python3_VERSION VERSION_LESS "3.8")
-    message(FATAL_ERROR "Halide requires Python v3.8 or later, but found ${Python3_VERSION}.")
-endif ()
-message(STATUS "Found Python ${Python3_VERSION} at ${Python3_EXECUTABLE}")
+find_package(Python3 3.8 REQUIRED COMPONENTS Interpreter Development.Module)
 
-if (PYBIND11_USE_FETCHCONTENT)
-    include(FetchContent)
-    FetchContent_Declare(
-        pybind11
-        GIT_REPOSITORY https://github.com/pybind/pybind11.git
-        GIT_TAG v${PYBIND11_VER}
-    )
-    FetchContent_MakeAvailable(pybind11)
-else ()
-    find_package(pybind11 ${PYBIND11_VER} REQUIRED)
-endif ()
+find_package(pybind11 2.10.4 REQUIRED)
 
 find_package(Halide REQUIRED Halide)
 if (NOT Halide_ENABLE_RTTI OR NOT Halide_ENABLE_EXCEPTIONS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -417,12 +417,18 @@ add_custom_target(HalideIncludes ALL DEPENDS "${Halide_BINARY_DIR}/include/Halid
 # Define the Halide library target.
 ##
 
-add_library(Halide
-            ${SOURCE_FILES}
-            ${HEADER_FILES}
-            # Including these as sources works around the need to "install" Halide_initmod
-            $<TARGET_OBJECTS:Halide_initmod>
-            $<TARGET_OBJECTS:Halide_c_templates>)
+add_library(Halide)
+add_library(Halide::Halide ALIAS Halide)
+
+target_sources(
+    Halide
+    PRIVATE
+    ${SOURCE_FILES}
+    ${HEADER_FILES}
+    # Including these as sources works around the need to "install" Halide_initmod
+    $<TARGET_OBJECTS:Halide_initmod>
+    $<TARGET_OBJECTS:Halide_c_templates>
+)
 
 ##
 # Flatbuffers and Serialization dependencies.
@@ -431,84 +437,25 @@ add_library(Halide
 # Build serialization, enabled by default
 option(WITH_SERIALIZATION "Include experimental Serialization/Deserialization code" ON)
 
-# flatbuffers is small and compiles quickly, but if you want/need to use
-# a local version (via find_package), configure with FLATBUFFERS_USE_FETCHCONTENT=OFF
-option(FLATBUFFERS_USE_FETCHCONTENT "Enable to download the Flatbuffers library via FetchContent" ON)
-set(FLATBUFFERS_VER 23.5.26 CACHE STRING "The Flatbuffers version to use (or download)")
-
 if (WITH_SERIALIZATION)
-    if (FLATBUFFERS_USE_FETCHCONTENT)
-        include(FetchContent)
-        message(STATUS "Fetching flatbuffers ${FLATBUFFERS_VER}...")
-        FetchContent_Declare(
-            flatbuffers
-            GIT_REPOSITORY https://github.com/google/flatbuffers.git
-            GIT_TAG v${FLATBUFFERS_VER}
-            GIT_SHALLOW TRUE
-        )
-        # configuration for flatbuffers
-        set(FLATBUFFERS_BUILD_TESTS OFF)
-        set(FLATBUFFERS_INSTALL OFF)
-        FetchContent_MakeAvailable(flatbuffers)
-        set_target_properties(flatbuffers PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-        add_library(Halide_flatbuffers INTERFACE)
-        target_sources(Halide_flatbuffers INTERFACE $<BUILD_INTERFACE:$<TARGET_OBJECTS:flatbuffers>>)
-        target_include_directories(Halide_flatbuffers
-                                   SYSTEM # Use -isystem instead of -I; this is a trick so that clang-tidy won't analyze these includes
-                                   INTERFACE
-                                   $<BUILD_INTERFACE:${flatbuffers_SOURCE_DIR}>/include
-                                   $<BUILD_INTERFACE:${flatbuffers_BINARY_DIR}>/include)
-        set_target_properties(Halide_flatbuffers PROPERTIES EXPORT_NAME flatbuffers)
-
-        add_executable(flatbuffers::flatc ALIAS flatc)
-        message(STATUS "Using fetched-and-built flatbuffers, version ${FLATBUFFERS_VER}")
-    else ()
-        # Sadly, there seem to be at least three variations of the Flatbuffer package
-        # in terms of the case of the relevant CMake files; if we guess wrong, we
-        # fail on case-sensitive file systems. We'll try this as a hack workaround:
-        # just try all three. (Note that the internal CMake library name appears to be
-        # `flatbuffers` in all cases.)
-        set(FB_NAME "")
-        foreach (N IN ITEMS flatbuffers Flatbuffers FlatBuffers)
-            # TODO: should we check the version here?
-            find_package(${N} QUIET)
-            if (${N}_FOUND)
-                set(FB_NAME ${N})
-                message(STATUS "Using installed flatbuffers, version ${${N}_VERSION}")
-                break()
-            endif ()
-        endforeach ()
-
-        if (NOT FB_NAME)
-            message(FATAL_ERROR "WITH_SERIALIZATION is ON and FLATBUFFERS_USE_FETCHCONTENT is OFF, "
-                                "but could not find flatbuffers installed locally. "
-                                "Either install flatbuffers or build with WITH_SERIALIZATION=OFF.")
-        endif ()
-
-        add_library(Halide_flatbuffers ALIAS flatbuffers::flatbuffers)
-    endif ()
-
-    set(fb_dir "${Halide_BINARY_DIR}/flatc/include")
+    find_package(flatbuffers 23.5.26 REQUIRED)
 
     set(fb_def "${CMAKE_CURRENT_SOURCE_DIR}/halide_ir.fbs")
+    set(fb_dir "${Halide_BINARY_DIR}/flatc/include")
     set(fb_header "${fb_dir}/halide_ir_generated.h")
+
     add_custom_command(
         OUTPUT "${fb_header}"
         COMMAND flatbuffers::flatc --cpp -o "${fb_dir}" "${fb_def}"
         DEPENDS "${fb_def}"
         VERBATIM
     )
-    add_custom_target(generate_fb_header DEPENDS "${fb_header}")
-    set_source_files_properties("${fb_header}" PROPERTIES GENERATED TRUE)
 
-    add_dependencies(Halide generate_fb_header)
-    target_include_directories(Halide PRIVATE "$<BUILD_INTERFACE:${fb_dir}>")
-    target_link_libraries(Halide PRIVATE Halide_flatbuffers)
     target_compile_definitions(Halide PRIVATE WITH_SERIALIZATION)
+    target_include_directories(Halide PRIVATE "$<BUILD_INTERFACE:${fb_dir}>")
+    target_link_libraries(Halide PRIVATE flatbuffers::flatbuffers)
+    target_sources(Halide PRIVATE "${fb_header}")
 endif ()
-
-add_library(Halide::Halide ALIAS Halide)
 
 target_link_libraries(Halide PRIVATE Halide::LLVM)
 target_link_libraries(Halide PUBLIC Halide::LanguageOptions)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(integration_tests NONE)
 
 enable_testing()

--- a/test/integration/aot/CMakeLists.txt
+++ b/test/integration/aot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(aot)
 
 enable_testing()

--- a/test/integration/jit/CMakeLists.txt
+++ b/test/integration/jit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(jit)
 
 enable_testing()

--- a/test/integration/xc/CMakeLists.txt
+++ b/test/integration/xc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 project(xc)
 
 enable_testing()


### PR DESCRIPTION
WIP -- still to-do is to audit our packaging rules (and maybe add some GHA tests, hmm) and update the READMEs.

This PR replaces all usage of `FetchContent` inside our build with `find_package`. When Halide is the top-level project, i.e. not being included into another project _via_ `FetchContent` (or `add_subdirectory`), it will load the new `cmake/dependencies.cmake`. This file contains a series of `FetchContent` calls that hook `find_package`. Some dependencies, like `wabt` and `flatbuffers` do not play nicely with `FetchContent`, and so some patches must be injected. We should consider opening issues/PRs upstream to enable us to remove these hacks down the line. (Unfortunately, this is difficult for me to do).

FetchContent can be disabled wholesale by setting `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=""` on the CMake command line. This should avoid issues like #5092 resurfacing. 

This also makes progress toward #7611 by deferring to the including project's dependency management strategy.