### PR TITLE
No longer silently hide errors in Metal completion handlers

### DIFF
--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -138,6 +138,7 @@ tests(GROUPS correctness
       gpu_jit_explicit_copy_to_device.cpp
       gpu_large_alloc.cpp
       gpu_many_kernels.cpp
+      gpu_metal_completion_handler_error_check.cpp
       gpu_mixed_dimensionality.cpp
       gpu_mixed_shared_mem_types.cpp
       gpu_multi_kernel.cpp

--- a/test/correctness/gpu_metal_completion_handler_error_check.cpp
+++ b/test/correctness/gpu_metal_completion_handler_error_check.cpp
@@ -1,0 +1,51 @@
+#include "Halide.h"
+#include <unistd.h>
+
+using namespace Halide;
+
+bool errored = false;
+void my_error(JITUserContext *, const char *msg) {
+    // Emitting "error.*:" to stdout or stderr will cause CMake to report the
+    // test as a failure on Windows, regardless of error code returned,
+    // hence the abbreviation to "err".
+    printf("Expected err: %s\n", msg);
+    errored = true;
+}
+
+int main(int argc, char **argv) {
+    Target t = get_jit_target_from_environment();
+    if (!t.has_feature(Target::Metal)) {
+        printf("[SKIP] Metal not enabled\n");
+        return 0;
+    }
+
+    Func f;
+    Var c, x, ci, xi;
+    RVar rxi;
+    RDom r(0, 1000, -327600, 327600);
+
+    // Create a function that is very costly to execute, resulting in a timeout
+    // on the GPU
+    f(x, c) = x + 0.1f * c; 
+    f(r.x, c) += cos(sin(tan(cosh(tanh(sinh(exp(tanh(exp(log(tan(cos(exp(f(r.x, c) / cos(cosh(sinh(sin(f(r.x, c))))) 
+        / tanh(tan(tan(f(r.x, c)))))))))) + cast<float>(cast<uint8_t>(f(r.x, c) / cast<uint8_t>(log(f(r.x, c))))))))))));
+  
+    f.gpu_tile(x, c, xi, ci, 4, 4);
+    f.update(0).gpu_tile(r.x, c, rxi, ci, 4, 4);
+
+    // Because the error handler is invoked from a Metal runtime thread, setting a custom handler for just
+    // this pipeline is insufficient.  Instead, we set a custom handler for the JIT runtime
+    JITHandlers handlers;
+    handlers.custom_error = my_error;
+    Internal::JITSharedRuntime::set_default_handlers(handlers);
+
+    f.realize({1000, 100}, t);
+
+    if (!errored) {
+        printf("There was supposed to be an error\n");
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Previously, an error executing a command buffer in the Metal backend would simply be logged via NSLog, but never reported to users as an error.  This PR changes the behavior to report the error via `halide_error()` which by default calls `abort()`, since this is unrecoverable as the pipeline that caused it has already executed..  Clients that override the `halide_error()` function can now detect this error and try to recover at the application level.

This is the simplest fix I could think of for #7780, but it does result in an `abort()` by default.  Alternatively, we could set some kind of error variable in the runtime, and make any subsequent call into the Metal runtime (e.g. context acquisition) fail if the error variable is set, but in either case it would be up to the calling application to figure out how to attribute the error to the pipeline that caused it and to figure out how to recover.