### PR TITLE
More targeted fix for gather instructions being slow on intel processors

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1122,7 +1122,7 @@ void CodeGen_LLVM::optimize_module() {
     PipelineTuningOptions pto;
     pto.LoopInterleaving = do_loop_opt;
     pto.LoopVectorization = do_loop_opt;
-    pto.SLPVectorization = use_slp_vectorization();
+    pto.SLPVectorization = true;
     pto.LoopUnrolling = do_loop_opt;
     // Clear ScEv info for all loops. Certain Halide applications spend a very
     // long time compiling in forgetLoop, and prefer to forget everything

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -127,13 +127,6 @@ protected:
     virtual bool use_pic() const;
     // @}
 
-    /** Should SLP vectorization be turned on in LLVM? SLP vectorization has no
-     * analogue in the Halide scheduling model so this is decided heuristically
-     * depending on the target. */
-    virtual bool use_slp_vectorization() const {
-        return true;
-    }
-
     /** Should indexing math be promoted to 64-bit on platforms with
      * 64-bit pointers? */
     virtual bool promote_indices() const {

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -68,8 +68,6 @@ protected:
     bool use_soft_float_abi() const override;
     int native_vector_bits() const override;
 
-    bool use_slp_vectorization() const override;
-
     int vector_lanes_for_slice(const Type &t) const;
 
     using CodeGen_Posix::visit;
@@ -918,6 +916,34 @@ string CodeGen_X86::mcpu_target() const {
     }
 }
 
+namespace {
+bool gather_might_be_slow(Target target) {
+    // Intel x86 processors between broadwell and tiger lake have a microcode
+    // mitigation that makes gather instructions very slow. If we know we're on
+    // an AMD processor, gather is safe to use. If we have the AVX512 extensions
+    // present in Zen4 (or above), we also know we're not on an affected
+    // processor.
+    switch (target.processor_tune) {
+    case Target::Processor::AMDFam10:
+    case Target::Processor::BdVer1:
+    case Target::Processor::BdVer2:
+    case Target::Processor::BdVer3:
+    case Target::Processor::BdVer4:
+    case Target::Processor::BtVer1:
+    case Target::Processor::BtVer2:
+    case Target::Processor::K8:
+    case Target::Processor::K8_SSE3:
+    case Target::Processor::ZnVer1:
+    case Target::Processor::ZnVer2:
+    case Target::Processor::ZnVer3:
+    case Target::Processor::ZnVer4:
+        return false;
+    default:
+        return !target.has_feature(Target::AVX512_Zen4);
+    }
+}
+}  // namespace
+
 string CodeGen_X86::mcpu_tune() const {
     // Check if any explicit request for tuning exists.
     switch (target.processor_tune) {  // Please keep sorted.
@@ -995,6 +1021,11 @@ string CodeGen_X86::mattrs() const {
             features += ",+avxvnni,+amx-int8,+amx-bf16";
         }
     }
+#if LLVM_VERSION >= 180
+    if (gather_might_be_slow(target)) {
+        features += ",+prefer-no-gather";
+    }
+#endif
     return features;
 }
 
@@ -1028,20 +1059,6 @@ int CodeGen_X86::vector_lanes_for_slice(const Type &t) const {
                                                                    128);
     // clang-format on
     return slice_bits / t.bits();
-}
-
-bool CodeGen_X86::use_slp_vectorization() const {
-    if (target.has_feature(Target::AVX512)) {
-        // LLVM's SLP vectorizer emits avx512 gather intrinsics for LUTs and
-        // boundary conditions, even though they're slower than just
-        // scalarizing. See https://github.com/llvm/llvm-project/issues/70259
-        //
-        // TODO: Once that issue is fixed, we should conditionalize this based on the
-        // LLVM version.
-        return false;
-    } else {
-        return true;
-    }
 }
 
 }  // namespace


### PR DESCRIPTION
gather being slow turned out to be a microcode mitigation on a range of intel processors

See https://github.com/llvm/llvm-project/issues/70259

Rather than turn off SLP vectorization entirely as in #7918 , this PR just turns of gather instruction emission unless we know for sure we're not on one of the affected processors.

Fixes #7917 (but in a different way)