### PR TITLE
Bump serialization version to 18.0.0

### DIFF
--- a/src/halide_ir.fbs
+++ b/src/halide_ir.fbs
@@ -10,6 +10,8 @@ enum SerializationVersionMajor: int {
     Value = 18
 }
 enum SerializationVersionMinor: int {
+    // 0 = Unstable
+    // 1 = First stable version
     Value = 0
 }
 enum SerializationVersionPatch: int {

--- a/src/halide_ir.fbs
+++ b/src/halide_ir.fbs
@@ -7,10 +7,10 @@ file_identifier "HLDE";
 file_extension "hlpipe";
 
 enum SerializationVersionMajor: int {
-    Value = 0
+    Value = 18
 }
 enum SerializationVersionMinor: int {
-    Value = 1
+    Value = 0
 }
 enum SerializationVersionPatch: int {
     Value = 0


### PR DESCRIPTION
As a matter of policy, we should probably bump the version of the serialization format for every version of Halide -- even if changes are minimal-to-nonexistent -- to reinforce the fact that this isn't intended in any way as a long-term archival format.

This PR suggests that we bump the major version to match the main Halide version, but I'm open for other suggestions.