### PR TITLE
Use a caching version of stmt_uses_vars in TightenProducerConsumer nodes

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -307,7 +307,7 @@ void lower_impl(const vector<Function> &output_funcs,
     debug(1) << "Simplifying...\n";
     s = simplify(s);
     s = unify_duplicate_lets(s);
-    log("Lowering after second simplifcation:", s);
+    log("Lowering after second simplification:", s);
 
     debug(1) << "Reduce prefetch dimension...\n";
     s = reduce_prefetch_dimension(s, t);


### PR DESCRIPTION
We were making a very large number stmt_uses_vars queries that covered the same sub-stmts. I solved it by adding a cache.

Speeds up local laplacian lowering by 10% by basically removing this pass from the profile.

Also a drive-by typo fix in Lower.cpp