### PR TITLE
Improve code size and compile time for local laplacian app

### DIFF
--- a/apps/interpolate/Makefile
+++ b/apps/interpolate/Makefile
@@ -1,6 +1,7 @@
 include ../support/Makefile.inc
 
 .PHONY: build clean test
+.SECONDARY:
 
 build: $(BIN)/$(HL_TARGET)/filter
 

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -79,8 +79,7 @@ public:
             Var yo, yi, xo, xi, ci, xii, yii;
             if (get_target().has_gpu_feature()) {
                 normalize
-                    .partition(x, Partition::Never)
-                    .partition(y, Partition::Never)
+                    .never_partition_all()
                     .bound(x, 0, input.width())
                     .bound(y, 0, input.height())
                     .bound(c, 0, 3)
@@ -96,8 +95,7 @@ public:
                 for (int l = 1; l < levels; l++) {
                     downsampled[l]
                         .compute_root()
-                        .partition(x, Partition::Never)
-                        .partition(y, Partition::Never)
+                        .never_partition_all()
                         .reorder(c, x, y)
                         .unroll(c)
                         .gpu_tile(x, y, xi, yi, 16, 16);
@@ -106,8 +104,7 @@ public:
                 for (int l = 3; l < levels; l += 2) {
                     interpolated[l]
                         .compute_root()
-                        .partition(x, Partition::Never)
-                        .partition(y, Partition::Never)
+                        .never_partition_all()
                         .reorder(c, x, y)
                         .tile(x, y, xi, yi, 32, 32, TailStrategy::RoundUp)
                         .tile(xi, yi, xii, yii, 2, 2)
@@ -120,8 +117,7 @@ public:
 
                 upsampledx[1]
                     .compute_at(normalize, x)
-                    .partition(x, Partition::Never)
-                    .partition(y, Partition::Never)
+                    .never_partition_all()
                     .reorder(c, x, y)
                     .tile(x, y, xi, yi, 2, 1)
                     .unroll(xi)
@@ -131,8 +127,7 @@ public:
 
                 interpolated[1]
                     .compute_at(normalize, x)
-                    .partition(x, Partition::Never)
-                    .partition(y, Partition::Never)
+                    .never_partition_all()
                     .reorder(c, x, y)
                     .tile(x, y, xi, yi, 2, 2)
                     .unroll(xi)
@@ -142,8 +137,7 @@ public:
 
                 interpolated[2]
                     .compute_at(normalize, x)
-                    .partition(x, Partition::Never)
-                    .partition(y, Partition::Never)
+                    .never_partition_all()
                     .reorder(c, x, y)
                     .unroll(c)
                     .gpu_threads(x, y);
@@ -160,7 +154,7 @@ public:
                     // the local_laplacian app.
                     downsampled[l]
                         .compute_root()
-                        .partition(x, Partition::Never)
+                        .never_partition(x)
                         .reorder(x, c, y)
                         .split(y, yo, yi, 8)
                         .parallel(yo)
@@ -179,13 +173,13 @@ public:
                     .reorder(c, x, y)
                     .unroll(c)
                     .vectorize(x, vec)
-                    .partition(y, Partition::Never);
+                    .never_partition(y);
 
                 normalize
                     .bound(x, 0, input.width())
                     .bound(y, 0, input.height())
                     .bound(c, 0, 3)
-                    .partition(y, Partition::Never)
+                    .never_partition(y)
                     .split(x, xo, xi, vec)
                     .split(y, yo, yi, 32)
                     .reorder(xi, c, xo, yi, yo)
@@ -197,7 +191,7 @@ public:
                     interpolated[l]
                         .store_at(normalize, yo)
                         .compute_at(normalize, yi)
-                        .partition(x, Partition::Never)
+                        .never_partition(x)
                         .vectorize(x, vec);
                 }
 

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -191,7 +191,7 @@ public:
                     interpolated[l]
                         .store_at(normalize, yo)
                         .compute_at(normalize, yi)
-                        .never_partition(x)
+                        .never_partition_all()
                         .vectorize(x, vec);
                 }
 

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -79,6 +79,8 @@ public:
             Var yo, yi, xo, xi, ci, xii, yii;
             if (get_target().has_gpu_feature()) {
                 normalize
+                    .partition(x, Partition::Never)
+                    .partition(y, Partition::Never)
                     .bound(x, 0, input.width())
                     .bound(y, 0, input.height())
                     .bound(c, 0, 3)
@@ -94,6 +96,8 @@ public:
                 for (int l = 1; l < levels; l++) {
                     downsampled[l]
                         .compute_root()
+                        .partition(x, Partition::Never)
+                        .partition(y, Partition::Never)
                         .reorder(c, x, y)
                         .unroll(c)
                         .gpu_tile(x, y, xi, yi, 16, 16);
@@ -102,6 +106,8 @@ public:
                 for (int l = 3; l < levels; l += 2) {
                     interpolated[l]
                         .compute_root()
+                        .partition(x, Partition::Never)
+                        .partition(y, Partition::Never)
                         .reorder(c, x, y)
                         .tile(x, y, xi, yi, 32, 32, TailStrategy::RoundUp)
                         .tile(xi, yi, xii, yii, 2, 2)
@@ -114,6 +120,8 @@ public:
 
                 upsampledx[1]
                     .compute_at(normalize, x)
+                    .partition(x, Partition::Never)
+                    .partition(y, Partition::Never)
                     .reorder(c, x, y)
                     .tile(x, y, xi, yi, 2, 1)
                     .unroll(xi)
@@ -123,6 +131,8 @@ public:
 
                 interpolated[1]
                     .compute_at(normalize, x)
+                    .partition(x, Partition::Never)
+                    .partition(y, Partition::Never)
                     .reorder(c, x, y)
                     .tile(x, y, xi, yi, 2, 2)
                     .unroll(xi)
@@ -132,6 +142,8 @@ public:
 
                 interpolated[2]
                     .compute_at(normalize, x)
+                    .partition(x, Partition::Never)
+                    .partition(y, Partition::Never)
                     .reorder(c, x, y)
                     .unroll(c)
                     .gpu_threads(x, y);
@@ -148,6 +160,7 @@ public:
                     // the local_laplacian app.
                     downsampled[l]
                         .compute_root()
+                        .partition(x, Partition::Never)
                         .reorder(x, c, y)
                         .split(y, yo, yi, 8)
                         .parallel(yo)
@@ -165,12 +178,14 @@ public:
                     .compute_at(downsampled[1], yi)
                     .reorder(c, x, y)
                     .unroll(c)
-                    .vectorize(x, vec);
+                    .vectorize(x, vec)
+                    .partition(y, Partition::Never);
 
                 normalize
                     .bound(x, 0, input.width())
                     .bound(y, 0, input.height())
                     .bound(c, 0, 3)
+                    .partition(y, Partition::Never)
                     .split(x, xo, xi, vec)
                     .split(y, yo, yi, 32)
                     .reorder(xi, c, xo, yi, yo)
@@ -182,6 +197,7 @@ public:
                     interpolated[l]
                         .store_at(normalize, yo)
                         .compute_at(normalize, yi)
+                        .partition(x, Partition::Never)
                         .vectorize(x, vec);
                 }
 

--- a/apps/local_laplacian/Makefile
+++ b/apps/local_laplacian/Makefile
@@ -1,6 +1,7 @@
 include ../support/Makefile.inc
 
 .PHONY: build clean test
+.SECONDARY:
 
 build: $(BIN)/$(HL_TARGET)/process
 

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -109,8 +109,7 @@ public:
             remap.compute_root();
             Var xi, yi;
             output.compute_root()
-                .partition(x, Partition::Never)
-                .partition(y, Partition::Never)
+                .never_partition_all()
                 .gpu_tile(x, y, xi, yi, 16, 8);
             for (int j = 0; j < J; j++) {
                 int blockw = 16, blockh = 8;
@@ -121,20 +120,17 @@ public:
                 if (j > 0) {
                     inGPyramid[j]
                         .compute_root()
-                        .partition(x, Partition::Never)
-                        .partition(y, Partition::Never)
+                        .never_partition_all()
                         .gpu_tile(x, y, xi, yi, blockw, blockh);
                     gPyramid[j]
                         .compute_root()
                         .reorder(k, x, y)
-                        .partition(x, Partition::Never)
-                        .partition(y, Partition::Never)
+                        .never_partition_all()
                         .gpu_tile(x, y, xi, yi, blockw, blockh);
                 }
                 outGPyramid[j]
                     .compute_root()
-                    .partition(x, Partition::Never)
-                    .partition(y, Partition::Never)
+                    .never_partition_all()
                     .gpu_tile(x, y, xi, yi, blockw, blockh);
             }
         } else {
@@ -157,7 +153,7 @@ public:
                 .vectorize(x, 8);
             gray
                 .compute_root()
-                .partition(y, Partition::Never)
+                .never_partition(y)
                 .parallel(y, 32)
                 .vectorize(x, 8);
             for (int j = 1; j < 5; j++) {
@@ -180,8 +176,8 @@ public:
                     // Turn off loop partitioning at higher pyramid levels. This
                     // shaves about 3% off code size and compile time without
                     // affecting performance.
-                    inGPyramid[j].partition(x, Partition::Never);
-                    gPyramid[j].partition(x, Partition::Never);
+                    inGPyramid[j].never_partition_all();
+                    gPyramid[j].never_partition_all();
                 }
             }
             outGPyramid[0]

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -138,6 +138,7 @@ public:
                 .vectorize(x, 8);
             gray
                 .compute_root()
+                .partition(y, Partition::Never)
                 .parallel(y, 32)
                 .vectorize(x, 8);
             for (int j = 1; j < 5; j++) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1650,7 +1650,7 @@ Stage &Stage::partition(const VarOrRVar &var, Partition policy) {
 }
 
 Stage &Stage::never_partition(const std::vector<VarOrRVar> &vars) {
-    for (auto v : vars) {
+    for (const auto &v : vars) {
         partition(v, Partition::Never);
     }
     return *this;
@@ -1661,6 +1661,22 @@ Stage &Stage::never_partition_all() {
     vector<Dim> &dims = definition.schedule().dims();
     for (auto &dim : dims) {
         dim.partition_policy = Partition::Never;
+    }
+    return *this;
+}
+
+Stage &Stage::always_partition(const std::vector<VarOrRVar> &vars) {
+    for (const auto &v : vars) {
+        partition(v, Partition::Always);
+    }
+    return *this;
+}
+
+Stage &Stage::always_partition_all() {
+    definition.schedule().touched() = true;
+    vector<Dim> &dims = definition.schedule().dims();
+    for (auto &dim : dims) {
+        dim.partition_policy = Partition::Always;
     }
     return *this;
 }
@@ -2367,6 +2383,18 @@ Func &Func::never_partition(const std::vector<VarOrRVar> &vars) {
 Func &Func::never_partition_all() {
     invalidate_cache();
     Stage(func, func.definition(), 0).never_partition_all();
+    return *this;
+}
+
+Func &Func::always_partition(const std::vector<VarOrRVar> &vars) {
+    invalidate_cache();
+    Stage(func, func.definition(), 0).always_partition(vars);
+    return *this;
+}
+
+Func &Func::always_partition_all() {
+    invalidate_cache();
+    Stage(func, func.definition(), 0).always_partition_all();
     return *this;
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1649,6 +1649,22 @@ Stage &Stage::partition(const VarOrRVar &var, Partition policy) {
     return *this;
 }
 
+Stage &Stage::never_partition(const std::vector<VarOrRVar> &vars) {
+    for (auto v : vars) {
+        partition(v, Partition::Never);
+    }
+    return *this;
+}
+
+Stage &Stage::never_partition_all() {
+    definition.schedule().touched() = true;
+    vector<Dim> &dims = definition.schedule().dims();
+    for (auto &dim : dims) {
+        dim.partition_policy = Partition::Never;
+    }
+    return *this;
+}
+
 Stage &Stage::tile(const VarOrRVar &x, const VarOrRVar &y,
                    const VarOrRVar &xo, const VarOrRVar &yo,
                    const VarOrRVar &xi, const VarOrRVar &yi,
@@ -2339,6 +2355,18 @@ Func &Func::unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail) 
 Func &Func::partition(const VarOrRVar &var, Partition policy) {
     invalidate_cache();
     Stage(func, func.definition(), 0).partition(var, policy);
+    return *this;
+}
+
+Func &Func::never_partition(const std::vector<VarOrRVar> &vars) {
+    invalidate_cache();
+    Stage(func, func.definition(), 0).never_partition(vars);
+    return *this;
+}
+
+Func &Func::never_partition_all() {
+    invalidate_cache();
+    Stage(func, func.definition(), 0).never_partition_all();
     return *this;
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -351,6 +351,9 @@ public:
     Stage &partition(const VarOrRVar &var, Partition partition_policy);
     Stage &never_partition_all();
     Stage &never_partition(const std::vector<VarOrRVar> &vars);
+    Stage &always_partition_all();
+    Stage &always_partition(const std::vector<VarOrRVar> &vars);
+
     Stage &tile(const VarOrRVar &x, const VarOrRVar &y,
                 const VarOrRVar &xo, const VarOrRVar &yo,
                 const VarOrRVar &xi, const VarOrRVar &yi, const Expr &xfactor, const Expr &yfactor,
@@ -387,6 +390,13 @@ public:
     never_partition(const VarOrRVar &x, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
         return never_partition(collected_args);
+    }
+
+    template<typename... Args>
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
+    always_partition(const VarOrRVar &x, Args &&...args) {
+        std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
+        return always_partition(collected_args);
     }
 
     Stage &rename(const VarOrRVar &old_name, const VarOrRVar &new_name);
@@ -1475,6 +1485,23 @@ public:
      * initial definition of the Func. It must be called separately on any
      * update definitions. */
     Func &never_partition_all();
+
+    /** Set the loop partition policy to Always for a vector of Vars and
+     * RVars. */
+    Func &always_partition(const std::vector<VarOrRVar> &vars);
+
+    /** Set the loop partition policy to Always for some number of Vars and RVars. */
+    template<typename... Args>
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
+    always_partition(const VarOrRVar &x, Args &&...args) {
+        std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
+        return always_partition(collected_args);
+    }
+
+    /** Set the loop partition policy to Always for all Vars and RVar of the
+     * initial definition of the Func. It must be called separately on any
+     * update definitions. */
+    Func &always_partition_all();
 
     /** Statically declare that the range over which a function should
      * be evaluated is given by the second and third arguments. This

--- a/src/Func.h
+++ b/src/Func.h
@@ -349,6 +349,8 @@ public:
     Stage &vectorize(const VarOrRVar &var, const Expr &factor, TailStrategy tail = TailStrategy::Auto);
     Stage &unroll(const VarOrRVar &var, const Expr &factor, TailStrategy tail = TailStrategy::Auto);
     Stage &partition(const VarOrRVar &var, Partition partition_policy);
+    Stage &never_partition_all();
+    Stage &never_partition(const std::vector<VarOrRVar> &vars);
     Stage &tile(const VarOrRVar &x, const VarOrRVar &y,
                 const VarOrRVar &xo, const VarOrRVar &yo,
                 const VarOrRVar &xi, const VarOrRVar &yi, const Expr &xfactor, const Expr &yfactor,
@@ -378,6 +380,13 @@ public:
     reorder(const VarOrRVar &x, const VarOrRVar &y, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
+    }
+
+    template<typename... Args>
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
+    never_partition(const VarOrRVar &x, Args &&...args) {
+        std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
+        return never_partition(collected_args);
     }
 
     Stage &rename(const VarOrRVar &old_name, const VarOrRVar &new_name);
@@ -1449,6 +1458,23 @@ public:
      * and an epilogue.
      * The default policy is Auto. */
     Func &partition(const VarOrRVar &var, Partition partition_policy);
+
+    /** Set the loop partition policy to Never for a vector of Vars and
+     * RVars. */
+    Func &never_partition(const std::vector<VarOrRVar> &vars);
+
+    /** Set the loop partition policy to Never for some number of Vars and RVars. */
+    template<typename... Args>
+    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
+    never_partition(const VarOrRVar &x, Args &&...args) {
+        std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
+        return never_partition(collected_args);
+    }
+
+    /** Set the loop partition policy to Never for all Vars and RVar of the
+     * initial definition of the Func. It must be called separately on any
+     * update definitions. */
+    Func &never_partition_all();
 
     /** Statically declare that the range over which a function should
      * be evaluated is given by the second and third arguments. This

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3052,6 +3052,7 @@ protected:
     using LoopLevel = Halide::LoopLevel;
     using MemoryType = Halide::MemoryType;
     using NameMangling = Halide::NameMangling;
+    using Partition = Halide::Partition;
     using Pipeline = Halide::Pipeline;
     using PrefetchBoundStrategy = Halide::PrefetchBoundStrategy;
     using RDom = Halide::RDom;

--- a/src/LoopPartitioningDirective.h
+++ b/src/LoopPartitioningDirective.h
@@ -20,8 +20,9 @@ enum class Partition {
     /** Disallow loop partitioning. */
     Never,
 
-    /** Force partitioning of the loop. If Halide can't find a way to partition this loop,
-     * it will raise an error. */
+    /** Force partitioning of the loop, even in the tail cases of outer
+     * partitioned loops. If Halide can't find a way to partition this loop, it
+     * will raise an error. */
     Always
 };
 

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -517,10 +517,13 @@ class PartitionLoops : public IRMutator {
     using IRMutator::visit;
 
     bool in_gpu_loop = false;
+    bool in_tail = false;
 
     Stmt visit(const For *op) override {
-        // Do not partition if the schedule explicitly forbids.
-        if (op->partition_policy == Partition::Never) {
+        // Do not partition if the schedule explicitly forbids, or if it's set
+        // to automatic and we're in a loop tail.
+        if (op->partition_policy == Partition::Never ||
+            (op->partition_policy == Partition::Auto && in_tail)) {
             return IRMutator::visit(op);
         }
 
@@ -686,6 +689,13 @@ class PartitionLoops : public IRMutator {
 
         // Recurse on the middle section.
         simpler_body = mutate(simpler_body);
+
+        // Recurse on the prologue and epilogue, just for loops set to Partition::Always
+        {
+            ScopedValue<bool> s(in_tail, true);
+            epilogue = mutate(epilogue);
+            prologue = mutate(prologue);
+        }
 
         // Construct variables for the bounds of the simplified middle section
         Expr min_steady = op->min, max_steady = op->extent + op->min;

--- a/test/correctness/likely.cpp
+++ b/test/correctness/likely.cpp
@@ -127,12 +127,12 @@ int main(int argc, char **argv) {
         count_partitions(g, 1);
     }
 
-    // The slicing applies to every loop level starting from the
-    // outermost one, but only recursively simplifies the clean steady
-    // state. It either splits things three (start, middle, end). So
-    // adding a boundary condition to a 2D computation will produce 5
-    // code paths for the top, bottom, left, right, and center of the
-    // image.
+    // The slicing applies to every loop level starting from the outermost one,
+    // but only recursively simplifies the clean steady state. It either splits
+    // things three (start, middle, end). So adding a boundary condition to a 2D
+    // computation will produce 5 code paths for the top, bottom, left, right,
+    // and center of the image. With explicit control over loop partitioning, we
+    // might produce more or fewer.
     {
         Var y;
         Func g;
@@ -144,7 +144,6 @@ int main(int argc, char **argv) {
         {
             debug(1) << "Never partition y, always partition x:\n";
             Func h2 = h;
-            // check that disabling works.
             h2.partition(x, Partition::Always);
             h2.partition(y, Partition::Never);
             count_partitions(h2, 3);  // We expect left-center-right
@@ -153,7 +152,6 @@ int main(int argc, char **argv) {
         {
             debug(1) << "Never partition x, always partition y:\n";
             Func h2 = h;
-            // check that disabling works.
             h2.partition(x, Partition::Never);
             h2.partition(y, Partition::Always);
             count_partitions(h2, 3);  // We expect top-middle-bottom
@@ -162,7 +160,6 @@ int main(int argc, char **argv) {
         {
             debug(1) << "Never partition x and y.\n";
             Func h2 = h;
-            // check that disabling works.
             h2.partition(x, Partition::Never);
             h2.partition(y, Partition::Never);
             count_partitions(h2, 1);
@@ -171,10 +168,10 @@ int main(int argc, char **argv) {
         {
             debug(1) << "Always partition x and y.\n";
             Func h2 = h;
-            // check that disabling works.
             h2.partition(x, Partition::Always);
             h2.partition(y, Partition::Always);
-            count_partitions(h2, 5);
+            // All loops get partitioned, including the tails of outer loops, so we expect 9 zones.
+            count_partitions(h2, 9);
         }
     }
 

--- a/test/correctness/likely.cpp
+++ b/test/correctness/likely.cpp
@@ -170,7 +170,16 @@ int main(int argc, char **argv) {
             Func h2 = h;
             h2.partition(x, Partition::Always);
             h2.partition(y, Partition::Always);
-            // All loops get partitioned, including the tails of outer loops, so we expect 9 zones.
+            // All loops get partitioned, including the tails of outer loops, so we expect 9 zones:
+            /*
+               ----------------------------------------------
+               | top left    | top middle    | top right    |
+               | ------------------------------------------ |
+               | left        | middle        | right        |
+               | ------------------------------------------ |
+               | bottom left | bottom middle | bottom right |
+               ----------------------------------------------
+            */
             count_partitions(h2, 9);
         }
     }


### PR DESCRIPTION
This reduces compile time for the manual local laplacian schedule from 4.9s to 2.2s, and reduces code size from 126k to 82k

It's all from avoiding loop partitioning. Most of the reduction comes from avoiding a pointless boundary condition in the output Func, which triggered partitioning. A smaller amount comes from using RoundUp and Partition::Never. The Partition::Never calls are responsible for a 3% reduction in code size and compile times by themselves.

This has basically no effect on runtime. It seems to reduce it very slightly, but it's in the noise.

There's also a drive-by fix to Generator.h, exporting the Partition enum class.