### PR TITLE
Loop Partitioning Policy through Stage::partition(VarOrRVar, LoopPartitionPolicy)

### DIFF
--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -35,7 +35,7 @@ protected:
         if (is_no_op(body)) {
             return body;
         } else {
-            return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+            return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
         }
     }
 

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -3720,7 +3720,7 @@ void bounds_test() {
     Buffer<int32_t> in(10);
     in.set_name("input");
 
-    Stmt loop = For::make("x", 3, 10, ForType::Serial, DeviceAPI::Host,
+    Stmt loop = For::make("x", 3, 10, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::Host,
                           Provide::make("output",
                                         {Add::make(Call::make(in, input_site_1),
                                                    Call::make(in, input_site_2))},

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -3720,7 +3720,7 @@ void bounds_test() {
     Buffer<int32_t> in(10);
     in.set_name("input");
 
-    Stmt loop = For::make("x", 3, 10, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::Host,
+    Stmt loop = For::make("x", 3, 10, ForType::Serial, Partition::Auto, DeviceAPI::Host,
                           Provide::make("output",
                                         {Add::make(Call::make(in, input_site_1),
                                                    Call::make(in, input_site_2))},

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -1318,7 +1318,7 @@ public:
             }
         }
 
-        return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+        return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
     }
 
     Scope<> let_vars_in_scope;
@@ -1389,7 +1389,7 @@ Stmt bounds_inference(Stmt s,
     s = Block::make(Evaluate::make(marker), s);
 
     // Add a synthetic outermost loop to act as 'root'.
-    s = For::make("<outermost>", 0, 1, ForType::Serial, DeviceAPI::None, s);
+    s = For::make("<outermost>", 0, 1, ForType::Serial, LoopPartitionPolicy::Never, DeviceAPI::None, s);
 
     s = BoundsInference(funcs, fused_func_groups, fused_pairs_in_groups,
                         outputs, func_bounds, target)

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -1389,7 +1389,7 @@ Stmt bounds_inference(Stmt s,
     s = Block::make(Evaluate::make(marker), s);
 
     // Add a synthetic outermost loop to act as 'root'.
-    s = For::make("<outermost>", 0, 1, ForType::Serial, LoopPartitionPolicy::Never, DeviceAPI::None, s);
+    s = For::make("<outermost>", 0, 1, ForType::Serial, Partition::Never, DeviceAPI::None, s);
 
     s = BoundsInference(funcs, fused_func_groups, fused_pairs_in_groups,
                         outputs, func_bounds, target)

--- a/src/CanonicalizeGPUVars.cpp
+++ b/src/CanonicalizeGPUVars.cpp
@@ -143,7 +143,7 @@ class CanonicalizeGPUVars : public IRMutator {
             body.same_as(op->body)) {
             return op;
         } else {
-            return For::make(name, min, extent, op->for_type, op->device_api, body);
+            return For::make(name, min, extent, op->for_type, op->partition_policy, op->device_api, body);
         }
     }
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -362,7 +362,7 @@ private:
                 body = acquire_hvx_context(body, target);
                 body = substitute("uses_hvx", true, body);
                 Stmt new_for = For::make(op->name, op->min, op->extent, op->for_type,
-                                         op->device_api, body);
+                                         op->partition_policy, op->device_api, body);
                 Stmt prolog =
                     IfThenElse::make(uses_hvx_var, call_halide_qurt_hvx_unlock());
                 Stmt epilog =
@@ -407,7 +407,7 @@ private:
                 //   halide_qurt_unlock
                 // }
                 s = For::make(op->name, op->min, op->extent, op->for_type,
-                              op->device_api, body);
+                              op->partition_policy, op->device_api, body);
             }
 
             uses_hvx = old_uses_hvx;

--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -71,7 +71,7 @@ private:
 
     DeviceAPI deserialize_device_api(Serialize::DeviceAPI device_api);
 
-    LoopPartitionPolicy deserialize_loop_partition_policy(Serialize::LoopPartitionPolicy loop_partition_policy);
+    Partition deserialize_partition(Serialize::Partition partition);
 
     Call::CallType deserialize_call_type(Serialize::CallType call_type);
 
@@ -203,17 +203,17 @@ ForType Deserializer::deserialize_for_type(Serialize::ForType for_type) {
     }
 }
 
-LoopPartitionPolicy Deserializer::deserialize_loop_partition_policy(Serialize::LoopPartitionPolicy loop_partition_policy) {
-    switch (loop_partition_policy) {
-    case Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Auto:
-        return Halide::LoopPartitionPolicy::Auto;
-    case Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Never:
-        return Halide::LoopPartitionPolicy::Never;
-    case Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Always:
-        return Halide::LoopPartitionPolicy::Always;
+Partition Deserializer::deserialize_partition(Serialize::Partition partition) {
+    switch (partition) {
+    case Serialize::Partition::Partition_Auto:
+        return Halide::Partition::Auto;
+    case Serialize::Partition::Partition_Never:
+        return Halide::Partition::Never;
+    case Serialize::Partition::Partition_Always:
+        return Halide::Partition::Always;
     default:
-        user_error << "unknown loop partition policy " << loop_partition_policy << "\n";
-        return Halide::LoopPartitionPolicy::Auto;
+        user_error << "unknown loop partition policy " << partition << "\n";
+        return Halide::Partition::Auto;
     }
 }
 
@@ -521,10 +521,10 @@ Stmt Deserializer::deserialize_stmt(Serialize::Stmt type_code, const void *stmt)
         const auto min = deserialize_expr(for_stmt->min_type(), for_stmt->min());
         const auto extent = deserialize_expr(for_stmt->extent_type(), for_stmt->extent());
         const ForType for_type = deserialize_for_type(for_stmt->for_type());
-        const LoopPartitionPolicy loop_partition_policy = deserialize_loop_partition_policy(for_stmt->loop_partition_policy());
+        const Partition partition_policy = deserialize_partition(for_stmt->partition_policy());
         const DeviceAPI device_api = deserialize_device_api(for_stmt->device_api());
         const auto body = deserialize_stmt(for_stmt->body_type(), for_stmt->body());
-        return For::make(name, min, extent, for_type, loop_partition_policy, device_api, body);
+        return For::make(name, min, extent, for_type, partition_policy, device_api, body);
     }
     case Serialize::Stmt_Store: {
         const auto *store_stmt = (const Serialize::Store *)stmt;

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -941,7 +941,7 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
         const auto &iter = std::find_if(dims.begin(), dims.end(),
                                         [&v](const Dim &dim) { return var_name_match(dim.var, v.name()); });
         if (iter == dims.end()) {
-            Dim d = {v.name(), ForType::Serial, DeviceAPI::None, DimType::PureVar};
+            Dim d = {v.name(), ForType::Serial, DeviceAPI::None, DimType::PureVar, LoopPartitionPolicy::Auto};
             dims.insert(dims.end() - 1, d);
         }
     }
@@ -1631,6 +1631,24 @@ Stage &Stage::unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail
     return *this;
 }
 
+Stage &Stage::partition(const VarOrRVar &var, LoopPartitionPolicy policy) {
+    definition.schedule().touched() = true;
+    bool found = false;
+    vector<Dim> &dims = definition.schedule().dims();
+    for (auto &dim : dims) {
+        if (var_name_match(dim.var, var.name())) {
+            found = true;
+            dim.loop_partition_policy = policy;
+        }
+    }
+    user_assert(found)
+        << "In schedule for " << name()
+        << ", could not find var " << var.name()
+        << " to set as loop partition policy.\n"
+        << dump_argument_list();
+    return *this;
+}
+
 Stage &Stage::tile(const VarOrRVar &x, const VarOrRVar &y,
                    const VarOrRVar &xo, const VarOrRVar &yo,
                    const VarOrRVar &xi, const VarOrRVar &yi,
@@ -2315,6 +2333,12 @@ Func &Func::vectorize(const VarOrRVar &var, const Expr &factor, TailStrategy tai
 Func &Func::unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail) {
     invalidate_cache();
     Stage(func, func.definition(), 0).unroll(var, factor, tail);
+    return *this;
+}
+
+Func &Func::partition(const VarOrRVar &var, LoopPartitionPolicy policy) {
+    invalidate_cache();
+    Stage(func, func.definition(), 0).partition(var, policy);
     return *this;
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -941,7 +941,7 @@ Func Stage::rfactor(vector<pair<RVar, Var>> preserved) {
         const auto &iter = std::find_if(dims.begin(), dims.end(),
                                         [&v](const Dim &dim) { return var_name_match(dim.var, v.name()); });
         if (iter == dims.end()) {
-            Dim d = {v.name(), ForType::Serial, DeviceAPI::None, DimType::PureVar, LoopPartitionPolicy::Auto};
+            Dim d = {v.name(), ForType::Serial, DeviceAPI::None, DimType::PureVar, Partition::Auto};
             dims.insert(dims.end() - 1, d);
         }
     }
@@ -1631,20 +1631,20 @@ Stage &Stage::unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail
     return *this;
 }
 
-Stage &Stage::partition(const VarOrRVar &var, LoopPartitionPolicy policy) {
+Stage &Stage::partition(const VarOrRVar &var, Partition policy) {
     definition.schedule().touched() = true;
     bool found = false;
     vector<Dim> &dims = definition.schedule().dims();
     for (auto &dim : dims) {
         if (var_name_match(dim.var, var.name())) {
             found = true;
-            dim.loop_partition_policy = policy;
+            dim.partition_policy = policy;
         }
     }
     user_assert(found)
         << "In schedule for " << name()
         << ", could not find var " << var.name()
-        << " to set as loop partition policy.\n"
+        << " to set loop partition policy.\n"
         << dump_argument_list();
     return *this;
 }
@@ -2336,7 +2336,7 @@ Func &Func::unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail) 
     return *this;
 }
 
-Func &Func::partition(const VarOrRVar &var, LoopPartitionPolicy policy) {
+Func &Func::partition(const VarOrRVar &var, Partition policy) {
     invalidate_cache();
     Stage(func, func.definition(), 0).partition(var, policy);
     return *this;

--- a/src/Func.h
+++ b/src/Func.h
@@ -348,7 +348,7 @@ public:
     Stage &parallel(const VarOrRVar &var, const Expr &task_size, TailStrategy tail = TailStrategy::Auto);
     Stage &vectorize(const VarOrRVar &var, const Expr &factor, TailStrategy tail = TailStrategy::Auto);
     Stage &unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail = TailStrategy::Auto);
-    Stage &partition(const VarOrRVar &var, LoopPartitionPolicy partition_policy);
+    Stage &partition(const VarOrRVar &var, Partition partition_policy);
     Stage &tile(const VarOrRVar &x, const VarOrRVar &y,
                 const VarOrRVar &xo, const VarOrRVar &yo,
                 const VarOrRVar &xi, const VarOrRVar &yi, const Expr &xfactor, const Expr &yfactor,
@@ -1448,7 +1448,7 @@ public:
      * splits a for loop into three for loops: a prologue, a steady-state,
      * and an epilogue.
      * The default policy is Auto. */
-    Func &partition(const VarOrRVar &var, LoopPartitionPolicy partition_policy);
+    Func &partition(const VarOrRVar &var, Partition partition_policy);
 
     /** Statically declare that the range over which a function should
      * be evaluated is given by the second and third arguments. This

--- a/src/Func.h
+++ b/src/Func.h
@@ -348,6 +348,7 @@ public:
     Stage &parallel(const VarOrRVar &var, const Expr &task_size, TailStrategy tail = TailStrategy::Auto);
     Stage &vectorize(const VarOrRVar &var, const Expr &factor, TailStrategy tail = TailStrategy::Auto);
     Stage &unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail = TailStrategy::Auto);
+    Stage &partition(const VarOrRVar &var, LoopPartitionPolicy partition_policy);
     Stage &tile(const VarOrRVar &x, const VarOrRVar &y,
                 const VarOrRVar &xo, const VarOrRVar &yo,
                 const VarOrRVar &xi, const VarOrRVar &yi, const Expr &xfactor, const Expr &yfactor,
@@ -1441,6 +1442,13 @@ public:
      * some constant factor. After this call, var refers to the outer
      * dimension of the split. 'factor' must be an integer. */
     Func &unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail = TailStrategy::Auto);
+
+    /** Set the loop partition policy. Loop partitioning can be useful to
+     * optimize boundary conditions (such as clamp_edge). Loop partitioning
+     * splits a for loop into three for loops: a prologue, a steady-state,
+     * and an epilogue.
+     * The default policy is Auto. */
+    Func &partition(const VarOrRVar &var, LoopPartitionPolicy partition_policy);
 
     /** Statically declare that the range over which a function should
      * be evaluated is given by the second and third arguments. This

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -143,7 +143,7 @@ class NormalizeDimensionality : public IRMutator {
         }
         while (max_depth < block_size.threads_dimensions()) {
             string name = thread_names[max_depth];
-            s = For::make("." + name, 0, 1, ForType::GPUThread, LoopPartitionPolicy::Never, device_api, s);
+            s = For::make("." + name, 0, 1, ForType::GPUThread, Partition::Never, device_api, s);
             max_depth++;
         }
         return s;
@@ -398,7 +398,7 @@ private:
             Expr v = Variable::make(Int(32), loop_name);
             host_side_preamble = substitute(op->name, v, host_side_preamble);
             host_side_preamble = For::make(loop_name, new_min, new_extent,
-                                           ForType::Serial, LoopPartitionPolicy::Never, DeviceAPI::None, host_side_preamble);
+                                           ForType::Serial, Partition::Never, DeviceAPI::None, host_side_preamble);
             if (old_preamble.defined()) {
                 host_side_preamble = Block::make(old_preamble, host_side_preamble);
             }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -143,7 +143,7 @@ class NormalizeDimensionality : public IRMutator {
         }
         while (max_depth < block_size.threads_dimensions()) {
             string name = thread_names[max_depth];
-            s = For::make("." + name, 0, 1, ForType::GPUThread, device_api, s);
+            s = For::make("." + name, 0, 1, ForType::GPUThread, LoopPartitionPolicy::Never, device_api, s);
             max_depth++;
         }
         return s;
@@ -398,7 +398,7 @@ private:
             Expr v = Variable::make(Int(32), loop_name);
             host_side_preamble = substitute(op->name, v, host_side_preamble);
             host_side_preamble = For::make(loop_name, new_min, new_extent,
-                                           ForType::Serial, DeviceAPI::None, host_side_preamble);
+                                           ForType::Serial, LoopPartitionPolicy::Never, DeviceAPI::None, host_side_preamble);
             if (old_preamble.defined()) {
                 host_side_preamble = Block::make(old_preamble, host_side_preamble);
             }
@@ -407,7 +407,8 @@ private:
         }
 
         return For::make(op->name, new_min, new_extent,
-                         op->for_type, op->device_api, body);
+                         op->for_type, op->partition_policy,
+                         op->device_api, body);
     }
 
     Stmt visit(const Block *op) override {
@@ -1101,7 +1102,7 @@ class ExtractRegisterAllocations : public IRMutator {
                 allocations.swap(old);
             }
 
-            return For::make(op->name, mutate(op->min), mutate(op->extent), op->for_type, op->device_api, body);
+            return For::make(op->name, mutate(op->min), mutate(op->extent), op->for_type, op->partition_policy, op->device_api, body);
         }
     }
 
@@ -1262,7 +1263,7 @@ class InjectThreadBarriers : public IRMutator {
                 body = Block::make(body, make_barrier(0));
             }
             return For::make(op->name, op->min, op->extent,
-                             op->for_type, op->device_api, body);
+                             op->for_type, op->partition_policy, op->device_api, body);
         } else {
             return IRMutator::visit(op);
         }
@@ -1413,14 +1414,14 @@ class FuseGPUThreadLoopsSingleKernel : public IRMutator {
             string thread_id = "." + thread_names[0];
             // Add back in any register-level allocations
             body = register_allocs.rewrap(body, thread_id);
-            body = For::make(thread_id, 0, block_size_x, innermost_loop_type, op->device_api, body);
+            body = For::make(thread_id, 0, block_size_x, innermost_loop_type, op->partition_policy, op->device_api, body);
 
             // Rewrap the whole thing in other loops over threads
             for (int i = 1; i < block_size.threads_dimensions(); i++) {
                 thread_id = "." + thread_names[i];
                 body = register_allocs.rewrap(body, thread_id);
                 body = For::make("." + thread_names[i], 0, block_size.num_threads(i),
-                                 ForType::GPUThread, op->device_api, body);
+                                 ForType::GPUThread, op->partition_policy, op->device_api, body);
             }
             thread_id.clear();
             body = register_allocs.rewrap(body, thread_id);
@@ -1436,7 +1437,7 @@ class FuseGPUThreadLoopsSingleKernel : public IRMutator {
             if (body.same_as(op->body)) {
                 return op;
             } else {
-                return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+                return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
             }
         } else {
             return IRMutator::visit(op);
@@ -1505,7 +1506,7 @@ class ZeroGPULoopMins : public IRMutator {
             internal_assert(op);
             Expr adjusted = Variable::make(Int(32), op->name) + op->min;
             Stmt body = substitute(op->name, adjusted, op->body);
-            stmt = For::make(op->name, 0, op->extent, op->for_type, op->device_api, body);
+            stmt = For::make(op->name, 0, op->extent, op->for_type, op->partition_policy, op->device_api, body);
         }
         return stmt;
     }
@@ -1587,7 +1588,7 @@ class AddConditionToALoop : public IRMutator {
             return IRMutator::visit(op);
         }
 
-        return For::make(op->name, op->min, op->extent, op->for_type, op->device_api,
+        return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api,
                          IfThenElse::make(condition, op->body, Stmt()));
     }
 

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -743,7 +743,7 @@ class InjectHexagonRpc : public IRMutator {
         if (is_const_one(loop->extent)) {
             body = LetStmt::make(loop->name, loop->min, loop->body);
         } else {
-            body = For::make(loop->name, loop->min, loop->extent, loop->for_type,
+            body = For::make(loop->name, loop->min, loop->extent, loop->for_type, loop->partition_policy,
                              DeviceAPI::None, loop->body);
         }
 

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -344,7 +344,7 @@ Stmt ProducerConsumer::make_consume(const std::string &name, Stmt body) {
 
 Stmt For::make(const std::string &name,
                Expr min, Expr extent,
-               ForType for_type, LoopPartitionPolicy partition_policy,
+               ForType for_type, Partition partition_policy,
                DeviceAPI device_api,
                Stmt body) {
     internal_assert(min.defined()) << "For of undefined\n";

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -342,7 +342,11 @@ Stmt ProducerConsumer::make_consume(const std::string &name, Stmt body) {
     return ProducerConsumer::make(name, false, std::move(body));
 }
 
-Stmt For::make(const std::string &name, Expr min, Expr extent, ForType for_type, DeviceAPI device_api, Stmt body) {
+Stmt For::make(const std::string &name,
+               Expr min, Expr extent,
+               ForType for_type, LoopPartitionPolicy partition_policy,
+               DeviceAPI device_api,
+               Stmt body) {
     internal_assert(min.defined()) << "For of undefined\n";
     internal_assert(extent.defined()) << "For of undefined\n";
     internal_assert(min.type() == Int(32)) << "For with non-integer min\n";
@@ -354,6 +358,7 @@ Stmt For::make(const std::string &name, Expr min, Expr extent, ForType for_type,
     node->min = std::move(min);
     node->extent = std::move(extent);
     node->for_type = for_type;
+    node->partition_policy = partition_policy;
     node->device_api = device_api;
     node->body = std::move(body);
     return node;

--- a/src/IR.h
+++ b/src/IR.h
@@ -11,6 +11,7 @@
 #include "Buffer.h"
 #include "Expr.h"
 #include "FunctionPtr.h"
+#include "LoopPartitioningDirective.h"
 #include "ModulusRemainder.h"
 #include "Parameter.h"
 #include "PrefetchDirective.h"
@@ -798,8 +799,13 @@ struct For : public StmtNode<For> {
     ForType for_type;
     DeviceAPI device_api;
     Stmt body;
+    LoopPartitionPolicy partition_policy;
 
-    static Stmt make(const std::string &name, Expr min, Expr extent, ForType for_type, DeviceAPI device_api, Stmt body);
+    static Stmt make(const std::string &name,
+                     Expr min, Expr extent,
+                     ForType for_type, LoopPartitionPolicy partition_policy,
+                     DeviceAPI device_api,
+                     Stmt body);
 
     bool is_unordered_parallel() const {
         return Halide::Internal::is_unordered_parallel(for_type);

--- a/src/IR.h
+++ b/src/IR.h
@@ -799,11 +799,11 @@ struct For : public StmtNode<For> {
     ForType for_type;
     DeviceAPI device_api;
     Stmt body;
-    LoopPartitionPolicy partition_policy;
+    Partition partition_policy;
 
     static Stmt make(const std::string &name,
                      Expr min, Expr extent,
-                     ForType for_type, LoopPartitionPolicy partition_policy,
+                     ForType for_type, Partition partition_policy,
                      DeviceAPI device_api,
                      Stmt body);
 

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -210,7 +210,7 @@ Stmt IRMutator::visit(const For *op) {
         return op;
     }
     return For::make(op->name, std::move(min), std::move(extent),
-                     op->for_type, op->device_api, std::move(body));
+                     op->for_type, op->partition_policy, op->device_api, std::move(body));
 }
 
 Stmt IRMutator::visit(const Store *op) {

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -184,15 +184,15 @@ std::ostream &operator<<(std::ostream &out, const TailStrategy &t) {
     return out;
 }
 
-std::ostream &operator<<(std::ostream &out, const LoopPartitionPolicy &p) {
+std::ostream &operator<<(std::ostream &out, const Partition &p) {
     switch (p) {
-    case LoopPartitionPolicy::Auto:
+    case Partition::Auto:
         out << "Auto";
         break;
-    case LoopPartitionPolicy::Never:
+    case Partition::Never:
         out << "Never";
         break;
-    case LoopPartitionPolicy::Always:
+    case Partition::Always:
         out << "Always";
         break;
     }
@@ -221,12 +221,12 @@ void IRPrinter::test() {
     internal_assert(expr_source.str() == "((x + 3)*((y/2) + 17))");
 
     Stmt store = Store::make("buf", (x * 17) / (x - 3), y - 1, Parameter(), const_true(), ModulusRemainder());
-    Stmt for_loop = For::make("x", -2, y + 2, ForType::Parallel, LoopPartitionPolicy::Auto, DeviceAPI::Host, store);
+    Stmt for_loop = For::make("x", -2, y + 2, ForType::Parallel, Partition::Auto, DeviceAPI::Host, store);
     vector<Expr> args(1);
     args[0] = x % 3;
     Expr call = Call::make(i32, "buf", args, Call::Extern);
     Stmt store2 = Store::make("out", call + 1, x, Parameter(), const_true(), ModulusRemainder(3, 5));
-    Stmt for_loop2 = For::make("x", 0, y, ForType::Vectorized, LoopPartitionPolicy::Auto, DeviceAPI::Host, store2);
+    Stmt for_loop2 = For::make("x", 0, y, ForType::Vectorized, Partition::Auto, DeviceAPI::Host, store2);
 
     Stmt producer = ProducerConsumer::make_produce("buf", for_loop);
     Stmt consumer = ProducerConsumer::make_consume("buf", for_loop2);

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -184,6 +184,21 @@ std::ostream &operator<<(std::ostream &out, const TailStrategy &t) {
     return out;
 }
 
+std::ostream &operator<<(std::ostream &out, const LoopPartitionPolicy &p) {
+    switch (p) {
+    case LoopPartitionPolicy::Auto:
+        out << "Auto";
+        break;
+    case LoopPartitionPolicy::Never:
+        out << "Never";
+        break;
+    case LoopPartitionPolicy::Always:
+        out << "Always";
+        break;
+    }
+    return out;
+}
+
 ostream &operator<<(ostream &stream, const LoopLevel &loop_level) {
     return stream << "loop_level("
                   << (loop_level.defined() ? loop_level.to_string() : "undefined")
@@ -206,12 +221,12 @@ void IRPrinter::test() {
     internal_assert(expr_source.str() == "((x + 3)*((y/2) + 17))");
 
     Stmt store = Store::make("buf", (x * 17) / (x - 3), y - 1, Parameter(), const_true(), ModulusRemainder());
-    Stmt for_loop = For::make("x", -2, y + 2, ForType::Parallel, DeviceAPI::Host, store);
+    Stmt for_loop = For::make("x", -2, y + 2, ForType::Parallel, LoopPartitionPolicy::Auto, DeviceAPI::Host, store);
     vector<Expr> args(1);
     args[0] = x % 3;
     Expr call = Call::make(i32, "buf", args, Call::Extern);
     Stmt store2 = Store::make("out", call + 1, x, Parameter(), const_true(), ModulusRemainder(3, 5));
-    Stmt for_loop2 = For::make("x", 0, y, ForType::Vectorized, DeviceAPI::Host, store2);
+    Stmt for_loop2 = For::make("x", 0, y, ForType::Vectorized, LoopPartitionPolicy::Auto, DeviceAPI::Host, store2);
 
     Stmt producer = ProducerConsumer::make_produce("buf", for_loop);
     Stmt consumer = ProducerConsumer::make_consume("buf", for_loop2);

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -41,7 +41,10 @@ std::ostream &operator<<(std::ostream &stream, const DeviceAPI &);
 std::ostream &operator<<(std::ostream &stream, const MemoryType &);
 
 /** Emit a halide tail strategy in human-readable form */
-std::ostream &operator<<(std::ostream &stream, const TailStrategy &t);
+std::ostream &operator<<(std::ostream &stream, const TailStrategy &);
+
+/** Emit a halide loop partitioning policy in human-readable form */
+std::ostream &operator<<(std::ostream &stream, const LoopPartitionPolicy &);
 
 /** Emit a halide LoopLevel in human-readable form */
 std::ostream &operator<<(std::ostream &stream, const LoopLevel &);

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -44,7 +44,7 @@ std::ostream &operator<<(std::ostream &stream, const MemoryType &);
 std::ostream &operator<<(std::ostream &stream, const TailStrategy &);
 
 /** Emit a halide loop partitioning policy in human-readable form */
-std::ostream &operator<<(std::ostream &stream, const LoopPartitionPolicy &);
+std::ostream &operator<<(std::ostream &stream, const Partition &);
 
 /** Emit a halide LoopLevel in human-readable form */
 std::ostream &operator<<(std::ostream &stream, const LoopLevel &);

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -319,7 +319,7 @@ class LICM : public IRMutator {
             internal_assert(loop);
 
             new_stmt = For::make(loop->name, loop->min, loop->extent,
-                                 loop->for_type, loop->device_api, mutate(loop->body));
+                                 loop->for_type, loop->partition_policy, loop->device_api, mutate(loop->body));
 
             // Wrap lets for the lifted invariants
             for (size_t i = 0; i < exprs.size(); i++) {
@@ -564,7 +564,7 @@ class HoistIfStatements : public IRMutator {
                 is_pure(i->condition) &&
                 !expr_uses_var(i->condition, op->name)) {
                 Stmt s = For::make(op->name, op->min, op->extent,
-                                   op->for_type, op->device_api, i->then_case);
+                                   op->for_type, op->partition_policy, op->device_api, i->then_case);
                 return IfThenElse::make(i->condition, s);
             }
         }
@@ -572,7 +572,7 @@ class HoistIfStatements : public IRMutator {
             return op;
         } else {
             return For::make(op->name, op->min, op->extent,
-                             op->for_type, op->device_api, body);
+                             op->for_type, op->partition_policy, op->device_api, body);
         }
     }
 

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -533,7 +533,7 @@ class LoopCarry : public IRMutator {
             if (body.same_as(op->body)) {
                 stmt = op;
             } else {
-                stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+                stmt = For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
             }
 
             // Inject the scratch buffer allocations.

--- a/src/LoopPartitioningDirective.h
+++ b/src/LoopPartitioningDirective.h
@@ -1,0 +1,30 @@
+#ifndef HALIDE_LOOP_PARTITIONING_DIRECTIVE_H
+#define HALIDE_LOOP_PARTITIONING_DIRECTIVE_H
+
+/** \file
+ * Defines the LoopPartitionPolicy enum.
+ */
+
+#include <string>
+
+#include "Expr.h"
+#include "Parameter.h"
+
+namespace Halide {
+
+/** Different ways to handle loops with a potentially optimizable boundary conditions. */
+enum class LoopPartitionPolicy {
+    /** Automatically let Halide decide on Loop Parititioning. */
+    Auto,
+
+    /** Disallow loop partitioning. */
+    Never,
+
+    /** Force partitioning of the loop. If Halide can't find a way to partition this loop,
+     * it will raise an error. */
+    Always
+};
+
+}  // namespace Halide
+
+#endif  // HALIDE_LOOP_PARTITIONING_DIRECTIVE_H

--- a/src/LoopPartitioningDirective.h
+++ b/src/LoopPartitioningDirective.h
@@ -2,7 +2,7 @@
 #define HALIDE_LOOP_PARTITIONING_DIRECTIVE_H
 
 /** \file
- * Defines the LoopPartitionPolicy enum.
+ * Defines the Partition enum.
  */
 
 #include <string>
@@ -13,7 +13,7 @@
 namespace Halide {
 
 /** Different ways to handle loops with a potentially optimizable boundary conditions. */
-enum class LoopPartitionPolicy {
+enum class Partition {
     /** Automatically let Halide decide on Loop Parititioning. */
     Auto,
 

--- a/src/LowerParallelTasks.cpp
+++ b/src/LowerParallelTasks.cpp
@@ -170,7 +170,7 @@ struct LowerParallelTasks : public IRMutator {
         Expr min, extent;
         Expr serial;
         std::string name;
-        LoopPartitionPolicy partition_policy;
+        Partition partition_policy;
     };
 
     using IRMutator::visit;
@@ -374,7 +374,7 @@ struct LowerParallelTasks : public IRMutator {
             const Variable *v = acquire->semaphore.as<Variable>();
             internal_assert(v);
             add_suffix(prefix, "." + v->name);
-            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix), LoopPartitionPolicy::Never};
+            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix), Partition::Never};
             while (acquire) {
                 t.semaphores.push_back({acquire->semaphore, acquire->count});
                 t.body = acquire->body;
@@ -401,7 +401,7 @@ struct LowerParallelTasks : public IRMutator {
             result.emplace_back(std::move(t));
         } else {
             add_suffix(prefix, "." + std::to_string(result.size()));
-            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix), LoopPartitionPolicy::Never};
+            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix), Partition::Never};
             result.emplace_back(std::move(t));
         }
     }

