### PR TITLE
Fix read-after-write hazard analysis in storage folding

### DIFF
--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -759,16 +759,16 @@ class Interleaver : public IRMutator {
         Expr predicate = Shuffle::make_interleave(predicates);
         Stmt new_store = Store::make(store->name, value, index, store->param, predicate, ModulusRemainder());
 
-        // Continue recursively into the stuff that
-        // collect_strided_stores didn't collect.
-        Stmt stmt = Block::make(new_store, mutate(rest));
-
         // Rewrap the let statements we pulled off.
         while (!let_stmts.empty()) {
             const LetStmt *let = let_stmts.back().as<LetStmt>();
-            stmt = LetStmt::make(let->name, let->value, stmt);
+            new_store = LetStmt::make(let->name, let->value, new_store);
             let_stmts.pop_back();
         }
+
+        // Continue recursively into the stuff that
+        // collect_strided_stores didn't collect.
+        Stmt stmt = Block::make(new_store, mutate(rest));
 
         // Success!
         return stmt;

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -669,6 +669,7 @@ const char *const intrinsic_op_names[] = {
     "shift_right",
     "signed_integer_overflow",
     "size_of_halide_buffer_t",
+    "sliding_window_marker",
     "sorted_avg",
     "strict_float",
     "stringify",

--- a/src/IR.h
+++ b/src/IR.h
@@ -593,6 +593,15 @@ struct Call : public ExprNode<Call> {
         signed_integer_overflow,
         size_of_halide_buffer_t,
 
+        // Takes a realization name and a loop variable. Declares that values of
+        // the realization that were stored on earlier loop iterations of the
+        // given loop are potentially loaded in this loop iteration somewhere
+        // after this point. Must occur inside a Realize node and For node of
+        // the given names but outside any corresponding ProducerConsumer
+        // nodes. Communicates to storage folding that sliding window took
+        // place.
+        sliding_window_marker,
+
         // Compute (arg[0] + arg[1]) / 2, assuming arg[0] < arg[1].
         sorted_avg,
         strict_float,

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -810,7 +810,9 @@ class SlidingWindow : public IRMutator {
                 }
             }
 
-            SlidingWindowOnFunctionAndLoop slider(func, name, prev_loop_min, slid_dimensions[func.name()]);
+            set<int> &slid_dims = slid_dimensions[func.name()];
+            size_t old_slid_dims_size = slid_dims.size();
+            SlidingWindowOnFunctionAndLoop slider(func, name, prev_loop_min, slid_dims);
             body = slider.mutate(body);
 
             if (func.schedule().memory_type() == MemoryType::Register &&
@@ -849,6 +851,15 @@ class SlidingWindow : public IRMutator {
                 new_lets.emplace_front(name + ".loop_min", new_loop_min);
                 new_lets.emplace_front(name + ".loop_min.orig", loop_min);
                 new_lets.emplace_front(name + ".loop_extent", (loop_max - loop_min) + 1);
+            }
+
+            if (slid_dims.size() > old_slid_dims_size) {
+                // Let storage folding know there's now a read-after-write hazard here
+                Expr marker = Call::make(Int(32),
+                                         Call::sliding_window_marker,
+                                         {func.name(), Variable::make(Int(32), op->name)},
+                                         Call::Intrinsic);
+                body = Block::make(Evaluate::make(marker), body);
             }
         }
 

--- a/test/correctness/fuzz_schedule.cpp
+++ b/test/correctness/fuzz_schedule.cpp
@@ -137,7 +137,29 @@ int main(int argc, char **argv) {
         check_blur_output(buf, correct);
     }
 
-    printf("Success!\n");
 
+    // https://github.com/halide/Halide/issues/7909
+    {
+        Func input("input");
+        Func local_sum("local_sum");
+        Func blurry("blurry");
+        Var x("x"), y("y");
+        input(x, y) = 2 * x + 5 * y;
+        RDom r(-2, 5, -2, 5);
+        local_sum(x, y) = 0;
+        local_sum(x, y) += input(x + r.x, y + r.y);
+        blurry(x, y) = cast<int32_t>(local_sum(x, y) / 25);
+        Var yo, yi;
+        blurry.split(y, yo, yi, 1, TailStrategy::Auto);
+        local_sum.compute_at(blurry, yo);
+        local_sum.store_root();
+        input.compute_at(local_sum, x);
+        input.store_root();
+        Pipeline p({blurry});
+        Buffer<int> buf = p.realize({32, 32});
+        check_blur_output(buf, correct);
+    }
+
+    printf("Success!\n");
     return 0;
 }

--- a/test/correctness/fuzz_schedule.cpp
+++ b/test/correctness/fuzz_schedule.cpp
@@ -89,10 +89,8 @@ int main(int argc, char **argv) {
         Var xo, xi;
         blurry.split(x, xo, xi, 2, TailStrategy::GuardWithIf);
         local_sum.store_at(blurry, y).compute_at(blurry, xi);
-        // local_sum.store_root();
-        blurry.bound(y, 0, 1);
         Pipeline p({blurry});
-        Buffer<int> buf = p.realize({4, 1});
+        Buffer<int> buf = p.realize({32, 32});
         check_blur_output(buf, correct);
     }
 
@@ -116,6 +114,27 @@ int main(int argc, char **argv) {
         local_sum.update(0).unscheduled();
         Pipeline p({blurry});
         Buffer<int> buf = p.realize({32, 32});
+        check_blur_output(buf, correct);
+    }
+
+    // https://github.com/halide/Halide/issues/7906
+    {
+        Func input("input");
+        Func local_sum("local_sum");
+        Func blurry("blurry");
+        Var x("x"), y("y");
+        input(x, y) = 2 * x + 5 * y;
+        RDom r(-2, 5, -2, 5);
+        local_sum(x, y) = 0;
+        local_sum(x, y) += input(x + r.x, y + r.y);
+        blurry(x, y) = cast<int32_t>(local_sum(x, y) / 25);
+        Var yo, yi, x_yo_f;
+        input.vectorize(y).split(y, yo, yi, 2, TailStrategy::ShiftInwards).unroll(x).fuse(x, yo, x_yo_f);
+        blurry.compute_root();
+        input.compute_at(blurry, x);
+        Pipeline p({blurry});
+        Buffer<int> buf = p.realize({32, 32});
+        check_blur_output(buf, correct);
     }
 
     printf("Success!\n");


### PR DESCRIPTION
Explicitly mark which loops get loop-carry-dependencies inserted by
sliding window to assist storage folding.

Storage folding needs to know about this so it doesn't try to fold in a
way that invalidates these read-after-write dependencies. It currently
tries to prove the absence of hazards with box_contains(box_provided,
box_required), but this is sometimes incorrect because box_provided
could be conservatively large, and the code it analyses might not
actually provide (store to) all the required (loaded from) values.

It's simpler for sliding window to just tell storage folding when it
inserts loop-carry-dependencies, and this is most simply done directly
in the IR itself.

Fixes #7909

Built on #7908 to avoid a merge conflict in the fuzz_schedule.cpp test