### PR TITLE
Static analysis (MSVC) fixes for device_buffer_utils.h

### DIFF
--- a/src/runtime/device_buffer_utils.h
+++ b/src/runtime/device_buffer_utils.h
@@ -93,7 +93,7 @@ WEAK device_copy make_buffer_copy(const halide_buffer_t *src, bool src_host,
     // Offset the src base pointer to the right point in its buffer.
     c.src_begin = 0;
     for (int i = 0; i < src->dimensions; i++) {
-        c.src_begin += (uint64_t)src->dim[i].stride * (uint64_t)(dst->dim[i].min - src->dim[i].min);
+        c.src_begin += (int64_t)src->dim[i].stride * (int64_t)(dst->dim[i].min - src->dim[i].min);
     }
     c.src_begin *= c.chunk_size;
 

--- a/src/runtime/device_buffer_utils.h
+++ b/src/runtime/device_buffer_utils.h
@@ -45,6 +45,10 @@ struct device_copy {
 };
 
 WEAK void copy_memory_helper(const device_copy &copy, int d, int64_t src_off, int64_t dst_off) {
+    if ((d < -1) || (d >= MAX_COPY_DIMS)) {
+        return; // TODO(marcos): we should probably flag an error somehow here
+    }
+
     // Skip size-1 dimensions
     while (d >= 0 && copy.extent[d] == 1) {
         d--;
@@ -89,7 +93,7 @@ WEAK device_copy make_buffer_copy(const halide_buffer_t *src, bool src_host,
     // Offset the src base pointer to the right point in its buffer.
     c.src_begin = 0;
     for (int i = 0; i < src->dimensions; i++) {
-        c.src_begin += (uint64_t)src->dim[i].stride * (dst->dim[i].min - src->dim[i].min);
+        c.src_begin += (uint64_t)src->dim[i].stride * (uint64_t)(dst->dim[i].min - src->dim[i].min);
     }
     c.src_begin *= c.chunk_size;
 
@@ -173,7 +177,7 @@ WEAK device_copy make_device_to_host_copy(const halide_buffer_t *buf) {
 ALWAYS_INLINE int64_t calc_device_crop_byte_offset(const struct halide_buffer_t *src, struct halide_buffer_t *dst) {
     int64_t offset = 0;
     for (int i = 0; i < src->dimensions; i++) {
-        offset += (dst->dim[i].min - src->dim[i].min) * (int64_t)src->dim[i].stride;
+        offset += (int64_t)(dst->dim[i].min - src->dim[i].min) * (int64_t)src->dim[i].stride;
     }
     offset *= src->type.bytes();
     return offset;
@@ -182,7 +186,7 @@ ALWAYS_INLINE int64_t calc_device_crop_byte_offset(const struct halide_buffer_t 
 // Caller is expected to verify that src->dimensions == dst->dimensions + 1,
 // and that slice_dim and slice_pos are valid within src
 ALWAYS_INLINE int64_t calc_device_slice_byte_offset(const struct halide_buffer_t *src, int slice_dim, int slice_pos) {
-    int64_t offset = (slice_pos - src->dim[slice_dim].min) * (int64_t)src->dim[slice_dim].stride;
+    int64_t offset = (int64_t)(slice_pos - src->dim[slice_dim].min) * (int64_t)src->dim[slice_dim].stride;
     offset *= src->type.bytes();
     return offset;
 }

--- a/src/runtime/device_buffer_utils.h
+++ b/src/runtime/device_buffer_utils.h
@@ -46,7 +46,7 @@ struct device_copy {
 
 WEAK void copy_memory_helper(const device_copy &copy, int d, int64_t src_off, int64_t dst_off) {
     if ((d < -1) || (d >= MAX_COPY_DIMS)) {
-        return; // TODO(marcos): we should probably flag an error somehow here
+        return;  // TODO(marcos): we should probably flag an error somehow here
     }
 
     // Skip size-1 dimensions


### PR DESCRIPTION
Preventing things like:
```
Warning	C26451	Arithmetic overflow: Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2).
```