### PR TITLE
Remove some unused includes

### DIFF
--- a/src/AlignLoads.cpp
+++ b/src/AlignLoads.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 
 #include "AlignLoads.h"
-#include "Bounds.h"
 #include "HexagonAlignment.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -1,5 +1,4 @@
 #include "CodeGen_GPU_Dev.h"
-#include "Bounds.h"
 #include "Deinterleave.h"
 #include "IRMutator.h"
 #include "IROperator.h"

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -6,7 +6,6 @@
 #include "IntegerDivisionTable.h"
 #include "LLVM_Headers.h"
 #include "Simplify.h"
-#include "Simplify_Internal.h"
 #include "runtime/constants.h"
 
 namespace Halide {

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -2,9 +2,7 @@
 
 #include "CodeGen_C.h"
 #include "CodeGen_PyTorch.h"
-#include "IROperator.h"
 #include "Module.h"
-#include "Param.h"
 #include "Util.h"
 #include "Var.h"
 

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -1,7 +1,6 @@
 #include "CSE.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_Posix.h"
-#include "ConciseCasts.h"
 #include "Debug.h"
 #include "IREquality.h"
 #include "IRMatch.h"

--- a/src/Float16.cpp
+++ b/src/Float16.cpp
@@ -1,5 +1,4 @@
 #include "Float16.h"
-#include "Error.h"
 #include "Util.h"
 
 #include <cmath>

--- a/src/OptimizeShuffles.cpp
+++ b/src/OptimizeShuffles.cpp
@@ -14,7 +14,6 @@
 #include "Scope.h"
 #include "Simplify.h"
 #include "Substitute.h"
-#include <unordered_map>
 #include <utility>
 
 namespace Halide {

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <numeric>
 #include <utility>
 
 #include "CSE.h"

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <atomic>
 #include <utility>
 
 #include "Argument.h"

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <map>
 #include <string>
 #include <utility>

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <limits>
 #include <map>
 #include <string>
 

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -3,7 +3,6 @@
 
 #include "FindCalls.h"
 #include "Func.h"
-#include "IREquality.h"
 #include "IRVisitor.h"
 #include "RealizationOrder.h"
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <memory>
 #include <set>
 #include <utility>
 

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -7,7 +7,6 @@
 #include "Simplify.h"
 #include "Substitute.h"
 
-#include <set>
 #include <utility>
 
 namespace Halide {


### PR DESCRIPTION
These were found with clang-tidy 18's misc-include-cleaner checker and then only taking the suggested deletions, so I believe these are truly unused, and not just transitively included or something.