### PR TITLE
Report useful error to user if the promise_clamp all fails to losslessly cast.

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -7,6 +7,7 @@
 #include "Associativity.h"
 #include "Closure.h"
 #include "ConstantInterval.h"
+#include "Expr.h"
 #include "IROperator.h"
 #include "Interval.h"
 #include "Module.h"
@@ -48,7 +49,6 @@ ostream &operator<<(ostream &out, const Type &type) {
     }
     return out;
 }
-
 ostream &operator<<(ostream &stream, const Expr &ir) {
     if (!ir.defined()) {
         stream << "(undefined)";
@@ -268,6 +268,66 @@ void IRPrinter::test() {
                        << source.str();
     }
     std::cout << "IRPrinter test passed\n";
+}
+
+std::ostream &operator<<(std::ostream &stream, IRNodeType type) {
+#define CASE(e)         \
+    case IRNodeType::e: \
+        stream << #e;   \
+        break;
+    switch (type) {
+        CASE(IntImm)
+        CASE(UIntImm)
+        CASE(FloatImm)
+        CASE(StringImm)
+        CASE(Broadcast)
+        CASE(Cast)
+        CASE(Reinterpret)
+        CASE(Variable)
+        CASE(Add)
+        CASE(Sub)
+        CASE(Mod)
+        CASE(Mul)
+        CASE(Div)
+        CASE(Min)
+        CASE(Max)
+        CASE(EQ)
+        CASE(NE)
+        CASE(LT)
+        CASE(LE)
+        CASE(GT)
+        CASE(GE)
+        CASE(And)
+        CASE(Or)
+        CASE(Not)
+        CASE(Select)
+        CASE(Load)
+        CASE(Ramp)
+        CASE(Call)
+        CASE(Let)
+        CASE(Shuffle)
+        CASE(VectorReduce)
+        // Stmts
+        CASE(LetStmt)
+        CASE(AssertStmt)
+        CASE(ProducerConsumer)
+        CASE(For)
+        CASE(Acquire)
+        CASE(Store)
+        CASE(Provide)
+        CASE(Allocate)
+        CASE(Free)
+        CASE(Realize)
+        CASE(Block)
+        CASE(Fork)
+        CASE(IfThenElse)
+        CASE(Evaluate)
+        CASE(Prefetch)
+        CASE(Atomic)
+        CASE(HoistedStorage)
+    }
+#undef CASE
+    return stream;
 }
 
 ostream &operator<<(ostream &stream, const AssociativePattern &p) {

--- a/src/IRPrinter.h
+++ b/src/IRPrinter.h
@@ -61,6 +61,11 @@ class Closure;
 struct Interval;
 struct ConstantInterval;
 struct ModulusRemainder;
+enum class IRNodeType;
+
+/** Emit a halide node type on an output stream (such as std::cout) in
+ * human-readable form */
+std::ostream &operator<<(std::ostream &stream, IRNodeType);
 
 /** Emit a halide associative pattern on an output stream (such as std::cout)
  * in a human-readable form */


### PR DESCRIPTION
[unsafe_]promise_clamped is sort of broken in a subtle way, which I didn't fix in this PR. I didn't change its functionality, but instead of an `internal_assert()` triggering, now a useful user error is reported, which allows the user to fix it. This behavior is better than crashing IMO.

The problem is when you for example call: `unsafe_promise_clamped(<uint16_t>, 0, <Variable int32_t>)`.
I ran into the situation where I naturally would start from:
```cpp
counter_output_buf(i) = undef<int32_t>();
counter_output_buf(index_func(rdom)) += 1;
```
Where counter_output_buf (a `GeneratorOutput<Buffer<int32_t>>`) counts the amount of times a certain index is observed in `index_func`. However, `index_func` is `uint16_t` in my case.
But want to promise that the index I have is within bounds of the buffer, so I did:
```cpp
counter_output_buf(i) = undef<int32_t>();
counter_output_buf(unsafe_promise_clamped(index_func(rdom), 0, counter_output_buf.dim(0).extent() - 1)) += 1;
```
This now fails, because the first value is `uint16_t`, and my upper bound is `int32_t`, which cannot be losslessly cast to `uint16_t`, as per:  https://github.com/halide/Halide/blob/33d5ba9536f5aa6d3702c2c764b899a8f45b3b62/src/IROperator.cpp#L1590-L1593

The `lossless_cast` returns an undefined Expr if it fails, which then trigger the `internal_assert` that makes sure all arguments to a `Call` are defined.

My point being that all of this feels a little odd behavior of this function. When you want to promise it's clamped, and it actually doesn't do it because of some type mismatch, feels kinda odd. But maybe that's perfectly on purpose and good? Not sure...