### PR TITLE
Fix -Wstrict-prototype warnings in HalideRuntime.h

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -214,7 +214,7 @@ typedef int (*halide_task_t)(void *user_context, int task_number, uint8_t *closu
 extern int halide_do_par_for(void *user_context,
                              halide_task_t task,
                              int min, int size, uint8_t *closure);
-extern void halide_shutdown_thread_pool();
+extern void halide_shutdown_thread_pool(void);
 //@}
 
 /** Set a custom method for performing a parallel for loop. Returns
@@ -751,7 +751,7 @@ extern int halide_get_trace_file(void *user_context);
 
 /** If tracing is writing to a file. This call closes that file
  * (flushing the trace). Returns zero on success. */
-extern int halide_shutdown_trace();
+extern int halide_shutdown_trace(void);
 
 /** All Halide GPU or device backend implementations provide an
  * interface to be used with halide_device_malloc, etc. This is
@@ -1005,7 +1005,7 @@ extern void halide_memoization_cache_release(void *user_context, void *host);
 /** Free all memory and resources associated with the memoization cache.
  * Must be called at a time when no other threads are accessing the cache.
  */
-extern void halide_memoization_cache_cleanup();
+extern void halide_memoization_cache_cleanup(void);
 
 /** Verify that a given range of memory has been initialized; only used when Target::MSAN is enabled.
  *
@@ -1911,7 +1911,7 @@ enum {
 
 /** Get a pointer to the global profiler state for programmatic
  * inspection. Lock it before using to pause the profiler. */
-extern struct halide_profiler_state *halide_profiler_get_state();
+extern struct halide_profiler_state *halide_profiler_get_state(void);
 
 /** Get a pointer to the pipeline state associated with pipeline_name.
  * This function grabs the global profiler state's lock on entry. */
@@ -1930,14 +1930,14 @@ extern int halide_profiler_sample(struct halide_profiler_state *s, uint64_t *pre
  * running; halide_profiler_memory_allocate/free and
  * halide_profiler_stack_peak_update update the profiler pipeline's
  * state without grabbing the global profiler state's lock. */
-extern void halide_profiler_reset();
+extern void halide_profiler_reset(void);
 
 /** Reset all profiler state.
  * WARNING: Do NOT call this method while any halide pipeline is
  * running; halide_profiler_memory_allocate/free and
  * halide_profiler_stack_peak_update update the profiler pipeline's
  * state without grabbing the global profiler state's lock. */
-void halide_profiler_shutdown();
+void halide_profiler_shutdown(void);
 
 /** Print out timing statistics for everything run since the last
  * reset. Also happens at process exit. */
@@ -1946,12 +1946,12 @@ extern void halide_profiler_report(void *user_context);
 /** For timer based profiling, this routine starts the timer chain running.
  * halide_get_profiler_state can be called to get the current timer interval.
  */
-extern void halide_start_timer_chain();
+extern void halide_start_timer_chain(void);
 /** These routines are called to temporarily disable and then reenable
  * timer interuppts for profiling */
 //@{
-extern void halide_disable_timer_interrupt();
-extern void halide_enable_timer_interrupt();
+extern void halide_disable_timer_interrupt(void);
+extern void halide_enable_timer_interrupt(void);
 //@}
 
 /// \name "Float16" functions


### PR DESCRIPTION
When HalideRuntime.h is included in a C file, functions that are declared with `()` instead of `(void)` for their arguments change meaning. These may cause issues downstream because different code is generated. 

E.g., [godbolt example](https://godbolt.org/#z:OYLghAFBqd5TKALEBjA9gEwKYFFMCWALugE4A0BIEAZgQDbYB2AhgLbYgDkAjF%2BTXRMiAZVQtGIHgBYBQogFUAztgAKAD24AGfgCsp5eiyagA%2BudTkVjVEQJDqzTAGF09AK5smIAMw9yTgAyBEzYAHKeAEbYpCAArOQADuhKxPZMrh5evv7JqXZCwaERbNGxCdbYtukiRCykRJme3n5W2DYFTLX1REXhUTHxVnUNTdmtSiO9If2lg3EAlFbo7qSonFzY6kQxTADUIUR7gugQCwCkPgBC51oAgrd3Wzuk%2B4d7kfUQAG7oBJgXa6PR7vNgsEIQd71YCWPaoJD1ABUiL20O%2BCz25wA7Dd7nt8R8voDcXcCcd0KdiY8yaRsERVvstJcSdiACJcJb0bhxfjeLg6cjobjOPZKFZrbCYgBMfn4RG0HKWAGtfD4AHQ%2BTVa7XagBshm40n4bHiWnIfIFQq4/CUIDN8v5HPIcFgKAwOHwxDIlGodEYrA43D4cmEYgknBkIcUKg0CvI%2BilhmMoFQ5ylN3TbQ66UcTBcbmaOQCeb6JTKQzyaSEYxauRSVaYpYG5SzVU63VGBfG/kq1SEHemxWbQ0mPRrRdHDSbc3KSzFq3W3GeuwOwnJlOZwPuy9eq6On1IPz%2BAM39xBa7BEKhpBh5DhCNIyNRN/RmJx1IJB7Op9JBJO36BPECVpeldyZQCHixdlOW5Xk4ytZw0wzK5RXFdZpR8KU5QVBYliQbAWBwWIzgNLgjXIE04jNC1%2BCtG07XIB0dFw8gVSo0ifDgx1BW4bDHSWF0EHgCA3XQNhEgYGIfQgDBxMk2JUGAHhMIEBgXltCBIjjSIQnqABPIN%2BB01hSD0gB5SJdDbQzyFkjhhDMph6AM7icEidxgGcCR6FtXh%2BBwMETEkVyCFpapvmwXyBS2Kp3B2GzDnaGz6AISJSH01wcDjIhSAIE0/KWGgjGAJQADUCGwAB3MzEmYGzBFDcRJEjBrozUTRuP0fwjBMEBzFMSwUsiW1ICWdBEk6XzaIi0hcpwEaSN7Tpc3zLJvH8IIZjLQY63ydJx12htp3LHt2jbGopgO1s%2By6KZjp24Yxy7dbHqnLbhx4Oc0IjGCuB5c14O4PZ1AADl1ABaXVpD2GFUD2ZS1SlPYIE9EhSAwz6%2BOY5VTVI8jKOowHrSsBimKdQSRLQMSJMYCgqBk6n5JAJSVL9dTqC07jjP0mzudMiyrNsGy7OYIhHOcuM3I8rz6B8myAuTYKBUIMK7AiqL%2BBi1A4o2YNEq5PzDFS9LTMyjYBRyvLDMK4qyoq6rar5YNWrDZrZFa5R2rjBMk161N0yQo3hvgMaJvSKbBRmubIpD67logJwDsTTahxnKRDs6JOknrTp7tiHhTuzftLueqREyWi6ejz9PXsaUueHLu73rTguvoXTgpV%2B/6aJ4rhgbByHodh%2BH1SRlHCDRjDO6xxVyHwwjBhIg38dxnu6JJ%2B0cJx9iDc4gHuPXsmWINrD98tXjGK38gZtSBxpCAA%3D)

~~This PR introduces a `HALIDE_NO_ARGS` macro that expands to nothing or `void` depending on whether the code is compiled in C++ or C mode. That way declarations such as `function(HALIDE_NO_ARGS)` mean "function `function` receives no arguments" in both C++ and C.~~
This PR replaces uses of `function()` with `function(void)` since `function(void)` means "function `function` receives no arguments in both C++ and C"

P.S. this issue was discovered when trying to use Halide with Chapel, but Chapel used `-Wstrict-prototypes`... 