### PR TITLE
Teach unrolling to exploit conditions in enclosing ifs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,7 @@ SOURCE_FILES = \
   BoundaryConditions.cpp \
   Bounds.cpp \
   BoundsInference.cpp \
+  BoundConstantExtentLoops.cpp \
   BoundSmallAllocations.cpp \
   Buffer.cpp \
   Callable.cpp \
@@ -665,6 +666,7 @@ HEADER_FILES = \
   BoundaryConditions.h \
   Bounds.h \
   BoundsInference.h \
+  BoundConstantExtentLoops.h \
   BoundSmallAllocations.h \
   Buffer.h \
   Callable.h \

--- a/src/BoundConstantExtentLoops.cpp
+++ b/src/BoundConstantExtentLoops.cpp
@@ -1,0 +1,136 @@
+#include "BoundConstantExtentLoops.h"
+#include "Bounds.h"
+#include "CSE.h"
+#include "IRMutator.h"
+#include "IROperator.h"
+#include "Simplify.h"
+#include "SimplifyCorrelatedDifferences.h"
+#include "Substitute.h"
+
+namespace Halide {
+namespace Internal {
+
+namespace {
+class BoundLoops : public IRMutator {
+    using IRMutator::visit;
+
+    std::vector<std::pair<std::string, Expr>> lets;
+
+    Stmt visit(const LetStmt *op) override {
+        if (is_pure(op->value)) {
+            lets.emplace_back(op->name, op->value);
+            Stmt s = IRMutator::visit(op);
+            lets.pop_back();
+            return s;
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+
+    std::vector<Expr> facts;
+    Stmt visit(const IfThenElse *op) override {
+        facts.push_back(op->condition);
+        Stmt then_case = mutate(op->then_case);
+        Stmt else_case;
+        if (op->else_case.defined()) {
+            facts.back() = simplify(!op->condition);
+            else_case = mutate(op->else_case);
+        }
+        facts.pop_back();
+        if (then_case.same_as(op->then_case) &&
+            else_case.same_as(op->else_case)) {
+            return op;
+        } else {
+            return IfThenElse::make(op->condition, then_case, else_case);
+        }
+    }
+
+    Stmt visit(const For *op) override {
+        if (is_const(op->extent)) {
+            // Nothing needs to be done
+            return IRMutator::visit(op);
+        }
+
+        if (op->for_type == ForType::Unrolled ||
+            op->for_type == ForType::Vectorized) {
+            // Give it one last chance to simplify to an int
+            Expr extent = simplify(op->extent);
+            Stmt body = op->body;
+            const IntImm *e = extent.as<IntImm>();
+
+            if (e == nullptr) {
+                // We're about to hard fail. Get really aggressive
+                // with the simplifier.
+                for (auto it = lets.rbegin(); it != lets.rend(); it++) {
+                    extent = Let::make(it->first, it->second, extent);
+                }
+                extent = remove_likelies(extent);
+                extent = substitute_in_all_lets(extent);
+                extent = simplify(extent,
+                                  true,
+                                  Scope<Interval>::empty_scope(),
+                                  Scope<ModulusRemainder>::empty_scope(),
+                                  facts);
+                e = extent.as<IntImm>();
+            }
+
+            Expr extent_upper;
+            if (e == nullptr) {
+                // Still no luck. Try taking an upper bound and
+                // injecting an if statement around the body.
+                extent_upper = find_constant_bound(extent, Direction::Upper, Scope<Interval>());
+                if (extent_upper.defined()) {
+                    e = extent_upper.as<IntImm>();
+                    body =
+                        IfThenElse::make(likely_if_innermost(Variable::make(Int(32), op->name) <
+                                                             op->min + op->extent),
+                                         body);
+                }
+            }
+
+            if (e == nullptr && permit_failed_unroll && op->for_type == ForType::Unrolled) {
+                // Still no luck, but we're allowed to fail. Rewrite
+                // to a serial loop.
+                user_warning << "HL_PERMIT_FAILED_UNROLL is allowing us to unroll a non-constant loop into a serial loop. Did you mean to do this?\n";
+                body = mutate(body);
+                return For::make(op->name, op->min, op->extent,
+                                 ForType::Serial, op->partition_policy, op->device_api, std::move(body));
+            }
+
+            user_assert(e)
+                << "Can only " << (op->for_type == ForType::Unrolled ? "unroll" : "vectorize")
+                << " for loops over a constant extent.\n"
+                << "Loop over " << op->name << " has extent " << extent << ".\n";
+            body = mutate(body);
+
+            return For::make(op->name, op->min, e,
+                             op->for_type, op->partition_policy, op->device_api, std::move(body));
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+    bool permit_failed_unroll = false;
+
+public:
+    BoundLoops() {
+        // Experimental autoschedulers may want to unroll without
+        // being totally confident the loop will indeed turn out
+        // to be constant-sized. If this feature continues to be
+        // important, we need to expose it in the scheduling
+        // language somewhere, but how? For now we do something
+        // ugly and expedient.
+
+        // For the tracking issue to fix this, see
+        // https://github.com/halide/Halide/issues/3479
+        permit_failed_unroll = get_env_variable("HL_PERMIT_FAILED_UNROLL") == "1";
+    }
+};
+
+}  // namespace
+
+Stmt bound_constant_extent_loops(const Stmt &s) {
+    return BoundLoops().mutate(s);
+}
+
+}  // namespace Internal
+}  // namespace Halide

--- a/src/BoundConstantExtentLoops.h
+++ b/src/BoundConstantExtentLoops.h
@@ -1,0 +1,24 @@
+#ifndef HALIDE_BOUND_CONSTANT_EXTENT_LOOPS_H
+#define HALIDE_BOUND_CONSTANT_EXTENT_LOOPS_H
+
+/** \file
+ * Defines the lowering pass that enforces a constant extent on all
+ * vectorized or unrolled loops.
+ */
+
+#include "Expr.h"
+
+namespace Halide {
+namespace Internal {
+
+/** Replace all loop extents of unrolled or vectorized loops with constants, by
+ * substituting and simplifying as needed. If we can't determine a constant
+ * extent, but can determine a constant upper bound, inject an if statement into
+ * the body. If we can't even determine a constant upper bound, throw a user
+ * error. */
+Stmt bound_constant_extent_loops(const Stmt &s);
+
+}  // namespace Internal
+}  // namespace Halide
+
+#endif

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -1013,11 +1013,11 @@ public:
                     }
 
                     // Dump out the region required of each stage for debugging.
-
                     /*
                     debug(0) << "Box required of " << producer.name
                              << " by " << consumer.name
-                             << " stage " << consumer.stage << ":\n";
+                             << " stage " << consumer.stage << ":\n"
+                             << " used: " << b.used << "\n";
                     for (size_t k = 0; k < b.size(); k++) {
                         debug(0) << "  " << b[k].min << " ... " << b[k].max << "\n";
                     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,8 @@ set(HEADER_FILES
     BoundaryConditions.h
     Bounds.h
     BoundsInference.h
-    BoundSmallAllocations.h
+    BoundConstantExtentLoops.h
+    BoundSmallAllocations.h    
     Buffer.h
     Callable.h
     CanonicalizeGPUVars.h
@@ -189,6 +190,7 @@ set(SOURCE_FILES
     BoundaryConditions.cpp
     Bounds.cpp
     BoundsInference.cpp
+    BoundConstantExtentLoops.cpp
     BoundSmallAllocations.cpp
     Buffer.cpp
     Callable.cpp

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -11,6 +11,7 @@
 #include "AddParameterChecks.h"
 #include "AllocationBoundsInference.h"
 #include "AsyncProducers.h"
+#include "BoundConstantExtentLoops.h"
 #include "BoundSmallAllocations.h"
 #include "Bounds.h"
 #include "BoundsInference.h"
@@ -311,6 +312,10 @@ void lower_impl(const vector<Function> &output_funcs,
     debug(1) << "Simplifying correlated differences...\n";
     s = simplify_correlated_differences(s);
     log("Lowering after simplifying correlated differences:", s);
+
+    debug(1) << "Bounding constant extent loops...\n";
+    s = bound_constant_extent_loops(s);
+    log("Lowering after bounding constant extent loops:", s);
 
     debug(1) << "Unrolling...\n";
     s = unroll_loops(s);

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -355,8 +355,13 @@ Simplify::ScopedFact::~ScopedFact() {
 
 Expr simplify(const Expr &e, bool remove_dead_let_stmts,
               const Scope<Interval> &bounds,
-              const Scope<ModulusRemainder> &alignment) {
+              const Scope<ModulusRemainder> &alignment,
+              const std::vector<Expr> &assumptions) {
     Simplify m(remove_dead_let_stmts, &bounds, &alignment);
+    std::vector<Simplify::ScopedFact> facts;
+    for (const Expr &a : assumptions) {
+        facts.push_back(m.scoped_truth(a));
+    }
     Expr result = m.mutate(e, nullptr);
     if (m.in_unreachable) {
         return unreachable(e.type());
@@ -366,8 +371,13 @@ Expr simplify(const Expr &e, bool remove_dead_let_stmts,
 
 Stmt simplify(const Stmt &s, bool remove_dead_let_stmts,
               const Scope<Interval> &bounds,
-              const Scope<ModulusRemainder> &alignment) {
+              const Scope<ModulusRemainder> &alignment,
+              const std::vector<Expr> &assumptions) {
     Simplify m(remove_dead_let_stmts, &bounds, &alignment);
+    std::vector<Simplify::ScopedFact> facts;
+    for (const Expr &a : assumptions) {
+        facts.push_back(m.scoped_truth(a));
+    }
     Stmt result = m.mutate(s);
     if (m.in_unreachable) {
         return Evaluate::make(unreachable());

--- a/src/Simplify.h
+++ b/src/Simplify.h
@@ -13,19 +13,22 @@
 namespace Halide {
 namespace Internal {
 
-/** Perform a a wide range of simplifications to expressions and
- * statements, including constant folding, substituting in trivial
- * values, arithmetic rearranging, etc. Simplifies across let
- * statements, so must not be called on stmts with dangling or
- * repeated variable names.
+/** Perform a wide range of simplifications to expressions and statements,
+ * including constant folding, substituting in trivial values, arithmetic
+ * rearranging, etc. Simplifies across let statements, so must not be called on
+ * stmts with dangling or repeated variable names. Can optionally be passed
+ * known bounds of any variables, known alignment properties, and any other
+ * Exprs that should be assumed to be true.
  */
 // @{
 Stmt simplify(const Stmt &, bool remove_dead_code = true,
               const Scope<Interval> &bounds = Scope<Interval>::empty_scope(),
-              const Scope<ModulusRemainder> &alignment = Scope<ModulusRemainder>::empty_scope());
+              const Scope<ModulusRemainder> &alignment = Scope<ModulusRemainder>::empty_scope(),
+              const std::vector<Expr> &assumptions = std::vector<Expr>());
 Expr simplify(const Expr &, bool remove_dead_code = true,
               const Scope<Interval> &bounds = Scope<Interval>::empty_scope(),
-              const Scope<ModulusRemainder> &alignment = Scope<ModulusRemainder>::empty_scope());
+              const Scope<ModulusRemainder> &alignment = Scope<ModulusRemainder>::empty_scope(),
+              const std::vector<Expr> &assumptions = std::vector<Expr>());
 // @}
 
 /** Attempt to statically prove an expression is true using the simplifier. */

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -1,10 +1,7 @@
 #include "UnrollLoops.h"
-#include "Bounds.h"
-#include "CSE.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "Simplify.h"
-#include "SimplifyCorrelatedDifferences.h"
 #include "Substitute.h"
 #include "UniquifyVariableNames.h"
 
@@ -19,84 +16,13 @@ namespace {
 class UnrollLoops : public IRMutator {
     using IRMutator::visit;
 
-    vector<pair<std::string, Expr>> lets;
-
-    Stmt visit(const LetStmt *op) override {
-        if (is_pure(op->value)) {
-            lets.emplace_back(op->name, op->value);
-            Stmt s = IRMutator::visit(op);
-            lets.pop_back();
-            return s;
-        } else {
-            return IRMutator::visit(op);
-        }
-    }
-
-    std::vector<Expr> facts;
-    Stmt visit(const IfThenElse *op) override {
-        facts.push_back(op->condition);
-        Stmt then_case = mutate(op->then_case);
-        Stmt else_case;
-        if (op->else_case.defined()) {
-            facts.back() = simplify(!op->condition);
-            else_case = mutate(op->else_case);
-        }
-        facts.pop_back();
-        if (then_case.same_as(op->then_case) &&
-            else_case.same_as(op->else_case)) {
-            return op;
-        } else {
-            return IfThenElse::make(op->condition, then_case, else_case);
-        }
-    }
-
     Stmt visit(const For *for_loop) override {
         if (for_loop->for_type == ForType::Unrolled) {
-            // Give it one last chance to simplify to an int
-            Expr extent = simplify(for_loop->extent);
             Stmt body = for_loop->body;
-            const IntImm *e = extent.as<IntImm>();
+            const IntImm *e = for_loop->extent.as<IntImm>();
 
-            if (e == nullptr) {
-                // We're about to hard fail. Get really aggressive
-                // with the simplifier.
-                for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-                    extent = Let::make(it->first, it->second, extent);
-                }
-                extent = remove_likelies(extent);
-                extent = substitute_in_all_lets(extent);
-                extent = simplify(extent,
-                                  true,
-                                  Scope<Interval>::empty_scope(),
-                                  Scope<ModulusRemainder>::empty_scope(),
-                                  facts);
-                e = extent.as<IntImm>();
-            }
-
-            Expr extent_upper;
-            bool use_guard = false;
-            if (e == nullptr) {
-                // Still no luck. Try taking an upper bound and
-                // injecting an if statement around the body.
-                extent_upper = find_constant_bound(extent, Direction::Upper, Scope<Interval>());
-                if (extent_upper.defined()) {
-                    e = extent_upper.as<IntImm>();
-                    use_guard = true;
-                }
-            }
-
-            if (e == nullptr && permit_failed_unroll) {
-                // Still no luck, but we're allowed to fail. Rewrite
-                // to a serial loop.
-                user_warning << "HL_PERMIT_FAILED_UNROLL is allowing us to unroll a non-constant loop into a serial loop. Did you mean to do this?\n";
-                body = mutate(body);
-                return For::make(for_loop->name, for_loop->min, for_loop->extent,
-                                 ForType::Serial, for_loop->partition_policy, for_loop->device_api, std::move(body));
-            }
-
-            user_assert(e)
-                << "Can only unroll for loops over a constant extent.\n"
-                << "Loop over " << for_loop->name << " has extent " << extent << ".\n";
+            internal_assert(e)
+                << "Loop over " << for_loop->name << " should have had a constant extent\n";
             body = mutate(body);
 
             if (e->value == 1) {
@@ -116,9 +42,6 @@ class UnrollLoops : public IRMutator {
                 } else {
                     iters = Block::make(iter, iters);
                 }
-                if (use_guard) {
-                    iters = IfThenElse::make(likely_if_innermost(i < for_loop->extent), iters);
-                }
             }
 
             return iters;
@@ -126,21 +49,6 @@ class UnrollLoops : public IRMutator {
         } else {
             return IRMutator::visit(for_loop);
         }
-    }
-    bool permit_failed_unroll = false;
-
-public:
-    UnrollLoops() {
-        // Experimental autoschedulers may want to unroll without
-        // being totally confident the loop will indeed turn out
-        // to be constant-sized. If this feature continues to be
-        // important, we need to expose it in the scheduling
-        // language somewhere, but how? For now we do something
-        // ugly and expedient.
-
-        // For the tracking issue to fix this, see
-        // https://github.com/halide/Halide/issues/3479
-        permit_failed_unroll = get_env_variable("HL_PERMIT_FAILED_UNROLL") == "1";
     }
 };
 

--- a/src/UnrollLoops.cpp
+++ b/src/UnrollLoops.cpp
@@ -5,9 +5,6 @@
 #include "Substitute.h"
 #include "UniquifyVariableNames.h"
 
-using std::pair;
-using std::vector;
-
 namespace Halide {
 namespace Internal {
 

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -951,7 +951,9 @@ class VectorSubs : public IRMutator {
 
         if (op->for_type == ForType::Vectorized) {
             const IntImm *extent_int = extent.as<IntImm>();
-            if (!extent_int || extent_int->value <= 1) {
+            internal_assert(extent_int)
+                << "Vectorized for loop extent should have been rewritten to a constant\n";
+            if (extent_int->value <= 1) {
                 user_error << "Loop over " << op->name
                            << " has extent " << extent
                            << ". Can only vectorize loops over a "

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -318,6 +318,7 @@ tests(GROUPS correctness
       uninitialized_read.cpp
       unique_func_image.cpp
       unroll_dynamic_loop.cpp
+      unroll_loop_with_implied_constant_bounds.cpp
       unrolled_reduction.cpp
       unsafe_dedup_lets.cpp
       unsafe_promises.cpp

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -336,6 +336,7 @@ tests(GROUPS correctness
       vectorize_nested.cpp
       vectorize_varying_allocation_size.cpp
       vectorized_gpu_allocation.cpp
+      vectorized_guard_with_if_tail.cpp
       vectorized_initialization.cpp
       vectorized_load_from_vectorized_allocation.cpp
       vectorized_reduction_bug.cpp

--- a/test/correctness/unroll_loop_with_implied_constant_bounds.cpp
+++ b/test/correctness/unroll_loop_with_implied_constant_bounds.cpp
@@ -48,5 +48,7 @@ int main(int argc, char **argv) {
         p.compile_jit();
     }
 
+    printf("Success!\n");
+
     return 0;
 }

--- a/test/correctness/unroll_loop_with_implied_constant_bounds.cpp
+++ b/test/correctness/unroll_loop_with_implied_constant_bounds.cpp
@@ -1,0 +1,45 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // This test verifies that unrolling is capable of inferring constant bounds
+    // of loops that are implied by containing if statement conditions, e.g the
+    // following structure should work:
+    /*
+      let extent = foo
+      if (foo == 7) {
+        unrolled for (x from 0 to extent) {...}
+      }
+    */
+
+    Func intermediate("intermediate");
+
+    Func output1("output1"), output2("output2");
+
+    Var x("x"), y("y"), c("c");
+
+    intermediate(x, y, c) = x + y + c;
+
+    output1(x, y, c) = intermediate(x, y, c);
+    output2(x, y, c) = intermediate(x, y, c);
+
+    Expr three_channels =
+        (output1.output_buffer().dim(2).extent() == 3 &&
+         output1.output_buffer().dim(2).min() == 0 &&
+         output2.output_buffer().dim(2).extent() == 3 &&
+         output2.output_buffer().dim(2).min() == 0);
+
+    intermediate.compute_root()
+        .specialize(three_channels)
+        .unroll(c);
+
+    Pipeline p{{output1, output2}};
+
+    // Should not throw an error in loop unrolling.
+    p.compile_jit();
+
+    printf("Success!\n");
+
+    return 0;
+}

--- a/test/correctness/unroll_loop_with_implied_constant_bounds.cpp
+++ b/test/correctness/unroll_loop_with_implied_constant_bounds.cpp
@@ -3,9 +3,10 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    // This test verifies that unrolling is capable of inferring constant bounds
-    // of loops that are implied by containing if statement conditions, e.g the
-    // following structure should work:
+    // This test verifies that unrolling/vectorizing is capable of inferring
+    // constant bounds of loops that are implied by containing if statement
+    // conditions, e.g the following structure should work:
+
     /*
       let extent = foo
       if (foo == 7) {
@@ -13,33 +14,39 @@ int main(int argc, char **argv) {
       }
     */
 
-    Func intermediate("intermediate");
+    for (int i = 0; i < 2; i++) {
+        Func intermediate("intermediate");
 
-    Func output1("output1"), output2("output2");
+        Func output1("output1"), output2("output2");
 
-    Var x("x"), y("y"), c("c");
+        Var x("x"), y("y"), c("c");
 
-    intermediate(x, y, c) = x + y + c;
+        intermediate(x, y, c) = x + y + c;
 
-    output1(x, y, c) = intermediate(x, y, c);
-    output2(x, y, c) = intermediate(x, y, c);
+        output1(x, y, c) = intermediate(x, y, c);
+        output2(x, y, c) = intermediate(x, y, c);
 
-    Expr three_channels =
-        (output1.output_buffer().dim(2).extent() == 3 &&
-         output1.output_buffer().dim(2).min() == 0 &&
-         output2.output_buffer().dim(2).extent() == 3 &&
-         output2.output_buffer().dim(2).min() == 0);
+        Expr three_channels =
+            (output1.output_buffer().dim(2).extent() == 3 &&
+             output1.output_buffer().dim(2).min() == 0 &&
+             output2.output_buffer().dim(2).extent() == 3 &&
+             output2.output_buffer().dim(2).min() == 0);
 
-    intermediate.compute_root()
-        .specialize(three_channels)
-        .unroll(c);
+        if (i == 0) {
+            intermediate.compute_root()
+                .specialize(three_channels)
+                .unroll(c);
+        } else {
+            intermediate.compute_root()
+                .specialize(three_channels)
+                .vectorize(c);
+        }
 
-    Pipeline p{{output1, output2}};
+        Pipeline p{{output1, output2}};
 
-    // Should not throw an error in loop unrolling.
-    p.compile_jit();
-
-    printf("Success!\n");
+        // Should not throw an error in loop unrolling or vectorization.
+        p.compile_jit();
+    }
 
     return 0;
 }

--- a/test/correctness/vectorized_guard_with_if_tail.cpp
+++ b/test/correctness/vectorized_guard_with_if_tail.cpp
@@ -1,0 +1,42 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Var x;
+
+    for (int i = 0; i < 2; i++) {
+        Func f, g;
+        f(x) = x;
+        g(x) = f(x) * 2;
+
+        g.vectorize(x, 8, TailStrategy::GuardWithIf);
+
+        f.compute_at(g, x);
+
+        // A varying amount of f is required depending on if we're in the steady
+        // state of g or the tail. Nonetheless, the amount required has a constant
+        // upper bound of 8. Vectorization, unrolling, and variants of store_in that
+        // require constant extent should all be able to handle this.
+        if (i == 0) {
+            f.vectorize(x);
+        } else {
+            f.unroll(x);
+        }
+        f.store_in(MemoryType::Register);
+
+        Buffer<int> buf = g.realize({37});
+
+        for (int i = 0; i < buf.width(); i++) {
+            int correct = i * 2;
+            if (buf(i) != correct) {
+                printf("buf(%d) = %d instead of %d\n",
+                       i, buf(i), correct);
+                return 1;
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #7968

This also changes the interface to simplify() to accept a vector of boolean Exprs that can be assumed to be true, which is a change I've been meaning to make for a while. The simplifier supports it internally, but it wasn't exposed in the API.