--- a/src/LowerParallelTasks.cpp
+++ b/src/LowerParallelTasks.cpp
@@ -8,6 +8,7 @@
 #include "ExprUsesVar.h"
 #include "IRMutator.h"
 #include "IROperator.h"
+#include "LoopPartitioningDirective.h"
 #include "Module.h"
 #include "Param.h"
 #include "Simplify.h"
@@ -169,6 +170,7 @@ struct LowerParallelTasks : public IRMutator {
         Expr min, extent;
         Expr serial;
         std::string name;
+        LoopPartitionPolicy partition_policy;
     };
 
     using IRMutator::visit;
@@ -272,6 +274,7 @@ struct LowerParallelTasks : public IRMutator {
                                        Variable::make(Int(32), loop_min_name),
                                        Variable::make(Int(32), loop_extent_name),
                                        ForType::Serial,
+                                       t.partition_policy,
                                        DeviceAPI::None,
                                        t.body);
                 } else {
@@ -371,7 +374,7 @@ struct LowerParallelTasks : public IRMutator {
             const Variable *v = acquire->semaphore.as<Variable>();
             internal_assert(v);
             add_suffix(prefix, "." + v->name);
-            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix)};
+            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix), LoopPartitionPolicy::Never};
             while (acquire) {
                 t.semaphores.push_back({acquire->semaphore, acquire->count});
                 t.body = acquire->body;
@@ -380,7 +383,7 @@ struct LowerParallelTasks : public IRMutator {
             result.emplace_back(std::move(t));
         } else if (loop && loop->for_type == ForType::Parallel) {
             add_suffix(prefix, ".par_for." + loop->name);
-            ParallelTask t{loop->body, {}, loop->name, loop->min, loop->extent, const_false(), task_debug_name(prefix)};
+            ParallelTask t{loop->body, {}, loop->name, loop->min, loop->extent, const_false(), task_debug_name(prefix), loop->partition_policy};
             result.emplace_back(std::move(t));
         } else if (loop &&
                    loop->for_type == ForType::Serial &&
@@ -389,7 +392,7 @@ struct LowerParallelTasks : public IRMutator {
             const Variable *v = acquire->semaphore.as<Variable>();
             internal_assert(v);
             add_suffix(prefix, ".for." + v->name);
-            ParallelTask t{loop->body, {}, loop->name, loop->min, loop->extent, const_true(), task_debug_name(prefix)};
+            ParallelTask t{loop->body, {}, loop->name, loop->min, loop->extent, const_true(), task_debug_name(prefix), loop->partition_policy};
             while (acquire) {
                 t.semaphores.push_back({acquire->semaphore, acquire->count});
                 t.body = acquire->body;
@@ -398,7 +401,7 @@ struct LowerParallelTasks : public IRMutator {
             result.emplace_back(std::move(t));
         } else {
             add_suffix(prefix, "." + std::to_string(result.size()));
-            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix)};
+            ParallelTask t{s, {}, "", 0, 1, const_false(), task_debug_name(prefix), LoopPartitionPolicy::Never};
             result.emplace_back(std::move(t));
         }
     }

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -456,7 +456,7 @@ class LowerWarpShuffles : public IRMutator {
             allocations.clear();
 
             return For::make(op->name, op->min, warp_size,
-                             op->for_type, op->device_api, body);
+                             op->for_type, op->partition_policy, op->device_api, body);
         } else {
             return IRMutator::visit(op);
         }
