### PR TITLE
Fix bounds inference for uint -> int casts

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -281,9 +281,10 @@ private:
         bool could_overflow = true;
         if (to.can_represent(from) || to.is_float()) {
             could_overflow = false;
-        } else if (to.is_int() && to.bits() >= 32) {
-            // If we cast to an int32 or greater, assume that it won't
-            // overflow. Signed 32-bit integer overflow is undefined.
+        } else if (from.is_float() && to.is_int() && to.bits() >= 32) {
+            // If we cast from float to an int32 or greater, assume that it
+            // won't overflow. Signed 32-bit integer overflow on floating point
+            // casts is undefined. (Casting from uint is defined to wrap).
             could_overflow = false;
         } else if (a.is_bounded()) {
             if (from.can_represent(to)) {

--- a/test/correctness/bounds_of_abs.cpp
+++ b/test/correctness/bounds_of_abs.cpp
@@ -45,6 +45,19 @@ int main(int argc, char **argv) {
     f5 = lambda(x, input(cast<int>(clamp(abs(1.0f / (x + .1f)), -50, 50))));
     check(f5, input, 0, 51);
 
+    // Verify that casting the result of abs of a uint32 back to an int32 is
+    // considered unbounded below - it may produce the most negative int if the
+    // cast wraps. We won't phrase this like the tests above, because we would
+    // expect it to fail to compile with an unbounded access error.
+    Internal::Scope<Internal::Interval> scope;
+    scope.push(x.name(), Internal::Interval::everything());
+    Internal::Interval i =
+        Internal::bounds_of_expr_in_scope(cast<int>(abs(x)), scope);
+    if (i.has_lower_bound()) {
+        printf("Interval should not have had a lower bound\n");
+        return 1;
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
Fixes #7807
Fixes #7811

Note that this may cause previously-functioning pipelines to throw a compile-time error, in cases where they cast a uint32 to an int32 for use in an index expression and were relying on Halide to assume the result is positive. Now that the uint32 -> int32 cast is defined to wrap, the result may not be positive. An example might be the expression:

```
lut(min(cast<int>(some_u32_param), 256))
```

Previously Halide would have treated this as bounded between 0 and 256. Now it's no longer bounded below, because the uint32 could have been large enough to wrap.

If this causes too much carnage in production pipelines we may have to revert the decision to define wrapping behavior for uint32 -> int32 casts.