### PR TITLE
Build rules for Xtensa tests with cstub library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1328,6 +1328,7 @@ GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_string_param,$
 
 # Tests below work, but need to disable parallel in the schedule.
 # TODO(vksnk): figure out what's wrong with parallel in this case.
+# https://github.com/halide/Halide/issues/7856
 GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_example,$(GENERATOR_AOTXTENSA_TESTS))
 GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_mandelbrot,$(GENERATOR_AOTXTENSA_TESTS))
 GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_pyramid,$(GENERATOR_AOTXTENSA_TESTS))
@@ -1340,6 +1341,7 @@ GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_tiled_blur,$(G
 GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_nested_externs,$(GENERATOR_AOTXTENSA_TESTS))
 
 # Segmentation fault, tests provide custom runtime and user context.
+# https://github.com/halide/Halide/issues/7857
 GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_user_context,$(GENERATOR_AOTXTENSA_TESTS))
 GENERATOR_AOTXTENSA_TESTS := $(filter-out generator_aotcpp_xtensa_user_context_insanity,$(GENERATOR_AOTXTENSA_TESTS))
 

--- a/apps/simd_op_check/Makefile
+++ b/apps/simd_op_check/Makefile
@@ -1,10 +1,13 @@
 include ../support/Makefile.inc
 
 CXX-hexagon-32-noos-hvx_128 ?= $(HL_HEXAGON_TOOLS)/bin/hexagon-clang++
+CXX-xtensa ?= clang++
 
 CXXFLAGS-hexagon-32-noos-hvx_128 ?= -mhvx -mhvx-length=128B -G0
+CXXFLAGS-xtensa ?= -std=c++17 -I$(CSTUB_INCLUDE_PATH) -D XCHAL_VISION_TYPE=7 -D XCHAL_VISION_SIMD16=32 -D XCHAL_DATA_WIDTH=64
 
 LDFLAGS-hexagon-32-noos-hvx_128 ?= -L../../src/runtime/hexagon_remote/bin/v60/ -lsim_qurt
+LDFLAGS-xtensa ?= -lpthread -ldl
 
 all: \
 	$(BIN)/driver-host \
@@ -18,6 +21,7 @@ arm_32: $(BIN)/driver-arm-32-android
 arm_64: $(BIN)/driver-arm-64-android
 
 host: $(BIN)/driver-host
+xtensa: $(BIN)/driver-xtensa
 
 $(BIN)/hexagon-32-noos-%/filters.h:
 	@mkdir -p $(@D)
@@ -27,6 +31,15 @@ $(BIN)/hexagon-32-noos-%/filters.h:
 	echo "filter filters[] = {" > $(BIN)/hexagon-32-noos-$*/filters.h
 	cd $(BIN)/hexagon-32-noos-$*; for f in test_*.h; do n=$${f/.h/}; echo '{"'$${n}'", &'$${n}'},'; done >> filters.h
 	echo '{NULL, NULL}};' >> $(BIN)/hexagon-32-noos-$*/filters.h
+
+$(BIN)/xtensa/filters.h:
+	@mkdir -p $(@D)
+	make -C ../../ bin/correctness_simd_op_check_xtensa
+	cd $(BIN)/xtensa && HL_TARGET=xtensa-32-noos LD_LIBRARY_PATH=../../../../bin:$$LD_LIBRARY_PATH ../../../../bin/correctness_simd_op_check_xtensa
+	cat $(BIN)/xtensa/test_*.h > $(BIN)/xtensa/filter_headers.h
+	echo "filter filters[] = {" > $(BIN)/xtensa/filters.h
+	cd $(BIN)/xtensa; for f in test_*.h; do n=$${f/.h/}; echo '{"'$${n}'", &'$${n}'},'; done >> filters.h
+	echo '{NULL, NULL}};' >> $(BIN)/xtensa/filters.h
 
 $(BIN)/%/filters.h:
 	@mkdir -p $(@D)
@@ -40,6 +53,10 @@ $(BIN)/%/filters.h:
 $(BIN)/driver-%: driver.cpp $(BIN)/%/filters.h
 	@mkdir -p $(@D)
 	$(CXX-$*) $(CXXFLAGS-$*) -I ../../include $(OPTIMIZE) -I $(BIN)/$* driver.cpp $(BIN)/$*/test_*.o $(BIN)/$*/simd_op_check_runtime.o -o $@ $(LDFLAGS-$*) $(HALIDE_SYSTEM_LIBS)
