### PR TITLE
Remove the deprecated API `llvm::Type::getInt8PtrTy` usage.

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -5161,7 +5161,7 @@ llvm::Type *CodeGen_LLVM::llvm_type_of(LLVMContext *c, Halide::Type t,
                 return nullptr;
             }
         } else if (t.is_handle()) {
-            return llvm::Type::getInt8PtrTy(*c);
+            return llvm::PointerType::getUnqual(*c);
         } else {
             return llvm::Type::getIntNTy(*c, t.bits());
         }


### PR DESCRIPTION
This API is removed in LLVM trunk now https://github.com/llvm/llvm-project/commit/7b9d73c2f90c0ed8497339a16fc39785349d9610.