### PR TITLE
Avoid redundant scope lookups

### DIFF
--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -201,8 +201,8 @@ class RemoveLets : public IRGraphMutator {
     Scope<Expr> scope;
 
     Expr visit(const Variable *op) override {
-        if (scope.contains(op->name)) {
-            return scope.get(op->name);
+        if (const Expr *e = scope.find(op->name)) {
+            return *e;
         } else {
             return op;
         }

--- a/src/ClampUnsafeAccesses.cpp
+++ b/src/ClampUnsafeAccesses.cpp
@@ -50,8 +50,10 @@ protected:
     }
 
     Expr visit(const Variable *var) override {
-        if (is_inside_indexing && let_var_inside_indexing.contains(var->name)) {
-            let_var_inside_indexing.ref(var->name) = true;
+        if (is_inside_indexing) {
+            if (bool *b = let_var_inside_indexing.shallow_find(var->name)) {
+                *b = true;
+            }
         }
         return var;
     }

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -82,13 +82,14 @@ class SubstituteInStridedLoads : public IRMutator {
     Expr visit(const Shuffle *op) override {
         int stride = op->slice_stride();
         const Variable *var = op->vectors[0].as<Variable>();
+        const Expr *vec = nullptr;
         if (var &&
             poisoned_vars.count(var->name) == 0 &&
             op->vectors.size() == 1 &&
             2 <= stride && stride <= 4 &&
             op->slice_begin() < stride &&
-            loads.contains(var->name)) {
-            return Shuffle::make_slice({loads.get(var->name)}, op->slice_begin(), op->slice_stride(), op->type.lanes());
+            (vec = loads.find(var->name))) {
+            return Shuffle::make_slice({*vec}, op->slice_begin(), op->slice_stride(), op->type.lanes());
         } else {
             return IRMutator::visit(op);
         }

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1936,8 +1936,9 @@ void CodeGen_C::visit(const Load *op) {
         user_assert(is_const_one(op->predicate)) << "Predicated scalar load is not supported by C backend.\n";
 
         string id_index = print_expr(op->index);
-        bool type_cast_needed = !(allocations.contains(op->name) &&
-                                  allocations.get(op->name).type.element_of() == t.element_of());
+        const auto *alloc = allocations.find(op->name);
+        bool type_cast_needed = !(alloc &&
+                                  alloc->type.element_of() == t.element_of());
         if (type_cast_needed) {
             const char *const_flag = output_kind == CPlusPlusImplementation ? " const" : "";
             rhs << "((" << print_type(t.element_of()) << const_flag << " *)" << name << ")";

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -592,8 +592,9 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const Load *op) {
     string id_index = print_expr(op->index);
 
     // Get the rhs just for the cache.
-    bool type_cast_needed = !(allocations.contains(op->name) &&
-                              allocations.get(op->name).type == op->type);
+    const auto *alloc = allocations.find(op->name);
+    bool type_cast_needed = !(alloc &&
+                              alloc->type == op->type);
 
     ostringstream rhs;
     if (type_cast_needed) {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -221,8 +221,8 @@ class SloppyUnpredicateLoadsAndStores : public IRMutator {
                 }
             }
         } else if (const Variable *op = e.as<Variable>()) {
-            if (monotonic_vectors.contains(op->name)) {
-                return monotonic_vectors.get(op->name);
+            if (const auto *p = monotonic_vectors.find(op->name)) {
+                return *p;
             }
         } else if (const Let *op = e.as<Let>()) {
             auto v = get_extreme_lanes(op->value);
@@ -2245,10 +2245,9 @@ void CodeGen_Hexagon::visit(const Allocate *alloc) {
         codegen(alloc->body);
 
         // If there was no early free, free it now.
-        if (allocations.contains(alloc->name)) {
-            Allocation alloc_obj = allocations.get(alloc->name);
-            internal_assert(alloc_obj.destructor);
-            trigger_destructor(alloc_obj.destructor_function, alloc_obj.destructor);
+        if (const Allocation *alloc_obj = allocations.find(alloc->name)) {
+            internal_assert(alloc_obj->destructor);
+            trigger_destructor(alloc_obj->destructor_function, alloc_obj->destructor);
 
             allocations.pop(alloc->name);
             sym_pop(alloc->name);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1268,7 +1268,8 @@ void CodeGen_LLVM::sym_pop(const string &name) {
 
 llvm::Value *CodeGen_LLVM::sym_get(const string &name, bool must_succeed) const {
     // look in the symbol table
-    if (!symbol_table.contains(name)) {
+    llvm::Value *const *v = symbol_table.find(name);
+    if (!v) {
         if (must_succeed) {
             std::ostringstream err;
             err << "Symbol not found: " << name << "\n";
@@ -1283,7 +1284,7 @@ llvm::Value *CodeGen_LLVM::sym_get(const string &name, bool must_succeed) const 
             return nullptr;
         }
     }
-    return symbol_table.get(name);
+    return *v;
 }
 
 bool CodeGen_LLVM::sym_exists(const string &name) const {

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -390,8 +390,9 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Load *op) {
     string id_index = print_expr(op->index);
 
     // Get the rhs just for the cache.
-    bool type_cast_needed = !(allocations.contains(op->name) &&
-                              allocations.get(op->name).type == op->type);
+    const auto *alloc = allocations.find(op->name);
+    bool type_cast_needed = !(alloc &&
+                              alloc->type == op->type);
     ostringstream rhs;
     if (type_cast_needed) {
         rhs << "((" << get_memory_space(op->name) << " "
@@ -467,8 +468,8 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Store *op) {
                    << id_value << "[" << i << "];\n";
         }
     } else {
-        bool type_cast_needed = !(allocations.contains(op->name) &&
-                                  allocations.get(op->name).type == t);
+        const auto *alloc = allocations.find(op->name);
+        bool type_cast_needed = !(alloc && alloc->type == t);
 
         string id_index = print_expr(op->index);
         stream << get_indent();

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -484,8 +484,8 @@ string CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::print_array_access(const string &na
                                                                 const Type &type,
                                                                 const string &id_index) {
     ostringstream rhs;
-    bool type_cast_needed = !(allocations.contains(name) &&
-                              allocations.get(name).type == type);
+    const auto *alloc = allocations.find(name);
+    bool type_cast_needed = !(alloc && alloc->type == type);
 
     if (type_cast_needed) {
         rhs << "((" << get_memory_space(name) << " "
@@ -583,8 +583,8 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Store *op) {
         // For atomicAdd, we check if op->value - store[index] is independent of store.
         // The atomicAdd operations in OpenCL only supports integers so we also check that.
         bool is_atomic_add = t.is_int_or_uint() && !expr_uses_var(delta, op->name);
-        bool type_cast_needed = !(allocations.contains(op->name) &&
-                                  allocations.get(op->name).type == t);
+        const auto *alloc = allocations.find(op->name);
+        bool type_cast_needed = !(alloc && alloc->type == t);
         auto print_store_var = [&]() {
             if (type_cast_needed) {
                 stream << "(("

--- a/src/CodeGen_Posix.cpp
+++ b/src/CodeGen_Posix.cpp
@@ -342,8 +342,8 @@ void CodeGen_Posix::free_allocation(const std::string &name) {
 }
 
 string CodeGen_Posix::get_allocation_name(const std::string &n) {
-    if (allocations.contains(n)) {
-        return allocations.get(n).name;
+    if (const auto *alloc = allocations.find(n)) {
+        return alloc->name;
     } else {
         return n;
     }

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -1539,10 +1539,10 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Load *op) {
     user_assert(is_const_one(op->predicate)) << "Predicated loads not supported by SPIR-V codegen\n";
 
     // Construct the pointer to read from
-    internal_assert(symbol_table.contains(op->name));
-    SymbolIdStorageClassPair id_and_storage_class = symbol_table.get(op->name);
-    SpvId variable_id = id_and_storage_class.first;
-    SpvStorageClass storage_class = id_and_storage_class.second;
+    const SymbolIdStorageClassPair *id_and_storage_class = symbol_table.find(op->name);
+    internal_assert(id_and_storage_class);
+    SpvId variable_id = id_and_storage_class->first;
+    SpvStorageClass storage_class = id_and_storage_class->second;
     internal_assert(variable_id != SpvInvalidId);
     internal_assert(((uint32_t)storage_class) < ((uint32_t)SpvStorageClassMax));
 
@@ -1576,10 +1576,10 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Store *op) {
     op->value.accept(this);
     SpvId value_id = builder.current_id();
 
-    internal_assert(symbol_table.contains(op->name));
-    SymbolIdStorageClassPair id_and_storage_class = symbol_table.get(op->name);
-    SpvId variable_id = id_and_storage_class.first;
-    SpvStorageClass storage_class = id_and_storage_class.second;
+    const SymbolIdStorageClassPair *id_and_storage_class = symbol_table.find(op->name);
+    internal_assert(id_and_storage_class);
+    SpvId variable_id = id_and_storage_class->first;
+    SpvStorageClass storage_class = id_and_storage_class->second;
     internal_assert(variable_id != SpvInvalidId);
     internal_assert(((uint32_t)storage_class) < ((uint32_t)SpvStorageClassMax));
 
@@ -1665,9 +1665,10 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const For *op) {
         const std::string intrinsic_var_name = std::string("k") + std::to_string(kernel_index) + std::string("_") + intrinsic.first;
 
         // Intrinsics are inserted when adding the kernel
-        internal_assert(symbol_table.contains(intrinsic_var_name));
-        SpvId intrinsic_id = symbol_table.get(intrinsic_var_name).first;
-        SpvStorageClass storage_class = symbol_table.get(intrinsic_var_name).second;
+        const auto *intrin = symbol_table.find(intrinsic_var_name);
+        internal_assert(intrin);
+        SpvId intrinsic_id = intrin->first;
+        SpvStorageClass storage_class = intrin->second;
 
         // extract and cast to the extent type (which is what's expected by Halide's for loops)
         Type unsigned_type = UInt(32);
@@ -1908,8 +1909,9 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Allocate *op) {
 
 void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Free *op) {
     debug(3) << "Vulkan: Popping allocation called " << op->name << " off the symbol table\n";
-    internal_assert(symbol_table.contains(op->name));
-    SpvId variable_id = symbol_table.get(op->name).first;
+    const auto *id = symbol_table.find(op->name);
+    internal_assert(id);
+    SpvId variable_id = id->first;
     storage_access_map.erase(variable_id);
     symbol_table.pop(op->name);
 }

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -684,8 +684,8 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::visit(const Load *op) {
 
     // Get the allocation type, which may be different from the result type.
     Type alloc_type = result_type;
-    if (allocations.contains(op->name)) {
-        alloc_type = allocations.get(op->name).type;
+    if (const auto *alloc = allocations.find(op->name)) {
+        alloc_type = alloc->type;
     } else if (workgroup_allocations.count(op->name)) {
         alloc_type = workgroup_allocations.at(op->name)->type;
     }
@@ -826,8 +826,8 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::visit(const Store *op) {
 
     // Get the allocation type, which may be different from the value type.
     Type alloc_type = value_type;
-    if (allocations.contains(op->name)) {
-        alloc_type = allocations.get(op->name).type;
+    if (const auto *alloc = allocations.find(op->name)) {
+        alloc_type = alloc->type;
     } else if (workgroup_allocations.count(op->name)) {
         alloc_type = workgroup_allocations.at(op->name)->type;
     }

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -882,7 +882,7 @@ void CodeGen_X86::visit(const Load *op) {
 
 void CodeGen_X86::visit(const Store *op) {
     if (const auto *mt = mem_type.find(op->name)) {
-        if (mem_type.get(op->name) == MemoryType::AMXTile) {
+        if (*mt == MemoryType::AMXTile) {
             Value *val = codegen(op->value);
             Halide::Type value_type = op->value.type();
             const Ramp *ramp = op->index.as<Ramp>();

--- a/src/EliminateBoolVectors.cpp
+++ b/src/EliminateBoolVectors.cpp
@@ -15,8 +15,8 @@ private:
     Scope<Type> lets;
 
     Expr visit(const Variable *op) override {
-        if (lets.contains(op->name)) {
-            return Variable::make(lets.get(op->name), op->name);
+        if (const Type *t = lets.find(op->name)) {
+            return Variable::make(*t, op->name);
         } else {
             return op;
         }

--- a/src/ExprUsesVar.h
+++ b/src/ExprUsesVar.h
@@ -36,8 +36,8 @@ class ExprUsesVars : public IRGraphVisitor {
     void visit_name(const std::string &name) {
         if (vars.contains(name)) {
             result = true;
-        } else if (scope.contains(name)) {
-            include(scope.get(name));
+        } else if (const Expr *e = scope.find(name)) {
+            IRGraphVisitor::include(*e);
         }
     }
 

--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -1083,8 +1083,8 @@ class SubstituteInWideningLets : public IRMutator {
 
     Scope<Expr> replacements;
     Expr visit(const Variable *op) override {
-        if (replacements.contains(op->name)) {
-            return replacements.get(op->name);
+        if (const Expr *e = replacements.find(op->name)) {
+            return *e;
         } else {
             return op;
         }

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -1140,21 +1140,21 @@ class ExtractRegisterAllocations : public IRMutator {
     }
 
     Expr visit(const Load *op) override {
-        string new_name = op->name;
-        if (alloc_renaming.contains(op->name)) {
-            new_name = alloc_renaming.get(op->name);
+        const string *new_name = alloc_renaming.find(op->name);
+        if (!new_name) {
+            new_name = &(op->name);
         }
-        return Load::make(op->type, new_name, mutate(op->index),
+        return Load::make(op->type, *new_name, mutate(op->index),
                           op->image, op->param, mutate(op->predicate),
                           op->alignment);
     }
 
     Stmt visit(const Store *op) override {
-        string new_name = op->name;
-        if (alloc_renaming.contains(op->name)) {
-            new_name = alloc_renaming.get(op->name);
+        const string *new_name = alloc_renaming.find(op->name);
+        if (!new_name) {
+            new_name = &(op->name);
         }
-        return Store::make(new_name, mutate(op->value), mutate(op->index),
+        return Store::make(*new_name, mutate(op->value), mutate(op->index),
                            op->param, mutate(op->predicate), op->alignment);
     }
 

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -350,8 +350,8 @@ class GroupLoopInvariants : public IRMutator {
         const Scope<int> &depth;
 
         void visit(const Variable *op) override {
-            if (depth.contains(op->name)) {
-                result = std::max(result, depth.get(op->name));
+            if (const int *d = depth.find(op->name)) {
+                result = std::max(result, *d);
             }
         }
 

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -475,10 +475,11 @@ class LowerWarpShuffles : public IRMutator {
         if ((lt && equal(lt->a, this_lane) && is_const(lt->b)) ||
             (le && equal(le->a, this_lane) && is_const(le->b))) {
             Expr condition = mutate(op->condition);
-            Interval *interval = bounds.shallow_find(this_lane_name);
-            internal_assert(interval);
-            interval->max = lt ? simplify(lt->b - 1) : le->b;
-            ScopedBinding<Interval> bind(bounds, this_lane_name, *interval);
+            const Interval *in = bounds.find(this_lane_name);
+            internal_assert(in);
+            Interval interval = *in;
+            interval.max = lt ? simplify(lt->b - 1) : le->b;
+            ScopedBinding<Interval> bind(bounds, this_lane_name, interval);
             Stmt then_case = mutate(op->then_case);
             Stmt else_case = mutate(op->else_case);
             return IfThenElse::make(condition, then_case, else_case);

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -149,8 +149,8 @@ class DetermineAllocStride : public IRVisitor {
         } else if (const Variable *var = e.as<Variable>()) {
             if (var->name == lane_var) {
                 return 1;
-            } else if (dependent_vars.contains(var->name)) {
-                return dependent_vars.get(var->name);
+            } else if (const Expr *e = dependent_vars.find(var->name)) {
+                return *e;
             } else {
                 return 0;
             }
@@ -475,10 +475,10 @@ class LowerWarpShuffles : public IRMutator {
         if ((lt && equal(lt->a, this_lane) && is_const(lt->b)) ||
             (le && equal(le->a, this_lane) && is_const(le->b))) {
             Expr condition = mutate(op->condition);
-            internal_assert(bounds.contains(this_lane_name));
-            Interval interval = bounds.get(this_lane_name);
-            interval.max = lt ? simplify(lt->b - 1) : le->b;
-            ScopedBinding<Interval> bind(bounds, this_lane_name, interval);
+            Interval *interval = bounds.shallow_find(this_lane_name);
+            internal_assert(interval);
+            interval->max = lt ? simplify(lt->b - 1) : le->b;
+            ScopedBinding<Interval> bind(bounds, this_lane_name, *interval);
             Stmt then_case = mutate(op->then_case);
             Stmt else_case = mutate(op->else_case);
             return IfThenElse::make(condition, then_case, else_case);
@@ -488,10 +488,10 @@ class LowerWarpShuffles : public IRMutator {
     }
 
     Stmt visit(const Store *op) override {
-        if (allocation_info.contains(op->name)) {
+        if (const auto *alloc = allocation_info.find(op->name)) {
             Expr idx = mutate(op->index);
             Expr value = mutate(op->value);
-            Expr stride = allocation_info.get(op->name).stride;
+            Expr stride = alloc->stride;
             internal_assert(stride.defined() && warp_size.defined());
 
             // Reduce the index to an index in my own stripe. We have
@@ -639,9 +639,9 @@ class LowerWarpShuffles : public IRMutator {
     }
 
     Expr visit(const Load *op) override {
-        if (allocation_info.contains(op->name)) {
+        if (const auto *alloc = allocation_info.find(op->name)) {
             Expr idx = mutate(op->index);
-            Expr stride = allocation_info.get(op->name).stride;
+            Expr stride = alloc->stride;
 
             // Break the index into lane and stripe components
             Expr lane = simplify(reduce_expr(idx / stride, warp_size, bounds), true, bounds);

--- a/src/ModulusRemainder.cpp
+++ b/src/ModulusRemainder.cpp
@@ -110,8 +110,8 @@ void ComputeModulusRemainder::visit(const Reinterpret *) {
 }
 
 void ComputeModulusRemainder::visit(const Variable *op) {
-    if (scope.contains(op->name)) {
-        result = scope.get(op->name);
+    if (const auto *m = scope.find(op->name)) {
+        result = *m;
     } else {
         result = ModulusRemainder{};
     }

--- a/src/Monotonic.cpp
+++ b/src/Monotonic.cpp
@@ -280,8 +280,8 @@ class DerivativeBounds : public IRVisitor {
     void visit(const Variable *op) override {
         if (op->name == var) {
             result = ConstantInterval::single_point(1);
-        } else if (scope.contains(op->name)) {
-            result = scope.get(op->name);
+        } else if (const auto *r = scope.find(op->name)) {
+            result = *r;
         } else {
             result = ConstantInterval::single_point(0);
         }

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -86,10 +86,9 @@ private:
     using IRMutator::visit;
 
     Box get_buffer_bounds(const string &name, int dims) {
-        if (buffer_bounds.contains(name)) {
-            const Box &b = buffer_bounds.ref(name);
-            internal_assert((int)b.size() == dims);
-            return b;
+        if (const Box *b = buffer_bounds.find(name)) {
+            internal_assert((int)b->size() == dims);
+            return *b;
         }
 
         // It is an external buffer.

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -94,12 +94,16 @@ private:
         Expr min_val = op->min, extent_val = op->extent;
         const Variable *min_var = min_val.as<Variable>();
         const Variable *extent_var = extent_val.as<Variable>();
-        if (min_var && constants.contains(min_var->name)) {
-            min_val = constants.get(min_var->name);
+        if (min_var) {
+            if (const Expr *e = constants.find(min_var->name)) {
+                min_val = *e;
+            }
         }
 
-        if (extent_var && constants.contains(extent_var->name)) {
-            extent_val = constants.get(extent_var->name);
+        if (extent_var) {
+            if (const Expr *e = constants.find(extent_var->name)) {
+                extent_val = *e;
+            }
         }
 
         if (extent_val.defined() && is_const(extent_val) &&
@@ -151,9 +155,8 @@ private:
 
     void visit(const LetStmt *op) override {
         if (is_const(op->value)) {
-            constants.push(op->name, op->value);
+            ScopedBinding<Expr> bind(constants, op->name, op->value);
             op->body.accept(this);
-            constants.pop(op->name);
         } else {
             op->body.accept(this);
         }

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -347,7 +347,7 @@ struct ScopedBinding {
     ScopedBinding(const ScopedBinding &that) = delete;
     ScopedBinding(ScopedBinding &&that) noexcept
         : scope(that.scope),
-          token(std::move(that.token)) {
+          token(that.token) {
         // The move constructor must null out scope, so we don't try to pop it
         that.scope = nullptr;
     }
@@ -377,7 +377,7 @@ struct ScopedBinding<void> {
     ScopedBinding(const ScopedBinding &that) = delete;
     ScopedBinding(ScopedBinding &&that) noexcept
         : scope(that.scope),
-          token(std::move(that.token)) {
+          token(that.token) {
         // The move constructor must null out scope, so we don't try to pop it
         that.scope = nullptr;
     }

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -150,7 +150,39 @@ public:
         return iter->second.top_ref();
     }
 
-    /** Tests if a name is in scope */
+    /** Returns a const pointer to an entry if it exists in this scope or any
+     * containing scope, or nullptr if it does not. Use this instead of if
+     * (scope.contains(foo)) { ... scope.get(foo) ... } to avoid doing two
+     * lookups. */
+    template<typename T2 = T,
+             typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+    const T2 *find(const std::string &name) const {
+        typename std::map<std::string, SmallStack<T>>::const_iterator iter = table.find(name);
+        if (iter == table.end() || iter->second.empty()) {
+            if (containing_scope) {
+                return containing_scope->find(name);
+            } else {
+                return nullptr;
+            }
+        }
+        return &(iter->second.top_ref());
+    }
+
+    /** A version of find that returns a non-const pointer, but ignores
+     * containing scope. */
+    template<typename T2 = T,
+             typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+    T2 *shallow_find(const std::string &name) {
+        typename std::map<std::string, SmallStack<T>>::iterator iter = table.find(name);
+        if (iter == table.end() || iter->second.empty()) {
+            return nullptr;
+        } else {
+            return &(iter->second.top_ref());
+        }
+    }
+
+    /** Tests if a name is in scope. If you plan to use the value if it is, call
+     * find instead. */
     bool contains(const std::string &name) const {
         typename std::map<std::string, SmallStack<T>>::const_iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
@@ -173,19 +205,28 @@ public:
         }
     }
 
-    /** Add a new (name, value) pair to the current scope. Hide old
-     * values that have this name until we pop this name.
+    struct PushToken {
+        typename std::map<std::string, SmallStack<T>>::iterator iter;
+    };
+
+    /** Add a new (name, value) pair to the current scope. Hide old values that
+     * have this name until we pop this name. Returns a token that can be used
+     * to pop the same value without doing a fresh lookup.
      */
     template<typename T2 = T,
              typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
-    void push(const std::string &name, T2 &&value) {
-        table[name].push(std::forward<T2>(value));
+    PushToken push(const std::string &name, T2 &&value) {
+        auto it = table.try_emplace(name).first;
+        it->second.push(std::forward<T2>(value));
+        return PushToken{it};
     }
 
     template<typename T2 = T,
              typename = typename std::enable_if<std::is_same<T2, void>::value>::type>
-    void push(const std::string &name) {
-        table[name].push();
+    PushToken push(const std::string &name) {
+        auto it = table.try_emplace(name).first;
+        it->second.push();
+        return PushToken{it};
     }
 
     /** A name goes out of scope. Restore whatever its old value
@@ -198,6 +239,14 @@ public:
         iter->second.pop();
         if (iter->second.empty()) {
             table.erase(iter);
+        }
+    }
+
+    /** Pop a name using a token returned by push instead of a string. */
+    void pop(PushToken p) {
+        p.iter->second.pop();
+        if (p.iter->second.empty()) {
+            table.erase(p.iter);
         }
     }
 
@@ -271,20 +320,17 @@ std::ostream &operator<<(std::ostream &stream, const Scope<T> &s) {
 template<typename T = void>
 struct ScopedBinding {
     Scope<T> *scope = nullptr;
-    std::string name;
+    typename Scope<T>::PushToken token;
 
     ScopedBinding() = default;
 
     ScopedBinding(Scope<T> &s, const std::string &n, T value)
-        : scope(&s), name(n) {
-        scope->push(name, std::move(value));
+        : scope(&s), token(scope->push(n, std::move(value))) {
     }
 
     ScopedBinding(bool condition, Scope<T> &s, const std::string &n, const T &value)
-        : scope(condition ? &s : nullptr), name(n) {
-        if (condition) {
-            scope->push(name, value);
-        }
+        : scope(condition ? &s : nullptr),
+          token(condition ? scope->push(n, value) : typename Scope<T>::PushToken{}) {
     }
 
     bool bound() const {
@@ -293,7 +339,7 @@ struct ScopedBinding {
 
     ~ScopedBinding() {
         if (scope) {
-            scope->pop(name);
+            scope->pop(token);
         }
     }
 
@@ -301,7 +347,7 @@ struct ScopedBinding {
     ScopedBinding(const ScopedBinding &that) = delete;
     ScopedBinding(ScopedBinding &&that) noexcept
         : scope(that.scope),
-          name(std::move(that.name)) {
+          token(std::move(that.token)) {
         // The move constructor must null out scope, so we don't try to pop it
         that.scope = nullptr;
     }
@@ -313,20 +359,17 @@ struct ScopedBinding {
 template<>
 struct ScopedBinding<void> {
     Scope<> *scope;
-    std::string name;
+    Scope<>::PushToken token;
     ScopedBinding(Scope<> &s, const std::string &n)
-        : scope(&s), name(n) {
-        scope->push(name);
+        : scope(&s), token(scope->push(n)) {
     }
     ScopedBinding(bool condition, Scope<> &s, const std::string &n)
-        : scope(condition ? &s : nullptr), name(n) {
-        if (condition) {
-            scope->push(name);
-        }
+        : scope(condition ? &s : nullptr),
+          token(condition ? scope->push(n) : Scope<>::PushToken{}) {
     }
     ~ScopedBinding() {
         if (scope) {
-            scope->pop(name);
+            scope->pop(token);
         }
     }
 
@@ -334,7 +377,7 @@ struct ScopedBinding<void> {
     ScopedBinding(const ScopedBinding &that) = delete;
     ScopedBinding(ScopedBinding &&that) noexcept
         : scope(that.scope),
-          name(std::move(that.name)) {
+          token(std::move(that.token)) {
         // The move constructor must null out scope, so we don't try to pop it
         that.scope = nullptr;
     }

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -34,8 +34,8 @@ Simplify::Simplify(bool r, const Scope<Interval> *bi, const Scope<ModulusRemaind
             bounds.max = *i_max;
         }
 
-        if (ai->contains(iter.name())) {
-            bounds.alignment = ai->get(iter.name());
+        if (const auto *a = ai->find(iter.name())) {
+            bounds.alignment = *a;
         }
 
         if (bounds.min_defined || bounds.max_defined || bounds.alignment.modulus != 1) {
@@ -74,18 +74,18 @@ std::pair<std::vector<Expr>, bool> Simplify::mutate_with_changes(const std::vect
 void Simplify::found_buffer_reference(const string &name, size_t dimensions) {
     for (size_t i = 0; i < dimensions; i++) {
         string stride = name + ".stride." + std::to_string(i);
-        if (var_info.contains(stride)) {
-            var_info.ref(stride).old_uses++;
+        if (auto *info = var_info.shallow_find(stride)) {
+            info->old_uses++;
         }
 
         string min = name + ".min." + std::to_string(i);
-        if (var_info.contains(min)) {
-            var_info.ref(min).old_uses++;
+        if (auto *info = var_info.shallow_find(min)) {
+            info->old_uses++;
         }
     }
 
-    if (var_info.contains(name)) {
-        var_info.ref(name).old_uses++;
+    if (auto *info = var_info.shallow_find(name)) {
+        info->old_uses++;
     }
 }
 
@@ -187,8 +187,8 @@ void Simplify::ScopedFact::learn_upper_bound(const Variable *v, int64_t val) {
     ExprInfo b;
     b.max_defined = true;
     b.max = val;
-    if (simplify->bounds_and_alignment_info.contains(v->name)) {
-        b.intersect(simplify->bounds_and_alignment_info.get(v->name));
+    if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
+        b.intersect(*info);
     }
     simplify->bounds_and_alignment_info.push(v->name, b);
     bounds_pop_list.push_back(v);
@@ -198,8 +198,8 @@ void Simplify::ScopedFact::learn_lower_bound(const Variable *v, int64_t val) {
     ExprInfo b;
     b.min_defined = true;
     b.min = val;
-    if (simplify->bounds_and_alignment_info.contains(v->name)) {
-        b.intersect(simplify->bounds_and_alignment_info.get(v->name));
+    if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
+        b.intersect(*info);
     }
     simplify->bounds_and_alignment_info.push(v->name, b);
     bounds_pop_list.push_back(v);
@@ -228,10 +228,9 @@ void Simplify::ScopedFact::learn_true(const Expr &fact) {
                 // TODO: Visiting it again is inefficient
                 Simplify::ExprInfo expr_info;
                 simplify->mutate(eq->b, &expr_info);
-                if (simplify->bounds_and_alignment_info.contains(v->name)) {
+                if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
                     // We already know something about this variable and don't want to suppress it.
-                    auto existing_knowledge = simplify->bounds_and_alignment_info.get(v->name);
-                    expr_info.intersect(existing_knowledge);
+                    expr_info.intersect(*info);
                 }
                 simplify->bounds_and_alignment_info.push(v->name, expr_info);
                 bounds_pop_list.push_back(v);
@@ -245,10 +244,9 @@ void Simplify::ScopedFact::learn_true(const Expr &fact) {
             // TODO: Visiting it again is inefficient
             Simplify::ExprInfo expr_info;
             simplify->mutate(eq->a, &expr_info);
-            if (simplify->bounds_and_alignment_info.contains(vb->name)) {
+            if (const auto *info = simplify->bounds_and_alignment_info.find(vb->name)) {
                 // We already know something about this variable and don't want to suppress it.
-                auto existing_knowledge = simplify->bounds_and_alignment_info.get(vb->name);
-                expr_info.intersect(existing_knowledge);
+                expr_info.intersect(*info);
             }
             simplify->bounds_and_alignment_info.push(vb->name, expr_info);
             bounds_pop_list.push_back(vb);
@@ -257,10 +255,9 @@ void Simplify::ScopedFact::learn_true(const Expr &fact) {
             Simplify::ExprInfo expr_info;
             expr_info.alignment.modulus = *modulus;
             expr_info.alignment.remainder = *remainder;
-            if (simplify->bounds_and_alignment_info.contains(v->name)) {
+            if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
                 // We already know something about this variable and don't want to suppress it.
-                auto existing_knowledge = simplify->bounds_and_alignment_info.get(v->name);
-                expr_info.intersect(existing_knowledge);
+                expr_info.intersect(*info);
             }
             simplify->bounds_and_alignment_info.push(v->name, expr_info);
             bounds_pop_list.push_back(v);
@@ -417,8 +414,8 @@ bool can_prove(Expr e, const Scope<Interval> &bounds) {
 
             Expr visit(const Variable *op) override {
                 auto it = vars.find(op->name);
-                if (lets.contains(op->name)) {
-                    return Variable::make(op->type, lets.get(op->name));
+                if (const std::string *n = lets.find(op->name)) {
+                    return Variable::make(op->type, *n);
                 } else if (it == vars.end()) {
                     std::string name = "v" + std::to_string(count++);
                     vars[op->name] = name;

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -305,18 +305,18 @@ Stmt Simplify::visit(const Store *op) {
     // but perhaps the branch was hard to prove constant true or false. This
     // provides an alternative mechanism to simplify these unreachable stores.
     string alloc_extent_name = op->name + ".total_extent_bytes";
-    if (is_const_one(op->predicate) &&
-        bounds_and_alignment_info.contains(alloc_extent_name)) {
-        if (index_info.max_defined && index_info.max < 0) {
-            in_unreachable = true;
-            return Evaluate::make(unreachable());
-        }
-        const ExprInfo &alloc_info = bounds_and_alignment_info.get(alloc_extent_name);
-        if (alloc_info.max_defined && index_info.min_defined) {
-            int index_min_bytes = index_info.min * op->value.type().bytes();
-            if (index_min_bytes > alloc_info.max) {
+    if (is_const_one(op->predicate)) {
+        if (const auto *alloc_info = bounds_and_alignment_info.find(alloc_extent_name)) {
+            if (index_info.max_defined && index_info.max < 0) {
                 in_unreachable = true;
                 return Evaluate::make(unreachable());
+            }
+            if (alloc_info->max_defined && index_info.min_defined) {
+                int index_min_bytes = index_info.min * op->value.type().bytes();
+                if (index_min_bytes > alloc_info->max) {
+                    in_unreachable = true;
+                    return Evaluate::make(unreachable());
+                }
             }
         }
     }

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -69,10 +69,9 @@ class ExpandExpr : public IRMutator {
     const Scope<Expr> &scope;
 
     Expr visit(const Variable *var) override {
-        if (scope.contains(var->name)) {
-            Expr expr = scope.get(var->name);
-            debug(4) << "Fully expanded " << var->name << " -> " << expr << "\n";
-            return expr;
+        if (const Expr *expr = scope.find(var->name)) {
+            debug(4) << "Fully expanded " << var->name << " -> " << *expr << "\n";
+            return *expr;
         } else {
             return var;
         }

--- a/src/StageStridedLoads.cpp
+++ b/src/StageStridedLoads.cpp
@@ -103,8 +103,8 @@ protected:
                 if (stride >= 2 && stride < r->lanes && r->stride.type().is_scalar()) {
                     const IRNode *s = scope;
                     const Allocate *a = nullptr;
-                    if (allocation_scope.contains(op->name)) {
-                        a = allocation_scope.get(op->name);
+                    if (const Allocate *const *a_ptr = allocation_scope.find(op->name)) {
+                        a = *a_ptr;
                     }
                     found_loads[Key{op->name, base, stride, r->lanes, op->type, a, s}][offset].push_back(op);
                 }
@@ -161,8 +161,8 @@ public:
 protected:
     Expr visit(const Load *op) override {
         const Allocate *alloc = nullptr;
-        if (allocation_scope.contains(op->name)) {
-            alloc = allocation_scope.get(op->name);
+        if (const Allocate *const *a_ptr = allocation_scope.find(op->name)) {
+            alloc = *a_ptr;
         }
         auto it = replacements.find({alloc, op});
         if (it != replacements.end()) {

--- a/src/StmtToHTML.cpp
+++ b/src/StmtToHTML.cpp
@@ -1134,8 +1134,8 @@ private:
 
     std::string variable(const std::string &x, const std::string &tooltip) {
         int id;
-        if (scope.contains(x)) {
-            id = scope.get(x);
+        if (const int *i = scope.find(x)) {
+            id = *i;
         } else {
             id = gen_unique_id();
             scope.push(x, id);

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -31,10 +31,9 @@ class ExpandExpr : public IRMutator {
     const Scope<Expr> &scope;
 
     Expr visit(const Variable *var) override {
-        if (scope.contains(var->name)) {
-            Expr expr = scope.get(var->name);
+        if (const Expr *e = scope.find(var->name)) {
             // Mutate the expression, so lets can get replaced recursively.
-            expr = mutate(expr);
+            Expr expr = mutate(*e);
             debug(4) << "Fully expanded " << var->name << " -> " << expr << "\n";
             return expr;
         } else {

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -104,10 +104,9 @@ class UniquifyVariableNames : public IRMutator {
     }
 
     Expr visit(const Variable *op) override {
-        if (renaming.contains(op->name)) {
-            string new_name = renaming.get(op->name);
-            if (new_name != op->name) {
-                return Variable::make(op->type, new_name);
+        if (const string *new_name = renaming.find(op->name)) {
+            if (*new_name != op->name) {
+                return Variable::make(op->type, *new_name);
             }
         }
         return op;

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -297,8 +297,8 @@ bool is_interleaved_ramp(const Expr &e, const Scope<Expr> &scope, InterleavedRam
             return true;
         }
     } else if (const Variable *var = e.as<Variable>()) {
-        if (scope.contains(var->name)) {
-            return is_interleaved_ramp(scope.get(var->name), scope, result);
+        if (const Expr *e = scope.find(var->name)) {
+            return is_interleaved_ramp(*e, scope, result);
         }
     }
     return false;


### PR DESCRIPTION
This pattern has been bugging me for a long time:

```
if (scope.contains(key)) {
  Foo f = scope.get(key);
}
```

This redundantly looks up the key in the scope twice. I've finally gotten around to fixing it. I've introduced a find method that either returns a const pointer to the value, if it exists, or null. It also searches any containing scopes, which are held by const pointer, so the method has to return a const pointer.

```
if (const Foo *f = scope.find(key)) {
}
```

For cases where you want to get and then mutate, I added shallow_find, which doesn't search enclosing scopes, but returns a mutable pointer.

We were also doing redundant scope lookups in ScopedBinding. We stored the key in the helper object, and then did a pop on that key in the ScopedBinding destructor. This commit changes Scope so that Scope::push returns an opaque token that you can pass to Scope::pop to have it remove that element without doing a fresh lookup. ScopedBinding now uses this. Under the hood it's just an iterator on the underlying map (map iterators are not invalidated on inserting or removing other stuff).

The net effect is to speed up local laplacian lowering by about 5%

I also considered making it look more like an stl class, and having find return an iterator, but it doesn't really work. The iterator it returns might point to an entry in an enclosing scope, in which case you can't compare it to the .end() method of the scope you have. Scopes are different enough from maps that the interface really needs to be distinct.