### PR TITLE
Update instructions to include generated schedules

### DIFF
--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -219,6 +219,15 @@ public:
             gray.compute_root();
             Iy.compute_root();
             Ix.compute_root();
+
+            // As discussed earlier, the generated schedule that is dumped to
+            // file is an actual Halide C++ source, which is readily copy-pasteable
+            // back into this very same source file with few modifications.
+            // Or, developers can save the generated schedules to the source directory,
+            // and then include the generated schedule here.
+            //
+            // #include "tutorial.schedule.h"
+            // apply_schedule_auto_schedule_true(get_pipeline(), get_target());
         }
     }
 


### PR DESCRIPTION
The generated schedule from the auto-scheduler can no longer be copy-n-pasted to the Generater source code. Update the tutorial to show how the generated schedules can be appled and included into Generator. Use case: version control and fine tuning of schedules.

Resolves: #7148
See also: #7900

cc'ed @derek-gerstmann .