### PR TITLE
Add missing condition to if renesting rule

### DIFF
--- a/src/Simplify_And.cpp
+++ b/src/Simplify_And.cpp
@@ -56,6 +56,7 @@ Expr Simplify::visit(const And *op, ExprInfo *bounds) {
          rewrite(x && !x, false) ||
          rewrite(!x && x, false) ||
          rewrite(y <= x && x < y, false) ||
+         rewrite(y < x && x < y, false) ||
          rewrite(x != c0 && x == c1, b, c0 != c1) ||
          rewrite(x == c0 && x == c1, false, c0 != c1) ||
          // Note: In the predicate below, if undefined overflow

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -596,6 +596,7 @@ Stmt Simplify::visit(const Block *op) {
         return mutate(result);
     } else if (if_first &&
                if_next &&
+               !if_next->else_case.defined() &&
                is_pure(if_first->condition) &&
                is_pure(if_next->condition) &&
                is_const_one(mutate(!(if_first->condition && if_next->condition), nullptr))) {

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1662,7 +1662,6 @@ void check_boolean() {
           Block::make(IfThenElse::make(x < y, not_no_op(x + 1), not_no_op(x + 2)),
                       IfThenElse::make(y <= x, not_no_op(x + 3), not_no_op(x + 4))));
 
-
     // The construct
     //     if (var == expr) then a else b;
     // was being simplified incorrectly, but *only* if var was of type Bool.

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1644,6 +1644,25 @@ void check_boolean() {
                            Block::make(not_no_op(x + 1), not_no_op(x + 2)),
                            not_no_op(x + 3)));
 
+    check(x < y && y < x, const_false());
+    check(Block::make(IfThenElse::make(x < y, not_no_op(x + 1), not_no_op(x + 2)),
+                      IfThenElse::make(y < x, not_no_op(x + 3))),
+          IfThenElse::make(x < y, not_no_op(x + 1),
+                           Block::make(not_no_op(x + 2),
+                                       IfThenElse::make(y < x, not_no_op(x + 3)))));
+
+    check(Block::make(IfThenElse::make(x < y, not_no_op(x + 1), not_no_op(x + 2)),
+                      IfThenElse::make(y <= x, not_no_op(x + 3))),
+          IfThenElse::make(x < y, not_no_op(x + 1),
+                           Block::make(not_no_op(x + 2),
+                                       not_no_op(x + 3))));
+
+    check(Block::make(IfThenElse::make(x < y, not_no_op(x + 1), not_no_op(x + 2)),
+                      IfThenElse::make(y <= x, not_no_op(x + 3), not_no_op(x + 4))),
+          Block::make(IfThenElse::make(x < y, not_no_op(x + 1), not_no_op(x + 2)),
+                      IfThenElse::make(y <= x, not_no_op(x + 3), not_no_op(x + 4))));
+
+
     // The construct
     //     if (var == expr) then a else b;
     // was being simplified incorrectly, but *only* if var was of type Bool.


### PR DESCRIPTION
This triggered in practice on some oddly-structured code.

Also added a simplifier rule that seemed like it was missing I encountered while adding a test.