### PR TITLE
Respect input buffer constraints in root-level bounds inference exprs

### DIFF
--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -254,6 +254,7 @@ tests(GROUPS correctness
       reorder_storage.cpp
       require.cpp
       reschedule.cpp
+      respect_input_constraint_in_bounds_inference.cpp
       reuse_stack_alloc.cpp
       round.cpp
       saturating_casts.cpp

--- a/test/correctness/respect_input_constraint_in_bounds_inference.cpp
+++ b/test/correctness/respect_input_constraint_in_bounds_inference.cpp
@@ -1,0 +1,23 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    ImageParam im(Float(32), 1);
+    Func f, g;
+    Var x;
+
+    f(x) = x;
+    g(x) = f(x % im.dim(0).extent());
+    im.dim(0).set_extent(16);
+
+    // Given the constraint, we know the bounds of f should be less than 16, so
+    // the compiler should be happy placing it in a register. This is just a way
+    // to assert that the size of the allocation has been statically determined.
+    f.compute_root().store_in(MemoryType::Register);
+
+    g.compile_jit();
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #7761 