@@ -731,7 +731,7 @@ class HoistWarpShufflesFromSingleIfStmt : public IRMutator {
         } else {
             debug(3) << "Successfully hoisted shuffle out of for loop\n";
         }
-        return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+        return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
     }
 
     Stmt visit(const Store *op) override {

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -519,7 +519,29 @@ class PartitionLoops : public IRMutator {
     bool in_gpu_loop = false;
 
     Stmt visit(const For *op) override {
+        // Do not partition if the schedule explicitly forbids.
+        if (op->partition_policy == LoopPartitionPolicy::Never) {
+            return op;
+        }
+
         Stmt body = op->body;
+
+        // A struct that upon destruction will check if the current For was partitioned
+        // and error out if it wasn't when the schedule demanded it.
+        struct ErrorIfNotMutated {
+            const For *op;
+            bool must_mutate;
+            bool mutated{false};
+            ErrorIfNotMutated(const For *op, bool must_mutate)
+                : op(op), must_mutate(must_mutate) {
+            }
+            ~ErrorIfNotMutated() {
+                if (must_mutate && !mutated) {
+                    user_error << "Loop Partition Policy is set to " << op->partition_policy
+                               << " for " << op->name << ", but no loop partitioning was performed.";
+                }
+            }
+        } mutation_checker{op, op->partition_policy == LoopPartitionPolicy::Always};
 
         ScopedValue<bool> old_in_gpu_loop(in_gpu_loop, in_gpu_loop ||
                                                            CodeGen_GPU_Dev::is_gpu_var(op->name));
@@ -706,17 +728,19 @@ class PartitionLoops : public IRMutator {
         // Bust simple serial for loops up into three.
         if (op->for_type == ForType::Serial && !op->body.as<Acquire>()) {
             stmt = For::make(op->name, min_steady, max_steady - min_steady,
-                             op->for_type, op->device_api, simpler_body);
+                             op->for_type, op->partition_policy, op->device_api, simpler_body);
 
             if (make_prologue) {
                 prologue = For::make(op->name, op->min, min_steady - op->min,
-                                     op->for_type, op->device_api, prologue);
+                                     op->for_type, op->partition_policy, op->device_api, prologue);
                 stmt = Block::make(prologue, stmt);
+                mutation_checker.mutated = true;
             }
             if (make_epilogue) {
                 epilogue = For::make(op->name, max_steady, op->min + op->extent - max_steady,
-                                     op->for_type, op->device_api, epilogue);
+                                     op->for_type, op->partition_policy, op->device_api, epilogue);
                 stmt = Block::make(stmt, epilogue);
+                mutation_checker.mutated = true;
             }
         } else {
             // For parallel for loops we could use a Fork node here,
@@ -735,15 +759,18 @@ class PartitionLoops : public IRMutator {
             stmt = simpler_body;
             if (make_epilogue && make_prologue && equal(prologue, epilogue)) {
                 stmt = IfThenElse::make(min_steady <= loop_var && loop_var < max_steady, stmt, prologue);
+                mutation_checker.mutated = true;
             } else {
                 if (make_epilogue) {
                     stmt = IfThenElse::make(loop_var < max_steady, stmt, epilogue);
+                    mutation_checker.mutated = true;
                 }
                 if (make_prologue) {
                     stmt = IfThenElse::make(loop_var < min_steady, prologue, stmt);
+                    mutation_checker.mutated = true;
                 }
             }
-            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, stmt);
+            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, stmt);
         }
 
         if (make_epilogue) {
@@ -866,7 +893,7 @@ class RenormalizeGPULoops : public IRMutator {
             internal_assert(!expr_uses_var(f->min, op->name) &&
                             !expr_uses_var(f->extent, op->name));
             Stmt inner = LetStmt::make(op->name, op->value, f->body);
-            inner = For::make(f->name, f->min, f->extent, f->for_type, f->device_api, inner);
+            inner = For::make(f->name, f->min, f->extent, f->for_type, f->partition_policy, f->device_api, inner);
             return mutate(inner);
         } else if (a && in_gpu_loop && !in_thread_loop) {
             internal_assert(a->extents.size() == 1);
@@ -944,7 +971,7 @@ class RenormalizeGPULoops : public IRMutator {
                    for_a->min.same_as(for_b->min) &&
                    for_a->extent.same_as(for_b->extent)) {
             Stmt inner = IfThenElse::make(op->condition, for_a->body, for_b->body);
-            inner = For::make(for_a->name, for_a->min, for_a->extent, for_a->for_type, for_a->device_api, inner);
+            inner = For::make(for_a->name, for_a->min, for_a->extent, for_a->for_type, for_a->partition_policy, for_a->device_api, inner);
             return mutate(inner);
         } else {
             internal_error << "Unexpected construct inside if statement: " << Stmt(op) << "\n";

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -520,8 +520,8 @@ class PartitionLoops : public IRMutator {
 
     Stmt visit(const For *op) override {
         // Do not partition if the schedule explicitly forbids.
-        if (op->partition_policy == LoopPartitionPolicy::Never) {
-            return op;
+        if (op->partition_policy == Partition::Never) {
+            return IRMutator::visit(op);
         }
 
         Stmt body = op->body;
@@ -541,7 +541,7 @@ class PartitionLoops : public IRMutator {
                                << " for " << op->name << ", but no loop partitioning was performed.";
                 }
             }
-        } mutation_checker{op, op->partition_policy == LoopPartitionPolicy::Always};
+        } mutation_checker{op, op->partition_policy == Partition::Always};
 
         ScopedValue<bool> old_in_gpu_loop(in_gpu_loop, in_gpu_loop ||
                                                            CodeGen_GPU_Dev::is_gpu_var(op->name));

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -303,7 +303,7 @@ class ReducePrefetchDimension : public IRMutator {
             stmt = Evaluate::make(Call::make(prefetch->type, Call::prefetch, args, Call::Intrinsic));
             for (size_t i = 0; i < index_names.size(); ++i) {
                 stmt = For::make(index_names[i], 0, prefetch->args[(i + max_dim) * 2 + 2],
-                                 ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, stmt);
+                                 ForType::Serial, Partition::Auto, DeviceAPI::None, stmt);
             }
             debug(5) << "\nReduce prefetch to " << max_dim << " dim:\n"
                      << "Before:\n"
@@ -374,7 +374,7 @@ class SplitPrefetch : public IRMutator {
             stmt = Evaluate::make(Call::make(prefetch->type, Call::prefetch, args, Call::Intrinsic));
             for (size_t i = 0; i < index_names.size(); ++i) {
                 stmt = For::make(index_names[i], 0, extents[i],
-                                 ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, stmt);
+                                 ForType::Serial, Partition::Auto, DeviceAPI::None, stmt);
             }
             debug(5) << "\nSplit prefetch to max of " << max_byte_size << " bytes:\n"
                      << "Before:\n"

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -248,7 +248,7 @@ private:
 
         Stmt stmt;
         if (!body.same_as(op->body)) {
-            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, std::move(body));
+            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, std::move(body));
         } else {
             stmt = op;
         }
@@ -303,7 +303,7 @@ class ReducePrefetchDimension : public IRMutator {
             stmt = Evaluate::make(Call::make(prefetch->type, Call::prefetch, args, Call::Intrinsic));
             for (size_t i = 0; i < index_names.size(); ++i) {
                 stmt = For::make(index_names[i], 0, prefetch->args[(i + max_dim) * 2 + 2],
-                                 ForType::Serial, DeviceAPI::None, stmt);
+                                 ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, stmt);
             }
             debug(5) << "\nReduce prefetch to " << max_dim << " dim:\n"
                      << "Before:\n"
@@ -374,7 +374,7 @@ class SplitPrefetch : public IRMutator {
             stmt = Evaluate::make(Call::make(prefetch->type, Call::prefetch, args, Call::Intrinsic));
             for (size_t i = 0; i < index_names.size(); ++i) {
                 stmt = For::make(index_names[i], 0, extents[i],
-                                 ForType::Serial, DeviceAPI::None, stmt);
+                                 ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, stmt);
             }
             debug(5) << "\nSplit prefetch to max of " << max_byte_size << " bytes:\n"
                      << "Before:\n"

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -396,7 +396,7 @@ private:
             most_recently_set_func = -1;
         }
 
