### PR TITLE
Rename the generated Flatbuffer headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1395,12 +1395,12 @@ $(BIN_DIR)/test_internal: $(ROOT_DIR)/test/internal.cpp $(BIN_DIR)/libHalide.$(S
 	$(CXX) $(TEST_CXX_FLAGS) $< -I$(SRC_DIR) $(TEST_LD_FLAGS) -o $@
 
 ifneq (,$(shell which flatc))
-$(BUILD_DIR)/Deserialization.o : $(BUILD_DIR)/halide_ir_generated.h
-$(BUILD_DIR)/Serialization.o : $(BUILD_DIR)/halide_ir_generated.h
+$(BUILD_DIR)/Deserialization.o : $(BUILD_DIR)/halide_ir.fbs.h
+$(BUILD_DIR)/Serialization.o : $(BUILD_DIR)/halide_ir.fbs.h
 endif
 
 # Generated header for serialization/deserialization
-$(BUILD_DIR)/halide_ir_generated.h: $(SRC_DIR)/halide_ir.fbs
+$(BUILD_DIR)/halide_ir.fbs.h: $(SRC_DIR)/halide_ir.fbs
 	@mkdir -p $(@D)
 	flatc -o $(BUILD_DIR) -c $^  
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -495,7 +495,7 @@ if (WITH_SERIALIZATION)
     set(fb_dir "${Halide_BINARY_DIR}/flatc/include")
 
     set(fb_def "${CMAKE_CURRENT_SOURCE_DIR}/halide_ir.fbs")
-    set(fb_header "${fb_dir}/halide_ir_generated.h")
+    set(fb_header "${fb_dir}/halide_ir.fbs.h")
     add_custom_command(
         OUTPUT "${fb_header}"
         COMMAND flatbuffers::flatc --cpp -o "${fb_dir}" "${fb_def}"

--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -7,7 +7,7 @@
 #include "Function.h"
 #include "IR.h"
 #include "Schedule.h"
-#include "halide_ir_generated.h"
+#include "halide_ir.fbs.h"
 
 #include <fstream>
 #include <functional>

--- a/src/Serialization.cpp
+++ b/src/Serialization.cpp
@@ -8,7 +8,7 @@
 #include "IR.h"
 #include "RealizationOrder.h"
 #include "Schedule.h"
-#include "halide_ir_generated.h"
+#include "halide_ir.fbs.h"
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
The Blaze/Bazel rules for Flatbuffers are inflexible and require this naming pattern :-/