### PR TITLE
Make sure all Halide arithmetic scalar types can be named from the Generator interface.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2467,7 +2467,7 @@ $(DISTRIB_DIR)/bin/featurization_to_sample $(DISTRIB_DIR)/bin/get_host_target: $
 	@mkdir -p $(@D)
 	$(MAKE) -f $(SRC_DIR)/autoschedulers/common/Makefile $(BIN_DIR)/featurization_to_sample $(BIN_DIR)/get_host_target HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR)
 	for TOOL in featurization_to_sample get_host_target; do \
-    		cp $(BIN_DIR)/$${TOOL} $(DISTRIB_DIR)/bin/;  \
+		cp $(BIN_DIR)/$${TOOL} $(DISTRIB_DIR)/bin/;  \
 	done
 
 # Adams2019 also includes autotuning tools
@@ -2476,7 +2476,7 @@ $(DISTRIB_DIR)/lib/libautoschedule_adams2019.$(PLUGIN_EXT): $(BIN_DIR)/libautosc
 	$(MAKE) -f $(SRC_DIR)/autoschedulers/adams2019/Makefile $(BIN_DIR)/adams2019_retrain_cost_model $(BIN_DIR)/adams2019_weightsdir_to_weightsfile HALIDE_DISTRIB_PATH=$(CURDIR)/$(DISTRIB_DIR)
 	cp $< $(DISTRIB_DIR)/lib/
 	for TOOL in adams2019_retrain_cost_model adams2019_weightsdir_to_weightsfile; do \
-    		cp $(BIN_DIR)/$${TOOL} $(DISTRIB_DIR)/bin/;  \
+		cp $(BIN_DIR)/$${TOOL} $(DISTRIB_DIR)/bin/;  \
 	done
 	cp $(SRC_DIR)/autoschedulers/adams2019/adams2019_autotune_loop.sh $(DISTRIB_DIR)/tools/
 ifeq ($(UNAME), Darwin)

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -590,12 +590,15 @@ const std::map<std::string, Type> &get_halide_type_enum_map() {
         {"int8", Int(8)},
         {"int16", Int(16)},
         {"int32", Int(32)},
+        {"int64", Int(64)},
         {"uint8", UInt(8)},
         {"uint16", UInt(16)},
         {"uint32", UInt(32)},
+        {"uint64", UInt(64)},
         {"float16", Float(16)},
         {"float32", Float(32)},
-        {"float64", Float(64)}};
+        {"float64", Float(64)},
+        {"bfloat16", BFloat(16)}};
     return halide_type_enum_map;
 }
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -973,11 +973,15 @@ using GeneratorParamImplBase =
  *   "int8"     Halide::Int(8)
  *   "int16"    Halide::Int(16)
  *   "int32"    Halide::Int(32)
+ *   "int64"    Halide::Int(64)
  *   "uint8"    Halide::UInt(8)
  *   "uint16"   Halide::UInt(16)
  *   "uint32"   Halide::UInt(32)
+ *   "uint64"   Halide::UInt(64)
+ *   "float16"  Halide::Float(16)
  *   "float32"  Halide::Float(32)
  *   "float64"  Halide::Float(64)
+ *   "bfloat16"  Halide::BFloat(16)
  *
  * No vector Types are currently supported by this mapping.
  *

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -248,6 +248,11 @@ endforeach ()
 _add_halide_aot_tests(alias
                       HALIDE_LIBRARIES alias ${EXTRA_ALIAS_LIBS})
 
+# all_type_names__aottest.cpp
+# all_type_names_generator.cpp
+_add_halide_libraries(all_type_names)
+_add_halide_aot_tests(all_type_names)
+
 # argvcall_aottest.cpp
 # argvcall_generator.cpp
 _add_halide_libraries(argvcall)

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -248,7 +248,7 @@ endforeach ()
 _add_halide_aot_tests(alias
                       HALIDE_LIBRARIES alias ${EXTRA_ALIAS_LIBS})
 
-# all_type_names__aottest.cpp
+# all_type_names_aottest.cpp
 # all_type_names_generator.cpp
 _add_halide_libraries(all_type_names)
 _add_halide_aot_tests(all_type_names)

--- a/test/generator/all_type_names_aottest.cpp
+++ b/test/generator/all_type_names_aottest.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
                             output);
     assert(result == 0);
     output.for_each_element([=](int x) {
-        assert(output(x) == 12.0);
+        assert(output(x) == 10.0);
     });
 
     printf("Success!\n");

