### PR TITLE
Add some EVAL_IN_LAMBDAs to Simplify_Sub.cpp

### DIFF
--- a/src/Simplify_Sub.cpp
+++ b/src/Simplify_Sub.cpp
@@ -184,7 +184,7 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
              rewrite((slice(x, c0, c1, c2) - z) - slice(y, c0, c1, c2), slice(x - y, c0, c1, c2) - z, c2 > 1 && lanes_of(x) == lanes_of(y)) ||
              rewrite((z - slice(x, c0, c1, c2)) - slice(y, c0, c1, c2), z - slice(x + y, c0, c1, c2), c2 > 1 && lanes_of(x) == lanes_of(y)) ||
 
-             (no_overflow(op->type) &&
+             (no_overflow(op->type) && EVAL_IN_LAMBDA
               (rewrite(max(x, y) - x, max(y - x, 0)) ||
                rewrite(min(x, y) - x, min(y - x, 0)) ||
                rewrite(max(x, y) - y, max(x - y, 0)) ||
@@ -387,7 +387,7 @@ Expr Simplify::visit(const Sub *op, ExprInfo *bounds) {
                rewrite(max(y, x + c0) - max(x + c1, w), max(y - max(x + c1, w), fold(c0 - c1)), can_prove(y + c1 >= w + c0, this)) ||
                rewrite(max(y, x + c0) - max(x + c1, w), min(max(x + c0, y) - w, fold(c0 - c1)), can_prove(y + c1 <= w + c0, this)))) ||
 
-             (no_overflow_int(op->type) &&
+             (no_overflow_int(op->type) && EVAL_IN_LAMBDA
               (rewrite(c0 - (c1 - x)/c2, (fold(c0*c2 - c1 + c2 - 1) + x)/c2, c2 > 0) ||
                rewrite(c0 - (x + c1)/c2, (fold(c0*c2 - c1 + c2 - 1) - x)/c2, c2 > 0) ||
                rewrite(x - (x + y)/c0, (x*fold(c0 - 1) - y + fold(c0 - 1))/c0, c0 > 0) ||


### PR DESCRIPTION
Massively reduces compile time and peak cl.exe memory consumption on windows (from 9.5gb down to 2.3gb).

Simplify_LT.cpp has these same EVAL_IN_LAMBDAs, which is probably why it hasn't been causing build problems.