### PR TITLE
Tweak the Printer code in runtime for smaller code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -874,6 +874,7 @@ RUNTIME_CPP_COMPONENTS = \
   posix_timer_profiler \
   powerpc_cpu_features \
   prefetch \
+  printer \
   profiler \
   profiler_inlined \
   pseudostack \

--- a/Makefile
+++ b/Makefile
@@ -1444,6 +1444,14 @@ $(BIN_DIR)/runtime_internal_to_string.o: $(ROOT_DIR)/src/runtime/to_string.cpp
 	@mkdir -p $(@D)
 	$(CXX) $(TEST_CXX_FLAGS) $(RUNTIME_TESTS_CXXFLAGS) -I$(ROOT_DIR)/test/runtime -I$(ROOT_DIR)/src/runtime $(OPTIMIZE_FOR_BUILD_TIME) -c $< -o $@
 
+$(BIN_DIR)/runtime_internal_float16_t.o: $(ROOT_DIR)/src/runtime/float16_t.cpp
+	@mkdir -p $(@D)
+	$(CXX) $(TEST_CXX_FLAGS) $(RUNTIME_TESTS_CXXFLAGS) -I$(ROOT_DIR)/test/runtime -I$(ROOT_DIR)/src/runtime $(OPTIMIZE_FOR_BUILD_TIME) -c $< -o $@
+
+$(BIN_DIR)/runtime_internal_printer.o: $(ROOT_DIR)/src/runtime/printer.cpp
+	@mkdir -p $(@D)
+	$(CXX) $(TEST_CXX_FLAGS) $(RUNTIME_TESTS_CXXFLAGS) -I$(ROOT_DIR)/test/runtime -I$(ROOT_DIR)/src/runtime $(OPTIMIZE_FOR_BUILD_TIME) -c $< -o $@
+
 $(BIN_DIR)/runtime_common:
 	@mkdir -p $(@D)
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -1448,7 +1448,7 @@ $(BIN_DIR)/runtime_common:
 	@mkdir -p $(@D)
 	touch $@
 
-$(BIN_DIR)/runtime_%: $(ROOT_DIR)/test/runtime/%.cpp $(BIN_DIR)/runtime_internal_common.o $(BIN_DIR)/runtime_internal_msan_stubs.o $(BIN_DIR)/runtime_internal_to_string.o
+$(BIN_DIR)/runtime_%: $(ROOT_DIR)/test/runtime/%.cpp $(BIN_DIR)/runtime_internal_common.o $(BIN_DIR)/runtime_internal_msan_stubs.o $(BIN_DIR)/runtime_internal_to_string.o $(BIN_DIR)/runtime_internal_float16_t.o $(BIN_DIR)/runtime_internal_printer.o
 	@mkdir -p $(@D)
 	$(CXX) $(TEST_CXX_FLAGS) $(RUNTIME_TESTS_CXXFLAGS) -I$(ROOT_DIR)/test/runtime -I$(ROOT_DIR)/src/runtime $(OPTIMIZE_FOR_BUILD_TIME) $^ $(COMMON_LD_FLAGS) -o $@
 

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -130,6 +130,7 @@ DECLARE_CPP_INITMOD(posix_threads)
 DECLARE_CPP_INITMOD(posix_threads_tsan)
 DECLARE_CPP_INITMOD(posix_timer_profiler)
 DECLARE_CPP_INITMOD(prefetch)
+DECLARE_CPP_INITMOD(printer)
 DECLARE_CPP_INITMOD(profiler)
 DECLARE_CPP_INITMOD(profiler_inlined)
 DECLARE_CPP_INITMOD(pseudostack)
