### PR TITLE
Python bindings: `add_python_test()`: do set `HL_JIT_TARGET` too

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -68,7 +68,7 @@ function(add_python_test)
     list(PREPEND ARG_PYTHONPATH "$<TARGET_FILE_DIR:Halide::Python>/..")
     list(TRANSFORM ARG_PYTHONPATH PREPEND "PYTHONPATH=path_list_prepend:")
 
-    list(PREPEND ARG_ENVIRONMENT "HL_TARGET=${Halide_TARGET}")
+    list(PREPEND ARG_ENVIRONMENT "HL_TARGET=${Halide_TARGET};HL_JIT_TARGET=${Halide_TARGET}")
 
     cmake_path(GET ARG_FILE STEM test_name)
     set(test_name "${ARG_LABEL}_${test_name}")


### PR DESCRIPTION
This one took quite a bit of digging.

I wanted to enable opencl tests on debian package, and `boundary_conditions.py`+`division.py` were failing when run with `HL_TARGET=host OCL_ICD_VENDORS=no-opencl-please.missing` env variables with `clGetPlatformIDs failed`, which made no sense to me.

Empty `HL_JIT_TARGET` results in `opencl` being detected, unsurprisingly.