### PR TITLE
Feature: mark a Func as no_profiling, to prevent injection of profiling. (2nd implementation)

### DIFF
--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -504,12 +504,14 @@ void Deserializer::deserialize_function(const Serialize::Func *function, Functio
     const std::vector<std::string> trace_tags =
         deserialize_vector<flatbuffers::String, std::string>(function->trace_tags(),
                                                              &Deserializer::deserialize_string);
+    const bool no_profiling = function->no_profiling();
     const bool frozen = function->frozen();
     hl_function.update_with_deserialization(name, origin_name, output_types, required_types,
                                             required_dim, args, func_schedule, init_def, updates,
                                             debug_file, output_buffers, extern_arguments, extern_function_name,
                                             name_mangling, extern_function_device_api, extern_proxy_expr,
-                                            trace_loads, trace_stores, trace_realizations, trace_tags, frozen);
+                                            trace_loads, trace_stores, trace_realizations, trace_tags,
+                                            no_profiling, frozen);
 }
 
 Stmt Deserializer::deserialize_stmt(Serialize::Stmt type_code, const void *stmt) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3037,6 +3037,11 @@ Func &Func::add_trace_tag(const std::string &trace_tag) {
     return *this;
 }
 
+Func &Func::no_profiling() {
+    func.do_not_profile();
+    return *this;
+}
+
 void Func::debug_to_file(const string &filename) {
     invalidate_cache();
     func.debug_file() = filename;

--- a/src/Func.h
+++ b/src/Func.h
@@ -2559,6 +2559,15 @@ public:
      */
     Func &add_trace_tag(const std::string &trace_tag);
 
+    /** Marks this function as a function that should not be profiled
+     * when using the target feature Profile or ProfileByTimer.
+     * This is useful when this function is does too little work at once
+     * such that the overhead of setting the profiling token might
+     * become significant, or that the measured time is not representative
+     * due to modern processors (instruction level parallelism, out-of-order
+     * execution). */
+    Func &no_profiling();
+
     /** Get a handle on the internal halide function that this Func
      * represents. Useful if you want to do introspection on Halide
      * functions */

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -1167,7 +1167,6 @@ void Function::lock_loop_levels() {
     }
 }
 