-        Stmt stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+        Stmt stmt = For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
 
         if (update_active_threads) {
             stmt = suspend_thread(stmt, profiler_state);

--- a/src/RebaseLoopsToZero.cpp
+++ b/src/RebaseLoopsToZero.cpp
@@ -39,7 +39,7 @@ class RebaseLoopsToZero : public IRMutator {
         if (body.same_as(op->body)) {
             return op;
         } else {
-            return For::make(name, 0, op->extent, op->for_type, op->device_api, body);
+            return For::make(name, 0, op->extent, op->for_type, op->partition_policy, op->device_api, body);
         }
     }
 };

--- a/src/RemoveUndef.cpp
+++ b/src/RemoveUndef.cpp
@@ -336,7 +336,7 @@ private:
             body.same_as(op->body)) {
             return op;
         } else {
-            return For::make(op->name, min, extent, op->for_type, op->device_api, body);
+            return For::make(op->name, min, extent, op->for_type, op->partition_policy, op->device_api, body);
         }
     }
 

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -443,7 +443,7 @@ struct Dim {
     DimType dim_type;
 
     /** The strategy for loop partitioning. */
-    LoopPartitionPolicy loop_partition_policy;
+    Partition partition_policy;
 
     /** Can this loop be evaluated in any order (including in
      * parallel)? Equivalently, are there no data hazards between

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -13,6 +13,7 @@
 #include "DeviceAPI.h"
 #include "Expr.h"
 #include "FunctionPtr.h"
+#include "LoopPartitioningDirective.h"
 #include "Parameter.h"
 #include "PrefetchDirective.h"
 
@@ -440,6 +441,9 @@ struct Dim {
     /** The DimType tells us what transformations are legal on this
      * loop (see the DimType enum above). */
     DimType dim_type;
+
+    /** The strategy for loop partitioning. */
+    LoopPartitionPolicy loop_partition_policy;
 
     /** Can this loop be evaluated in any order (including in
      * parallel)? Equivalently, are there no data hazards between

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -397,7 +397,7 @@ Stmt build_loop_nest(
             const Dim &dim = stage_s.dims()[nest[i].dim_idx];
             Expr min = Variable::make(Int(32), nest[i].name + ".loop_min");
             Expr extent = Variable::make(Int(32), nest[i].name + ".loop_extent");
-            stmt = For::make(nest[i].name, min, extent, dim.for_type, dim.loop_partition_policy, dim.device_api, stmt);
+            stmt = For::make(nest[i].name, min, extent, dim.for_type, dim.partition_policy, dim.device_api, stmt);
         }
     }
 
@@ -2480,7 +2480,7 @@ Stmt schedule_functions(const vector<Function> &outputs,
                         const Target &target,
                         bool &any_memoized) {
     string root_var = LoopLevel::root().lock().to_string();
-    Stmt s = For::make(root_var, 0, 1, ForType::Serial, LoopPartitionPolicy::Never, DeviceAPI::Host, Evaluate::make(0));
+    Stmt s = For::make(root_var, 0, 1, ForType::Serial, Partition::Never, DeviceAPI::Host, Evaluate::make(0));
 
     any_memoized = false;
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -397,7 +397,7 @@ Stmt build_loop_nest(
             const Dim &dim = stage_s.dims()[nest[i].dim_idx];
             Expr min = Variable::make(Int(32), nest[i].name + ".loop_min");
             Expr extent = Variable::make(Int(32), nest[i].name + ".loop_extent");
-            stmt = For::make(nest[i].name, min, extent, dim.for_type, dim.device_api, stmt);
+            stmt = For::make(nest[i].name, min, extent, dim.for_type, dim.loop_partition_policy, dim.device_api, stmt);
         }
     }
 
@@ -966,6 +966,7 @@ private:
                              for_loop->min,
                              for_loop->extent,
                              for_loop->for_type,
+                             for_loop->partition_policy,
                              for_loop->device_api,
                              body);
         }
@@ -1065,7 +1066,7 @@ private:
 
             Stmt stmt = For::make(new_var, Variable::make(Int(32), new_var + ".loop_min"),
                                   Variable::make(Int(32), new_var + ".loop_extent"),
-                                  for_type, device_api, body);
+                                  for_type, op->partition_policy, device_api, body);
 
             // Add let stmts defining the bound of the renamed for-loop.
             stmt = LetStmt::make(new_var + ".loop_min", min_val, stmt);
@@ -1106,7 +1107,7 @@ class ShiftLoopNest : public IRMutator {
             internal_assert(op);
             Expr adjusted = Variable::make(Int(32), op->name) + iter->second;
             Stmt body = substitute(op->name, adjusted, op->body);
-            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
         }
         return stmt;
     }
@@ -1270,6 +1271,7 @@ protected:
                              for_loop->min,
                              for_loop->extent,
                              for_loop->for_type,
+                             for_loop->partition_policy,
                              for_loop->device_api,
                              body);
         }
@@ -2478,7 +2480,7 @@ Stmt schedule_functions(const vector<Function> &outputs,
                         const Target &target,
                         bool &any_memoized) {
     string root_var = LoopLevel::root().lock().to_string();
-    Stmt s = For::make(root_var, 0, 1, ForType::Serial, DeviceAPI::Host, Evaluate::make(0));
+    Stmt s = For::make(root_var, 0, 1, ForType::Serial, LoopPartitionPolicy::Never, DeviceAPI::Host, Evaluate::make(0));
 
     any_memoized = false;
 

--- a/src/SelectGPUAPI.cpp
+++ b/src/SelectGPUAPI.cpp
@@ -35,7 +35,7 @@ class SelectGPUAPI : public IRMutator {
         internal_assert(op);
 
         if (op->device_api != selected_api) {
-            return For::make(op->name, op->min, op->extent, op->for_type, selected_api, op->body);
+            return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, selected_api, op->body);
         }
         return stmt;
     }

--- a/src/Serialization.cpp
+++ b/src/Serialization.cpp
@@ -60,6 +60,8 @@ private:
 
     Serialize::DeviceAPI serialize_device_api(const DeviceAPI &device_api);
 
+    Serialize::LoopPartitionPolicy serialize_loop_partition_policy(const LoopPartitionPolicy &loop_partition_policy);
+
     Serialize::CallType serialize_call_type(const Call::CallType &call_type);
 
     Serialize::VectorReduceOp serialize_vector_reduce_op(const VectorReduce::Operator &vector_reduce_op);
@@ -181,6 +183,20 @@ Serialize::ForType Serializer::serialize_for_type(const ForType &for_type) {
     default:
         user_error << "Unsupported for type\n";
         return Serialize::ForType_Serial;
+    }
+}
+
+Serialize::LoopPartitionPolicy Serializer::serialize_loop_partition_policy(const LoopPartitionPolicy &loop_partition_policy) {
+    switch (loop_partition_policy) {
+    case Halide::LoopPartitionPolicy::Auto:
+        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Auto;
+    case Halide::LoopPartitionPolicy::Never:
+        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Never;
+    case Halide::LoopPartitionPolicy::Always:
+        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Always;
+    default:
+        user_error << "Unsupported loop partition policy\n";
+        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Auto;
     }
 }
 
@@ -428,13 +444,14 @@ std::pair<Serialize::Stmt, Offset<void>> Serializer::serialize_stmt(FlatBufferBu
         const auto min_serialized = serialize_expr(builder, for_stmt->min);
         const auto extent_serialized = serialize_expr(builder, for_stmt->extent);
         const Serialize::ForType for_type = serialize_for_type(for_stmt->for_type);
+        const Serialize::LoopPartitionPolicy loop_partition_policy = serialize_loop_partition_policy(for_stmt->partition_policy);
         const Serialize::DeviceAPI device_api = serialize_device_api(for_stmt->device_api);
         const auto body_serialized = serialize_stmt(builder, for_stmt->body);
         return std::make_pair(Serialize::Stmt::Stmt_For,
                               Serialize::CreateFor(builder, name_serialized,
                                                    min_serialized.first, min_serialized.second,
                                                    extent_serialized.first, extent_serialized.second,
-                                                   for_type, device_api,
+                                                   for_type, loop_partition_policy, device_api,
                                                    body_serialized.first, body_serialized.second)
                                   .Union());
     }

--- a/src/Serialization.cpp
+++ b/src/Serialization.cpp
@@ -60,7 +60,7 @@ private:
 
     Serialize::DeviceAPI serialize_device_api(const DeviceAPI &device_api);
 
-    Serialize::LoopPartitionPolicy serialize_loop_partition_policy(const LoopPartitionPolicy &loop_partition_policy);
+    Serialize::Partition serialize_partition(const Partition &partition);
 
     Serialize::CallType serialize_call_type(const Call::CallType &call_type);
 
@@ -186,17 +186,17 @@ Serialize::ForType Serializer::serialize_for_type(const ForType &for_type) {
     }
 }
 
-Serialize::LoopPartitionPolicy Serializer::serialize_loop_partition_policy(const LoopPartitionPolicy &loop_partition_policy) {
-    switch (loop_partition_policy) {
-    case Halide::LoopPartitionPolicy::Auto:
-        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Auto;
-    case Halide::LoopPartitionPolicy::Never:
-        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Never;
-    case Halide::LoopPartitionPolicy::Always:
-        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Always;
+Serialize::Partition Serializer::serialize_partition(const Partition &partition) {
+    switch (partition) {
+    case Halide::Partition::Auto:
+        return Serialize::Partition::Partition_Auto;
+    case Halide::Partition::Never:
+        return Serialize::Partition::Partition_Never;
+    case Halide::Partition::Always:
+        return Serialize::Partition::Partition_Always;
     default:
         user_error << "Unsupported loop partition policy\n";
-        return Serialize::LoopPartitionPolicy::LoopPartitionPolicy_Auto;
+        return Serialize::Partition::Partition_Auto;
     }
 }
 
@@ -444,14 +444,14 @@ std::pair<Serialize::Stmt, Offset<void>> Serializer::serialize_stmt(FlatBufferBu
         const auto min_serialized = serialize_expr(builder, for_stmt->min);
         const auto extent_serialized = serialize_expr(builder, for_stmt->extent);
         const Serialize::ForType for_type = serialize_for_type(for_stmt->for_type);
-        const Serialize::LoopPartitionPolicy loop_partition_policy = serialize_loop_partition_policy(for_stmt->partition_policy);
+        const Serialize::Partition partition_policy = serialize_partition(for_stmt->partition_policy);
         const Serialize::DeviceAPI device_api = serialize_device_api(for_stmt->device_api);
         const auto body_serialized = serialize_stmt(builder, for_stmt->body);
         return std::make_pair(Serialize::Stmt::Stmt_For,
                               Serialize::CreateFor(builder, name_serialized,
                                                    min_serialized.first, min_serialized.second,
                                                    extent_serialized.first, extent_serialized.second,
-                                                   for_type, loop_partition_policy, device_api,
+                                                   for_type, partition_policy, device_api,
                                                    body_serialized.first, body_serialized.second)
                                   .Union());
     }

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -266,13 +266,13 @@ Stmt Simplify::visit(const For *op) {
         }
         return mutate(s);
     } else if (!stmt_uses_var(new_body, op->name) && !is_const_zero(op->min)) {
-        return For::make(op->name, make_zero(Int(32)), new_extent, op->for_type, op->device_api, new_body);
+        return For::make(op->name, make_zero(Int(32)), new_extent, op->for_type, op->partition_policy, op->device_api, new_body);
     } else if (op->min.same_as(new_min) &&
                op->extent.same_as(new_extent) &&
                op->body.same_as(new_body)) {
         return op;
     } else {
-        return For::make(op->name, new_min, new_extent, op->for_type, op->device_api, new_body);
+        return For::make(op->name, new_min, new_extent, op->for_type, op->partition_policy, op->device_api, new_body);
     }
 }
 

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -199,7 +199,7 @@ class RollFunc : public IRMutator {
             Stmt body = substitute(op->name, Variable::make(Int(32), new_name) + op->min, op->body);
             // use op->name *before* the re-assignment of result, which will clobber it
             loops_to_rebase.erase(op->name);
-            result = For::make(new_name, 0, op->extent, op->for_type, op->device_api, body);
+            result = For::make(new_name, 0, op->extent, op->for_type, op->partition_policy, op->device_api, body);
         }
         return result;
     }
@@ -571,7 +571,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
             // Unpack it back into the for
             const LetStmt *l = s.as<LetStmt>();
             internal_assert(l);
-            return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, l->body);
+            return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, l->body);
         } else if (is_monotonic(min, loop_var) != Monotonic::Constant ||
                    is_monotonic(extent, loop_var) != Monotonic::Constant) {
             debug(3) << "Not entering loop over " << op->name
@@ -863,7 +863,7 @@ class SlidingWindow : public IRMutator {
         if (body.same_as(op->body) && loop_min.same_as(op->min) && loop_extent.same_as(op->extent) && name == op->name) {
             return op;
         } else {
-            Stmt result = For::make(name, loop_min, loop_extent, op->for_type, op->device_api, body);
+            Stmt result = For::make(name, loop_min, loop_extent, op->for_type, op->partition_policy, op->device_api, body);
             if (!new_lets.empty()) {
                 result = LetStmt::make(name + ".loop_max", loop_max, result);
             }
@@ -909,7 +909,7 @@ class AddLoopMinOrig : public IRMutator {
         if (body.same_as(op->body) && min.same_as(op->min) && extent.same_as(op->extent)) {
             result = op;
         } else {
-            result = For::make(op->name, min, extent, op->for_type, op->device_api, body);
+            result = For::make(op->name, min, extent, op->for_type, op->partition_policy, op->device_api, body);
         }
         return LetStmt::make(op->name + ".loop_min.orig", Variable::make(Int(32), op->name + ".loop_min"), result);
     }

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -867,7 +867,7 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
                 // for further folding opportunities
                 // recursively.
             } else if (!body.same_as(op->body)) {
-                stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+                stmt = For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
                 break;
             } else {
                 stmt = op;
@@ -888,7 +888,7 @@ class AttemptStorageFoldingOfFunction : public IRMutator {
         if (body.same_as(op->body)) {
             stmt = op;
         } else {
-            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+            stmt = For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
         }
 
         if (func.schedule().async() && !dynamic_footprint.empty()) {

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -93,7 +93,7 @@ public:
             new_body.same_as(op->body)) {
             return op;
         } else {
-            return For::make(op->name, new_min, new_extent, op->for_type, op->device_api, new_body);
+            return For::make(op->name, new_min, new_extent, op->for_type, op->partition_policy, op->device_api, new_body);
         }
     }
 };

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -339,7 +339,7 @@ class SimplifyUsingBounds : public IRMutator {
         containing_loops.push_back({op->name, {min, min + extent - 1}});
         Stmt body = mutate(op->body);
         containing_loops.pop_back();
-        return For::make(op->name, min, extent, op->for_type, op->device_api, body);
+        return For::make(op->name, min, extent, op->for_type, op->partition_policy, op->device_api, body);
     }
 
 public:
@@ -381,7 +381,7 @@ class TrimNoOps : public IRMutator {
             if (body.same_as(op->body)) {
                 return op;
             } else {
-                return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+                return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
             }
         }
 
@@ -394,7 +394,7 @@ class TrimNoOps : public IRMutator {
 
         if (i.is_everything()) {
             // Nope.
-            return For::make(op->name, op->min, op->extent, op->for_type, op->device_api, body);
+            return For::make(op->name, op->min, op->extent, op->for_type, op->partition_policy, op->device_api, body);
         }
 
         if (i.is_empty()) {
@@ -437,7 +437,7 @@ class TrimNoOps : public IRMutator {
 
         Expr new_extent = new_max_var - new_min_var;
 
-        Stmt stmt = For::make(op->name, new_min_var, new_extent, op->for_type, op->device_api, body);
+        Stmt stmt = For::make(op->name, new_min_var, new_extent, op->for_type, op->partition_policy, op->device_api, body);
         stmt = LetStmt::make(new_max_name, new_max, stmt);
         stmt = LetStmt::make(new_min_name, new_min, stmt);
         stmt = LetStmt::make(old_max_name, old_max, stmt);

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -99,7 +99,7 @@ class UniquifyVariableNames : public IRMutator {
             extent.same_as(op->extent)) {
             return op;
         } else {
-            return For::make(new_name, min, extent, op->for_type, op->device_api, body);
+            return For::make(new_name, min, extent, op->for_type, op->partition_policy, op->device_api, body);
         }
     }
 

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -69,7 +69,7 @@ class UnrollLoops : public IRMutator {
                 user_warning << "HL_PERMIT_FAILED_UNROLL is allowing us to unroll a non-constant loop into a serial loop. Did you mean to do this?\n";
                 body = mutate(body);
                 return For::make(for_loop->name, for_loop->min, for_loop->extent,
-                                 ForType::Serial, for_loop->device_api, std::move(body));
+                                 ForType::Serial, for_loop->partition_policy, for_loop->device_api, std::move(body));
             }
 
             user_assert(e)

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1292,7 +1292,7 @@ class VectorSubs : public IRMutator {
 
         for (int ix = vectorized_vars.size() - 1; ix >= 0; ix--) {
             s = For::make(vectorized_vars[ix].name, vectorized_vars[ix].min,
-                          vectorized_vars[ix].lanes, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, s);
+                          vectorized_vars[ix].lanes, ForType::Serial, Partition::Auto, DeviceAPI::None, s);
         }
 
         return s;

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -342,7 +342,7 @@ class SerializeLoops : public IRMutator {
     Stmt visit(const For *op) override {
         if (op->for_type == ForType::Vectorized) {
             return For::make(op->name, op->min, op->extent,
-                             ForType::Serial, op->device_api, mutate(op->body));
+                             ForType::Serial, op->partition_policy, op->device_api, mutate(op->body));
         }
 
         return IRMutator::visit(op);
@@ -935,7 +935,7 @@ class VectorSubs : public IRMutator {
             // Rebase the loop to zero and try again
             Expr var = Variable::make(Int(32), op->name);
             Stmt body = substitute(op->name, var + op->min, op->body);
-            Stmt transformed = For::make(op->name, 0, op->extent, for_type, op->device_api, body);
+            Stmt transformed = For::make(op->name, 0, op->extent, for_type, op->partition_policy, op->device_api, body);
             return mutate(transformed);
         }
 
@@ -1002,7 +1002,7 @@ class VectorSubs : public IRMutator {
                 for_type == op->for_type) {
                 return op;
             } else {
-                return For::make(op->name, min, extent, for_type, op->device_api, body);
+                return For::make(op->name, min, extent, for_type, op->partition_policy, op->device_api, body);
             }
         }
     }
@@ -1292,7 +1292,7 @@ class VectorSubs : public IRMutator {
 
         for (int ix = vectorized_vars.size() - 1; ix >= 0; ix--) {
             s = For::make(vectorized_vars[ix].name, vectorized_vars[ix].min,
-                          vectorized_vars[ix].lanes, ForType::Serial, DeviceAPI::None, s);
+                          vectorized_vars[ix].lanes, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, s);
         }
 
         return s;

--- a/src/halide_ir.fbs
+++ b/src/halide_ir.fbs
@@ -73,6 +73,12 @@ enum ForType: byte {
     GPULane,
 }
 
+enum LoopPartitionPolicy: byte {
+    Auto,
+    Never,
+    Always,
+}
+
 enum DeviceAPI: byte {
     None,
     Host,
@@ -127,6 +133,7 @@ table For {
     min: Expr;
     extent: Expr;
     for_type: ForType;
+    loop_partition_policy: LoopPartitionPolicy;
     device_api: DeviceAPI;
     body: Stmt;
 }

--- a/src/halide_ir.fbs
+++ b/src/halide_ir.fbs
@@ -73,7 +73,7 @@ enum ForType: byte {
     GPULane,
 }
 
-enum LoopPartitionPolicy: byte {
+enum Partition: byte {
     Auto,
     Never,
     Always,
@@ -133,7 +133,7 @@ table For {
     min: Expr;
     extent: Expr;
     for_type: ForType;
-    loop_partition_policy: LoopPartitionPolicy;
+    partition_policy: Partition;
     device_api: DeviceAPI;
     body: Stmt;
 }

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1700,7 +1700,7 @@ void check_boolean() {
 
     // A for loop is also an if statement that the extent is greater than zero
     Stmt body = AssertStmt::make(y == z, y);
-    Stmt loop = For::make("t", 0, x, ForType::Serial, DeviceAPI::None, body);
+    Stmt loop = For::make("t", 0, x, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, body);
     check(IfThenElse::make(0 < x, loop), loop);
 
     // A for loop where the extent is exactly one is just the body
@@ -2146,9 +2146,9 @@ void check_unreachable() {
     check(Call::make(Int(32), Call::if_then_else, {x != 0, y, unreachable()}, Call::PureIntrinsic), y);
     check(Call::make(Int(32), Call::if_then_else, {x != 0, unreachable(), y}, Call::PureIntrinsic), y);
 
-    check(Block::make(not_no_op(y), For::make("i", 0, 1, ForType::Serial, DeviceAPI::None, Evaluate::make(unreachable()))),
+    check(Block::make(not_no_op(y), For::make("i", 0, 1, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, Evaluate::make(unreachable()))),
           Evaluate::make(unreachable()));
-    check(For::make("i", 0, x, ForType::Serial, DeviceAPI::None, Evaluate::make(unreachable())),
+    check(For::make("i", 0, x, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, Evaluate::make(unreachable())),
           Evaluate::make(0));
 }
 
@@ -2383,7 +2383,7 @@ int main(int argc, char **argv) {
 
     {
         Stmt body = AssertStmt::make(x > 0, y);
-        check(For::make("t", 0, x, ForType::Serial, DeviceAPI::None, body),
+        check(For::make("t", 0, x, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, body),
               Evaluate::make(0));
     }
 

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1700,7 +1700,7 @@ void check_boolean() {
 
     // A for loop is also an if statement that the extent is greater than zero
     Stmt body = AssertStmt::make(y == z, y);
-    Stmt loop = For::make("t", 0, x, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, body);
+    Stmt loop = For::make("t", 0, x, ForType::Serial, Partition::Auto, DeviceAPI::None, body);
     check(IfThenElse::make(0 < x, loop), loop);
 
     // A for loop where the extent is exactly one is just the body
@@ -2146,9 +2146,9 @@ void check_unreachable() {
     check(Call::make(Int(32), Call::if_then_else, {x != 0, y, unreachable()}, Call::PureIntrinsic), y);
     check(Call::make(Int(32), Call::if_then_else, {x != 0, unreachable(), y}, Call::PureIntrinsic), y);
 
-    check(Block::make(not_no_op(y), For::make("i", 0, 1, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, Evaluate::make(unreachable()))),
+    check(Block::make(not_no_op(y), For::make("i", 0, 1, ForType::Serial, Partition::Auto, DeviceAPI::None, Evaluate::make(unreachable()))),
           Evaluate::make(unreachable()));
-    check(For::make("i", 0, x, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, Evaluate::make(unreachable())),
+    check(For::make("i", 0, x, ForType::Serial, Partition::Auto, DeviceAPI::None, Evaluate::make(unreachable())),
           Evaluate::make(0));
 }
 
@@ -2383,7 +2383,7 @@ int main(int argc, char **argv) {
 
     {
         Stmt body = AssertStmt::make(x > 0, y);
-        check(For::make("t", 0, x, ForType::Serial, LoopPartitionPolicy::Auto, DeviceAPI::None, body),
+        check(For::make("t", 0, x, ForType::Serial, Partition::Auto, DeviceAPI::None, body),
               Evaluate::make(0));
     }
 

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -21,6 +21,7 @@ tests(GROUPS error
       bad_extern_split.cpp
       bad_fold.cpp
       bad_host_alignment.cpp
+      bad_partition_always.cpp
       bad_prefetch.cpp
       bad_reorder.cpp
       bad_reorder_storage.cpp

--- a/test/error/bad_partition_always.cpp
+++ b/test/error/bad_partition_always.cpp
@@ -1,0 +1,17 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Func f("f");
+    Var x("x");
+
+    f(x) = 0;
+    f.partition(x, Partition::Always);
+
+    f.realize({10});
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
As per the last dev-meeting, implemented it with a ternary enum. Replaces #7882, and solves #7881.

Changes compared to #7882:
 - Given the multiple usage sites (both in IR.h for the `For`, and in Schedule.h for the `Dim`), I put the ternary enum in a new file `LoopPartitioningDirective.h`. Feeback on this name is welcome.
 - Put the `LoopPartitionPolicy` argument _before_ the DeviceAPI.
 - LowerParalellTasks now respects the policy by extracting it from the `For` when turning it into a `ParallelTask`.
 - Implemented the Serialization and Deserialization code.

I went with the name `LoopPartitionPolicy` for the enum. I can do a find-and-replace if the name is not good. 