### PR TITLE
Optionally print the time taken by each lowering pass

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -121,7 +121,7 @@ public:
         if (time_lowering_passes) {
             debug(0) << "Lowering pass runtimes:\n";
             std::sort(timings.begin(), timings.end());
-            for (auto p : timings) {
+            for (const auto &p : timings) {
                 debug(0) << " " << p.first << " ms : " << p.second << "\n";
             }
         }

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -91,15 +91,39 @@ namespace {
 
 class LoweringLogger {
     Stmt last_written;
+    std::chrono::time_point<std::chrono::high_resolution_clock> last_time;
+    std::vector<std::pair<double, std::string>> timings;
+    bool time_lowering_passes = false;
 
 public:
+    LoweringLogger() {
+        last_time = std::chrono::high_resolution_clock::now();
+        static bool should_time = !get_env_variable("HL_TIME_LOWERING_PASSES").empty();
+        time_lowering_passes = should_time;
+    }
+
     void operator()(const string &message, const Stmt &s) {
+        auto t = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> diff = t - last_time;
         if (!s.same_as(last_written)) {
             debug(2) << message << "\n"
                      << s << "\n";
             last_written = s;
+            last_time = t;
         } else {
             debug(2) << message << " (unchanged)\n\n";
+            last_time = t;
+        }
+        timings.emplace_back(diff.count() * 1000, message);
+    }
+
+    ~LoweringLogger() {
+        if (time_lowering_passes) {
+            debug(0) << "Lowering pass runtimes:\n";
+            std::sort(timings.begin(), timings.end());
+            for (auto p : timings) {
+                debug(0) << " " << p.first << " ms : " << p.second << "\n";
+            }
         }
     }
 };


### PR DESCRIPTION
I've been copy-pasting this from branch to branch, but I should just check it in. This is useful for performance optimization of the compiler itself.