### PR TITLE
Use python itself to get the extension suffix, not python-config

### DIFF
--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -90,6 +90,11 @@ ifeq ($(UNAME), Darwin)
     # Keep OS X builds from complaining about missing libpython symbols
     PYBIND11_CFLAGS += -undefined dynamic_lookup
 endif
+# Get the python extension module suffix from python itself. You can
+# also do this with python-config, but that's not resistant to version
+# mismatches between python and python-config. This can happen when
+# using a virtualenv, because virtualenvs override python, but not
+# python-config.
 PY_EXT = $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
 PY_MODEL_EXT = model_cpp$(PY_EXT)
 PYCXXFLAGS = $(PYBIND11_CFLAGS) $(CXXFLAGS) -Wno-deprecated-register

--- a/apps/onnx/Makefile
+++ b/apps/onnx/Makefile
@@ -90,7 +90,7 @@ ifeq ($(UNAME), Darwin)
     # Keep OS X builds from complaining about missing libpython symbols
     PYBIND11_CFLAGS += -undefined dynamic_lookup
 endif
-PY_EXT = $(shell $(PYTHON)-config --extension-suffix)
+PY_EXT = $(shell $(PYTHON) -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
 PY_MODEL_EXT = model_cpp$(PY_EXT)
 PYCXXFLAGS = $(PYBIND11_CFLAGS) $(CXXFLAGS) -Wno-deprecated-register
 


### PR DESCRIPTION
One of the buildbots has gotten itself into a weird state where python-config is from python 3.12, but the python used in the venv is python 3.11, so the extension suffix on the python module in the onnx app is wrong.

virtual envs don't seem to include python-config, so rather than mess with the system this PR just changes the makefile to get the extension suffix from python itself.