@@ -804,6 +805,7 @@ std::unique_ptr<llvm::Module> link_with_wasm_jit_runtime(llvm::LLVMContext *c, c
     modules.push_back(get_initmod_float16_t(c, bits_64, debug));
     modules.push_back(get_initmod_errors(c, bits_64, debug));
     modules.push_back(get_initmod_msan_stubs(c, bits_64, debug));
+    modules.push_back(get_initmod_printer(c, bits_64, debug));
 
     // We don't want anything marked as weak for the wasm-jit runtime,
     // so convert all of them to linkonce
@@ -857,6 +859,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             // OS-dependent modules
             if (t.os == Target::Linux) {
                 add_allocator();
+                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
@@ -876,6 +879,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::WebAssemblyRuntime) {
                 add_allocator();
+                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -891,6 +895,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_fake_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::OSX) {
                 add_allocator();
+                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_osx_clock(c, bits_64, debug));
@@ -906,6 +911,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_osx_host_cpu_count(c, bits_64, debug));
             } else if (t.os == Target::Android) {
                 add_allocator();
+                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 if (t.arch == Target::ARM || t.arch == Target::RISCV) {
@@ -938,6 +944,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_windows_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::IOS) {
                 add_allocator();
+                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -964,6 +971,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 // process instead at link time. Less aggressive than
                 // NoRuntime, as OS-agnostic modules like tracing are
                 // still included below.
+                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 if (t.arch == Target::Hexagon) {
                     modules.push_back(get_initmod_posix_aligned_alloc(c, bits_64, debug));
                     modules.push_back(get_initmod_qurt_allocator(c, bits_64, debug));
@@ -977,6 +985,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));
             } else if (t.os == Target::Fuchsia) {
                 add_allocator();
+                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_fuchsia_clock(c, bits_64, debug));

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -859,7 +859,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             // OS-dependent modules
             if (t.os == Target::Linux) {
                 add_allocator();
-                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
@@ -879,7 +878,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::WebAssemblyRuntime) {
                 add_allocator();
-                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -895,7 +893,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_fake_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::OSX) {
                 add_allocator();
-                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_osx_clock(c, bits_64, debug));
@@ -911,7 +908,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_osx_host_cpu_count(c, bits_64, debug));
             } else if (t.os == Target::Android) {
                 add_allocator();
-                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 if (t.arch == Target::ARM || t.arch == Target::RISCV) {
@@ -944,7 +940,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_windows_get_symbol(c, bits_64, debug));
             } else if (t.os == Target::IOS) {
                 add_allocator();
-                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -971,7 +966,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 // process instead at link time. Less aggressive than
                 // NoRuntime, as OS-agnostic modules like tracing are
                 // still included below.
-                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 if (t.arch == Target::Hexagon) {
                     modules.push_back(get_initmod_posix_aligned_alloc(c, bits_64, debug));
                     modules.push_back(get_initmod_qurt_allocator(c, bits_64, debug));
@@ -985,7 +979,6 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));
             } else if (t.os == Target::Fuchsia) {
                 add_allocator();
-                modules.push_back(get_initmod_printer(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
                 modules.push_back(get_initmod_fuchsia_clock(c, bits_64, debug));
@@ -1194,8 +1187,10 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
 
     if (module_type == ModuleJITShared || module_type == ModuleGPU) {
         modules.push_back(get_initmod_module_jit_ref_count(c, bits_64, debug));
+        modules.push_back(get_initmod_printer(c, bits_64, debug));
     } else if (module_type == ModuleAOT) {
         modules.push_back(get_initmod_module_aot_ref_count(c, bits_64, debug));
+        modules.push_back(get_initmod_printer(c, bits_64, debug));
     }
 
     if (module_type == ModuleAOT || module_type == ModuleGPU) {

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -63,6 +63,7 @@ set(RUNTIME_CPP
     posix_timer_profiler
     powerpc_cpu_features
     prefetch
+    printer
     profiler
     profiler_inlined
     pseudostack

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -98,11 +98,11 @@ static constexpr uint64_t trace_buf_size = 4096;
 WEAK char trace_buf[trace_buf_size] = {};
 WEAK int trace_indent = 0;
 
-struct trace : public BasicPrinter<trace_buf_size> {
+struct trace : public PrinterBase {
     ScopedMutexLock lock;
 
     explicit trace(void *user_context = nullptr)
-        : BasicPrinter<trace_buf_size>(user_context, trace_buf),
+        : PrinterBase(user_context, trace_buf, trace_buf_size),
           lock(&trace_lock) {
         for (int i = 0; i < trace_indent; i++) {
             *this << "    ";

--- a/src/runtime/posix_error_handler.cpp
+++ b/src/runtime/posix_error_handler.cpp
@@ -11,7 +11,11 @@ WEAK void halide_default_error(void *user_context, const char *msg) {
     constexpr int buf_size = 4096;
     char buf[buf_size];
     PrinterBase dst(user_context, buf, buf + buf_size);
-    dst << "Error: " << msg << "\n";
+    dst << "Error: " << msg;
+    const char *d = dst.str();
+    if (d && *d && d[strlen(d) - 1] != '\n') {
+        dst << "\n";
+    }
     halide_print(user_context, dst.str());
     abort();
 }

--- a/src/runtime/posix_error_handler.cpp
+++ b/src/runtime/posix_error_handler.cpp
@@ -7,18 +7,12 @@ extern "C" {
 extern void abort();
 
 WEAK void halide_default_error(void *user_context, const char *msg) {
-    char buf[4096];
-    char *dst = halide_string_to_string(buf, buf + 4094, "Error: ");
-    dst = halide_string_to_string(dst, dst + 4094, msg);
-    // We still have one character free. Add a newline if there
-    // isn't one already.
-    if (dst[-1] != '\n') {
-        dst[0] = '\n';
-        dst[1] = 0;
-        dst += 1;
-    }
-    (void)halide_msan_annotate_memory_is_initialized(user_context, buf, dst - buf + 1);
-    halide_print(user_context, buf);
+    // Can't use StackBasicPrinter here because it limits size to 256
+    constexpr int buf_size = 4096;
+    char buf[buf_size];
+    PrinterBase dst(user_context, buf, buf + buf_size);
+    dst << "Error: " << msg << "\n";
+    halide_print(user_context, dst.str());
     abort();
 }
 }

--- a/src/runtime/printer.cpp
+++ b/src/runtime/printer.cpp
@@ -1,0 +1,110 @@
+#include "printer.h"
+
+namespace Halide {
+namespace Runtime {
+namespace Internal {
+
+PrinterBase::PrinterBase(void *user_context, char *start, char *end)
+    : dst(start), end(end), start(start), user_context(user_context) {
+    if (!start) {
+        // Pointers equal ensures no writes to buffer via formatting code
+        end = dst;
+    } else {
+        // null-terminate ahead of time
+        *end = 0;
+    }
+}
+
+const char *PrinterBase::str() {
+    (void)halide_msan_annotate_memory_is_initialized(user_context, start, dst - start + 1);
+    return start;
+}
+
+uint64_t PrinterBase::size() const {
+    return (uint64_t)(dst - start);
+}
+
+uint64_t PrinterBase::capacity() const {
+    return (uint64_t)(end - start);
+}
+
+void PrinterBase::clear() {
+    dst = start;
+    if (dst) {
+        dst[0] = 0;
+    }
+}
+
+void PrinterBase::erase(int n) {
+    if (dst) {
+        dst -= n;
+        if (dst < start) {
+            dst = start;
+        }
+        dst[0] = 0;
+    }
+}
+
+void PrinterBase::allocation_error() const {
+    halide_error(user_context, "Printer buffer allocation failed.\n");
+}
+
+PrinterBase &PrinterBase::operator<<(const char *arg) {
+    dst = halide_string_to_string(dst, end, arg);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(int64_t arg) {
+    dst = halide_int64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(int32_t arg) {
+    dst = halide_int64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(uint64_t arg) {
+    dst = halide_uint64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(uint32_t arg) {
+    dst = halide_uint64_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(double arg) {
+    dst = halide_double_to_string(dst, end, arg, 1);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(float arg) {
+    dst = halide_double_to_string(dst, end, arg, 0);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(PrinterBase::Float16Bits arg) {
+    double value = halide_float16_bits_to_double(arg.bits);
+    dst = halide_double_to_string(dst, end, value, 1);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(const void *arg) {
+    dst = halide_pointer_to_string(dst, end, arg);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(const halide_type_t &t) {
+    dst = halide_type_to_string(dst, end, &t);
+    return *this;
+}
+
+PrinterBase &PrinterBase::operator<<(const halide_buffer_t &buf) {
+    dst = halide_buffer_to_string(dst, end, &buf);
+    return *this;
+}
+
+}  // namespace Internal
+}  // namespace Runtime
+}  // namespace Halide

--- a/src/runtime/printer.h
+++ b/src/runtime/printer.h
@@ -41,29 +41,72 @@ constexpr uint64_t default_printer_buffer_length = 1024;
 // Then remember the print only happens when the debug object leaves
 // scope, which may print at a confusing time.
 
-namespace {
-template<PrinterType printer_type, uint64_t buffer_length = default_printer_buffer_length>
-class Printer {
-    char *buf, *dst, *end;
-    void *user_context;
-    bool own_mem;
+class PrinterBase {
+protected:
+    char *dst;
+    char *const end;
+    char *const start;
+    void *const user_context;
+
+    NEVER_INLINE void allocation_error() const;
 
 public:
-    explicit Printer(void *ctx, char *mem = nullptr)
-        : user_context(ctx), own_mem(mem == nullptr) {
-        if (mem != nullptr) {
-            buf = mem;
-        } else {
-            buf = (char *)malloc(buffer_length);
-        }
+    // This class will stream text into the range [start, end).
+    // It does *not* assume any ownership of the memory; it assumes
+    // the memory will remain valid for its lifespan, and doesn't
+    // attempt to free any allocations. It also doesn't do any sanity
+    // checking of the pointers, so if you pass in a null or bogus value,
+    // it will attempt to use it.
+    NEVER_INLINE PrinterBase(void *user_context, char *start, char *end);
 
-        dst = buf;
-        if (dst) {
-            end = buf + (buffer_length - 1);
-            *end = 0;
-        } else {
-            // Pointers equal ensures no writes to buffer via formatting code
-            end = dst;
+    // Alternate start-and-size ctor that is more convenient for the Printer subclass
+    PrinterBase(void *user_context, char *start, uint64_t size)
+        : PrinterBase(user_context, start, start + size) {
+    }
+
+    NEVER_INLINE const char *str();
+    NEVER_INLINE uint64_t size() const;
+    NEVER_INLINE uint64_t capacity() const;
+    NEVER_INLINE void clear();
+    NEVER_INLINE void erase(int n);
+
+    struct Float16Bits {
+        uint16_t bits;
+    };
+
+    NEVER_INLINE PrinterBase &operator<<(const char *arg);
+    NEVER_INLINE PrinterBase &operator<<(int64_t arg);
+    NEVER_INLINE PrinterBase &operator<<(int32_t arg);
+    NEVER_INLINE PrinterBase &operator<<(uint64_t arg);
+    NEVER_INLINE PrinterBase &operator<<(uint32_t arg);
+    NEVER_INLINE PrinterBase &operator<<(double arg);
+    NEVER_INLINE PrinterBase &operator<<(float arg);
+    NEVER_INLINE PrinterBase &operator<<(Float16Bits arg);
+    NEVER_INLINE PrinterBase &operator<<(const void *arg);
+    NEVER_INLINE PrinterBase &operator<<(const halide_type_t &t);
+    NEVER_INLINE PrinterBase &operator<<(const halide_buffer_t &buf);
+
+    template<typename... Args>
+    void append(const Args &...args) {
+        ((*this << args), ...);
+    }
+
+    // Not movable, not copyable
+    PrinterBase(const PrinterBase &copy) = delete;
+    PrinterBase &operator=(const PrinterBase &) = delete;
+    PrinterBase(PrinterBase &&) = delete;
+    PrinterBase &operator=(PrinterBase &&) = delete;
+};
+
+namespace {
+
+template<PrinterType printer_type, uint64_t buffer_length = default_printer_buffer_length>
+class HeapPrinter : public PrinterBase {
+public:
+    NEVER_INLINE explicit HeapPrinter(void *user_context)
+        : PrinterBase(user_context, (char *)malloc(buffer_length), buffer_length) {
+        if (!start) {
+            allocation_error();
         }
 
 #if HALIDE_RUNTIME_PRINTER_LOG_THREADID
@@ -73,147 +116,18 @@ public:
 #endif
     }
 
-    // Not movable, not copyable
-    Printer(const Printer &copy) = delete;
-    Printer &operator=(const Printer &) = delete;
-    Printer(Printer &&) = delete;
-    Printer &operator=(Printer &&) = delete;
-
-    Printer &operator<<(const char *arg) {
-        dst = halide_string_to_string(dst, end, arg);
-        return *this;
-    }
-
-    Printer &operator<<(int64_t arg) {
-        dst = halide_int64_to_string(dst, end, arg, 1);
-        return *this;
-    }
-
-    Printer &operator<<(int32_t arg) {
-        dst = halide_int64_to_string(dst, end, arg, 1);
-        return *this;
-    }
-
-    Printer &operator<<(uint64_t arg) {
-        dst = halide_uint64_to_string(dst, end, arg, 1);
-        return *this;
-    }
-
-    Printer &operator<<(uint32_t arg) {
-        dst = halide_uint64_to_string(dst, end, arg, 1);
-        return *this;
-    }
-
-    Printer &operator<<(double arg) {
-        dst = halide_double_to_string(dst, end, arg, 1);
-        return *this;
-    }
-
-    Printer &operator<<(float arg) {
-        dst = halide_double_to_string(dst, end, arg, 0);
-        return *this;
-    }
-
-    Printer &operator<<(const void *arg) {
-        dst = halide_pointer_to_string(dst, end, arg);
-        return *this;
-    }
-
-    Printer &write_float16_from_bits(const uint16_t arg) {
-        double value = halide_float16_bits_to_double(arg);
-        dst = halide_double_to_string(dst, end, value, 1);
-        return *this;
-    }
-
-    Printer &operator<<(const halide_type_t &t) {
-        dst = halide_type_to_string(dst, end, &t);
-        return *this;
-    }
-
-    Printer &operator<<(const halide_buffer_t &buf) {
-        dst = halide_buffer_to_string(dst, end, &buf);
-        return *this;
-    }
-
-    template<typename T>
-    void append(const T &value) {
-        *this << value;
-    }
-
-    template<typename First, typename Second, typename... Rest>
-    void append(const First &first, const Second &second, const Rest &...rest) {
-        append<First>(first);
-        append<Second, Rest...>(second, rest...);
-    }
-
-    // Use it like a stringstream.
-    const char *str() {
-        if (buf) {
-            if (printer_type == StringStreamPrinterType) {
-                msan_annotate_is_initialized();
-            }
-            return buf;
+    NEVER_INLINE ~HeapPrinter() {
+        if (printer_type == ErrorPrinterType) {
+            halide_error(user_context, str());
+        } else if (printer_type == BasicPrinterType) {
+            halide_print(user_context, str());
         } else {
-            return allocation_error();
-        }
-    }
-
-    // Clear it. Useful for reusing a stringstream.
-    void clear() {
-        dst = buf;
-        if (dst) {
-            dst[0] = 0;
-        }
-    }
-
-    // Returns the number of characters in the buffer
-    uint64_t size() const {
-        return (uint64_t)(dst - buf);
-    }
-
-    uint64_t capacity() const {
-        return buffer_length;
-    }
-
-    // Delete the last N characters
-    void erase(int n) {
-        if (dst) {
-            dst -= n;
-            if (dst < buf) {
-                dst = buf;
-            }
-            dst[0] = 0;
-        }
-    }
-
-    const char *allocation_error() {
-        return "Printer buffer allocation failed.\n";
-    }
-
-    void msan_annotate_is_initialized() {
-        (void)halide_msan_annotate_memory_is_initialized(user_context, buf, dst - buf + 1);
-    }
-
-    ~Printer() {
-        if (!buf) {
-            halide_error(user_context, allocation_error());
-        } else {
-            msan_annotate_is_initialized();
-            if (printer_type == ErrorPrinterType) {
-                halide_error(user_context, buf);
-            } else if (printer_type == BasicPrinterType) {
-                halide_print(user_context, buf);
-            } else {
-                // It's a stringstream. Do nothing.
-            }
+            // It's a stringstream. Do nothing.
         }
 
-        if (own_mem) {
-            free(buf);
-        }
+        free(start);
     }
 };
-
 // A class that supports << with all the same types as Printer, but
 // does nothing and should compile to a no-op.
 class SinkPrinter {
@@ -227,13 +141,13 @@ ALWAYS_INLINE SinkPrinter operator<<(const SinkPrinter &s, T) {
 }
 
 template<uint64_t buffer_length = default_printer_buffer_length>
-using BasicPrinter = Printer<BasicPrinterType, buffer_length>;
+using BasicPrinter = HeapPrinter<BasicPrinterType, buffer_length>;
 
 template<uint64_t buffer_length = default_printer_buffer_length>
-using ErrorPrinter = Printer<ErrorPrinterType, buffer_length>;
+using ErrorPrinter = HeapPrinter<ErrorPrinterType, buffer_length>;
 
 template<uint64_t buffer_length = default_printer_buffer_length>
-using StringStreamPrinter = Printer<StringStreamPrinterType, buffer_length>;
+using StringStreamPrinter = HeapPrinter<StringStreamPrinterType, buffer_length>;
 
 using print = BasicPrinter<>;
 using error = ErrorPrinter<>;
@@ -244,17 +158,16 @@ using debug = BasicPrinter<>;
 #else
 using debug = SinkPrinter;
 #endif
-}  // namespace
 
 // A Printer that automatically reserves stack space for the printer buffer, rather than malloc.
 // Note that this requires an explicit buffer_length, and it (generally) should be <= 256.
 template<PrinterType printer_type, uint64_t buffer_length>
-class StackPrinter : public Printer<printer_type, buffer_length> {
+class StackPrinter : public PrinterBase {
     char scratch[buffer_length];
 
 public:
-    explicit StackPrinter(void *ctx)
-        : Printer<printer_type, buffer_length>(ctx, scratch) {
+    explicit StackPrinter(void *user_context)
+        : PrinterBase(user_context, scratch, buffer_length) {
         static_assert(buffer_length <= 256, "StackPrinter is meant only for small buffer sizes; you are probably making a mistake.");
     }
 };
@@ -267,6 +180,8 @@ using StackErrorPrinter = StackPrinter<ErrorPrinterType, buffer_length>;
 
 template<uint64_t buffer_length = default_printer_buffer_length>
 using StackStringStreamPrinter = StackPrinter<StringStreamPrinterType, buffer_length>;
+
+}  // namespace
 
 }  // namespace Internal
 }  // namespace Runtime

--- a/src/runtime/runtime_internal.h
+++ b/src/runtime/runtime_internal.h
@@ -51,6 +51,8 @@ typedef ptrdiff_t ssize_t;
 
 #define WEAK __attribute__((weak))
 
+#define NEVER_INLINE __attribute__((noinline))
+
 // Note that ALWAYS_INLINE should *always* also be `inline`.
 #define ALWAYS_INLINE inline __attribute__((always_inline))
 

--- a/src/runtime/tracing.cpp
+++ b/src/runtime/tracing.cpp
@@ -308,7 +308,7 @@ WEAK int32_t halide_default_trace(void *user_context, const halide_trace_event_t
                     if (print_bits == 32) {
                         ss << ((float *)(e->value))[i];
                     } else if (print_bits == 16) {
-                        ss.write_float16_from_bits(((uint16_t *)(e->value))[i]);
+                        ss << PrinterBase::Float16Bits{((uint16_t *)(e->value))[i]};
                     } else {
                         ss << ((double *)(e->value))[i];
                     }

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -29,7 +29,9 @@ if(NOT MSVC)
     # Weak linkages are easier to get right with OBJECT libraries
     add_library(runtime_internal_common OBJECT
                 common.cpp
+                "${Halide_SOURCE_DIR}/src/runtime/float16_t.cpp"
                 "${Halide_SOURCE_DIR}/src/runtime/msan_stubs.cpp"
+                "${Halide_SOURCE_DIR}/src/runtime/printer.cpp"
                 "${Halide_SOURCE_DIR}/src/runtime/to_string.cpp")
     _set_target_options(runtime_internal_common)
 


### PR DESCRIPTION
TL;DR: template expansion meant that we had more replicated code than expected from the inline expansion of code in Printer and friends. Restructured to try to make the call sites as small as possible. It's a modest code-size savings but nonzero.

(In hindsight, I could have done most of this by just adding NEVER_INLINE to select parts of the existing code, but the refactoring into a non-template base felt like cleaner code; we still need the NEVER_INLINE in various places because the Clang inliner is smarter than us, and is preferring speed to code size with aggressive inlining, but 99% of the time we want to use Printer in the runtime is not speed critical.)