### PR TITLE
[Vulkan] Region allocator fixes for memory requirements and allocations

### DIFF
--- a/src/runtime/internal/block_allocator.h
+++ b/src/runtime/internal/block_allocator.h
@@ -126,7 +126,7 @@ BlockAllocator *BlockAllocator::create(void *user_context, const Config &cfg, co
         allocators.system.allocate(user_context, sizeof(BlockAllocator)));
 
     if (result == nullptr) {
-        error(user_context) << "BlockAllocator: Failed to create instance! Out of memory!\n";
+        error(user_context) << "BlockAllocator: Failed to create instance! Out of memory\n";
         return nullptr;
     }
 
@@ -160,12 +160,12 @@ MemoryRegion *BlockAllocator::reserve(void *user_context, const MemoryRequest &r
                         << "dedicated=" << (request.dedicated ? "true" : "false") << " "
                         << "usage=" << halide_memory_usage_name(request.properties.usage) << " "
                         << "caching=" << halide_memory_caching_name(request.properties.caching) << " "
-                        << "visibility=" << halide_memory_visibility_name(request.properties.visibility) << ") ...\n";
+                        << "visibility=" << halide_memory_visibility_name(request.properties.visibility) << ") ...";
 #endif
     BlockEntry *block_entry = reserve_block_entry(user_context, request.properties, request.size, request.dedicated);
     if (block_entry == nullptr) {
         error(user_context) << "BlockAllocator: Failed to allocate new empty block of requested size ("
-                            << (int32_t)(request.size) << " bytes)!\n";
+                            << (int32_t)(request.size) << " bytes)\n";
         return nullptr;
     }
 
@@ -180,7 +180,7 @@ MemoryRegion *BlockAllocator::reserve(void *user_context, const MemoryRequest &r
         block_entry = create_block_entry(user_context, request.properties, request.size, request.dedicated);
         if (block_entry == nullptr) {
             error(user_context) << "BlockAllocator: Out of memory! Failed to allocate empty block of size ("
-                                << (int32_t)(request.size) << " bytes)!\n";
+                                << (int32_t)(request.size) << " bytes)\n";
             return nullptr;
         }
 
@@ -288,7 +288,7 @@ MemoryRegion *BlockAllocator::reserve_memory_region(void *user_context, RegionAl
     if (result == nullptr) {
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "BlockAllocator: Failed to allocate region of size ("
-                            << (int32_t)(request.size) << " bytes)!\n";
+                            << (int32_t)(request.size) << " bytes)\n";
 #endif
         // allocator has enough free space, but not enough contiguous space
         // -- collect and try to reallocate
@@ -302,17 +302,17 @@ MemoryRegion *BlockAllocator::reserve_memory_region(void *user_context, RegionAl
 bool BlockAllocator::is_block_suitable_for_request(void *user_context, const BlockResource *block, const MemoryProperties &properties, size_t size, bool dedicated) const {
     if (!is_compatible_block(block, properties)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "BlockAllocator: skipping block ... incompatible properties!\n"
-                            << " block_resource=" << (void *)block << "\n"
-                            << " block_size=" << (uint32_t)block->memory.size << "\n"
-                            << " block_reserved=" << (uint32_t)block->reserved << "\n"
-                            << " block_usage=" << halide_memory_usage_name(block->memory.properties.usage) << "\n"
-                            << " block_caching=" << halide_memory_caching_name(block->memory.properties.caching) << "\n"
-                            << " block_visibility=" << halide_memory_visibility_name(block->memory.properties.visibility) << "\n";
-        debug(user_context) << " request_size=" << (uint32_t)size << "\n"
-                            << " request_usage=" << halide_memory_usage_name(properties.usage) << "\n"
-                            << " request_caching=" << halide_memory_caching_name(properties.caching) << "\n"
-                            << " request_visibility=" << halide_memory_visibility_name(properties.visibility) << "\n";
+        debug(user_context) << "BlockAllocator: skipping block ... incompatible properties! ("
+                            << "block_resource=" << (void *)block << " "
+                            << "block_size=" << (uint32_t)block->memory.size << " "
+                            << "block_reserved=" << (uint32_t)block->reserved << " "
+                            << "block_usage=" << halide_memory_usage_name(block->memory.properties.usage) << " "
+                            << "block_caching=" << halide_memory_caching_name(block->memory.properties.caching) << " "
+                            << "block_visibility=" << halide_memory_visibility_name(block->memory.properties.visibility) << " "
+                            << "request_size=" << (uint32_t)size << " "
+                            << "request_usage=" << halide_memory_usage_name(properties.usage) << " "
+                            << "request_caching=" << halide_memory_caching_name(properties.caching) << " "
+                            << "request_visibility=" << halide_memory_visibility_name(properties.visibility) << ")";
 #endif
         // skip blocks that are using incompatible memory
         return false;
@@ -320,20 +320,20 @@ bool BlockAllocator::is_block_suitable_for_request(void *user_context, const Blo
 
     if (dedicated && (block->reserved > 0)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "BlockAllocator: skipping block ... can be used for dedicated allocation!\n"
-                            << " block_resource=" << (void *)block << "\n"
-                            << " block_size=" << (uint32_t)block->memory.size << "\n"
-                            << " block_reserved=" << (uint32_t)block->reserved << "\n";
+        debug(user_context) << "BlockAllocator: skipping block ... can be used for dedicated allocation! ("
+                            << "block_resource=" << (void *)block << " "
+                            << "block_size=" << (uint32_t)block->memory.size << " "
+                            << "block_reserved=" << (uint32_t)block->reserved << ")";
 #endif
         // skip blocks that can't be dedicated to a single allocation
         return false;
 
     } else if (block->memory.dedicated && (block->reserved > 0)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "BlockAllocator: skipping block ... already dedicated to an allocation!\n"
-                            << " block_resource=" << (void *)block << "\n"
-                            << " block_size=" << (uint32_t)block->memory.size << "\n"
-                            << " block_reserved=" << (uint32_t)block->reserved << "\n";
+        debug(user_context) << "BlockAllocator: skipping block ... already dedicated to an allocation! ("
+                            << "block_resource=" << (void *)block << " "
+                            << "block_size=" << (uint32_t)block->memory.size << " "
+                            << "block_reserved=" << (uint32_t)block->reserved << ")";
 #endif
         // skip dedicated blocks that are already allocated
         return false;
@@ -355,16 +355,16 @@ BlockAllocator::find_block_entry(void *user_context, const MemoryProperties &pro
         const BlockResource *block = static_cast<BlockResource *>(block_entry->value);
         if (is_block_suitable_for_request(user_context, block, properties, size, dedicated)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-            debug(user_context) << "BlockAllocator: found suitable block ...\n"
-                                << " user_context=" << (void *)(user_context) << "\n"
-                                << " block_resource=" << (void *)block << "\n"
-                                << " block_size=" << (uint32_t)block->memory.size << "\n"
-                                << " block_reserved=" << (uint32_t)block->reserved << "\n"
-                                << " request_size=" << (uint32_t)size << "\n"
-                                << " dedicated=" << (dedicated ? "true" : "false") << "\n"
-                                << " usage=" << halide_memory_usage_name(properties.usage) << "\n"
-                                << " caching=" << halide_memory_caching_name(properties.caching) << "\n"
-                                << " visibility=" << halide_memory_visibility_name(properties.visibility) << "\n";
+            debug(user_context) << "BlockAllocator: found suitable block ("
+                                << "user_context=" << (void *)(user_context) << " "
+                                << "block_resource=" << (void *)block << " "
+                                << "block_size=" << (uint32_t)block->memory.size << " "
+                                << "block_reserved=" << (uint32_t)block->reserved << " "
+                                << "request_size=" << (uint32_t)size << " "
+                                << "dedicated=" << (dedicated ? "true" : "false") << " "
+                                << "usage=" << halide_memory_usage_name(properties.usage) << " "
+                                << "caching=" << halide_memory_caching_name(properties.caching) << " "
+                                << "visibility=" << halide_memory_visibility_name(properties.visibility) << ")";
 #endif
             return block_entry;
         }
@@ -373,13 +373,13 @@ BlockAllocator::find_block_entry(void *user_context, const MemoryProperties &pro
 
     if (block_entry == nullptr) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "BlockAllocator: couldn't find suitable block!\n"
-                            << " user_context=" << (void *)(user_context) << "\n"
-                            << " request_size=" << (uint32_t)size << "\n"
-                            << " dedicated=" << (dedicated ? "true" : "false") << "\n"
-                            << " usage=" << halide_memory_usage_name(properties.usage) << "\n"
-                            << " caching=" << halide_memory_caching_name(properties.caching) << "\n"
-                            << " visibility=" << halide_memory_visibility_name(properties.visibility) << "\n";
+        debug(user_context) << "BlockAllocator: couldn't find suitable block! ("
+                            << "user_context=" << (void *)(user_context) << " "
+                            << "request_size=" << (uint32_t)size << " "
+                            << "dedicated=" << (dedicated ? "true" : "false") << " "
+                            << "usage=" << halide_memory_usage_name(properties.usage) << " "
+                            << "caching=" << halide_memory_caching_name(properties.caching) << " "
+                            << "visibility=" << halide_memory_visibility_name(properties.visibility) << ")";
 #endif
     }
     return block_entry;
@@ -388,22 +388,22 @@ BlockAllocator::find_block_entry(void *user_context, const MemoryProperties &pro
 BlockAllocator::BlockEntry *
 BlockAllocator::reserve_block_entry(void *user_context, const MemoryProperties &properties, size_t size, bool dedicated) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "BlockAllocator: reserving block ... !\n"
-                        << " requested_size=" << (uint32_t)size << "\n"
-                        << " requested_is_dedicated=" << (dedicated ? "true" : "false") << "\n"
-                        << " requested_usage=" << halide_memory_usage_name(properties.usage) << "\n"
-                        << " requested_caching=" << halide_memory_caching_name(properties.caching) << "\n"
-                        << " requested_visibility=" << halide_memory_visibility_name(properties.visibility) << "\n";
+    debug(user_context) << "BlockAllocator: reserving block ... ! ("
+                        << "requested_size=" << (uint32_t)size << " "
+                        << "requested_is_dedicated=" << (dedicated ? "true" : "false") << " "
+                        << "requested_usage=" << halide_memory_usage_name(properties.usage) << " "
+                        << "requested_caching=" << halide_memory_caching_name(properties.caching) << " "
+                        << "requested_visibility=" << halide_memory_visibility_name(properties.visibility) << ")";
 #endif
     BlockEntry *block_entry = find_block_entry(user_context, properties, size, dedicated);
     if (block_entry == nullptr) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "BlockAllocator: creating block ... !\n"
-                            << " requested_size=" << (uint32_t)size << "\n"
-                            << " requested_is_dedicated=" << (dedicated ? "true" : "false") << "\n"
-                            << " requested_usage=" << halide_memory_usage_name(properties.usage) << "\n"
-                            << " requested_caching=" << halide_memory_caching_name(properties.caching) << "\n"
-                            << " requested_visibility=" << halide_memory_visibility_name(properties.visibility) << "\n";
+        debug(user_context) << "BlockAllocator: creating block ... ! ("
+                            << "requested_size=" << (uint32_t)size << " "
+                            << "requested_is_dedicated=" << (dedicated ? "true" : "false") << " "
+                            << "requested_usage=" << halide_memory_usage_name(properties.usage) << " "
+                            << "requested_caching=" << halide_memory_caching_name(properties.caching) << " "
+                            << "requested_visibility=" << halide_memory_visibility_name(properties.visibility) << ")";
 #endif
         block_entry = create_block_entry(user_context, properties, size, dedicated);
     }
@@ -422,14 +422,14 @@ BlockAllocator::create_region_allocator(void *user_context, BlockResource *block
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "BlockAllocator: Creating region allocator ("
                         << "user_context=" << (void *)(user_context) << " "
-                        << "block_resource=" << (void *)(block) << ")...\n";
+                        << "block_resource=" << (void *)(block) << ")...";
 #endif
     halide_abort_if_false(user_context, block != nullptr);
     RegionAllocator *region_allocator = RegionAllocator::create(
         user_context, block, {allocators.system, allocators.region});
 
     if (region_allocator == nullptr) {
-        error(user_context) << "BlockAllocator: Failed to create new region allocator!\n";
+        error(user_context) << "BlockAllocator: Failed to create new region allocator\n";
         return nullptr;
     }
 
@@ -440,7 +440,7 @@ int BlockAllocator::destroy_region_allocator(void *user_context, RegionAllocator
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "BlockAllocator: Destroying region allocator ("
                         << "user_context=" << (void *)(user_context) << " "
-                        << "region_allocator=" << (void *)(region_allocator) << ")...\n";
+                        << "region_allocator=" << (void *)(region_allocator) << ")...";
 #endif
     if (region_allocator == nullptr) {
         return 0;
@@ -459,13 +459,13 @@ BlockAllocator::create_block_entry(void *user_context, const MemoryProperties &p
 
     if (config.maximum_block_count && (block_count() >= config.maximum_block_count)) {
         error(user_context) << "BlockAllocator: No free blocks found! Maximum block count reached ("
-                            << (int32_t)(config.maximum_block_count) << ")!\n";
+                            << (int32_t)(config.maximum_block_count) << ")\n";
         return nullptr;
     }
 
     BlockEntry *block_entry = block_list.append(user_context);
     if (block_entry == nullptr) {
-        debug(user_context) << "BlockAllocator: Failed to allocate new block entry!\n";
+        debug(user_context) << "BlockAllocator: Failed to allocate new block entry\n";
         return nullptr;
     }
 
@@ -473,7 +473,7 @@ BlockAllocator::create_block_entry(void *user_context, const MemoryProperties &p
     debug(user_context) << "BlockAllocator: Creating block entry ("
                         << "block_entry=" << (void *)(block_entry) << " "
                         << "block=" << (void *)(block_entry->value) << " "
-                        << "allocator=" << (void *)(allocators.block.allocate) << ")...\n";
+                        << "allocator=" << (void *)(allocators.block.allocate) << ")...";
 #endif
 
     BlockResource *block = static_cast<BlockResource *>(block_entry->value);
@@ -492,7 +492,7 @@ int BlockAllocator::release_block_entry(void *user_context, BlockAllocator::Bloc
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "BlockAllocator: Releasing block entry ("
                         << "block_entry=" << (void *)(block_entry) << " "
-                        << "block=" << (void *)(block_entry->value) << ")...\n";
+                        << "block=" << (void *)(block_entry->value) << ")...";
 #endif
     BlockResource *block = static_cast<BlockResource *>(block_entry->value);
     if (block->allocator) {
@@ -506,7 +506,7 @@ int BlockAllocator::destroy_block_entry(void *user_context, BlockAllocator::Bloc
     debug(user_context) << "BlockAllocator: Destroying block entry ("
                         << "block_entry=" << (void *)(block_entry) << " "
                         << "block=" << (void *)(block_entry->value) << " "
-                        << "deallocator=" << (void *)(allocators.block.deallocate) << ")...\n";
+                        << "deallocator=" << (void *)(allocators.block.deallocate) << ")...";
 #endif
     BlockResource *block = static_cast<BlockResource *>(block_entry->value);
     if (block->allocator) {
@@ -520,7 +520,7 @@ int BlockAllocator::destroy_block_entry(void *user_context, BlockAllocator::Bloc
 
 int BlockAllocator::alloc_memory_block(void *user_context, BlockResource *block) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "BlockAllocator: Allocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.allocate << ")...\n";
+    debug(user_context) << "BlockAllocator: Allocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.allocate << ")...";
 #endif
     halide_abort_if_false(user_context, allocators.block.allocate != nullptr);
     MemoryBlock *memory_block = &(block->memory);
@@ -531,7 +531,7 @@ int BlockAllocator::alloc_memory_block(void *user_context, BlockResource *block)
 
 int BlockAllocator::free_memory_block(void *user_context, BlockResource *block) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "BlockAllocator: Deallocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.deallocate << ")...\n";
+    debug(user_context) << "BlockAllocator: Deallocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.deallocate << ")...";
 #endif
     halide_abort_if_false(user_context, allocators.block.deallocate != nullptr);
     MemoryBlock *memory_block = &(block->memory);

--- a/src/runtime/internal/memory_arena.h
+++ b/src/runtime/internal/memory_arena.h
@@ -271,7 +271,7 @@ void *MemoryArena::create_entry(void *user_context, Block *block, uint32_t index
     void *entry_ptr = lookup_entry(user_context, block, index);
     block->free_index = block->indices[index];
     block->status[index] = AllocationStatus::InUse;
-#if DEBUG_RUNTIME_INTERNAL
+#ifdef DEBUG_RUNTIME_INTERNAL
     memset(entry_ptr, 0, config.entry_size);
 #endif
     return entry_ptr;

--- a/src/runtime/internal/memory_resources.h
+++ b/src/runtime/internal/memory_resources.h
@@ -127,7 +127,7 @@ ALWAYS_INLINE bool is_power_of_two_alignment(size_t x) {
 // -- Alignment must be power of two!
 ALWAYS_INLINE size_t aligned_offset(size_t offset, size_t alignment) {
     halide_abort_if_false(nullptr, is_power_of_two_alignment(alignment));
-    return (offset + (alignment - 1)) & ~(alignment - 1);
+    return (alignment == 0) ? (offset) : (offset + (alignment - 1)) & ~(alignment - 1);
 }
 
 // Returns a suitable alignment such that requested alignment is a suitable

--- a/src/runtime/internal/region_allocator.h
+++ b/src/runtime/internal/region_allocator.h
@@ -80,7 +80,7 @@ private:
 
     // Creates a new block region and adds it to the region list
     BlockRegion *create_block_region(void *user_context, const MemoryProperties &properties, size_t offset, size_t size, bool dedicated);
-    
+
     // Creates a new block region and adds it to the region list
     int destroy_block_region(void *user_context, BlockRegion *region);
 
@@ -271,7 +271,7 @@ bool RegionAllocator::is_block_region_suitable_for_request(void *user_context, c
                             << " block_region=" << (void *)region
                             << " request_size=" << (uint32_t)(request.size)
                             << " actual_size=" << (uint32_t)(actual_size)
-                            << " region_size=" << (uint32_t)(region->memory.size) 
+                            << " region_size=" << (uint32_t)(region->memory.size)
                             << ")";
 #endif
         return true;  // you betcha
@@ -282,13 +282,13 @@ bool RegionAllocator::is_block_region_suitable_for_request(void *user_context, c
 
 BlockRegion *RegionAllocator::find_block_region(void *user_context, const MemoryRequest &request) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "RegionAllocator: find block region ( "
-                            << "user_context=" << (void *)(user_context) << " "
-                            << "requested_size=" << (uint32_t)request.size << " "
-                            << "requested_is_dedicated=" << (request.dedicated ? "true" : "false") << " "
-                            << "requested_usage=" << halide_memory_usage_name(request.properties.usage) << " "
-                            << "requested_caching=" << halide_memory_caching_name(request.properties.caching) << " "
-                            << "requested_visibility=" << halide_memory_visibility_name(request.properties.visibility) << ")";
+    debug(user_context) << "RegionAllocator: find block region ( "
+                        << "user_context=" << (void *)(user_context) << " "
+                        << "requested_size=" << (uint32_t)request.size << " "
+                        << "requested_is_dedicated=" << (request.dedicated ? "true" : "false") << " "
+                        << "requested_usage=" << halide_memory_usage_name(request.properties.usage) << " "
+                        << "requested_caching=" << halide_memory_caching_name(request.properties.caching) << " "
+                        << "requested_visibility=" << halide_memory_visibility_name(request.properties.visibility) << ")";
 #endif
     BlockRegion *block_region = block->regions;
     while (block_region != nullptr) {
@@ -752,7 +752,7 @@ int RegionAllocator::destroy(void *user_context) {
     block->reserved = 0;
     block->regions = nullptr;
     block->allocator = nullptr;
-    if(arena != nullptr) {
+    if (arena != nullptr) {
         MemoryArena::destroy(user_context, arena);
     }
     arena = nullptr;

--- a/test/runtime/block_allocator.cpp
+++ b/test/runtime/block_allocator.cpp
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
         // Manually create a block resource and allocate memory
         size_t block_size = 4 * 1024 * 1024;
         BlockResource block_resource = {};
-        MemoryBlock* memory_block = &(block_resource.memory);
+        MemoryBlock *memory_block = &(block_resource.memory);
         memory_block->size = block_size;
         allocate_block(user_context, memory_block);
 
@@ -125,12 +125,12 @@ int main(int argc, char **argv) {
         instance->release(user_context, r2);
         HALIDE_CHECK(user_context, true == instance->collect(user_context));
 
-        request.size = block_size / 2; // request two half-size regions
+        request.size = block_size / 2;  // request two half-size regions
         MemoryRegion *r4 = instance->reserve(user_context, request);
         HALIDE_CHECK(user_context, r4 != nullptr);
         MemoryRegion *r5 = instance->reserve(user_context, request);
         HALIDE_CHECK(user_context, r5 != nullptr);
-        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request)); // requesting a third should fail
+        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request));  // requesting a third should fail
 
         HALIDE_CHECK(user_context, allocated_block_memory == block_size);
         HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
         size_t block_size = 4 * 1024 * 1024;
         size_t padded_size = 32;
         BlockResource block_resource = {};
-        MemoryBlock* memory_block = &(block_resource.memory);
+        MemoryBlock *memory_block = &(block_resource.memory);
         memory_block->size = block_size;
         memory_block->properties.nearest_multiple = padded_size;
         allocate_block(user_context, memory_block);
@@ -201,12 +201,12 @@ int main(int argc, char **argv) {
         HALIDE_CHECK(user_context, allocated_region_memory == (2 * padded_size));
         HALIDE_CHECK(user_context, true == instance->collect(user_context));
 
-        request.size = block_size / 2; // request two half-size regions
+        request.size = block_size / 2;  // request two half-size regions
         MemoryRegion *r4 = instance->reserve(user_context, request);
         HALIDE_CHECK(user_context, r4 != nullptr);
         MemoryRegion *r5 = instance->reserve(user_context, request);
         HALIDE_CHECK(user_context, r5 != nullptr);
-        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request)); // requesting a third should fail
+        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request));  // requesting a third should fail
 
         HALIDE_CHECK(user_context, allocated_block_memory == block_size);
         HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
@@ -238,7 +238,6 @@ int main(int argc, char **argv) {
                             << ") ...";
 
         HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
-
     }
 
     // test block allocator class interface

--- a/test/runtime/block_allocator.cpp
+++ b/test/runtime/block_allocator.cpp
@@ -21,7 +21,7 @@ int allocate_block(void *user_context, MemoryBlock *block) {
                         << "block=" << (void *)(block) << " "
                         << "block_size=" << int32_t(block->size) << " "
                         << "allocated_block_memory=" << int32_t(allocated_block_memory) << " "
-                        << ") !\n";
+                        << ") ...";
 
     return halide_error_code_success;
 }
@@ -34,7 +34,7 @@ int deallocate_block(void *user_context, MemoryBlock *block) {
                         << "block=" << (void *)(block) << " "
                         << "block_size=" << int32_t(block->size) << " "
                         << "allocated_block_memory=" << int32_t(allocated_block_memory) << " "
-                        << ") !\n";
+                        << ") ...";
 
     return halide_error_code_success;
 }
@@ -47,7 +47,7 @@ int allocate_region(void *user_context, MemoryRegion *region) {
                         << "region=" << (void *)(region) << " "
                         << "region_size=" << int32_t(region->size) << " "
                         << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
-                        << ") !\n";
+                        << ") ...";
 
     return halide_error_code_success;
 }
@@ -60,7 +60,7 @@ int deallocate_region(void *user_context, MemoryRegion *region) {
                         << "region=" << (void *)(region) << " "
                         << "region_size=" << int32_t(region->size) << " "
                         << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
-                        << ") !\n";
+                        << ") ...";
 
     return halide_error_code_success;
 }
@@ -74,7 +74,174 @@ int main(int argc, char **argv) {
     MemoryBlockAllocatorFns block_allocator = {allocate_block, deallocate_block};
     MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region};
 
-    // test class interface
+    // test region allocator class interface
+    {
+        // Manually create a block resource and allocate memory
+        size_t block_size = 4 * 1024 * 1024;
+        BlockResource block_resource = {};
+        MemoryBlock* memory_block = &(block_resource.memory);
+        memory_block->size = block_size;
+        allocate_block(user_context, memory_block);
+
+        // Create a region allocator to manage the block resource
+        RegionAllocator::MemoryAllocators allocators = {system_allocator, region_allocator};
+        RegionAllocator *instance = RegionAllocator::create(user_context, &block_resource, allocators);
+
+        MemoryRequest request = {0};
+        request.size = sizeof(int);
+        request.alignment = sizeof(int);
+        request.properties.visibility = MemoryVisibility::DefaultVisibility;
+        request.properties.caching = MemoryCaching::DefaultCaching;
+        request.properties.usage = MemoryUsage::DefaultUsage;
+
+        MemoryRegion *r1 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r1 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == request.size);
+
+        MemoryRegion *r2 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r2 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
+
+        instance->reclaim(user_context, r1);
+        HALIDE_CHECK(user_context, allocated_region_memory == (1 * request.size));
+
+        MemoryRegion *r3 = instance->reserve(user_context, request);
+        halide_abort_if_false(user_context, r3 != nullptr);
+        halide_abort_if_false(user_context, allocated_block_memory == block_size);
+        halide_abort_if_false(user_context, allocated_region_memory == (2 * request.size));
+        instance->retain(user_context, r3);
+        halide_abort_if_false(user_context, allocated_region_memory == (2 * request.size));
+        instance->release(user_context, r3);
+        halide_abort_if_false(user_context, allocated_region_memory == (2 * request.size));
+        instance->reclaim(user_context, r3);
+        instance->release(user_context, r1);
+
+        // [r1 = available] [r2 = in use] [r3 = available] ... no contiguous regions
+        HALIDE_CHECK(user_context, false == instance->collect(user_context));
+
+        // release r2 to make three consecutive regions to collect
+        instance->release(user_context, r2);
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size / 2; // request two half-size regions
+        MemoryRegion *r4 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r4 != nullptr);
+        MemoryRegion *r5 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r5 != nullptr);
+        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request)); // requesting a third should fail
+
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
+
+        instance->release(user_context, r4);
+        instance->release(user_context, r5);
+
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size;
+        MemoryRegion *r6 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r6 != nullptr);
+
+        instance->destroy(user_context);
+        deallocate_block(user_context, memory_block);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_block_memory=" << int32_t(allocated_block_memory) << " "
+                            << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, allocated_block_memory == 0);
+        HALIDE_CHECK(user_context, allocated_region_memory == 0);
+
+        RegionAllocator::destroy(user_context, instance);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
+    }
+
+    // test region allocator nearest_multiple padding
+    {
+        // Manually create a block resource and allocate memory
+        size_t block_size = 4 * 1024 * 1024;
+        size_t padded_size = 32;
+        BlockResource block_resource = {};
+        MemoryBlock* memory_block = &(block_resource.memory);
+        memory_block->size = block_size;
+        memory_block->properties.nearest_multiple = padded_size;
+        allocate_block(user_context, memory_block);
+
+        // Create a region allocator to manage the block resource
+        RegionAllocator::MemoryAllocators allocators = {system_allocator, region_allocator};
+        RegionAllocator *instance = RegionAllocator::create(user_context, &block_resource, allocators);
+
+        MemoryRequest request = {0};
+        request.size = sizeof(int);
+        request.alignment = sizeof(int);
+        request.properties.visibility = MemoryVisibility::DefaultVisibility;
+        request.properties.caching = MemoryCaching::DefaultCaching;
+        request.properties.usage = MemoryUsage::DefaultUsage;
+
+        MemoryRegion *r1 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r1 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == padded_size);
+
+        MemoryRegion *r2 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r2 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * padded_size));
+
+        instance->release(user_context, r1);
+        instance->release(user_context, r2);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * padded_size));
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size / 2; // request two half-size regions
+        MemoryRegion *r4 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r4 != nullptr);
+        MemoryRegion *r5 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r5 != nullptr);
+        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request)); // requesting a third should fail
+
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
+
+        instance->release(user_context, r4);
+        instance->release(user_context, r5);
+
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size;
+        MemoryRegion *r6 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r6 != nullptr);
+
+        instance->destroy(user_context);
+        deallocate_block(user_context, memory_block);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_block_memory=" << int32_t(allocated_block_memory) << " "
+                            << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, allocated_block_memory == 0);
+        HALIDE_CHECK(user_context, allocated_region_memory == 0);
+
+        RegionAllocator::destroy(user_context, instance);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
+
+    }
+
+    // test block allocator class interface
     {
         BlockAllocator::Config config = {0};
         config.minimum_block_size = 1024;
@@ -116,7 +283,7 @@ int main(int argc, char **argv) {
         debug(user_context) << "Test : block_allocator::destroy ("
                             << "allocated_block_memory=" << int32_t(allocated_block_memory) << " "
                             << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
-                            << ") !\n";
+                            << ") ...";
 
         HALIDE_CHECK(user_context, allocated_block_memory == 0);
         HALIDE_CHECK(user_context, allocated_region_memory == 0);
@@ -125,7 +292,7 @@ int main(int argc, char **argv) {
 
         debug(user_context) << "Test : block_allocator::destroy ("
                             << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
-                            << ") !\n";
+                            << ") ...";
 
         HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }


### PR DESCRIPTION
As reported by https://github.com/halide/Halide/issues/8079

+ Add region allocator tests that check alignment, nearest_multiple and collect routines
+ Fix can_split() routine to use conformed sizes so that split allocation matches
+ Fix region size accounting so that coalesce never has zero size regions to merge
+ Fix aligned_offset() routine to check for zero alignment (which means no constraint)
+ Use Vulkan memory_requirements to determine nearest_multiple during initialization
+ Query Vulkan memory_requirements for each region, and reallocate if driver requires additional device memory