### PR TITLE
Update clang-tidy action to stop breaking

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install clang-tidy
         run: |
           brew update
-          brew install llvm@16 ninja coreutils
+          brew install llvm@16 ninja coreutils flatbuffers
       - name: Run clang-tidy
         run: |
           export CC=/usr/local/opt/llvm/bin/clang

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -28,7 +28,7 @@ jobs:
   # a bit of a sluggard
   check_clang_tidy:
     name: Check clang-tidy
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install clang-tidy

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install clang-tidy
         run: |
+          # see https://github.com/actions/runner-images/issues/7725
+          rm -rf /usr/local/bin/2to3
           brew update
           brew install llvm@16 ninja coreutils
       - name: Run clang-tidy

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -31,14 +31,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      # Workaround for https://github.com/actions/setup-python/issues/577
+      - name: Clean up python binaries
+        run: |
+          rm -f /usr/local/bin/2to3*;
+          rm -f /usr/local/bin/idle3*;
+          rm -f /usr/local/bin/pydoc3*;
+          rm -f /usr/local/bin/python3*;
+          rm -f /usr/local/bin/python3*-config;
       - name: Install clang-tidy
         run: |
           brew update
-          #
-          # see https://github.com/actions/runner-images/issues/7725
-          brew install python@3.11
-          brew link --overwrite python@3.11
-          #
           brew install llvm@16 ninja coreutils
       - name: Run clang-tidy
         run: |

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,9 +33,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install clang-tidy
         run: |
-          # see https://github.com/actions/runner-images/issues/7725
-          rm -rf /usr/local/bin/2to3
           brew update
+          #
+          # see https://github.com/actions/runner-images/issues/7725
+          brew install python@3.11
+          brew link --overwrite python@3.11
+          #
           brew install llvm@16 ninja coreutils
       - name: Run clang-tidy
         run: |

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -638,9 +638,6 @@ int generate_filter_main_inner(int argc,
                                const GeneratorFactoryProvider &generator_factory_provider) {
     static const char kUsage[] = R"INLINE_CODE(
 gengen
-
-FOO
-
   [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME]
   [-d 1|0] [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME]
   [-s AUTOSCHEDULER_NAME] [-t TIMEOUT]

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -638,6 +638,9 @@ int generate_filter_main_inner(int argc,
                                const GeneratorFactoryProvider &generator_factory_provider) {
     static const char kUsage[] = R"INLINE_CODE(
 gengen
+
+FOO
+
   [-g GENERATOR_NAME] [-f FUNCTION_NAME] [-o OUTPUT_DIR] [-r RUNTIME_NAME]
   [-d 1|0] [-e EMIT_OPTIONS] [-n FILE_BASE_NAME] [-p PLUGIN_NAME]
   [-s AUTOSCHEDULER_NAME] [-t TIMEOUT]


### PR DESCRIPTION
~`macos-latest` is actually macos-12 (macos13 is considered "beta" on the GHA runners). Hopefully this will fix the recent install snafus that are breaking clang-tidy.~

TL;DR: the GHA macOS image has junk installed that conflicts with Homebrew. Brute-force removal is apparently the workaround. 

Also, drive-by install of flatbuffers in anticipation of https://github.com/halide/Halide/pull/7794.