+
+$(BIN)/driver-xtensa: driver.cpp $(BIN)/xtensa/filters.h
+	@mkdir -p $(@D)
+	$(CXX-xtensa) $(CXXFLAGS-xtensa) -I ../../include $(OPTIMIZE) -I $(BIN)/xtensa driver.cpp $(BIN)/xtensa/test_*.cpp $(BIN)/xtensa/simd_op_check_runtime.o $(CSTUB_LIB_PATH)/libcstub.a -o $@ $(LDFLAGS-xtensa) $(HALIDE_SYSTEM_LIBS)
 
 clean:
 	rm -rf $(BIN)

--- a/test/correctness/simd_op_check_xtensa.cpp
+++ b/test/correctness/simd_op_check_xtensa.cpp
@@ -111,13 +111,15 @@ public:
         // some of these could overflow that limit. (Omitting the spaces is
         // a bit of a band-aid here; a better solution would probably be
         // to allow arbitrary names that don't match, but for now, this will do.)
-        check("convert<float16x32_t,float32x32_t>", vector_width / 2, f16(f32_1));
-        check("convert<float32x32_t,float16x32_t>", vector_width / 2, f32(f16_1));
+        // TODO(vksnk): float16 doesnt't seem to be supported well by cstubs library.
+        // check("convert<float16x32_t,float32x32_t>", vector_width / 2, f16(f32_1));
+        // check("convert<float32x32_t,float16x32_t>", vector_width / 2, f32(f16_1));
         check("convert<float32x32_t,int16x32_t>", vector_width / 2, f32(i16_1));
         check("convert<float32x32_t,uint16x32_t>", vector_width / 2, f32(u16_1));
         check("convert<uint32x32_t,uint16x32_t>", vector_width / 2, u32(u16_1));
         check("convert<int32x32_t,uint16x32_t>", vector_width / 2, i32(u16_1));
         check("convert<int32x32_t,int16x32_t>", vector_width / 2, i32(i16_1));
+        check("convert<uint16x64_t,uint8x64_t>", vector_width, u16(u8_1));
         check("store_narrowing<int32x16_t,int16_t,16>", vector_width / 4, i16(i32_1));
         check("store_narrowing<uint32x16_t,uint16_t,16>", vector_width / 4, u16(u32_1));
         check("store_narrowing<int16x32_t,int8_t,32>", vector_width / 2, i8(i16_1));
@@ -201,6 +203,10 @@ int main(int argc, char **argv) {
     if (!success) {
         return 1;
     }
+
+    // Compile a runtime for this target, for use in the static test.
+    // This is going to be used with cstubs library, so it's fine to compile runtime for the host target.
+    compile_standalone_runtime(test_xtensa.output_directory + "simd_op_check_runtime.o", get_host_target());
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/simd_op_check_xtensa.cpp
+++ b/test/correctness/simd_op_check_xtensa.cpp
@@ -112,6 +112,7 @@ public:
         // a bit of a band-aid here; a better solution would probably be
         // to allow arbitrary names that don't match, but for now, this will do.)
         // TODO(vksnk): float16 doesnt't seem to be supported well by cstubs library.
+        // https://github.com/halide/Halide/issues/7858
         // check("convert<float16x32_t,float32x32_t>", vector_width / 2, f16(f32_1));
         // check("convert<float32x32_t,float16x32_t>", vector_width / 2, f32(f16_1));
         check("convert<float32x32_t,int16x32_t>", vector_width / 2, f32(i16_1));


### PR DESCRIPTION
This PR adds some testing for Xtensa target and requires a cstub library which can be obtained from the vendor.

Only tests/generator are supported, because Xtensa codegen is based on C++ codegen and doesn't support JIT execution. There are a few tests which fail and excluded right now, so need to be fixed later, but I don't think any of them are really critical.

To run the tests:
```
make test_aotcpp_xtensa_generator
```
In addition, apps/simd_op_check will compile and verify correctness of operations listed in test/correctness/simd_op_check_xtensa (which in turn will verify that specific intrinsic was generated for corresponding pattern).

To run the app:
```
make clean && make xtensa -j 12 && ./bin/driver-xtensa
```

Finally, this is only added for Make build, I will repeat the exercise for CMake in a follow-up.