### PR TITLE
Consider all dimensions before deciding to slide over a new dimension

### DIFF
--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -300,12 +300,13 @@ Stmt Simplify::visit(const Store *op) {
     ExprInfo index_info;
     Expr index = mutate(op->index, &index_info);
 
-    // If the store is fully out of bounds, drop it.
+    // If the store is fully unconditional and out of bounds, drop it.
     // This should only occur inside branches that make the store unreachable,
     // but perhaps the branch was hard to prove constant true or false. This
     // provides an alternative mechanism to simplify these unreachable stores.
     string alloc_extent_name = op->name + ".total_extent_bytes";
-    if (bounds_and_alignment_info.contains(alloc_extent_name)) {
+    if (is_const_one(op->predicate) &&
+        bounds_and_alignment_info.contains(alloc_extent_name)) {
         if (index_info.max_defined && index_info.max < 0) {
             in_unreachable = true;
             return Evaluate::make(unreachable());

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -266,10 +266,6 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
             string prefix = func.name() + ".s" + std::to_string(func.updates().size()) + ".";
             const std::vector<string> func_args = func.args();
             for (int i = 0; i < func.dimensions(); i++) {
-                if (slid_dimensions.count(i)) {
-                    debug(3) << "Already slid over dimension " << i << ", so skipping it.\n";
-                    continue;
-                }
                 // Look up the region required of this function's last stage
                 string var = prefix + func_args[i];
                 internal_assert(scope.contains(var + ".min") && scope.contains(var + ".max"));
@@ -304,6 +300,12 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
                 }
             }
 
+            if (!dim.empty() && slid_dimensions.count(dim_idx)) {
+                debug(1) << "Already slid over dimension " << dim_idx << ", so skipping it.\n";
+                dim = "";
+                min_required = Expr();
+                max_required = Expr();
+            }
             if (!min_required.defined()) {
                 debug(3) << "Could not perform sliding window optimization of "
                          << func.name() << " over " << loop_var << " because multiple "

--- a/test/correctness/fuzz_schedule.cpp
+++ b/test/correctness/fuzz_schedule.cpp
@@ -74,6 +74,28 @@ int main(int argc, char **argv) {
         check_blur_output(buf, correct);
     }
 
+    // https://github.com/halide/Halide/issues/7872
+    {
+        Func input("input");
+        Func local_sum("local_sum");
+        Func blurry("blurry");
+        Var x("x"), y("y");
+        RVar yryf;
+        input(x, y) = 2 * x + 5 * y;
+        RDom r(-2, 5, -2, 5, "rdom_r");
+        local_sum(x, y) = 0;
+        local_sum(x, y) += input(x + r.x, y + r.y);
+        blurry(x, y) = cast<int32_t>(local_sum(x, y) / 25);
+        Var xo, xi;
+        blurry.split(x, xo, xi, 2, TailStrategy::GuardWithIf);
+        local_sum.store_at(blurry, y).compute_at(blurry, xi);
+        // local_sum.store_root();
+        blurry.bound(y, 0, 1);
+        Pipeline p({blurry});
+        Buffer<int> buf = p.realize({4, 1});
+        check_blur_output(buf, correct);
+    }
+
     printf("Success!\n");
 
     return 0;


### PR DESCRIPTION
Even ones we've already slid over. The previous version of this code
could try to slide over a loop where multiple dimensions depend on the
loop var, because it ignored dimensions that had already been slid over.
Moving a check resolves the issue.

Fixes #7872