### PR TITLE
Skip simd_op_check_sve2 for now

### DIFF
--- a/test/correctness/simd_op_check_sve2.cpp
+++ b/test/correctness/simd_op_check_sve2.cpp
@@ -1379,6 +1379,7 @@ int main(int argc, char **argv) {
     }
 
     std::cout << "[SKIP] simd_op_check_sve2 is temporarily broken, skipping pending an LLVM fix.\n";
+    return 0;
 
     return SimdOpCheckTest::main<SimdOpCheckArmSve>(
         argc, argv,

--- a/test/correctness/simd_op_check_sve2.cpp
+++ b/test/correctness/simd_op_check_sve2.cpp
@@ -1378,6 +1378,8 @@ int main(int argc, char **argv) {
         return 0;
     }
 
+    std::cout << "[SKIP] simd_op_check_sve2 is temporarily broken, skipping pending an LLVM fix.\n";
+
     return SimdOpCheckTest::main<SimdOpCheckArmSve>(
         argc, argv,
         {


### PR DESCRIPTION
top-of-tree LLVM has broken it; disable it for now to avoid mass failures in presubmits