### PR TITLE
Make gpu thread and block for loop names opaque

### DIFF
--- a/src/CanonicalizeGPUVars.h
+++ b/src/CanonicalizeGPUVars.h
@@ -15,6 +15,13 @@ namespace Internal {
  * by the nesting order: innermost is assigned to x and so on. */
 Stmt canonicalize_gpu_vars(Stmt s);
 
+/** Names for the thread and block id variables. Includes the leading
+ * dot. Indexed from inside out, so 0 gives you the innermost loop. */
+// @{
+const std::string &gpu_thread_name(int index);
+const std::string &gpu_block_name(int index);
+// @}
+
 }  // namespace Internal
 }  // namespace Halide
 

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <utility>
 
+#include "CanonicalizeGPUVars.h"
 #include "CodeGen_D3D12Compute_Dev.h"
 #include "CodeGen_GPU_Dev.h"
 #include "CodeGen_Internal.h"
@@ -221,22 +222,18 @@ string CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::print_reinterpret(Type 
 
 namespace {
 string simt_intrinsic(const string &name) {
-    if (ends_with(name, ".__thread_id_x")) {
+    if (ends_with(name, gpu_thread_name(0))) {
         return "tid_in_tgroup.x";
-    } else if (ends_with(name, ".__thread_id_y")) {
+    } else if (ends_with(name, gpu_thread_name(1))) {
         return "tid_in_tgroup.y";
-    } else if (ends_with(name, ".__thread_id_z")) {
+    } else if (ends_with(name, gpu_thread_name(2))) {
         return "tid_in_tgroup.z";
-    } else if (ends_with(name, ".__thread_id_w")) {
-        user_error << "HLSL (SM5.1) does not support more than three dimensions for compute kernel threads.\n";
-    } else if (ends_with(name, ".__block_id_x")) {
+    } else if (ends_with(name, gpu_block_name(0))) {
         return "tgroup_index.x";
-    } else if (ends_with(name, ".__block_id_y")) {
+    } else if (ends_with(name, gpu_block_name(1))) {
         return "tgroup_index.y";
-    } else if (ends_with(name, ".__block_id_z")) {
+    } else if (ends_with(name, gpu_block_name(2))) {
         return "tgroup_index.z";
-    } else if (ends_with(name, ".__block_id_w")) {
-        user_error << "HLSL (SM5.1) does not support more than three dimensions for compute dispatch groups.\n";
     }
     internal_error << "simt_intrinsic called on bad variable name: " << name << "\n";
     return "";
@@ -300,15 +297,10 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const For *loop) {
     user_assert(loop->for_type != ForType::GPULane)
         << "The D3D12Compute backend does not support the gpu_lanes() scheduling directive.";
 
-    if (!is_gpu_var(loop->name)) {
-        user_assert(loop->for_type != ForType::Parallel) << "Cannot use parallel loops inside D3D12Compute kernel\n";
+    if (!is_gpu(loop->for_type)) {
         CodeGen_GPU_C::visit(loop);
         return;
     }
-
-    internal_assert((loop->for_type == ForType::GPUBlock) ||
-                    (loop->for_type == ForType::GPUThread))
-        << "kernel loop must be either gpu block or gpu thread\n";
     internal_assert(is_const_zero(loop->min));
 
     stream << get_indent() << print_type(Int(32)) << " " << print_name(loop->name)
@@ -1153,7 +1145,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
     struct FindThreadGroupSize : public IRVisitor {
         using IRVisitor::visit;
         void visit(const For *loop) override {
-            if (!is_gpu_var(loop->name)) {
+            if (!is_gpu(loop->for_type)) {
                 return loop->body.accept(this);
             }
             if (loop->for_type != ForType::GPUThread) {
@@ -1175,13 +1167,9 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
             loop->body.accept(this);
         }
         int thread_loop_workgroup_index(const string &name) {
-            string ids[] = {".__thread_id_x",
-                            ".__thread_id_y",
-                            ".__thread_id_z",
-                            ".__thread_id_w"};
-            for (auto &id : ids) {
-                if (ends_with(name, id)) {
-                    return (&id - ids);
+            for (int i = 0; i < 3; i++) {
+                if (ends_with(name, gpu_thread_name(i))) {
+                    return i;
                 }
             }
             return -1;

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -55,10 +55,6 @@ struct CodeGen_GPU_Dev {
         return false;
     }
 
-    static bool is_gpu_var(const std::string &name);
-    static bool is_gpu_block_var(const std::string &name);
-    static bool is_gpu_thread_var(const std::string &name);
-
     /** Checks if expr is block uniform, i.e. does not depend on a thread
      * var. */
     static bool is_block_uniform(const Expr &expr);

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -4,6 +4,7 @@
 #include <unordered_set>
 
 #include "CSE.h"
+#include "CanonicalizeGPUVars.h"
 #include "CodeGen_GPU_Dev.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_Vulkan_Dev.h"
@@ -381,12 +382,10 @@ private:
 struct FindWorkGroupSize : public IRVisitor {
     using IRVisitor::visit;
     void visit(const For *loop) override {
-        if (!CodeGen_GPU_Dev::is_gpu_var(loop->name)) {
-            return loop->body.accept(this);
-        }
+        user_assert(loop->for_type != ForType::GPULane)
+            << "The Vulkan backend does not support the gpu_lanes() scheduling directive.";
 
-        if ((loop->for_type == ForType::GPUBlock) ||
-            (loop->for_type == ForType::GPUThread)) {
+        if (is_gpu(loop->for_type)) {
 
             // This should always be true at this point in codegen
             internal_assert(is_const_zero(loop->min));
@@ -411,11 +410,8 @@ struct FindWorkGroupSize : public IRVisitor {
     }
 
     int thread_loop_workgroup_index(const std::string &name) {
-        std::string ids[] = {".__thread_id_x",
-                             ".__thread_id_y",
-                             ".__thread_id_z"};
-        for (size_t i = 0; i < sizeof(ids) / sizeof(std::string); i++) {
-            if (ends_with(name, ids[i])) {
+        for (size_t i = 0; i < 3; i++) {
+            if (ends_with(name, gpu_thread_name(i))) {
                 return i;
             }
         }
@@ -1630,20 +1626,18 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const AssertStmt *stmt) {
 
 namespace {
 std::pair<std::string, uint32_t> simt_intrinsic(const std::string &name) {
-    if (ends_with(name, ".__thread_id_x")) {
+    if (ends_with(name, gpu_thread_name(0))) {
         return {"LocalInvocationId", 0};
-    } else if (ends_with(name, ".__thread_id_y")) {
+    } else if (ends_with(name, gpu_thread_name(1))) {
         return {"LocalInvocationId", 1};
-    } else if (ends_with(name, ".__thread_id_z")) {
+    } else if (ends_with(name, gpu_thread_name(2))) {
         return {"LocalInvocationId", 2};
-    } else if (ends_with(name, ".__block_id_x")) {
+    } else if (ends_with(name, gpu_block_name(0))) {
         return {"WorkgroupId", 0};
-    } else if (ends_with(name, ".__block_id_y")) {
+    } else if (ends_with(name, gpu_block_name(1))) {
         return {"WorkgroupId", 1};
-    } else if (ends_with(name, ".__block_id_z")) {
+    } else if (ends_with(name, gpu_block_name(2))) {
         return {"WorkgroupId", 2};
-    } else if (ends_with(name, "id_w")) {
-        user_error << "Vulkan only supports <=3 dimensions for gpu blocks";
     }
     internal_error << "simt_intrinsic called on bad variable name: " << name << "\n";
     return {"", -1};
@@ -1654,11 +1648,7 @@ std::pair<std::string, uint32_t> simt_intrinsic(const std::string &name) {
 void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const For *op) {
     debug(2) << "CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(For): name=" << op->name << " min=" << op->min << " extent=" << op->extent << "\n";
 
-    if (is_gpu_var(op->name)) {
-        internal_assert((op->for_type == ForType::GPUBlock) ||
-                        (op->for_type == ForType::GPUThread))
-            << "kernel loops must be either gpu block or gpu thread\n";
-
+    if (is_gpu(op->for_type)) {
         // This should always be true at this point in codegen
         internal_assert(is_const_zero(op->min));
         auto intrinsic = simt_intrinsic(op->name);
@@ -2477,11 +2467,6 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::declare_workgroup_size(SpvId kernel_func
             local_size_y_id,
             local_size_z_id};
 
-        const char *local_size_names[3] = {
-            "__thread_id_x",
-            "__thread_id_y",
-            "__thread_id_z"};
-
         debug(1) << "Vulkan: Using dynamic workgroup local size with default of [" << local_size_x << ", " << local_size_y << ", " << local_size_z << "]...\n";
 
         // annotate each local size with a corresponding specialization constant
@@ -2489,8 +2474,8 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::declare_workgroup_size(SpvId kernel_func
             SpvId constant_id = (uint32_t)(descriptor_set_table.back().specialization_constants.size() + 1);
             SpvBuilder::Literals spec_id = {constant_id};
             builder.add_annotation(local_size_ids[dim], SpvDecorationSpecId, spec_id);
-            builder.add_symbol(local_size_names[dim], local_size_ids[dim], builder.current_module().id());
-            SpecializationBinding spec_binding = {constant_id, (uint32_t)sizeof(uint32_t), local_size_names[dim]};
+            builder.add_symbol(gpu_thread_name(dim), local_size_ids[dim], builder.current_module().id());
+            SpecializationBinding spec_binding = {constant_id, (uint32_t)sizeof(uint32_t), gpu_thread_name(dim)};
             descriptor_set_table.back().specialization_constants.push_back(spec_binding);
             descriptor_set_table.back().workgroup_size_binding.local_size_constant_id[dim] = constant_id;
         }
@@ -2520,17 +2505,11 @@ namespace {
 class FindIntrinsicsUsed : public IRVisitor {
     using IRVisitor::visit;
     void visit(const For *op) override {
-        if (CodeGen_GPU_Dev::is_gpu_var(op->name)) {
+        if (is_gpu(op->for_type)) {
             auto intrinsic = simt_intrinsic(op->name);
-            intrinsics_used.insert(intrinsic.first);
+            intrinsics_used.insert(op->name);
         }
         op->body.accept(this);
-    }
-    void visit(const Variable *op) override {
-        if (CodeGen_GPU_Dev::is_gpu_var(op->name)) {
-            auto intrinsic = simt_intrinsic(op->name);
-            intrinsics_used.insert(intrinsic.first);
-        }
     }
 
 public:

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -4,6 +4,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "CanonicalizeGPUVars.h"
 #include "CodeGen_GPU_Dev.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_WebGPU_Dev.h"
@@ -603,22 +604,18 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::visit(const FloatImm *op) {
 
 namespace {
 string simt_intrinsic(const string &name) {
-    if (ends_with(name, ".__thread_id_x")) {
+    if (ends_with(name, gpu_thread_name(0))) {
         return "local_id.x";
-    } else if (ends_with(name, ".__thread_id_y")) {
+    } else if (ends_with(name, gpu_thread_name(1))) {
         return "local_id.y";
-    } else if (ends_with(name, ".__thread_id_z")) {
+    } else if (ends_with(name, gpu_thread_name(2))) {
         return "local_id.z";
-    } else if (ends_with(name, ".__thread_id_w")) {
-        user_error << "WebGPU does not support more than three dimensions.\n";
-    } else if (ends_with(name, ".__block_id_x")) {
+    } else if (ends_with(name, gpu_block_name(0))) {
         return "group_id.x";
-    } else if (ends_with(name, ".__block_id_y")) {
+    } else if (ends_with(name, gpu_block_name(1))) {
         return "group_id.y";
-    } else if (ends_with(name, ".__block_id_z")) {
+    } else if (ends_with(name, gpu_block_name(2))) {
         return "group_id.z";
-    } else if (ends_with(name, ".__block_id_w")) {
-        user_error << "WebGPU does not support more than three dimensions.\n";
     }
     internal_error << "invalid simt_intrinsic name: " << name << "\n";
     return "";
@@ -646,10 +643,7 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::visit(const For *loop) {
     user_assert(loop->for_type != ForType::GPULane)
         << "The WebGPU backend does not support the gpu_lanes() directive.";
 
-    if (is_gpu_var(loop->name)) {
-        internal_assert((loop->for_type == ForType::GPUBlock) ||
-                        (loop->for_type == ForType::GPUThread))
-            << "kernel loop must be either gpu block or gpu thread\n";
+    if (is_gpu(loop->for_type)) {
         internal_assert(is_const_zero(loop->min));
 
         stream << get_indent()

--- a/src/DeviceArgument.cpp
+++ b/src/DeviceArgument.cpp
@@ -65,7 +65,7 @@ void HostClosure::visit(const Call *op) {
 }
 
 void HostClosure::visit(const For *loop) {
-    if (CodeGen_GPU_Dev::is_gpu_var(loop->name)) {
+    if (is_gpu(loop->for_type)) {
         // The size of the threads and blocks is not part of the closure
         ScopedBinding<> p(ignore, loop->name);
         loop->body.accept(this);

--- a/src/Expr.cpp
+++ b/src/Expr.cpp
@@ -87,6 +87,13 @@ bool is_parallel(ForType for_type) {
             for_type == ForType::GPULane);
 }
 
+/** Returns true if for_type is GPUBlock, GPUThread, or GPULane. */
+bool is_gpu(ForType for_type) {
+    return (for_type == ForType::GPUBlock ||
+            for_type == ForType::GPUThread ||
+            for_type == ForType::GPULane);
+}
+
 }  // namespace Internal
 
 Range::Range(const Expr &min_in, const Expr &extent_in)

--- a/src/Expr.h
+++ b/src/Expr.h
@@ -415,6 +415,9 @@ bool is_unordered_parallel(ForType for_type);
 /** Returns true if for_type executes for loop iterations in parallel. */
 bool is_parallel(ForType for_type);
 
+/** Returns true if for_type is GPUBlock, GPUThread, or GPULane. */
+bool is_gpu(ForType for_type);
+
 /** A reference-counted handle to a statement node. */
 struct Stmt : public IRHandle {
     Stmt() = default;

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -355,7 +355,7 @@ class TrimNoOps : public IRMutator {
 
     Stmt visit(const For *op) override {
         // Bounds of GPU loops can't depend on outer gpu loop vars
-        if (CodeGen_GPU_Dev::is_gpu_var(op->name)) {
+        if (is_gpu(op->for_type)) {
             debug(3) << "TrimNoOps found gpu loop var: " << op->name << "\n";
             return IRMutator::visit(op);
         }


### PR DESCRIPTION
This is one of our largest remaining type of magic name. These were explicitly constructed in lots of places and then explicitly checked for with ends_with in lots of places.

This PR makes the names opaque. Only CanonicalizeGPUVars.cpp knows what they are, and they don't have to be a single fixed thing as long as they're consistent within a process.

Also reduced the number of GPU dimensions to three more uniformly. We were already asserting this, but there was lots of dead code in lowering passes after gpu loop validation that allowed for four.

Also fixed a bug I found in is_block_uniform. It didn't consider that the dependence on a gpu thread variable in a load index could be because a let variable encountered depends on a gpu thread variable.