### PR TITLE
Experimental precompiled header

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -429,6 +429,8 @@ add_library(Halide
             $<TARGET_OBJECTS:Halide_initmod>
             $<TARGET_OBJECTS:Halide_c_templates>)
 
+target_precompile_headers(Halide PRIVATE "precompiled_header.hpp")
+
 ##
 # Flatbuffers and Serialization dependencies.
 ##

--- a/src/precompiled_header.hpp
+++ b/src/precompiled_header.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+// Below is a list of common STL includes in the Halide codebase.
+// To find them, you can use:
+//
+// ag --nofilename --nonumbers --nobreak "#include <" src include | sort | uniq -c | sort -h
+// I'm explicitly exluding the test folder, because somebody already set up
+// a precompiled header for the test directory.
+
+#include <algorithm>
+#include <cstdlib>
+#include <functional>
+#include <sstream>
+#include <cstring>
+#include <limits>
+#include <set>
+#include <stdint.h>
+#include <iostream>
+#include <cstdint>
+#include <utility>
+#include <memory>
+#include <map>
+#include <vector>
+#include <string>


### PR DESCRIPTION
PR to test results described in #8061.
For clarity: This does not include enabling `mold`.