### PR TITLE
CMake: warn if the user did not set a build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,9 @@ include(HalideGeneratorHelpers)
 # Build Halide as a shared lib by default, but still honor command-line settings.
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-# Warn if the user did not set a build type and is using a single-configuration generator.
-get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-if (NOT IS_MULTI_CONFIG AND NOT DEFINED CMAKE_BUILD_TYPE)
-    message(WARNING "Single-configuration generators require CMAKE_BUILD_TYPE to be set.")
+# Warn if the user did not set a build type.
+if (NOT DEFINED CMAKE_BUILD_TYPE)
+    message(SEND_ERROR "CMAKE_BUILD_TYPE should be set.")
 endif ()
 
 # Windows has file name length restrictions and lacks an RPATH mechanism.


### PR DESCRIPTION
I did not get a warning for `-GNinja`,
and the resulting failure is bizarre:
```
$ ninja Halide_Python
[10/1842] Generating .__init__.py.stamp
FAILED: python_bindings/src/halide/.__init__.py.stamp /repositories/halide/build-halide/python_bindings/src/halide/.__init__.py.stamp
cd /repositories/halide/build-halide/python_bindings/src/halide && /usr/bin/cmake -E copy /repositories/halide/python_bindings/src/halide/__init__.py /halide/__init__.py1111 && /usr/bin/cmake -E touch /repositories/halide/build-halide/python_bindings/src/halide/.__init__.py.stamp
Error copying file "/repositories/halide/python_bindings/src/halide/__init__.py" to "/halide/__init__.py".
[43/1842] Building CXX object _deps/flatbuffers-build/CMakeFiles/flatbuffers.dir/src/idl_parser.cpp.o
ninja: build stopped: subcommand failed.
```
(`TARGET_FILE_DIR` is somehow missing `CMAKE_CURRENT_BINARY_DIR` prefix)