### PR TITLE
Add an easy way to print vectors in debug output.

### DIFF
--- a/src/Debug.h
+++ b/src/Debug.h
@@ -65,6 +65,42 @@ public:
     static int debug_level();
 };
 
+// "ConPrint" Stands for Container Print.
+// Mainly intended for debugging.
+template <typename T> struct ConPrint {
+    const T &container;
+    ConPrint(const T &container) : container(container) { }
+};
+
+template <typename StreamT, typename T>
+inline StreamT &operator<<(StreamT &stream, const ConPrint<T> &wrapper) {
+    stream << "{ ";
+    const char *sep = "";
+    for (const auto &e : wrapper.container) {
+        stream << sep << e;
+        sep = ", ";
+    }
+    stream << " }";
+    return stream;
+}
+
+// "ConPrintLn" Stands for Container Print Line. Prints items one per line.
+// Mainly intended for debugging.
+template <typename T> struct ConPrintLn {
+    const T &container;
+    ConPrintLn(const T &container) : container(container) { }
+};
+
+template <typename StreamT, typename T>
+inline StreamT &operator<<(StreamT &stream, const ConPrintLn<T> &wrapper) {
+    stream << "\n{\n";
+    for (const auto &e : wrapper.container) {
+        stream << "\t" << e << ",\n";
+    }
+    stream << "}\n";
+    return stream;
+}
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -65,8 +65,12 @@ public:
     static int debug_level();
 };
 
-// "ConPrint" Stands for Container Print.
-// Mainly intended for debugging.
+/** Allow easily printing the contents of containers, or std::vector-like containers,
+ *  in debug output. Used like so:
+ *        std::vector<Type> arg_types;
+ *        debug(4) << "arg_types: " << ConPrint(arg_types) << "\n";
+ * Which results in output like "arg_types: { uint8x8, uint8x8 }" on one line.
+ * "ConPrint" Stands for "Container Print." */
 template <typename T> struct ConPrint {
     const T &container;
     ConPrint(const T &container) : container(container) { }
@@ -84,8 +88,17 @@ inline StreamT &operator<<(StreamT &stream, const ConPrint<T> &wrapper) {
     return stream;
 }
 
-// "ConPrintLn" Stands for Container Print Line. Prints items one per line.
-// Mainly intended for debugging.
+/** Allow easily printing the contents of containers, or std::vector-like containers,
+ *  in debug output. Used like so:
+ *        std::vector<Type> arg_types;
+ *        debug(4) << "arg_types: " << ConPrint(arg_types) << "\n";
+ * Which results in output like:
+ *     arg_types:
+ *     {
+ *             uint8x8,
+ *             uint8x8,
+ *     }
+ * Indentation uses a tab character. "ConPrintLn" Stands for "Container Print Line." */
 template <typename T> struct ConPrintLn {
     const T &container;
     ConPrintLn(const T &container) : container(container) { }

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -68,22 +68,21 @@ public:
 /** Allow easily printing the contents of containers, or std::vector-like containers,
  *  in debug output. Used like so:
  *        std::vector<Type> arg_types;
- *        debug(4) << "arg_types: " << ConPrint(arg_types) << "\n";
- * Which results in output like "arg_types: { uint8x8, uint8x8 }" on one line.
- * "ConPrint" Stands for "Container Print." */
+ *        debug(4) << "arg_types: " << PrintSpan(arg_types) << "\n";
+ * Which results in output like "arg_types: { uint8x8, uint8x8 }" on one line. */
 template<typename T>
-struct ConPrint {
-    const T &container;
-    ConPrint(const T &container)
-        : container(container) {
+struct PrintSpan {
+    const T &span;
+    PrintSpan(const T &span)
+        : span(span) {
     }
 };
 
 template<typename StreamT, typename T>
-inline StreamT &operator<<(StreamT &stream, const ConPrint<T> &wrapper) {
+inline StreamT &operator<<(StreamT &stream, const PrintSpan<T> &wrapper) {
     stream << "{ ";
     const char *sep = "";
-    for (const auto &e : wrapper.container) {
+    for (const auto &e : wrapper.span) {
         stream << sep << e;
         sep = ", ";
     }
@@ -91,29 +90,29 @@ inline StreamT &operator<<(StreamT &stream, const ConPrint<T> &wrapper) {
     return stream;
 }
 
-/** Allow easily printing the contents of containers, or std::vector-like containers,
+/** Allow easily printing the contents of spans, or std::vector-like spans,
  *  in debug output. Used like so:
  *        std::vector<Type> arg_types;
- *        debug(4) << "arg_types: " << ConPrint(arg_types) << "\n";
+ *        debug(4) << "arg_types: " << PrintSpan(arg_types) << "\n";
  * Which results in output like:
  *     arg_types:
  *     {
  *             uint8x8,
  *             uint8x8,
  *     }
- * Indentation uses a tab character. "ConPrintLn" Stands for "Container Print Line." */
+ * Indentation uses a tab character. */
 template<typename T>
-struct ConPrintLn {
-    const T &container;
-    ConPrintLn(const T &container)
-        : container(container) {
+struct PrintSpanLn {
+    const T &span;
+    PrintSpanLn(const T &span)
+        : span(span) {
     }
 };
 
 template<typename StreamT, typename T>
-inline StreamT &operator<<(StreamT &stream, const ConPrintLn<T> &wrapper) {
+inline StreamT &operator<<(StreamT &stream, const PrintSpanLn<T> &wrapper) {
     stream << "\n{\n";
-    for (const auto &e : wrapper.container) {
+    for (const auto &e : wrapper.span) {
         stream << "\t" << e << ",\n";
     }
     stream << "}\n";

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -71,12 +71,15 @@ public:
  *        debug(4) << "arg_types: " << ConPrint(arg_types) << "\n";
  * Which results in output like "arg_types: { uint8x8, uint8x8 }" on one line.
  * "ConPrint" Stands for "Container Print." */
-template <typename T> struct ConPrint {
+template<typename T>
+struct ConPrint {
     const T &container;
-    ConPrint(const T &container) : container(container) { }
+    ConPrint(const T &container)
+        : container(container) {
+    }
 };
 
-template <typename StreamT, typename T>
+template<typename StreamT, typename T>
 inline StreamT &operator<<(StreamT &stream, const ConPrint<T> &wrapper) {
     stream << "{ ";
     const char *sep = "";
@@ -99,12 +102,15 @@ inline StreamT &operator<<(StreamT &stream, const ConPrint<T> &wrapper) {
  *             uint8x8,
  *     }
  * Indentation uses a tab character. "ConPrintLn" Stands for "Container Print Line." */
-template <typename T> struct ConPrintLn {
+template<typename T>
+struct ConPrintLn {
     const T &container;
-    ConPrintLn(const T &container) : container(container) { }
+    ConPrintLn(const T &container)
+        : container(container) {
+    }
 };
 
-template <typename StreamT, typename T>
+template<typename StreamT, typename T>
 inline StreamT &operator<<(StreamT &stream, const ConPrintLn<T> &wrapper) {
     stream << "\n{\n";
     for (const auto &e : wrapper.container) {


### PR DESCRIPTION
Allow wrapping vectors and vector like containers with `ConPrint` or `ConPrintLn` to pass to `operator<<` for use in Halide debug output.

Open to advice on naming. I am not aware of other idioms for this and end up writing quick loops to print values fairly frequently. There is a routine for doing this with `std::vector<Function>` in ScheduleFunctions.cpp as well.

Might need perfect forwarding support, but I don't think so.