### PR TITLE
Enable emission of float16/32 casts on x86

### DIFF
--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -494,7 +494,7 @@ void CodeGen_X86::visit(const Cast *op) {
         src.code() == Type::Float &&
         (dst.bits() == 16 || src.bits() == 16)) {
         // Node we use code() == Type::Float instead of is_float(), because we
-        // don't want to bfloat casts.
+        // don't want to catch bfloat casts.
 
         // This target doesn't support full float16 arithmetic, but it *does*
         // support float16 casts, so we emit a vanilla LLVM cast node.

--- a/test/correctness/simd_op_check_x86.cpp
+++ b/test/correctness/simd_op_check_x86.cpp
@@ -644,9 +644,9 @@ int main(int argc, char **argv) {
         {
             Target("x86-32-linux"),
             Target("x86-32-linux-sse41"),
-            // Always turn on f16c when using avx. Haswell had avx without f16c,
-            // but f16c is orthogonal to everything else, so there's no real
-            // reason to test avx without it.
+            // Always turn on f16c when using avx. Sandy Bridge had avx without
+            // f16c, but f16c is orthogonal to everything else, so there's no
+            // real reason to test avx without it.
             Target("x86-64-linux-sse41-avx-f16c"),
             Target("x86-64-linux-sse41-avx-f16c-avx2"),
             // See above: don't test avx512 without extra features, the test

--- a/test/correctness/simd_op_check_x86.cpp
+++ b/test/correctness/simd_op_check_x86.cpp
@@ -45,6 +45,7 @@ public:
     void check_sse_and_avx() {
         Expr f64_1 = in_f64(x), f64_2 = in_f64(x + 16), f64_3 = in_f64(x + 32);
         Expr f32_1 = in_f32(x), f32_2 = in_f32(x + 16), f32_3 = in_f32(x + 32);
+        Expr f16_1 = in_f16(x), f16_2 = in_f16(x + 16), f16_3 = in_f16(x + 32);
         Expr i8_1 = in_i8(x), i8_2 = in_i8(x + 16), i8_3 = in_i8(x + 32);
         Expr u8_1 = in_u8(x), u8_2 = in_u8(x + 16), u8_3 = in_u8(x + 32);
         Expr i16_1 = in_i16(x), i16_2 = in_i16(x + 16), i16_3 = in_i16(x + 32);
@@ -496,6 +497,11 @@ public:
                 check_x86_fixed_point("zmm", 2);
             }
 
+            if (target.has_feature(Target::F16C)) {
+                check("vcvtps2ph", 8, cast(Float(16), f32_1));
+                check("vcvtph2ps", 8, cast(Float(32), f16_1));
+            }
+
             check(use_avx512 ? "vpaddq*zmm" : "vpaddq*ymm", 8, i64_1 + i64_2);
             check(use_avx512 ? "vpsubq*zmm" : "vpsubq*ymm", 8, i64_1 - i64_2);
             check(use_avx512 ? "vpmullq" : "vpmuludq*ymm", 8, u64_1 * u64_2);
@@ -638,14 +644,17 @@ int main(int argc, char **argv) {
         {
             Target("x86-32-linux"),
             Target("x86-32-linux-sse41"),
-            Target("x86-64-linux-sse41-avx"),
-            Target("x86-64-linux-sse41-avx-avx2"),
+            // Always turn on f16c when using avx. Haswell had avx without f16c,
+            // but f16c is orthogonal to everything else, so there's no real
+            // reason to test avx without it.
+            Target("x86-64-linux-sse41-avx-f16c"),
+            Target("x86-64-linux-sse41-avx-f16c-avx2"),
             // See above: don't test avx512 without extra features, the test
             // isn't yet set up to test it properly.
             // Target("x86-64-linux-sse41-avx-avx2-avx512"),
             // Target("x86-64-linux-sse41-avx-avx2-avx512-avx512_knl"),
-            Target("x86-64-linux-sse41-avx-avx2-avx512-avx512_skylake"),
-            Target("x86-64-linux-sse41-avx-avx2-avx512-avx512_skylake-avx512_cannonlake"),
-            Target("x86-64-linux-sse41-avx-avx2-avx512-avx512_skylake-avx512_cannonlake-avx512_sapphirerapids"),
+            Target("x86-64-linux-sse41-avx-f16c-avx2-avx512-avx512_skylake"),
+            Target("x86-64-linux-sse41-avx-f16c-avx2-avx512-avx512_skylake-avx512_cannonlake"),
+            Target("x86-64-linux-sse41-avx-f16c-avx2-avx512-avx512_skylake-avx512_cannonlake-avx512_sapphirerapids"),
         });
 }


### PR DESCRIPTION
Fixes #7836
Fixes #4166

These weren't enabled yet because the last time this code was touched, float16 wasn't a legal type in llvm on x86 (See https://bugs.llvm.org/show_bug.cgi?id=43065)