### PR TITLE
Unbreak WebGPU builds

### DIFF
--- a/src/runtime/webgpu.cpp
+++ b/src/runtime/webgpu.cpp
@@ -242,12 +242,13 @@ namespace {
 
 halide_error_code_t init_error_code = halide_error_code_success;
 
-void device_lost_callback(WGPUDeviceLostReason reason,
-                          char const *message,
-                          void *user_context) {
-    error(user_context) << "WGPU device lost (" << reason << "): "
-                        << message << "\n";
-}
+// TODO: missing from recent Emscripten/Dawn builds, commenting out to unbreak build
+// void device_lost_callback(WGPUDeviceLostReason reason,
+//                           char const *message,
+//                           void *user_context) {
+//     error(user_context) << "WGPU device lost (" << reason << "): "
+//                         << message << "\n";
+// }
 
 void request_device_callback(WGPURequestDeviceStatus status,
                              WGPUDevice device,
@@ -260,7 +261,8 @@ void request_device_callback(WGPURequestDeviceStatus status,
         return;
     }
     device_was_lost = false;
-    wgpuDeviceSetDeviceLostCallback(device, device_lost_callback, user_context);
+    // TODO: missing from recent Emscripten/Dawn builds, commenting out to unbreak build
+    // wgpuDeviceSetDeviceLostCallback(device, device_lost_callback, user_context);
     global_device = device;
 }
 
@@ -514,7 +516,8 @@ WEAK int halide_webgpu_device_release(void *user_context) {
                 global_staging_buffer = nullptr;
             }
 
-            wgpuDeviceSetDeviceLostCallback(device, nullptr, nullptr);
+            // TODO: missing from recent Emscripten/Dawn builds, commenting out to unbreak build
+            // wgpuDeviceSetDeviceLostCallback(device, nullptr, nullptr);
             wgpuDeviceRelease(device);
             global_device = nullptr;
 

--- a/test/common/gpu_context.h
+++ b/test/common/gpu_context.h
@@ -246,7 +246,8 @@ inline bool create_webgpu_context(WGPUInstance *instance_out, WGPUAdapter *adapt
                 fprintf(stderr, "WGPU Device Lost: %d %s", (int)reason, message);
                 abort();
             };
-            wgpuDeviceSetDeviceLostCallback(device, device_lost_callback, userdata);
+            // TODO: missing from recent Emscripten/Dawn builds, commenting out to unbreak build
+            // wgpuDeviceSetDeviceLostCallback(device, device_lost_callback, userdata);
 
             // Create a staging buffer for transfers.
             constexpr int kStagingBufferSize = 4 * 1024 * 1024;
@@ -287,7 +288,8 @@ inline bool create_webgpu_context(WGPUInstance *instance_out, WGPUAdapter *adapt
 }
 
 inline void destroy_webgpu_context(WGPUInstance instance, WGPUAdapter adapter, WGPUDevice device, WGPUBuffer staging_buffer) {
-    wgpuDeviceSetDeviceLostCallback(device, nullptr, nullptr);
+    // TODO: missing from recent Emscripten/Dawn builds, commenting out to unbreak build
+    // wgpuDeviceSetDeviceLostCallback(device, nullptr, nullptr);
     wgpuBufferRelease(staging_buffer);
     wgpuDeviceRelease(device);
     wgpuAdapterRelease(adapter);


### PR DESCRIPTION
It seems that newer versions of emcc and/or dawn no longer have the `wgpuDeviceSetDeviceLostCallback()` fn available. This just comments these out temporarily, to unbreak the builds; it's not clear if these are no longer necessary or if there is an alternate API to accomplish this, but while I'm investigating, this is better than nothing.

attn: @jrprice 