### PR TITLE
Add support for fcvtm/p, make scalars go through pattern matching too

### DIFF
--- a/src/IRMatch.cpp
+++ b/src/IRMatch.cpp
@@ -262,6 +262,9 @@ public:
         if (result && e && types_match(op->type, e->type)) {
             expr = e->value;
             op->value.accept(this);
+        } else if (op->lanes == 0 && types_match(op->value.type(), expr.type())) {
+            // zero lanes means any number of lanes, so match scalars too.
+            op->value.accept(this);
         } else {
             result = false;
         }

--- a/test/correctness/simd_op_check_arm.cpp
+++ b/test/correctness/simd_op_check_arm.cpp
@@ -230,6 +230,13 @@ public:
             check(arm32 ? "vcvt.s32.f32" : "fcvtzs", 2 * w, i32(f32_1));
             // skip the fixed point conversions for now
 
+            if (!arm32) {
+                check("fcvtmu *v", 2 * w, u32(floor(f32_1)));
+                check("fcvtpu *v", 2 * w, u32(ceil(f32_1)));
+                check("fcvtms *v", 2 * w, i32(floor(f32_1)));
+                check("fcvtps *v", 2 * w, i32(ceil(f32_1)));
+            }
+
             // VDIV     -       F, D    Divide
             // This doesn't actually get vectorized in 32-bit. Not sure cortex processors can do vectorized division.
             check(arm32 ? "vdiv.f32" : "fdiv", 2 * w, f32_1 / f32_2);


### PR DESCRIPTION
This change fixes the only regression from main I could find in the sve branch, and improves things on top of that.