### PR TITLE
Don't use variable-length arrays

### DIFF
--- a/test/runtime/memory_arena.cpp
+++ b/test/runtime/memory_arena.cpp
@@ -44,7 +44,7 @@ int main(int argc, char **argv) {
         MemoryArena::Config config = {sizeof(double), 32, 0};
         MemoryArena *arena = MemoryArena::create(user_context, config, test_allocator);
 
-        size_t count = 4 * 1024;
+        constexpr size_t count = 4 * 1024;
         void *pointers[count];
         for (size_t n = 0; n < count; ++n) {
             pointers[n] = arena->reserve(user_context, true);
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
 
         arena.destroy(user_context);
 
-        size_t count = 4 * 1024;
+        constexpr size_t count = 4 * 1024;
         void *pointers[count];
         for (size_t n = 0; n < count; ++n) {
             pointers[n] = arena.reserve(user_context, true);


### PR DESCRIPTION
There was a rogue use of VLAs (an extension we don't want to use) in one of the runtime tests. Fixed the test. I'll follow up with a separate PR to ensure this warning is enabled everywhere to flush out other usages.