### PR TITLE
Feature: mark a Func as no_profiling, to prevent injection of profiling.

### DIFF
--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -391,7 +391,7 @@ protected:
         }
         Stmt body = mutate(op->body);
         body = allocate_mutex(finder.mutex_name, extent, body);
-        return ProducerConsumer::make(op->name, op->is_producer, std::move(body));
+        return ProducerConsumer::make(op->name, op->is_producer, std::move(body), op->no_profiling);
     }
 
     Stmt visit(const Atomic *op) override {

--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -504,12 +504,13 @@ void Deserializer::deserialize_function(const Serialize::Func *function, Functio
     const std::vector<std::string> trace_tags =
         deserialize_vector<flatbuffers::String, std::string>(function->trace_tags(),
                                                              &Deserializer::deserialize_string);
+    const bool no_profiling = function->no_profiling();
     const bool frozen = function->frozen();
     hl_function.update_with_deserialization(name, origin_name, output_types, required_types,
                                             required_dim, args, func_schedule, init_def, updates,
                                             debug_file, output_buffers, extern_arguments, extern_function_name,
                                             name_mangling, extern_function_device_api, extern_proxy_expr,
-                                            trace_loads, trace_stores, trace_realizations, trace_tags, frozen);
+                                            trace_loads, trace_stores, trace_realizations, trace_tags, no_profiling, frozen);
 }
 
 Stmt Deserializer::deserialize_stmt(Serialize::Stmt type_code, const void *stmt) {
@@ -533,7 +534,8 @@ Stmt Deserializer::deserialize_stmt(Serialize::Stmt type_code, const void *stmt)
         const auto name = deserialize_string(producer_consumer->name());
         const auto is_producer = producer_consumer->is_producer();
         const auto body = deserialize_stmt(producer_consumer->body_type(), producer_consumer->body());
-        return ProducerConsumer::make(name, is_producer, body);
+        const auto no_profiling = producer_consumer->no_profiling();
+        return ProducerConsumer::make(name, is_producer, body, no_profiling);
     }
     case Serialize::Stmt::For: {
         const auto *for_stmt = (const Serialize::For *)stmt;

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -618,7 +618,7 @@ class ExtractTileOperations : public IRMutator {
         }
 
         auto body = mutate(op->body);
-        return ProducerConsumer::make(amx_name, op->is_producer, std::move(body));
+        return ProducerConsumer::make(amx_name, op->is_producer, std::move(body), op->no_profiling);
     }
 
     Expr visit(const Load *op) override {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3037,6 +3037,11 @@ Func &Func::add_trace_tag(const std::string &trace_tag) {
     return *this;
 }
 
+Func &Func::no_profiling() {
+    func.do_not_profile();
+    return *this;
+}
+
 void Func::debug_to_file(const string &filename) {
     invalidate_cache();
     func.debug_file() = filename;

--- a/src/Func.h
+++ b/src/Func.h
@@ -2559,6 +2559,15 @@ public:
      */
     Func &add_trace_tag(const std::string &trace_tag);
 
+    /** Marks this function as a function that should not be profiled
+     * when using the target feature Profile or ProfileByTimer.
+     * This is useful when this function is does too little work at once
+     * such that the overhead of setting the profiling token might
+     * become significant, or that the measured time is not representative
+     * due to modern processors (instruction level parallelism, out-of-order
+     * execution). */
+    Func &no_profiling();
+
     /** Get a handle on the internal halide function that this Func
      * represents. Useful if you want to do introspection on Halide
      * functions */

--- a/src/Function.h
+++ b/src/Function.h
@@ -88,6 +88,7 @@ public:
                                      bool trace_stores,
                                      bool trace_realizations,
                                      const std::vector<std::string> &trace_tags,
+                                     bool should_not_profile,
                                      bool frozen);
 
     /** Get a handle on the halide function contents that this Function
@@ -289,6 +290,12 @@ public:
     /** Replace this Function's LoopLevels with locked copies that
      * cannot be mutated further. */
     void lock_loop_levels();
+
+    /** Mark the function as too small for meaningful profiling. */
+    void do_not_profile();
+
+    /** Check if the function is marked as one that should not be profiled. */
+    bool should_not_profile() const;
 
     /** Mark function as frozen, which means it cannot accept new
      * definitions. */

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -324,22 +324,23 @@ Stmt AssertStmt::make(Expr condition, Expr message) {
     return node;
 }
 
-Stmt ProducerConsumer::make(const std::string &name, bool is_producer, Stmt body) {
+Stmt ProducerConsumer::make(const std::string &name, bool is_producer, Stmt body, bool no_profiling) {
     internal_assert(body.defined()) << "ProducerConsumer of undefined\n";
 
     ProducerConsumer *node = new ProducerConsumer;
     node->name = name;
     node->is_producer = is_producer;
     node->body = std::move(body);
+    node->no_profiling = no_profiling;
     return node;
 }
 
-Stmt ProducerConsumer::make_produce(const std::string &name, Stmt body) {
-    return ProducerConsumer::make(name, true, std::move(body));
+Stmt ProducerConsumer::make_produce(const std::string &name, Stmt body, bool no_profiling) {
+    return ProducerConsumer::make(name, true, std::move(body), no_profiling);
 }
 
-Stmt ProducerConsumer::make_consume(const std::string &name, Stmt body) {
-    return ProducerConsumer::make(name, false, std::move(body));
+Stmt ProducerConsumer::make_consume(const std::string &name, Stmt body, bool no_profiling) {
+    return ProducerConsumer::make(name, false, std::move(body), no_profiling);
 }
 
 Stmt For::make(const std::string &name,

--- a/src/IR.h
+++ b/src/IR.h
@@ -316,11 +316,17 @@ struct ProducerConsumer : public StmtNode<ProducerConsumer> {
     std::string name;
     bool is_producer;
     Stmt body;
+    // This boolean is useful to set on very tiny Funcs, where
+    // the profiling would become a significant overhead of the
+    // runtime of that Func. Setting this on true will simply
+    // not inject the profiling, and sample attribution will go
+    // to the enclosing ProducerConsumer.
+    bool no_profiling;
 
-    static Stmt make(const std::string &name, bool is_producer, Stmt body);
+    static Stmt make(const std::string &name, bool is_producer, Stmt body, bool no_profiling);
 
-    static Stmt make_produce(const std::string &name, Stmt body);
-    static Stmt make_consume(const std::string &name, Stmt body);
+    static Stmt make_produce(const std::string &name, Stmt body, bool no_profiling);
+    static Stmt make_consume(const std::string &name, Stmt body, bool no_profiling);
 
     static const IRNodeType _node_type = IRNodeType::ProducerConsumer;
 };

--- a/src/IRMutator.cpp
+++ b/src/IRMutator.cpp
@@ -197,7 +197,7 @@ Stmt IRMutator::visit(const ProducerConsumer *op) {
     if (body.same_as(op->body)) {
         return op;
     }
-    return ProducerConsumer::make(op->name, op->is_producer, std::move(body));
+    return ProducerConsumer::make(op->name, op->is_producer, std::move(body), op->no_profiling);
 }
 
 Stmt IRMutator::visit(const For *op) {

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -231,8 +231,8 @@ void IRPrinter::test() {
     Stmt store2 = Store::make("out", call + 1, x, Parameter(), const_true(), ModulusRemainder(3, 5));
     Stmt for_loop2 = For::make("x", 0, y, ForType::Vectorized, Partition::Auto, DeviceAPI::Host, store2);
 
-    Stmt producer = ProducerConsumer::make_produce("buf", for_loop);
-    Stmt consumer = ProducerConsumer::make_consume("buf", for_loop2);
+    Stmt producer = ProducerConsumer::make_produce("buf", for_loop, false);
+    Stmt consumer = ProducerConsumer::make_consume("buf", for_loop2, false);
     Stmt pipeline = Block::make(producer, consumer);
 
     Stmt assertion = AssertStmt::make(y >= 3, Call::make(Int(32), "halide_error_param_too_small_i64",

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -581,14 +581,14 @@ class HoistIfStatements : public IRMutator {
         if (const IfThenElse *i = body.as<IfThenElse>()) {
             if (!i->else_case.defined() &&
                 is_pure(i->condition)) {
-                Stmt s = ProducerConsumer::make(op->name, op->is_producer, i->then_case);
+                Stmt s = ProducerConsumer::make(op->name, op->is_producer, i->then_case, op->no_profiling);
                 return IfThenElse::make(i->condition, s);
             }
         }
         if (body.same_as(op->body)) {
             return op;
         } else {
-            return ProducerConsumer::make(op->name, op->is_producer, body);
+            return ProducerConsumer::make(op->name, op->is_producer, body, op->no_profiling);
         }
     }
 

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -547,7 +547,7 @@ class LoopCarry : public IRMutator {
         } else {
             ScopedBinding<> bind(in_consume, op->name);
             Stmt body = mutate(op->body);
-            return ProducerConsumer::make(op->name, op->is_producer, body);
+            return ProducerConsumer::make(op->name, op->is_producer, body, op->no_profiling);
         }
     }
 

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -447,7 +447,7 @@ private:
                 body = Block::make(body, cache_store_back);
                 body = IfThenElse::make(cache_miss, body);
             }
-            return ProducerConsumer::make(op->name, op->is_producer, body);
+            return ProducerConsumer::make(op->name, op->is_producer, body, op->no_profiling);
         } else {
             return IRMutator::visit(op);
         }

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -282,24 +282,24 @@ private:
     Stmt visit(const ProducerConsumer *op) override {
         int idx;
         Stmt body;
-        if (op->no_profiling) {
-            body = mutate(op->body);
-            if (body.same_as(op->body)) {
-                return op;
-            }
-        } else {
-            if (op->is_producer) {
+        if (op->is_producer) {
+            if (op->no_profiling) {
+                body = mutate(op->body);
+                if (body.same_as(op->body)) {
+                    return op;
+                }
+            } else {
                 idx = get_func_id(op->name);
                 stack.push_back(idx);
                 Stmt set_current = set_current_func(idx);
                 body = Block::make(set_current, mutate(op->body));
                 stack.pop_back();
-            } else {
-                // At the beginning of the consume step, set the current task
-                // back to the outer one.
-                Stmt set_current = set_current_func(stack.back());
-                body = Block::make(set_current, mutate(op->body));
             }
+        } else {
+            // At the beginning of the consume step, set the current task
+            // back to the outer one.
+            Stmt set_current = set_current_func(stack.back());
+            body = Block::make(set_current, mutate(op->body));
         }
 
         return ProducerConsumer::make(op->name, op->is_producer, body, op->no_profiling);

--- a/src/RemoveUndef.cpp
+++ b/src/RemoveUndef.cpp
@@ -314,7 +314,7 @@ private:
         if (body.same_as(op->body)) {
             return op;
         } else {
-            return ProducerConsumer::make(op->name, op->is_producer, body);
+            return ProducerConsumer::make(op->name, op->is_producer, body, op->no_profiling);
         }
     }
 

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1770,7 +1770,7 @@ private:
 
         // Rewrap the loop in the containing lets.
         for (size_t i = add_lets.size(); i > 0; --i) {
-            const auto &b = add_lets[i - 1];
+            const pair<string, Expr> &b = add_lets[i - 1];
             producer = LetStmt::make(b.first, b.second, producer);
         }
 
@@ -1782,7 +1782,7 @@ private:
         // loop bounds should remain unchanged.
         map<string, Expr> shifts;
         for (auto i = funcs.size(); i-- > 0;) {
-            const auto &func = funcs[i];
+            const Function &func = funcs[i];
             compute_shift_factor(func, func.name() + ".s0.", func.definition(), bounds, shifts);
             for (size_t j = 0; j < func.updates().size(); ++j) {
                 string prefix = func.name() + ".s" + std::to_string(j + 1) + ".";
@@ -1802,14 +1802,14 @@ private:
         producer = replace_parent_bound_with_union_bound(funcs.back(), producer, bounds);
 
         // Add the producer nodes.
-        for (const auto &i : funcs) {
-            producer = ProducerConsumer::make_produce(i.name(), producer);
+        for (const Function &func : funcs) {
+            producer = ProducerConsumer::make_produce(func.name(), producer, func.should_not_profile());
         }
 
         // Add the consumer nodes.
         for (size_t i = 0; i < funcs.size(); i++) {
             if (!is_output_list[i]) {
-                consumer = ProducerConsumer::make_consume(funcs[i].name(), consumer);
+                consumer = ProducerConsumer::make_consume(funcs[i].name(), consumer, funcs[i].should_not_profile());
             }
         }
 

--- a/src/Serialization.cpp
+++ b/src/Serialization.cpp
@@ -439,7 +439,8 @@ std::pair<Serialize::Stmt, Offset<void>> Serializer::serialize_stmt(FlatBufferBu
         return std::make_pair(Serialize::Stmt::ProducerConsumer,
                               Serialize::CreateProducerConsumer(builder, name_serialized,
                                                                 producer_consumer->is_producer,
-                                                                body_serialized.first, body_serialized.second)
+                                                                body_serialized.first, body_serialized.second,
+                                                                producer_consumer->no_profiling)
                                   .Union());
     }
     case IRNodeType::For: {
@@ -1029,6 +1030,7 @@ Offset<Serialize::Func> Serializer::serialize_function(FlatBufferBuilder &builde
     for (const auto &tag : function.get_trace_tags()) {
         trace_tags_serialized.push_back(serialize_string(builder, tag));
     }
+    const bool no_profiling = function.should_not_profile();
     const bool frozen = function.frozen();
     auto func = Serialize::CreateFunc(builder,
                                       name_serialized,
@@ -1050,7 +1052,9 @@ Offset<Serialize::Func> Serializer::serialize_function(FlatBufferBuilder &builde
                                       trace_loads,
                                       trace_stores,
                                       trace_realizations,
-                                      builder.CreateVector(trace_tags_serialized), frozen);
+                                      builder.CreateVector(trace_tags_serialized),
+                                      no_profiling,
+                                      frozen);
     return func;
 }
 

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -116,11 +116,11 @@ Stmt Simplify::visit(const IfThenElse *op) {
                then_pc->name == else_pc->name &&
                then_pc->is_producer == else_pc->is_producer) {
         return ProducerConsumer::make(then_pc->name, then_pc->is_producer,
-                                      mutate(IfThenElse::make(condition, then_pc->body, else_pc->body)));
+                                      mutate(IfThenElse::make(condition, then_pc->body, else_pc->body)), then_pc->no_profiling);
     } else if (then_pc &&
                is_no_op(else_case)) {
         return ProducerConsumer::make(then_pc->name, then_pc->is_producer,
-                                      mutate(IfThenElse::make(condition, then_pc->body)));
+                                      mutate(IfThenElse::make(condition, then_pc->body)), then_pc->no_profiling);
     } else if (then_block &&
                else_block &&
                equal(then_block->first, else_block->first)) {
@@ -445,7 +445,7 @@ Stmt Simplify::visit(const ProducerConsumer *op) {
     } else if (body.same_as(op->body)) {
         return op;
     } else {
-        return ProducerConsumer::make(op->name, op->is_producer, body);
+        return ProducerConsumer::make(op->name, op->is_producer, body, op->no_profiling);
     }
 }
 

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -613,7 +613,7 @@ protected:
             if (body.same_as(op->body)) {
                 return op;
             } else {
-                return ProducerConsumer::make(op->name, op->is_producer, std::move(body));
+                return ProducerConsumer::make(op->name, op->is_producer, std::move(body), op->no_profiling);
             }
         } else {
             ScopedBinding<> bind_if(!unconditionally_used &&

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -550,7 +550,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
             if (body.same_as(op->body)) {
                 return op;
             } else {
-                return ProducerConsumer::make_consume(op->name, body);
+                return ProducerConsumer::make_consume(op->name, body, op->no_profiling);
             }
         } else {
             return IRMutator::visit(op);

--- a/src/StorageFolding.cpp
+++ b/src/StorageFolding.cpp
@@ -298,7 +298,7 @@ class InjectFoldingCheck : public IRMutator {
                 }
             }
 
-            return ProducerConsumer::make(op->name, op->is_producer, body);
+            return ProducerConsumer::make(op->name, op->is_producer, body, op->no_profiling);
         } else {
             return IRMutator::visit(op);
         }

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -309,7 +309,7 @@ private:
             Stmt new_body = Block::make(op->body, Evaluate::make(end_op_call));
 
             stmt = LetStmt::make(f.name() + ".trace_id", begin_op_call,
-                                 ProducerConsumer::make(op->name, op->is_producer, new_body));
+                                 ProducerConsumer::make(op->name, op->is_producer, new_body, op->no_profiling));
         }
         return stmt;
     }

--- a/src/halide_ir.fbs
+++ b/src/halide_ir.fbs
@@ -138,6 +138,7 @@ table ProducerConsumer {
     name: string;
     is_producer: bool;
     body: Stmt;
+    no_profiling: bool;
 }
 
 table For {
@@ -713,6 +714,7 @@ table Func {
     trace_stores: bool = false;
     trace_realizations: bool = false;
     trace_tags: [string];
+    no_profiling: bool = false;
     frozen: bool = false;
 }
 


### PR DESCRIPTION
This PR adds a small change that allows you to `.no_profiling()` on a `Func` to prevent the corresponding ProducerConsumer node to not be instrumented with profiling. Therefore all the collected samples are attributed to the enclosing `ProducerConsumer`. I wanted to give this a try to see what the generated code looks like.

I was thinking this might be useful to get rid of this overhead manually when you are working on pipelines that have a `Func` without any loops sitting in the innermost loop nest level, e.g.: the `Func` gets compiled to only 1 to 5 instructions.

Feedback and opinions welcome!

---

**My use case:**

This code full of profiling injections (with an unrolled loop around it):
![image](https://github.com/halide/Halide/assets/845012/9b31e7b5-4b8e-40f8-bd8d-80cdd976cca3)

Became this:
![image](https://github.com/halide/Halide/assets/845012/9d5b06d8-8520-4f4e-ab6c-e53ab71972da)

Meanwhile, the profile report went from:

```
neonraw_highlight_ratio_extractor
 total time: 1389.949829 ms  samples: 1309  runs: 48  time/run: 28.957289 ms
 average threads used: 2.828113
 heap allocations: 0  peak heap usage: 0 bytes
    halide_malloc:                0.000ms ( 0.0%)   threads: 0.000 
    halide_free:                  0.000ms ( 0.0%)   threads: 0.000 
    ratio_map:                   20.969ms (72.4%)   threads: 2.685 
    repeat_edge:                  3.639ms (12.5%)   threads: 3.219  stack: 2040
    max_field_hpass:              0.617ms ( 2.1%)   threads: 3.678  stack: 1920
    max_field:                    0.263ms ( 0.9%)   threads: 2.000  stack: 1536
    min_field_hpass:              0.462ms ( 1.5%)   threads: 2.333  stack: 640
    max_channel:                  0.088ms ( 0.3%)   threads: 1.500  stack: 68
    min_field:                    0.044ms ( 0.1%)   threads: 1.500  stack: 512
    b:                            0.352ms ( 1.2%)   threads: 1.750  stack: 32
    g:                            0.154ms ( 0.5%)   threads: 1.571  stack: 32
    r:                            0.110ms ( 0.3%)   threads: 4.000  stack: 32
    lum:                          0.619ms ( 2.1%)   threads: 4.222  stack: 32
    lum_pow3:                     0.044ms ( 0.1%)   threads: 1.500  stack: 32
    lum4:                         1.547ms ( 5.3%)   threads: 3.542  stack: 32
    w_0:                          0.000ms ( 0.0%)   threads: 0.000  stack: 32
    w_1:                          0.022ms ( 0.0%)   threads: 14.000 stack: 32
    w_2:                          0.022ms ( 0.0%)   threads: 2.000  stack: 32
```

to:

```
neonraw_highlight_ratio_extractor
 total time: 1376.182739 ms  samples: 1295  runs: 48  time/run: 28.670473 ms
 average threads used: 2.325097
 heap allocations: 0  peak heap usage: 0 bytes
    halide_malloc:                0.000ms ( 0.0%)   threads: 0.000 
    halide_free:                  0.000ms ( 0.0%)   threads: 0.000 
    ratio_map:                   24.013ms (83.7%)   threads: 2.245 
    repeat_edge:                  3.434ms (11.9%)   threads: 2.647  stack: 2040
    max_field_hpass:              0.515ms ( 1.7%)   threads: 3.130  stack: 1920
    max_field:                    0.176ms ( 0.6%)   threads: 3.500  stack: 1536
    min_field_hpass:              0.486ms ( 1.6%)   threads: 2.181  stack: 640
    max_channel:                  0.000ms ( 0.0%)   threads: 0.000  stack: 68
    min_field:                    0.044ms ( 0.1%)   threads: 8.500  stack: 512
    b:                            0.000ms ( 0.0%)   threads: 0.000  stack: 32
    g:                            0.000ms ( 0.0%)   threads: 0.000  stack: 32
    r:                            0.000ms ( 0.0%)   threads: 0.000  stack: 32
    lum:                          0.000ms ( 0.0%)   threads: 0.000  stack: 32
    lum_pow3:                     0.000ms ( 0.0%)   threads: 0.000  stack: 32
    lum4:                         0.000ms ( 0.0%)   threads: 0.000  stack: 32
    w_0:                          0.000ms ( 0.0%)   threads: 0.000  stack: 32
    w_1:                          0.000ms ( 0.0%)   threads: 0.000  stack: 32
    w_2:                          0.000ms ( 0.0%)   threads: 0.000  stack: 32
```