--- a/test/generator/all_type_names_aottest.cpp
+++ b/test/generator/all_type_names_aottest.cpp
@@ -1,0 +1,58 @@
+#include "HalideBuffer.h"
+#include "HalideRuntime.h"
+
+#include <math.h>
+#include <stdio.h>
+
+#include "all_type_names.h"
+
+using namespace Halide::Runtime;
+
+const int kSize = 32;
+
+int main(int argc, char **argv) {
+    int32_t result;
+
+    Buffer<int8_t, 1> input_i8(kSize);
+    Buffer<int16_t, 1> input_i16(kSize);
+    Buffer<int32_t, 1> input_i32(kSize);
+    Buffer<int64_t, 1> input_i64(kSize);
+    Buffer<uint8_t, 1> input_u8(kSize);
+    Buffer<uint16_t, 1> input_u16(kSize);
+    Buffer<uint32_t, 1> input_u32(kSize);
+    Buffer<uint64_t, 1> input_u64(kSize);
+    Buffer<uint16_t, 1> input_f16(kSize);
+    Buffer<float, 1> input_f32(kSize);
+    Buffer<double, 1> input_f64(kSize);
+    Buffer<uint16_t, 1> input_bf16(kSize);
+    Buffer<double, 1> output(kSize);
+
+    input_i8.fill(1);
+    input_i16.fill(1);
+    input_i32.fill(1);
+    input_i64.fill(1);
+    input_u8.fill(1);
+    input_u16.fill(1);
+    input_u32.fill(1);
+    input_u64.fill(1);
+    // Start with a u16 Buffer so it can be initialized then convert to float16.
+    input_f16.fill(0x3C00);
+    input_f16.raw_buffer()->type.code = halide_type_float;
+    input_f32.fill(1.0f);
+    input_f64.fill(1.0);
+    // Start with a u16 Buffer so it can be initialized then convert to bfloat16.
+    input_bf16.fill(0x3F80);
+    input_bf16.raw_buffer()->type.code = halide_type_bfloat;
+
+    result = all_type_names(input_i8, input_i16, input_i32, input_i64,
+                            input_u8, input_u16, input_u32, input_u64,
+                            input_f16, input_f32, input_f64, input_bf16,
+                            output);
+    assert(result == 0);
+    output.for_each_element([=](int x) {
+        assert(output(x) == 12.0);
+    });
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/generator/all_type_names_generator.cpp
+++ b/test/generator/all_type_names_generator.cpp
@@ -20,9 +20,11 @@ public:
 
     void generate() {
         Var x;
+
+        // Don't use float16 and bfloat16 arguments as they do not compile with C++ code generation.
         output(x) = cast<double>(input_i8(x) + input_i16(x) + input_i32(x) + input_i64(x)) +
                     cast<double>(input_u8(x) + input_u16(x) + input_u32(x) + input_u64(x)) +
-                    input_f16(x) + input_f32(x) + input_f64(x) + input_bf16(x);
+                    input_f32(x) + input_f64(x);
 
         // set estimates for the autoschedulers
         input_i8.set_estimates({{0, 32}});

--- a/test/generator/all_type_names_generator.cpp
+++ b/test/generator/all_type_names_generator.cpp
@@ -4,19 +4,19 @@ namespace {
 
 class AllTypeNamesGeneric : public Halide::Generator<AllTypeNamesGeneric> {
 public:
-  Input<Func> input_i8{"input_i8", 1};
-  Input<Func> input_i16{"input_i16", 1};
-  Input<Func> input_i32{"input_i32", 1};
-  Input<Func> input_i64{"input_i64", 1};
-  Input<Func> input_u8{"input_u8", 1};
-  Input<Func> input_u16{"input_u16", 1};
-  Input<Func> input_u32{"input_u32", 1};
-  Input<Func> input_u64{"input_u64", 1};
-  Input<Func> input_f16{"input_f16", 1};
-  Input<Func> input_f32{"input_f32", 1};
-  Input<Func> input_f64{"input_f64", 1};
-  Input<Func> input_bf16{"input_bf16", 1};
-  Output<Func> output{"output", 1};
+    Input<Func> input_i8{"input_i8", 1};
+    Input<Func> input_i16{"input_i16", 1};
+    Input<Func> input_i32{"input_i32", 1};
+    Input<Func> input_i64{"input_i64", 1};
+    Input<Func> input_u8{"input_u8", 1};
+    Input<Func> input_u16{"input_u16", 1};
+    Input<Func> input_u32{"input_u32", 1};
+    Input<Func> input_u64{"input_u64", 1};
+    Input<Func> input_f16{"input_f16", 1};
+    Input<Func> input_f32{"input_f32", 1};
+    Input<Func> input_f64{"input_f64", 1};
+    Input<Func> input_bf16{"input_bf16", 1};
+    Output<Func> output{"output", 1};
 
     void generate() {
         Var x;

--- a/test/generator/all_type_names_generator.cpp
+++ b/test/generator/all_type_names_generator.cpp
@@ -1,0 +1,55 @@
+#include "Halide.h"
+
+namespace {
+
+class AllTypeNamesGeneric : public Halide::Generator<AllTypeNamesGeneric> {
+public:
+  Input<Func> input_i8{"input_i8", 1};
+  Input<Func> input_i16{"input_i16", 1};
+  Input<Func> input_i32{"input_i32", 1};
+  Input<Func> input_i64{"input_i64", 1};
+  Input<Func> input_u8{"input_u8", 1};
+  Input<Func> input_u16{"input_u16", 1};
+  Input<Func> input_u32{"input_u32", 1};
+  Input<Func> input_u64{"input_u64", 1};
+  Input<Func> input_f16{"input_f16", 1};
+  Input<Func> input_f32{"input_f32", 1};
+  Input<Func> input_f64{"input_f64", 1};
+  Input<Func> input_bf16{"input_bf16", 1};
+  Output<Func> output{"output", 1};
+
+    void generate() {
+        Var x;
+        output(x) = cast<double>(input_i8(x) + input_i16(x)  + input_i32(x) + input_i64(x)) +
+                    cast<double>(input_u8(x) + input_u16(x)  + input_u32(x) + input_u64(x)) +
+                    input_f16(x) + input_f32(x)  + input_f64(x) + input_bf16(x);
+
+        // set estimates for the autoschedulers
+        input_i8.set_estimates({{0, 32}});
+        input_i16.set_estimates({{0, 32}});
+        input_i32.set_estimates({{0, 32}});
+        input_i64.set_estimates({{0, 32}});
+        input_u8.set_estimates({{0, 32}});
+        input_u16.set_estimates({{0, 32}});
+        input_u32.set_estimates({{0, 32}});
+        input_u64.set_estimates({{0, 32}});
+        input_f16.set_estimates({{0, 32}});
+        input_f32.set_estimates({{0, 32}});
+        input_f64.set_estimates({{0, 32}});
+        input_bf16.set_estimates({{0, 32}});
+        output.set_estimates({{0, 32}});
+
+        if (!using_autoscheduler()) {
+            output.vectorize(x, natural_vector_size<int64_t>()).compute_root();
+        }
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(AllTypeNamesGeneric, all_type_names_generic)
+HALIDE_REGISTER_GENERATOR_ALIAS(all_type_names, all_type_names_generic, {
+    {"input_i8.type", "int8"}, {"input_i16.type", "int16"}, {"input_i32.type", "int32"}, {"input_i64.type", "int64"},
+    {"input_u8.type", "uint8"}, {"input_u16.type", "uint16"},{"input_u32.type", "uint32"}, {"input_u64.type", "uint64"},
+    {"input_f16.type", "float16"}, {"input_f32.type", "float32"}, {"input_f64.type", "float64"}, {"input_bf16.type", "bfloat16"},
+    {"output.type", "float64"}})

--- a/test/generator/all_type_names_generator.cpp
+++ b/test/generator/all_type_names_generator.cpp
@@ -20,9 +20,9 @@ public:
 
     void generate() {
         Var x;
-        output(x) = cast<double>(input_i8(x) + input_i16(x)  + input_i32(x) + input_i64(x)) +
-                    cast<double>(input_u8(x) + input_u16(x)  + input_u32(x) + input_u64(x)) +
-                    input_f16(x) + input_f32(x)  + input_f64(x) + input_bf16(x);
+        output(x) = cast<double>(input_i8(x) + input_i16(x) + input_i32(x) + input_i64(x)) +
+                    cast<double>(input_u8(x) + input_u16(x) + input_u32(x) + input_u64(x)) +
+                    input_f16(x) + input_f32(x) + input_f64(x) + input_bf16(x);
 
         // set estimates for the autoschedulers
         input_i8.set_estimates({{0, 32}});
@@ -48,8 +48,4 @@ public:
 }  // namespace
 
 HALIDE_REGISTER_GENERATOR(AllTypeNamesGeneric, all_type_names_generic)
-HALIDE_REGISTER_GENERATOR_ALIAS(all_type_names, all_type_names_generic, {
-    {"input_i8.type", "int8"}, {"input_i16.type", "int16"}, {"input_i32.type", "int32"}, {"input_i64.type", "int64"},
-    {"input_u8.type", "uint8"}, {"input_u16.type", "uint16"},{"input_u32.type", "uint32"}, {"input_u64.type", "uint64"},
-    {"input_f16.type", "float16"}, {"input_f32.type", "float32"}, {"input_f64.type", "float64"}, {"input_bf16.type", "bfloat16"},
-    {"output.type", "float64"}})
+HALIDE_REGISTER_GENERATOR_ALIAS(all_type_names, all_type_names_generic, {{"input_i8.type", "int8"}, {"input_i16.type", "int16"}, {"input_i32.type", "int32"}, {"input_i64.type", "int64"}, {"input_u8.type", "uint8"}, {"input_u16.type", "uint16"}, {"input_u32.type", "uint32"}, {"input_u64.type", "uint64"}, {"input_f16.type", "float16"}, {"input_f32.type", "float32"}, {"input_f64.type", "float64"}, {"input_bf16.type", "bfloat16"}, {"output.type", "float64"}})


### PR DESCRIPTION
Specifically adding 64-bit signed and unsigned integers and making sure float16 and bfloat16 are fully supported and documented.

Add a simple test for all the type names.