### PR TITLE
Permit hvx_128 instruction in Blur Target

### DIFF
--- a/apps/blur/Makefile
+++ b/apps/blur/Makefile
@@ -11,7 +11,7 @@ $(GENERATOR_BIN)/halide_blur.generator: halide_blur_generator.cpp $(GENERATOR_DE
 
 $(BIN)/%/halide_blur.a: $(GENERATOR_BIN)/halide_blur.generator
 	@mkdir -p $(@D)
-	$^ -g halide_blur -e $(GENERATOR_OUTPUTS) -o $(@D) target=$*
+	$^ -g halide_blur -e $(GENERATOR_OUTPUTS) -o $(@D) target=$(HL_TARGET)
 
 # g++ on OS X might actually be system clang without openmp
 CXX_VERSION=$(shell $(CXX) --version)

--- a/apps/blur/halide_blur_generator.cpp
+++ b/apps/blur/halide_blur_generator.cpp
@@ -86,8 +86,6 @@ public:
             const int vector_size = 128;
 
             blur_y.compute_root()
-                .hexagon()
-                .prefetch(input, y, y, 2)
                 .split(y, y, yi, 128)
                 .parallel(y)
                 .vectorize(x, vector_size * 2);


### PR DESCRIPTION
I noticed that the variable `HL_TARGET` is not used in the generator when building the blur app for a Hexagon device. Instead, the target is always the generic 
`arm-64-android`. The output from calling the generator is:
```
➜  blur git:(blur_hexagon) ✗ HL_TARGET=arm-64-android-hvx_128 ./adb_run_on_device.sh
...
bin/host/halide_blur.generator -g halide_blur -e static_library,h,registration,stmt,assembly -o bin/arm-64-android target=arm-64-android
...
```
The app then runs with the following timings:
```
times: 0.037547 0.004319 0.001070
```

In contrast, if explicitly use the environment variable `HL_TARGET` in the Makefile, the output from the build is:
```
bin/host/halide_blur.generator -g halide_blur -e static_library,h,registration,stmt,assembly -o bin/arm-64-android target=arm-64-android-hvx_128
```
The timings for the app on an Snapdragon 865 are:
```
times: 0.002937 0.001223 0.000097
```
To permit building the app with the hvx instructions I had to change the following lines in the generator:
```
+++ b/apps/blur/halide_blur_generator.cpp
@@ -86,8 +86,6 @@ public:
             const int vector_size = 128;
 
             blur_y.compute_root()
-                .hexagon()
-                .prefetch(input, y, y, 2)
                 .split(y, y, yi, 128)
                 .parallel(y)
                 .vectorize(x, vector_size * 2);

```
Because of the lower latency and higher degree of control, I wonder whether these changes seem beneficial or if the results are idiosyncratic to my setup.  I understand the `hexagon()` call should be used then work is shared between the CPU and the DSP. 