-
 void Function::do_not_profile() {
     contents->no_profiling = true;
 }

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -110,6 +110,8 @@ struct FunctionContents {
     bool trace_loads = false, trace_stores = false, trace_realizations = false;
     std::vector<string> trace_tags;
 
+    bool no_profiling = false;
+
     bool frozen = false;
 
     void accept(IRVisitor *visitor) const {
@@ -352,6 +354,7 @@ void Function::update_with_deserialization(const std::string &name,
                                            bool trace_stores,
                                            bool trace_realizations,
                                            const std::vector<std::string> &trace_tags,
+                                           bool no_profiling,
                                            bool frozen) {
     contents->name = name;
     contents->origin_name = origin_name;
@@ -373,6 +376,7 @@ void Function::update_with_deserialization(const std::string &name,
     contents->trace_stores = trace_stores;
     contents->trace_realizations = trace_realizations;
     contents->trace_tags = trace_tags;
+    contents->no_profiling = no_profiling;
     contents->frozen = frozen;
 }
 
@@ -509,6 +513,7 @@ void Function::deep_copy(const FunctionPtr &copy, DeepCopyMap &copied_map) const
     copy->trace_stores = contents->trace_stores;
     copy->trace_realizations = contents->trace_realizations;
     copy->trace_tags = contents->trace_tags;
+    copy->no_profiling = contents->no_profiling;
     copy->frozen = contents->frozen;
     copy->output_buffers = contents->output_buffers;
     copy->func_schedule = contents->func_schedule.deep_copy(copied_map);
@@ -1139,10 +1144,6 @@ const std::vector<std::string> &Function::get_trace_tags() const {
     return contents->trace_tags;
 }
 
-void Function::freeze() {
-    contents->frozen = true;
-}
-
 void Function::lock_loop_levels() {
     auto &schedule = contents->func_schedule;
     schedule.compute_level().lock();
@@ -1166,6 +1167,17 @@ void Function::lock_loop_levels() {
     }
 }
 
+
+void Function::do_not_profile() {
+    contents->no_profiling = true;
+}
+bool Function::should_not_profile() const {
+    return contents->no_profiling;
+}
+
+void Function::freeze() {
+    contents->frozen = true;
+}
 bool Function::frozen() const {
     return contents->frozen;
 }

--- a/src/Function.h
+++ b/src/Function.h
@@ -88,6 +88,7 @@ public:
                                      bool trace_stores,
                                      bool trace_realizations,
                                      const std::vector<std::string> &trace_tags,
+                                     bool no_profiling,
                                      bool frozen);
 
     /** Get a handle on the halide function contents that this Function
@@ -289,6 +290,12 @@ public:
     /** Replace this Function's LoopLevels with locked copies that
      * cannot be mutated further. */
     void lock_loop_levels();
+
+    /** Mark the function as too small for meaningful profiling. */
+    void do_not_profile();
+
+    /** Check if the function is marked as one that should not be profiled. */
+    bool should_not_profile() const;
 
     /** Mark function as frozen, which means it cannot accept new
      * definitions. */

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -408,7 +408,7 @@ void lower_impl(const vector<Function> &output_funcs,
 
     if (t.has_feature(Target::Profile) || t.has_feature(Target::ProfileByTimer)) {
         debug(1) << "Injecting profiling...\n";
-        s = inject_profiling(s, pipeline_name);
+        s = inject_profiling(s, pipeline_name, env);
         log("Lowering after injecting profiling:", s);
     }
 

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -120,7 +120,7 @@ private:
     bool profiling_memory = true;
 
     // Strip down the tuple name, e.g. f.0 into f
-    string normalize_name(const string &name) {
+    string normalize_name(const string &name) const {
         vector<string> v = split_string(name, ".");
         internal_assert(!v.empty());
         return v[0];
@@ -131,14 +131,10 @@ private:
         if (it != env.end()) {
             return &it->second;
         }
-        for (const auto &entry : env) {
-            const std::string &cand_name = entry.first;
-            // Names sometimes get deduplicated by appending '.<somenumber>'.
-            if (cand_name.size() < name.size() && name[cand_name.size()] == '.') {
-                if (name.substr(0, cand_name.size()) == cand_name) {
-                    return &entry.second;
-                }
-            }
+        string norm_name = normalize_name(name);
+        it = env.find(norm_name);
+        if (it != env.end()) {
+            return &it->second;
         }
         internal_error << "No function in the environment found for name '" << name << "'.\n";
         return nullptr;

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "CodeGen_Internal.h"
-#include "ExprUsesVar.h"
+#include "Function.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "InjectHostDevBufferCopies.h"
@@ -71,13 +71,14 @@ public:
     vector<int> stack;  // What produce nodes are we currently inside of.
 
     string pipeline_name;
+    const map<string, Function> &env;
 
     bool in_fork = false;
     bool in_parallel = false;
     bool in_leaf_task = false;
 
-    InjectProfiling(const string &pipeline_name)
-        : pipeline_name(pipeline_name) {
+    InjectProfiling(const string &pipeline_name, const map<string, Function> &env)
+        : pipeline_name(pipeline_name), env(env) {
         stack.push_back(get_func_id("overhead"));
         // ID 0 is treated specially in the runtime as overhead
         internal_assert(stack.back() == 0);
@@ -123,6 +124,24 @@ private:
         vector<string> v = split_string(name, ".");
         internal_assert(!v.empty());
         return v[0];
+    }
+
+    const Function *lookup_function(const string &name) const {
+        auto it = env.find(name);
+        if (it != env.end()) {
+            return &it->second;
+        }
+        for (const auto &entry : env) {
+            const std::string &cand_name = entry.first;
+            // Names sometimes get deduplicated by appending '.<somenumber>'.
+            if (cand_name.size() < name.size() && name[cand_name.size()] == '.') {
+                if (name.substr(0, cand_name.size()) == cand_name) {
+                    return &entry.second;
+                }
+            }
+        }
+        internal_error << "No function in the environment found for name '" << name << "'.\n";
+        return nullptr;
     }
 
     int get_func_id(const string &name) {
@@ -185,7 +204,6 @@ private:
     }
 
     Stmt visit(const Allocate *op) override {
-        int idx = get_func_id(op->name);
 
         auto [new_extents, changed] = mutate_with_changes(op->extents);
         Expr condition = mutate(op->condition);
@@ -199,6 +217,13 @@ private:
         // always conditionally false. remove_dead_allocations() is called after
         // inject_profiling() so this is a possible scenario.
         if (!is_const_zero(size) && on_stack) {
+            int idx;
+            const Function *func = lookup_function(op->name);
+            if (func->should_not_profile()) {
+                idx = stack.back(); // Attribute the stack size contribution to the deepest _profiled_ func.
+            } else {
+                idx = get_func_id(op->name);
+            }
             const uint64_t *int_size = as_const_uint(size);
             internal_assert(int_size != nullptr);  // Stack size is always a const int
             func_stack_current[idx] += *int_size;
@@ -212,6 +237,7 @@ private:
         vector<Stmt> tasks;
         bool track_heap_allocation = !is_const_zero(size) && !on_stack && profiling_memory;
         if (track_heap_allocation) {
+            int idx = get_func_id(op->name);
             debug(3) << "  Allocation on heap: " << op->name
                      << "(" << size << ") in pipeline "
                      << pipeline_name << "\n";
@@ -245,8 +271,6 @@ private:
     }
 
     Stmt visit(const Free *op) override {
-        int idx = get_func_id(op->name);
-
         AllocSize alloc = func_alloc_sizes.get(op->name);
         internal_assert(alloc.size.type() == UInt(64));
         func_alloc_sizes.pop(op->name);
@@ -256,6 +280,7 @@ private:
         if (!is_const_zero(alloc.size)) {
             if (!alloc.on_stack) {
                 if (profiling_memory) {
+                    int idx = get_func_id(op->name);
                     debug(3) << "  Free on heap: " << op->name << "(" << alloc.size << ") in pipeline " << pipeline_name << "\n";
 
                     vector<Stmt> tasks{
@@ -271,6 +296,13 @@ private:
                 const uint64_t *int_size = as_const_uint(alloc.size);
                 internal_assert(int_size != nullptr);
 
+                int idx;
+                const Function *func = lookup_function(op->name);
+                if (func->should_not_profile()) {
+                    idx = stack.back(); // Attribute the stack size contribution to the deepest _profiled_ func.
+                } else {
+                    idx = get_func_id(op->name);
+                }
                 func_stack_current[idx] -= *int_size;
                 debug(3) << "  Free on stack: " << op->name << "(" << alloc.size << ") in pipeline " << pipeline_name
                          << "; current: " << func_stack_current[idx] << "; peak: " << func_stack_peak[idx] << "\n";
@@ -283,11 +315,19 @@ private:
         int idx;
         Stmt body;
         if (op->is_producer) {
-            idx = get_func_id(op->name);
-            stack.push_back(idx);
-            Stmt set_current = set_current_func(idx);
-            body = Block::make(set_current, mutate(op->body));
-            stack.pop_back();
+            const Function *func = lookup_function(op->name);
+            if (func->should_not_profile()) {
+                body = mutate(op->body);
+                if (body.same_as(op->body)) {
+                    return op;
+                }
+            } else {
+                idx = get_func_id(op->name);
+                stack.push_back(idx);
+                Stmt set_current = set_current_func(idx);
+                body = Block::make(set_current, mutate(op->body));
+                stack.pop_back();
+            }
         } else {
             // At the beginning of the consume step, set the current task
             // back to the outer one.
@@ -498,8 +538,8 @@ private:
 
 }  // namespace
 
-Stmt inject_profiling(Stmt s, const string &pipeline_name) {
-    InjectProfiling profiling(pipeline_name);
+Stmt inject_profiling(Stmt s, const string &pipeline_name, const std::map<string, Function> &env) {
+    InjectProfiling profiling(pipeline_name, env);
     s = profiling.mutate(s);
 
     int num_funcs = (int)(profiling.indices.size());

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -130,18 +130,18 @@ private:
         }
     }
 
-    const Function *lookup_function(const string &name) const {
+    Function lookup_function(const string &name) const {
         auto it = env.find(name);
         if (it != env.end()) {
-            return &it->second;
+            return it->second;
         }
         string norm_name = normalize_name(name);
         it = env.find(norm_name);
         if (it != env.end()) {
-            return &it->second;
+            return it->second;
         }
         internal_error << "No function in the environment found for name '" << name << "'.\n";
-        return nullptr;
+        return {};
     }
 
     int get_func_id(const string &name) {
@@ -218,8 +218,8 @@ private:
         // inject_profiling() so this is a possible scenario.
         if (!is_const_zero(size) && on_stack) {
             int idx;
-            const Function *func = lookup_function(op->name);
-            if (func->should_not_profile()) {
+            Function func = lookup_function(op->name);
+            if (func.should_not_profile()) {
                 idx = stack.back();  // Attribute the stack size contribution to the deepest _profiled_ func.
             } else {
                 idx = get_func_id(op->name);
@@ -297,8 +297,8 @@ private:
                 internal_assert(int_size != nullptr);
 
                 int idx;
-                const Function *func = lookup_function(op->name);
-                if (func->should_not_profile()) {
+                Function func = lookup_function(op->name);
+                if (func.should_not_profile()) {
                     idx = stack.back();  // Attribute the stack size contribution to the deepest _profiled_ func.
                 } else {
                     idx = get_func_id(op->name);
@@ -315,8 +315,8 @@ private:
         int idx;
         Stmt body;
         if (op->is_producer) {
-            const Function *func = lookup_function(op->name);
-            if (func->should_not_profile()) {
+            Function func = lookup_function(op->name);
+            if (func.should_not_profile()) {
                 body = mutate(op->body);
                 if (body.same_as(op->body)) {
                     return op;

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -121,9 +121,13 @@ private:
 
     // Strip down the tuple name, e.g. f.0 into f
     string normalize_name(const string &name) const {
-        vector<string> v = split_string(name, ".");
-        internal_assert(!v.empty());
-        return v[0];
+        size_t idx = name.find('.');
+        if (idx != std::string::npos) {
+            internal_assert(idx != 0);
+            return name.substr(0, idx);
+        } else {
+            return name;
+        }
     }
 
     const Function *lookup_function(const string &name) const {

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -220,7 +220,7 @@ private:
             int idx;
             const Function *func = lookup_function(op->name);
             if (func->should_not_profile()) {
-                idx = stack.back(); // Attribute the stack size contribution to the deepest _profiled_ func.
+                idx = stack.back();  // Attribute the stack size contribution to the deepest _profiled_ func.
             } else {
                 idx = get_func_id(op->name);
             }
@@ -299,7 +299,7 @@ private:
                 int idx;
                 const Function *func = lookup_function(op->name);
                 if (func->should_not_profile()) {
-                    idx = stack.back(); // Attribute the stack size contribution to the deepest _profiled_ func.
+                    idx = stack.back();  // Attribute the stack size contribution to the deepest _profiled_ func.
                 } else {
                     idx = get_func_id(op->name);
                 }

--- a/src/Profiling.h
+++ b/src/Profiling.h
@@ -23,12 +23,15 @@
  *   mandelbrot:  0.006444ms (10%)   peak: 505344   num: 104000   avg: 5376
  *   argmin:      0.027715ms (46%)   stack: 20
  */
+#include <map>
 #include <string>
 
 #include "Expr.h"
 
 namespace Halide {
 namespace Internal {
+
+class Function;
 
 /** Take a statement representing a halide pipeline insert
  * high-resolution timing into the generated code (via spawning a
@@ -37,7 +40,7 @@ namespace Internal {
  * storage flattening, but after all bounds inference.
  *
  */
-Stmt inject_profiling(Stmt, const std::string &);
+Stmt inject_profiling(Stmt, const std::string &, const std::map<std::string, Function> &env);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Serialization.cpp
+++ b/src/Serialization.cpp
@@ -1029,6 +1029,7 @@ Offset<Serialize::Func> Serializer::serialize_function(FlatBufferBuilder &builde
     for (const auto &tag : function.get_trace_tags()) {
         trace_tags_serialized.push_back(serialize_string(builder, tag));
     }
+    const bool no_profiling = function.should_not_profile();
     const bool frozen = function.frozen();
     auto func = Serialize::CreateFunc(builder,
                                       name_serialized,
@@ -1050,7 +1051,9 @@ Offset<Serialize::Func> Serializer::serialize_function(FlatBufferBuilder &builde
                                       trace_loads,
                                       trace_stores,
                                       trace_realizations,
-                                      builder.CreateVector(trace_tags_serialized), frozen);
+                                      builder.CreateVector(trace_tags_serialized),
+                                      no_profiling,
+                                      frozen);
     return func;
 }
 

--- a/src/halide_ir.fbs
+++ b/src/halide_ir.fbs
@@ -15,7 +15,7 @@ enum SerializationVersionMinor: int {
     Value = 0
 }
 enum SerializationVersionPatch: int {
-    Value = 0
+    Value = 1
 }
 
 // from src/IR.cpp

--- a/src/halide_ir.fbs
+++ b/src/halide_ir.fbs
@@ -713,6 +713,7 @@ table Func {
     trace_stores: bool = false;
     trace_realizations: bool = false;
     trace_tags: [string];
+    no_profiling: bool = false;
     frozen: bool = false;
 }
 


### PR DESCRIPTION
Replaces #8136 with a cleaner implementation.

@abadams I took your suggestion, and this implementation is much better. Very small changes, and the issue I reported in the previous one is gone. The trick with the "environment" was a good lesson!

Additionally, I managed to also clean up the report by having the stack-allocated `Allocate`/`Free` nodes also have their allocation contribute to the enclosing `Func`. Doing that changed my profiling report from (`w_0`, `w_1`, `w_2`, `max_channel`, `lum`, `lum_pow3`, `r`, `g`, `b` all marked with `no_profiling()`, but still producing lines in the report):

```
neonraw_highlight_ratio_extractor
 total time: 1338.695068 ms  samples: 1262  runs: 48  time/run: 27.889481 ms
 average threads used: 2.657686
 heap allocations: 0  peak heap usage: 0 bytes
    halide_malloc:                0.000ms ( 0.0%)   threads: 0.000 
    halide_free:                  0.000ms ( 0.0%)   threads: 0.000 
    ratio_map:                   21.282ms (76.3%)   threads: 2.663 
    repeat_edge:                  2.764ms ( 9.9%)   threads: 3.248  stack: 3960
    max_field_hpass:              0.683ms ( 2.4%)   threads: 2.967  stack: 3840
    max_field:                    0.352ms ( 1.2%)   threads: 2.125  stack: 3072
    min_field_hpass:              0.507ms ( 1.8%)   threads: 2.826  stack: 1280
    max_channel:                  0.000ms ( 0.0%)   threads: 0.000  stack: 132
    min_field:                    0.088ms ( 0.3%)   threads: 1.250  stack: 1024
    b:                            0.000ms ( 0.0%)   threads: 0.000  stack: 64
    g:                            0.000ms ( 0.0%)   threads: 0.000  stack: 64
    r:                            0.000ms ( 0.0%)   threads: 0.000  stack: 64
    lum:                          0.000ms ( 0.0%)   threads: 0.000  stack: 64
    lum_pow3:                     0.000ms ( 0.0%)   threads: 0.000  stack: 64
    lum4:                         2.210ms ( 7.9%)   threads: 1.870  stack: 64
    w_0:                          0.000ms ( 0.0%)   threads: 0.000  stack: 64
    w_1:                          0.000ms ( 0.0%)   threads: 0.000  stack: 64
    w_2:                          0.000ms ( 0.0%)   threads: 0.000  stack: 64
```

to this (note how the stack size contributions (132 + 8 * 64 = 644) moved up into the enclosing `Func`s:

 - `min_field_hpass`: 1412 - 1280 = 132 bytes extra,
 - `ratio_map` 384 - 0 = 384 bytes extra

The total difference is less than 644 bytes, because the lifetimes of some of the variables were actually fully-disjunct, causing them to not actually have a peak stack usage of that much.):

```
neonraw_highlight_ratio_extractor
 total time: 1524.809326 ms  samples: 1416  runs: 48  time/run: 31.766861 ms
 average threads used: 4.375706
 heap allocations: 0  peak heap usage: 0 bytes
    halide_malloc:                0.000ms ( 0.0%)   threads: 0.000 
    halide_free:                  0.000ms ( 0.0%)   threads: 0.000 
    ratio_map:                   24.556ms (77.3%)   threads: 4.067  stack: 384
    repeat_edge:                  3.719ms (11.7%)   threads: 5.716  stack: 3960
    max_field_hpass:              0.420ms ( 1.3%)   threads: 3.000  stack: 3840
    max_field:                    0.336ms ( 1.0%)   threads: 5.666  stack: 3072
    min_field_hpass:              0.575ms ( 1.8%)   threads: 3.846  stack: 1412
    min_field:                    0.088ms ( 0.2%)   threads: 8.500  stack: 1024
    lum4:                         2.069ms ( 6.5%)   threads: 5.813  stack: 64
```