### PR TITLE
Tighten bounds of abs()

### DIFF
--- a/dependencies/llvm/CMakeLists.txt
+++ b/dependencies/llvm/CMakeLists.txt
@@ -21,7 +21,7 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 
 if (LLVM_PACKAGE_VERSION VERSION_LESS 16.0)
-    message(FATAL_ERROR "LLVM version must be 15.0 or newer")
+    message(FATAL_ERROR "LLVM version must be 16.0 or newer")
 endif ()
 
 if (LLVM_PACKAGE_VERSION VERSION_GREATER 19.0)

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1242,7 +1242,7 @@ private:
                 if (equal(a.min, a.max)) {
                     interval = Interval::single_point(Call::make(t, Call::abs, {a.max}, Call::PureIntrinsic));
                 } else if (op->args[0].type().is_int() && op->args[0].type().bits() >= 32) {
-                    interval.min = Cast::make(t, Max::make(make_zero(a.min.type()), Max::make(a.min, -a.max)));
+                    interval.min = Cast::make(t, Max::make(a.min, -Min::make(make_zero(a.min.type()), a.max)));
                     interval.max = Cast::make(t, Max::make(-a.min, a.max));
                 } else {
                     interval.min = Cast::make(t, Max::make(a.min, -Min::make(make_zero(a.min.type()), a.max)));

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1238,12 +1238,6 @@ private:
         if (op->is_intrinsic(Call::abs)) {
             Interval a = arg_bounds.get(0);
 
-            if (a.has_lower_bound()) {
-                interval.min = cast(t, Max::make(make_zero(a.min.type()), a.min));
-            } else {
-                interval.min = make_zero(t);
-            }
-
             if (a.is_bounded()) {
                 if (equal(a.min, a.max)) {
                     interval = Interval::single_point(Call::make(t, Call::abs, {a.max}, Call::PureIntrinsic));
@@ -1251,11 +1245,21 @@ private:
                     interval.min = Cast::make(t, Max::make(make_zero(a.min.type()), Max::make(a.min, -a.max)));
                     interval.max = Cast::make(t, Max::make(-a.min, a.max));
                 } else {
+                    interval.min = Cast::make(t, Max::make(a.min, -Min::make(make_zero(a.min.type()), a.max)));
                     a.min = Call::make(t, Call::abs, {a.min}, Call::PureIntrinsic);
                     a.max = Call::make(t, Call::abs, {a.max}, Call::PureIntrinsic);
                     interval.max = Max::make(a.min, a.max);
                 }
             } else {
+                if (a.has_lower_bound()) {
+                    // If a is strictly positive, then abs(a) is strictly positive.
+                    interval.min = Cast::make(t, Max::make(make_zero(a.min.type()), a.min));
+                } else if (a.has_upper_bound()) {
+                    // If a is strictly negative, then abs(a) is strictly positive.
+                    interval.min = Cast::make(t, -Min::make(make_zero(a.max.type()), a.max));
+                } else {
+                    interval.min = make_zero(t);
+                }
                 // If the argument is unbounded on one side, then the max is unbounded.
                 interval.max = Interval::pos_inf();
             }
@@ -3662,7 +3666,17 @@ void bounds_test() {
     check(scope, abs(x - 11), u32(1), u32(11));
     check(scope, abs(x - 5), u32(0), u32(5));
     check(scope, abs(2 + cast<float>(x)), 2.f, 12.f);
+    check(scope, abs(cast<float>(x) - 11), 1.f, 11.f);
     check(scope, abs(cast<float>(x) - 5), 0.f, 5.f);
+    check(scope, abs(2 + cast<int8_t>(x)), u8(2), u8(12));
+    check(scope, abs(cast<int8_t>(x) - 11), u8(1), u8(11));
+    check(scope, abs(cast<int8_t>(x) - 5), u8(0), u8(5));
+    scope.push("x", Interval(123, Interval::pos_inf()));
+    check(scope, abs(x), u32(123), Interval::pos_inf());
+    scope.pop("x");
+    scope.push("x", Interval(Interval::neg_inf(), -123));
+    check(scope, abs(x), u32(123), Interval::pos_inf());
+    scope.pop("x");
 
     // Check some vectors
     check(scope, Ramp::make(x * 2, 5, 5), 0, 40);


### PR DESCRIPTION
This PR does four things:

- Drive-by update of error message regarding LLVM version.
- Tightens bounds of `abs()` on an expression that is strictly positive
- Tightens bounds of `abs()` on an ~~int32/int64~~ expression that is strictly negative
- Fixes horrendous upper bound overflow on `abs()` of an int32/int64 that could be negative. (move cast outside of the max).

~~I am struggling to come up with the right lower bound that tightens the interval for `abs()` of a strictly negative thing that is a smaller integer type, because `-a.max` could overflow.~~

Update: figured out the right expression for tightening bounds without negating something that could overflow. (updated z3 example as well)

Also, new bounds are formally verified via z3:
```
import z3
abs = lambda x: z3.If(x > 0, x, 0 - x)
min = lambda x, y: z3.If(x > y, y, x)
max = lambda x, y: z3.If(x > y, x, y)
x, xl, xu = z3.Ints("x xl xu")

z3.solve(xl <= x, x <= xu, abs(x) < max(xl, 0 - min(0, xu)))
z3.solve(xl <= x, abs(x) < max(xl, 0))
z3.solve(x <= xu, abs(x) < 0 - min(0, xu))
```