### PR TITLE
Ensure string(REPLACE) is called with the right number of arguments

### DIFF
--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -164,7 +164,7 @@ function(find_node_js)
     execute_process(COMMAND "${NODE_JS_EXECUTABLE}" --version
                     OUTPUT_VARIABLE NODE_JS_VERSION_RAW
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(REPLACE "v" "" NODE_JS_VERSION ${NODE_JS_VERSION_RAW})
+    string(REPLACE "v" "" NODE_JS_VERSION "${NODE_JS_VERSION_RAW}")
 
     if (NODE_JS_VERSION VERSION_LESS "16.13")
         message(FATAL_ERROR "Halide requires Node v16.13 or later, but found ${NODE_JS_VERSION_RAW} at ${NODE_JS_EXECUTABLE}. Please set NODE_JS_EXECUTABLE on the CMake command line.")


### PR DESCRIPTION
Found while debugging macbot 3