### PR TITLE
Delete unused function

### DIFF
--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -402,11 +402,6 @@ protected:
     void visit(const Realize *) override;
     // @}
 
-    /** If we have to bail out of a pipeline midway, this should
-     * inject the appropriate target-specific cleanup code. */
-    virtual void prepare_for_early_exit() {
-    }
-
     /** Get the llvm type equivalent to the given halide type in the
      * current context. */
     virtual llvm::Type *llvm_type_of(const Type &) const;


### PR DESCRIPTION
This function is never called by the base class, so overriding it in a derived class will also do nothing.