### PR TITLE
Fix corner case in if_then_else simplification

### DIFF
--- a/src/Simplify_Call.cpp
+++ b/src/Simplify_Call.cpp
@@ -576,7 +576,11 @@ Expr Simplify::visit(const Call *op, ExprInfo *bounds) {
             }
             in_unreachable = false;
             if (true_unreachable) {
-                return false_value;
+                if (false_value.defined()) {
+                    return false_value;
+                } else {
+                    return make_zero(op->type);
+                }
             } else if (false_unreachable) {
                 return true_value;
             }


### PR DESCRIPTION
Fixes the segfault reported in #8170 

I have no idea how to repro this in a test. It came about as a result of applying the adams autoscheduler to an hvx pipeline, which produced a schedule with vectors wider than tiles, which turned into predication, which was then turned into something invalid inside the hexagon lowering path.

The if_then_else intrinsic is supposed to evaluate to zero if the condition is false and there's no false value defined.