### PR TITLE
Don't print on parallel task entry/exit with -debug flag

### DIFF
--- a/src/LowerParallelTasks.cpp
+++ b/src/LowerParallelTasks.cpp
@@ -302,9 +302,6 @@ struct LowerParallelTasks : public IRMutator {
                 // TODO(zvookin): Figure out how we want to handle name mangling of closures.
                 // For now, the C++ backend makes them extern "C" so they have to be NameMangling::C.
                 LoweredFunc closure_func{new_function_name, closure_args, std::move(wrapped_body), LinkageType::Internal, NameMangling::C};
-                if (target.has_feature(Target::Debug)) {
-                    debug_arguments(&closure_func, target);
-                }
                 closure_implementations.emplace_back(std::move(closure_func));
             }
 


### PR DESCRIPTION
Opened for discussion, because presumably this was added for a reason.

Fixes #8184
