### PR TITLE
Add HVX_v68 target to support Hexagon HVX v68.

### DIFF
--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -148,6 +148,7 @@ void define_enums(py::module &m) {
         .value("HVX_v62", Target::Feature::HVX_v62)
         .value("HVX_v65", Target::Feature::HVX_v65)
         .value("HVX_v66", Target::Feature::HVX_v66)
+        .value("HVX_v68", Target::Feature::HVX_v68)
         .value("FuzzFloatStores", Target::Feature::FuzzFloatStores)
         .value("SoftFloatABI", Target::Feature::SoftFloatABI)
         .value("MSAN", Target::Feature::MSAN)

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -128,7 +128,9 @@ private:
 
 CodeGen_Hexagon::CodeGen_Hexagon(const Target &t)
     : CodeGen_Posix(t) {
-    if (target.has_feature(Halide::Target::HVX_v66)) {
+    if (target.has_feature(Halide::Target::HVX_v68)) {
+        isa_version = 68;
+    } else if (target.has_feature(Halide::Target::HVX_v66)) {
         isa_version = 66;
     } else if (target.has_feature(Halide::Target::HVX_v65)) {
         isa_version = 65;
@@ -1787,7 +1789,9 @@ Value *CodeGen_Hexagon::call_intrin(llvm::Type *result_type, const string &name,
 }
 
 string CodeGen_Hexagon::mcpu_target() const {
-    if (target.has_feature(Halide::Target::HVX_v66)) {
+    if (target.has_feature(Halide::Target::HVX_v68)) {
+        return "hexagonv68";
+    } else if (target.has_feature(Halide::Target::HVX_v66)) {
         return "hexagonv66";
     } else if (target.has_feature(Halide::Target::HVX_v65)) {
         return "hexagonv65";
@@ -1856,6 +1860,12 @@ void CodeGen_Hexagon::visit(const Mul *op) {
             return;
         }
 
+        // v68 has vector support for single-precision float.
+        if (target.has_feature(Halide::Target::HVX_v68) &&
+            op->type.is_float() && op->type.bits() == 32) {
+            CodeGen_Posix::visit(op);
+            return;
+        }
         internal_error << "Unhandled HVX multiply " << op->a.type() << "*"
                        << op->b.type() << "\n"
                        << Expr(op) << "\n";

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -674,8 +674,16 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 #else
     const auto opt_level = llvm::CodeGenOpt::Aggressive;
 #endif
+
+    // Get module mcpu_target and mattrs.
+    std::string mcpu_target;
+    get_md_string(module.getModuleFlag("halide_mcpu_target"), mcpu_target);
+    std::string mattrs;
+    get_md_string(module.getModuleFlag("halide_mattrs"), mattrs);
+
     auto *tm = llvm_target->createTargetMachine(module.getTargetTriple(),
-                                                /*CPU target=*/"", /*Features=*/"",
+                                                mcpu_target,
+                                                mattrs,
                                                 options,
                                                 use_pic ? llvm::Reloc::PIC_ : llvm::Reloc::Static,
                                                 use_large_code_model ? llvm::CodeModel::Large : llvm::CodeModel::Small,

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -43,6 +43,7 @@ enum {
     EF_HEXAGON_MACH_V62 = 0x62,
     EF_HEXAGON_MACH_V65 = 0x65,
     EF_HEXAGON_MACH_V66 = 0x66,
+    EF_HEXAGON_MACH_V68 = 0x68,
 };
 
 enum {
@@ -551,7 +552,9 @@ public:
     uint32_t flags;
 
     HexagonLinker(const Target &target) {
-        if (target.has_feature(Target::HVX_v66)) {
+        if (target.has_feature(Target::HVX_v68)) {
+            flags = Elf::EF_HEXAGON_MACH_V68;
+        } else if (target.has_feature(Target::HVX_v66)) {
             flags = Elf::EF_HEXAGON_MACH_V66;
         } else if (target.has_feature(Target::HVX_v65)) {
             flags = Elf::EF_HEXAGON_MACH_V65;
@@ -983,6 +986,7 @@ Stmt inject_hexagon_rpc(Stmt s, const Target &host_target,
         Target::HVX_v62,
         Target::HVX_v65,
         Target::HVX_v66,
+        Target::HVX_v68,
     };
     for (Target::Feature i : shared_features) {
         if (host_target.has_feature(i)) {

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -1129,7 +1129,8 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             if (t.arch == Target::Hexagon) {
                 modules.push_back(get_initmod_qurt_hvx(c, bits_64, debug));
                 modules.push_back(get_initmod_hvx_128_ll(c));
-                if (t.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
+                if (t.features_any_of({Target::HVX_v65, Target::HVX_v66,
+                                       Target::HVX_v68})) {
                     modules.push_back(get_initmod_qurt_hvx_vtcm(c, bits_64,
                                                                 debug));
                 }

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -338,6 +338,7 @@ bool is_using_hexagon(const Target &t) {
             t.has_feature(Target::HVX_v62) ||
             t.has_feature(Target::HVX_v65) ||
             t.has_feature(Target::HVX_v66) ||
+            t.has_feature(Target::HVX_v68) ||
             t.has_feature(Target::HexagonDma) ||
             t.arch == Target::Hexagon);
 }
@@ -354,6 +355,9 @@ int get_hvx_lower_bound(const Target &t) {
     }
     if (t.has_feature(Target::HVX_v66)) {
         return 66;
+    }
+    if (t.has_feature(Target::HVX_v68)) {
+        return 68;
     }
     return 60;
 }
@@ -543,6 +547,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"hvx_v62", Target::HVX_v62},
     {"hvx_v65", Target::HVX_v65},
     {"hvx_v66", Target::HVX_v66},
+    {"hvx_v68", Target::HVX_v68},
     {"fuzz_float_stores", Target::FuzzFloatStores},
     {"soft_float_abi", Target::SoftFloatABI},
     {"msan", Target::MSAN},
@@ -892,6 +897,7 @@ void Target::validate_features() const {
                                 HVX_v62,
                                 HVX_v65,
                                 HVX_v66,
+                                HVX_v68,
                                 NoNEON,
                                 POWER_ARCH_2_07,
                                 RVV,
@@ -1371,6 +1377,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
         HVX_v62,
         HVX_v65,
         HVX_v66,
+        HVX_v68,
         VulkanV10,
         VulkanV12,
         VulkanV13,
@@ -1514,6 +1521,9 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     }
     if (hvx_version < 66) {
         output.features.reset(HVX_v66);
+    }
+    if (hvx_version < 68) {
+        output.features.reset(HVX_v68);
     }
 
     result = output;

--- a/src/Target.h
+++ b/src/Target.h
@@ -122,6 +122,7 @@ struct Target {
         HVX_v62 = halide_target_feature_hvx_v62,
         HVX_v65 = halide_target_feature_hvx_v65,
         HVX_v66 = halide_target_feature_hvx_v66,
+        HVX_v68 = halide_target_feature_hvx_v68,
         FuzzFloatStores = halide_target_feature_fuzz_float_stores,
         SoftFloatABI = halide_target_feature_soft_float_abi,
         MSAN = halide_target_feature_msan,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1409,6 +1409,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_trace_pipeline,         ///< Trace the pipeline.
     halide_target_feature_hvx_v65,                ///< Enable Hexagon v65 architecture.
     halide_target_feature_hvx_v66,                ///< Enable Hexagon v66 architecture.
+    halide_target_feature_hvx_v68,                ///< Enable Hexagon v68 architecture.
     halide_target_feature_cl_half,                ///< Enable half support on OpenCL targets
     halide_target_feature_strict_float,           ///< Turn off all non-IEEE floating-point optimization. Currently applies only to LLVM targets.
     halide_target_feature_tsan,                   ///< Enable hooks for TSAN support.

--- a/test/correctness/gather.cpp
+++ b/test/correctness/gather.cpp
@@ -49,7 +49,8 @@ bool test() {
             .parallel(y)
             .vectorize(x, vector_size);
 
-        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
+        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66,
+                                    Target::HVX_v68})) {
             lut_vtcm
                 .store_in(MemoryType::VTCM)
                 .compute_at(output, Var::outermost())

--- a/test/correctness/hexagon_scatter.cpp
+++ b/test/correctness/hexagon_scatter.cpp
@@ -76,7 +76,8 @@ int test() {
             .parallel(y)
             .vectorize(x, vector_size / 2);
 
-        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
+        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66,
+                                    Target::HVX_v68})) {
             f.store_in(MemoryType::VTCM);
         }
     }

--- a/test/correctness/histogram.cpp
+++ b/test/correctness/histogram.cpp
@@ -50,7 +50,8 @@ bool test() {
             .compute_at(g, Var::outermost())
             .vectorize(x, vector_size);
 
-        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66})) {
+        if (target.features_any_of({Target::HVX_v65, Target::HVX_v66,
+                                    Target::HVX_v68})) {
             hist.store_in(MemoryType::VTCM);
 
             hist

--- a/test/correctness/simd_op_check_hvx.cpp
+++ b/test/correctness/simd_op_check_hvx.cpp
@@ -13,7 +13,7 @@
 // simd_op_check into two tests, simd_op_check.cpp and simd_op_check_hvx.cpp
 // so that the latter is free to do its own thing - for simd_op_check_hvx.cpp
 // to run any tests, all that is needed is that HL_TARGET have a HVX related
-// target feature, i.e. one of HVX, HVX_v62, HVX_v65 and HVX_v66.
+// target feature, i.e. one of HVX, HVX_v62, HVX_v65, HVX_v66 and HVX_v68.
 
 using namespace Halide;
 using namespace Halide::ConciseCasts;
@@ -44,7 +44,9 @@ public:
         constexpr int hvx_width = 128;
 
         int isa_version;
-        if (target.has_feature(Halide::Target::HVX_v66)) {
+        if (target.has_feature(Halide::Target::HVX_v68)) {
+            isa_version = 68;
+        } else if (target.has_feature(Halide::Target::HVX_v66)) {
             isa_version = 66;
         } else if (target.has_feature(Halide::Target::HVX_v65)) {
             isa_version = 65;
@@ -718,5 +720,6 @@ int main(int argc, char **argv) {
             Target("hexagon-32-noos-hvx-hvx_128-hvx_v62"),
             Target("hexagon-32-noos-hvx-hvx_128-hvx_v65"),
             Target("hexagon-32-noos-hvx-hvx_128-hvx_v66"),
+            Target("hexagon-32-noos-hvx-hvx_128-hvx_v68"),
         });
 }


### PR DESCRIPTION
Hexagon v68 or later support floating-point HVX instruction.   This CL add a new HVX_v68 target to enable code generation for floating-point HVX instruction.