### PR TITLE
No longer silently hide errors in Metal completion handlers (alternative approach)

### DIFF
--- a/src/runtime/HalideRuntimeMetal.h
+++ b/src/runtime/HalideRuntimeMetal.h
@@ -101,9 +101,8 @@ extern int halide_metal_release_context(void *user_context);
  * This is called from the Metal driver, and thus:
  * - Any user_context must be preserved between the call to halide_metal_run and the corresponding callback
  * - The function must be thread-safe
- * - For Objective-C API reasons, the user context is passed in as a void *const
  */
-extern int halide_metal_command_buffer_completion_handler(void *const user_context, struct halide_metal_command_buffer *buffer,
+extern int halide_metal_command_buffer_completion_handler(void *user_context, struct halide_metal_command_buffer *buffer,
                                                           char **returned_error_string);
 
 #ifdef __cplusplus

--- a/src/runtime/HalideRuntimeMetal.h
+++ b/src/runtime/HalideRuntimeMetal.h
@@ -68,6 +68,7 @@ extern uint64_t halide_metal_get_crop_offset(void *user_context, struct halide_b
 
 struct halide_metal_device;
 struct halide_metal_command_queue;
+struct halide_metal_command_buffer;
 
 /** This prototype is exported as applications will typically need to
  * replace it to get Halide filters to execute on the same device and
@@ -92,6 +93,17 @@ extern int halide_metal_acquire_context(void *user_context, struct halide_metal_
  * as well.
  */
 extern int halide_metal_release_context(void *user_context);
+
+/** This function is called as part of the callback when a Metal command buffer completes.
+ * The return value, if not halide_error_code_success, will be stashed in Metal runtime and returned
+ * to the next call into the runtime, and the error string will be saved as well.  
+ * The error string will be freed by the caller. The return value must be a valid Halide error code.
+ * This is called from the Metal driver, and thus:
+ * - Any user_context must be preserved between the call to halide_metal_run and the corresponding callback
+ * - The function must be thread-safe
+*/
+extern int halide_metal_command_buffer_completion_handler(void* user_context, struct halide_metal_command_buffer *buffer, 
+                                                          char **returned_error_string);
 
 #ifdef __cplusplus
 }  // End extern "C"

--- a/src/runtime/HalideRuntimeMetal.h
+++ b/src/runtime/HalideRuntimeMetal.h
@@ -96,13 +96,13 @@ extern int halide_metal_release_context(void *user_context);
 
 /** This function is called as part of the callback when a Metal command buffer completes.
  * The return value, if not halide_error_code_success, will be stashed in Metal runtime and returned
- * to the next call into the runtime, and the error string will be saved as well.  
+ * to the next call into the runtime, and the error string will be saved as well.
  * The error string will be freed by the caller. The return value must be a valid Halide error code.
  * This is called from the Metal driver, and thus:
  * - Any user_context must be preserved between the call to halide_metal_run and the corresponding callback
  * - The function must be thread-safe
-*/
-extern int halide_metal_command_buffer_completion_handler(void* user_context, struct halide_metal_command_buffer *buffer, 
+ */
+extern int halide_metal_command_buffer_completion_handler(void *user_context, struct halide_metal_command_buffer *buffer,
                                                           char **returned_error_string);
 
 #ifdef __cplusplus

--- a/src/runtime/HalideRuntimeMetal.h
+++ b/src/runtime/HalideRuntimeMetal.h
@@ -101,8 +101,9 @@ extern int halide_metal_release_context(void *user_context);
  * This is called from the Metal driver, and thus:
  * - Any user_context must be preserved between the call to halide_metal_run and the corresponding callback
  * - The function must be thread-safe
+ * - For Objective-C API reasons, the user context is passed in as a void *const
  */
-extern int halide_metal_command_buffer_completion_handler(void *user_context, struct halide_metal_command_buffer *buffer,
+extern int halide_metal_command_buffer_completion_handler(void *const user_context, struct halide_metal_command_buffer *buffer,
                                                           char **returned_error_string);
 
 #ifdef __cplusplus

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -487,7 +487,6 @@ extern "C" {
  * This is called from the Metal driver, and thus:
  * - Any user_context must be preserved between the call to halide_metal_run and the corresponding callback
  * - The function must be thread-safe
- * - For Objective-C API reasons, the user context is passed in as a void *const
  */
 WEAK int halide_metal_command_buffer_completion_handler(void *const user_context, mtl_command_buffer *buffer, char **returned_error_string) {
     objc_id buffer_error = command_buffer_error(buffer);

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -1015,8 +1015,8 @@ WEAK int halide_metal_run(void *user_context,
         user_context};
 
     command_buffer_completed_handler_block_literal command_buffer_completed_handler_block = {
-        &_NSConcreteGlobalBlock,
-        /*(1 << 28) | */ (1 << 29),  // BLOCK_IS_GLOBAL | BLOCK_HAS_DESCRIPTOR
+        &_NSConcreteStackBlock,
+        (1 << 29),  // BLOCK_HAS_DESCRIPTOR
         0, command_buffer_completed_handler_invoke,
         &command_buffer_completed_handler_descriptor,
         &user_context_holder};

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -418,6 +418,7 @@ public:
         saved_status = halide_error_code_success;
         if (error_string != nullptr && result != halide_error_code_success && strnlen(MetalContextHolder::error_string, 1024) > 0) {
             strncpy(error_string, MetalContextHolder::error_string, 1024);
+            // Ensure null-termination, since strncpy won't if the source string is too long
             error_string[1023] = '\0';
             MetalContextHolder::error_string[0] = '\0';
             debug(nullptr) << "MetalContextHolder::get_and_clear_saved_status: " << error_string << "\n";
@@ -432,6 +433,7 @@ public:
         int result = saved_status;
         if (error_string != nullptr && result != halide_error_code_success && strnlen(MetalContextHolder::error_string, 1024) > 0) {
             strncpy(error_string, MetalContextHolder::error_string, 1024);
+            // Ensure null-termination, since strncpy won't if the source string is too long
             error_string[1023] = '\0';
         }
         halide_mutex_unlock(&saved_status_mutex);
@@ -443,6 +445,7 @@ public:
         saved_status = new_status;
         if (error_string != nullptr) {
             strncpy(MetalContextHolder::error_string, error_string, 1024);
+            // Ensure null-termination, since strncpy won't if the source string is too long
             error_string[1023] = '\0';
             debug(nullptr) << "MetalContextHolder::set_saved_status: " << error_string << "\n";
         }
@@ -509,6 +512,7 @@ WEAK int halide_metal_command_buffer_completion_handler(void *user_context, mtl_
             *returned_error_string = (char *)malloc(sizeof(char) * 1024);
             if (*returned_error_string != nullptr) {
                 strncpy(*returned_error_string, error_string, 1024);
+                // Ensure null-termination, since strncpy won't if the source string is too long
                 (*returned_error_string)[1023] = '\0';
             } else {
                 debug(user_context) << "halide_metal_command_buffer_completion_handler: Failed to allocate memory for error string.\n";

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -1004,10 +1004,10 @@ WEAK int halide_metal_run(void *user_context,
                           blocksX, blocksY, blocksZ,
                           threadsX, threadsY, threadsZ);
     end_encoding(encoder);
-    
+
     command_buffer_completed_handler_block_literal command_buffer_completed_handler_block = {
         &_NSConcreteStackBlock,
-        0, // must be 0 for stack blocks
+        0,  // must be 0 for stack blocks
         0, command_buffer_completed_handler_invoke,
         &command_buffer_completed_handler_descriptor,
         user_context};

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -418,7 +418,7 @@ public:
         saved_status = halide_error_code_success;
         if (error_string != nullptr && result != halide_error_code_success && strnlen(MetalContextHolder::error_string, 1024) > 0) {
             strncpy(error_string, MetalContextHolder::error_string, 1024);
-            error_string[1023] = '\0'; 
+            error_string[1023] = '\0';
             MetalContextHolder::error_string[0] = '\0';
             debug(nullptr) << "MetalContextHolder::get_and_clear_saved_status: " << error_string << "\n";
         }
@@ -432,7 +432,7 @@ public:
         int result = saved_status;
         if (error_string != nullptr && result != halide_error_code_success && strnlen(MetalContextHolder::error_string, 1024) > 0) {
             strncpy(error_string, MetalContextHolder::error_string, 1024);
-            error_string[1023] = '\0'; 
+            error_string[1023] = '\0';
         }
         halide_mutex_unlock(&saved_status_mutex);
         return result;
@@ -443,7 +443,7 @@ public:
         saved_status = new_status;
         if (error_string != nullptr) {
             strncpy(MetalContextHolder::error_string, error_string, 1024);
-            error_string[1023] = '\0'; 
+            error_string[1023] = '\0';
             debug(nullptr) << "MetalContextHolder::set_saved_status: " << error_string << "\n";
         }
         halide_mutex_unlock(&saved_status_mutex);
@@ -479,13 +479,13 @@ char MetalContextHolder::error_string[1024] = {0};
 extern "C" {
 /** This function is called as part of the callback when a Metal command buffer completes.
  * The return value, if not halide_error_code_success, will be stashed in Metal runtime and returned
- * to the next call into the runtime, and the error string will be saved as well.  
+ * to the next call into the runtime, and the error string will be saved as well.
  * The error string will be freed by the caller. The return value must be a valid Halide error code.
  * This is called from the Metal driver, and thus:
  * - Any user_context must be preserved between the call to halide_metal_run and the corresponding callback
  * - The function must be thread-safe
-*/
-WEAK int halide_metal_command_buffer_completion_handler(void* user_context, mtl_command_buffer *buffer, char **returned_error_string) {
+ */
+WEAK int halide_metal_command_buffer_completion_handler(void *user_context, mtl_command_buffer *buffer, char **returned_error_string) {
     objc_id buffer_error = command_buffer_error(buffer);
     if (buffer_error != nullptr) {
         retain_ns_object(buffer_error);
@@ -506,7 +506,7 @@ WEAK int halide_metal_command_buffer_completion_handler(void* user_context, mtl_
 
         // Copy C-style string into a fresh buffer
         if (returned_error_string != nullptr) {
-            *returned_error_string = (char*)malloc(sizeof(char) * 1024);
+            *returned_error_string = (char *)malloc(sizeof(char) * 1024);
             if (*returned_error_string != nullptr) {
                 strncpy(*returned_error_string, error_string, 1024);
                 (*returned_error_string)[1023] = '\0';
@@ -521,7 +521,7 @@ WEAK int halide_metal_command_buffer_completion_handler(void* user_context, mtl_
     }
     return halide_error_code_success;
 }
-} // extern "C"
+}  // extern "C"
 
 namespace Halide {
 namespace Runtime {
@@ -533,7 +533,7 @@ struct user_context_block_byref {
     struct user_context_block_byref *forwarding;
     int flags;
     int size;
-    void* user_context;
+    void *user_context;
 };
 
 struct command_buffer_completed_handler_block_descriptor_1 {
@@ -555,16 +555,13 @@ WEAK command_buffer_completed_handler_block_descriptor_1 command_buffer_complete
 
 WEAK void command_buffer_completed_handler_invoke(command_buffer_completed_handler_block_literal *block, mtl_command_buffer *buffer) {
     retain_ns_object(buffer);
-    char* error_string = nullptr;
+    char *error_string = nullptr;
     auto status = halide_metal_command_buffer_completion_handler(block->user_context_holder->user_context, buffer, &error_string);
     release_ns_object(buffer);
 
     MetalContextHolder::set_saved_status(status, error_string);
     free(error_string);
-
 }
-
-
 
 }  // namespace Metal
 }  // namespace Internal

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -138,6 +138,7 @@ tests(GROUPS correctness
       gpu_jit_explicit_copy_to_device.cpp
       gpu_large_alloc.cpp
       gpu_many_kernels.cpp
+      gpu_metal_completion_handler_error_check.cpp
       gpu_mixed_dimensionality.cpp
       gpu_mixed_shared_mem_types.cpp
       gpu_multi_kernel.cpp

--- a/test/correctness/gpu_metal_completion_handler_error_check.cpp
+++ b/test/correctness/gpu_metal_completion_handler_error_check.cpp
@@ -1,5 +1,5 @@
 #include "Halide.h"
-#include <unistd.h>
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/gpu_metal_completion_handler_error_check.cpp
+++ b/test/correctness/gpu_metal_completion_handler_error_check.cpp
@@ -26,10 +26,9 @@ int main(int argc, char **argv) {
 
     // Create a function that is very costly to execute, resulting in a timeout
     // on the GPU
-    f(x, c) = x + 0.1f * c; 
-    f(r.x, c) += cos(sin(tan(cosh(tanh(sinh(exp(tanh(exp(log(tan(cos(exp(f(r.x, c) / cos(cosh(sinh(sin(f(r.x, c))))) 
-        / tanh(tan(tan(f(r.x, c)))))))))) + cast<float>(cast<uint8_t>(f(r.x, c) / cast<uint8_t>(log(f(r.x, c))))))))))));
-  
+    f(x, c) = x + 0.1f * c;
+    f(r.x, c) += cos(sin(tan(cosh(tanh(sinh(exp(tanh(exp(log(tan(cos(exp(f(r.x, c) / cos(cosh(sinh(sin(f(r.x, c))))) / tanh(tan(tan(f(r.x, c)))))))))) + cast<float>(cast<uint8_t>(f(r.x, c) / cast<uint8_t>(log(f(r.x, c))))))))))));
+
     f.gpu_tile(x, c, xi, ci, 4, 4);
     f.update(0).gpu_tile(r.x, c, rxi, ci, 4, 4);
 
@@ -41,7 +40,7 @@ int main(int argc, char **argv) {
     f.jit_handlers().custom_error = my_error;
 
     // Metal is surprisingly resilient.  Run this in a loop just to make sure we trigger the error.
-    for (int i = 0; (i < 10) && !errored ; i++) {
+    for (int i = 0; (i < 10) && !errored; i++) {
         auto out = f.realize({1000, 100}, t);
         int result = out.device_sync();
         if (result != halide_error_code_success) {

--- a/test/correctness/gpu_metal_completion_handler_error_check.cpp
+++ b/test/correctness/gpu_metal_completion_handler_error_check.cpp
@@ -1,0 +1,51 @@
+#include "Halide.h"
+#include <unistd.h>
+
+using namespace Halide;
+
+bool errored = false;
+void my_error(JITUserContext *, const char *msg) {
+    // Emitting "error.*:" to stdout or stderr will cause CMake to report the
+    // test as a failure on Windows, regardless of error code returned,
+    // hence the abbreviation to "err".
+    printf("Expected err: %s\n", msg);
+    errored = true;
+}
+
+int main(int argc, char **argv) {
+    Target t = get_jit_target_from_environment();
+    if (!t.has_feature(Target::Metal)) {
+        printf("[SKIP] Metal not enabled\n");
+        return 0;
+    }
+
+    Func f;
+    Var c, x, ci, xi;
+    RVar rxi;
+    RDom r(0, 1000, -327600, 327600);
+
+    // Create a function that is very costly to execute, resulting in a timeout
+    // on the GPU
+    f(x, c) = x + 0.1f * c; 
+    f(r.x, c) += cos(sin(tan(cosh(tanh(sinh(exp(tanh(exp(log(tan(cos(exp(f(r.x, c) / cos(cosh(sinh(sin(f(r.x, c))))) 
+        / tanh(tan(tan(f(r.x, c)))))))))) + cast<float>(cast<uint8_t>(f(r.x, c) / cast<uint8_t>(log(f(r.x, c))))))))))));
+  
+    f.gpu_tile(x, c, xi, ci, 4, 4);
+    f.update(0).gpu_tile(r.x, c, rxi, ci, 4, 4);
+
+    // Because the error handler is invoked from a Metal runtime thread, setting a custom handler for just
+    // this pipeline is insufficient.  Instead, we set a custom handler for the JIT runtime
+    JITHandlers handlers;
+    handlers.custom_error = my_error;
+    Internal::JITSharedRuntime::set_default_handlers(handlers);
+
+    f.realize({1000, 100}, t);
+
+    if (!errored) {
+        printf("There was supposed to be an error\n");
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/gpu_metal_completion_handler_error_check.cpp
+++ b/test/correctness/gpu_metal_completion_handler_error_check.cpp
@@ -25,7 +25,6 @@ int main(int argc, char **argv) {
     f.gpu_tile(x, c, xi, ci, 4, 4);
     f.update(0).gpu_tile(r.x, c, rxi, ci, 4, 4);
 
-
     // Metal is surprisingly resilient.  Run this in a loop just to make sure we trigger the error.
     for (int i = 0; (i < 10) && !errored; i++) {
         auto out = f.realize({1000, 100}, t);

--- a/test/correctness/gpu_metal_completion_handler_error_check.cpp
+++ b/test/correctness/gpu_metal_completion_handler_error_check.cpp
@@ -4,13 +4,6 @@
 using namespace Halide;
 
 bool errored = false;
-void my_error(JITUserContext *, const char *msg) {
-    // Emitting "error.*:" to stdout or stderr will cause CMake to report the
-    // test as a failure on Windows, regardless of error code returned,
-    // hence the abbreviation to "err".
-    printf("Expected err: %s\n", msg);
-    errored = true;
-}
 
 int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
@@ -32,12 +25,6 @@ int main(int argc, char **argv) {
     f.gpu_tile(x, c, xi, ci, 4, 4);
     f.update(0).gpu_tile(r.x, c, rxi, ci, 4, 4);
 
-    // Because the error handler is invoked from a Metal runtime thread, setting a custom handler for just
-    // this pipeline is insufficient.  Instead, we set a custom handler for the JIT runtime
-    JITHandlers handlers;
-    handlers.custom_error = my_error;
-    Internal::JITSharedRuntime::set_default_handlers(handlers);
-    f.jit_handlers().custom_error = my_error;
 
     // Metal is surprisingly resilient.  Run this in a loop just to make sure we trigger the error.
     for (int i = 0; (i < 10) && !errored; i++) {

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -497,6 +497,11 @@ _add_halide_libraries(metadata_tester_ucon
 _add_halide_aot_tests(metadata_tester
                       HALIDE_LIBRARIES metadata_tester metadata_tester_ucon)
 
+# metal_completion_handler_override_aottest.cpp
+# metal_completion_handler_override_generator.cpp
+_add_halide_libraries(metal_completion_handler_override FEATURES user_context)
+_add_halide_aot_tests(metal_completion_handler_override)
+
 # msan_aottest.cpp
 # msan_generator.cpp
 if ("${Halide_TARGET}" MATCHES "webgpu")

--- a/test/generator/metal_completion_handler_override_aottest.cpp
+++ b/test/generator/metal_completion_handler_override_aottest.cpp
@@ -4,20 +4,21 @@
 
 #include "metal_completion_handler_override.h"
 
-
 struct MyUserContext {
     int counter;
 
-    MyUserContext() : counter(0) {}
+    MyUserContext()
+        : counter(0) {
+    }
 };
 
-extern "C" int halide_metal_command_buffer_completion_handler(void* user_context, struct halide_metal_command_buffer *, char **) {
+extern "C" int halide_metal_command_buffer_completion_handler(void *user_context, struct halide_metal_command_buffer *, char **) {
     auto ctx = (MyUserContext *)user_context;
     ctx->counter++;
     return halide_error_code_success;
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char *argv[]) {
 #if defined(TEST_METAL)
     Halide::Runtime::Buffer<int32_t> output(32, 32);
 
@@ -39,7 +40,7 @@ int main(int argc, char* argv[]) {
         printf("Error: completion handler was not called\n");
         return -1;
     }
-    
+
     printf("Success!\n");
 #else
     printf("[SKIP] Metal not enabled\n");

--- a/test/generator/metal_completion_handler_override_aottest.cpp
+++ b/test/generator/metal_completion_handler_override_aottest.cpp
@@ -1,3 +1,5 @@
+#include <stdio.h>
+
 #include "HalideBuffer.h"
 #include "HalideRuntime.h"
 #include "HalideRuntimeMetal.h"

--- a/test/generator/metal_completion_handler_override_aottest.cpp
+++ b/test/generator/metal_completion_handler_override_aottest.cpp
@@ -14,7 +14,11 @@ struct MyUserContext {
     }
 };
 
-extern "C" int halide_metal_command_buffer_completion_handler(void *user_context, struct halide_metal_command_buffer *, char **) {
+extern "C" int halide_metal_command_buffer_completion_handler(void *const user_context, struct halide_metal_command_buffer *, char **) {
+    if (user_context == nullptr) {
+        printf("Error: user_context is nullptr\n");
+        return -1;
+    }
     auto ctx = (MyUserContext *)user_context;
     ctx->counter++;
     return halide_error_code_success;

--- a/test/generator/metal_completion_handler_override_aottest.cpp
+++ b/test/generator/metal_completion_handler_override_aottest.cpp
@@ -1,0 +1,48 @@
+#include "HalideBuffer.h"
+#include "HalideRuntime.h"
+#include "HalideRuntimeMetal.h"
+
+#include "metal_completion_handler_override.h"
+
+
+struct MyUserContext {
+    int counter;
+
+    MyUserContext() : counter(0) {}
+};
+
+extern "C" int halide_metal_command_buffer_completion_handler(void* user_context, struct halide_metal_command_buffer *, char **) {
+    auto ctx = (MyUserContext *)user_context;
+    ctx->counter++;
+    return halide_error_code_success;
+}
+
+int main(int argc, char* argv[]) {
+#if defined(TEST_METAL)
+    Halide::Runtime::Buffer<int32_t> output(32, 32);
+
+    MyUserContext my_context;
+    metal_completion_handler_override(&my_context, output);
+    output.copy_to_host();
+
+    // Check the output
+    for (int y = 0; y < output.height(); y++) {
+        for (int x = 0; x < output.width(); x++) {
+            if (output(x, y) != x + y * 2) {
+                printf("Error: output(%d, %d) = %d instead of %d\n", x, y, output(x, y), x + y * 2);
+                return -1;
+            }
+        }
+    }
+
+    if (my_context.counter < 1) {
+        printf("Error: completion handler was not called\n");
+        return -1;
+    }
+    
+    printf("Success!\n");
+#else
+    printf("[SKIP] Metal not enabled\n");
+#endif
+    return 0;
+}

--- a/test/generator/metal_completion_handler_override_generator.cpp
+++ b/test/generator/metal_completion_handler_override_generator.cpp
@@ -10,7 +10,7 @@ public:
         Var x("x"), y("y");
 
         // Create a simple pipeline that scales pixel values by 2.
-        output(x, y) = x + y * 2; 
+        output(x, y) = x + y * 2;
 
         Target target = get_target();
         if (target.has_gpu_feature()) {

--- a/test/generator/metal_completion_handler_override_generator.cpp
+++ b/test/generator/metal_completion_handler_override_generator.cpp
@@ -1,0 +1,25 @@
+#include "Halide.h"
+
+namespace {
+
+class SimpleMetalPipeline : public Halide::Generator<SimpleMetalPipeline> {
+public:
+    Output<Buffer<int32_t, 2>> output{"output"};
+
+    void generate() {
+        Var x("x"), y("y");
+
+        // Create a simple pipeline that scales pixel values by 2.
+        output(x, y) = x + y * 2; 
+
+        Target target = get_target();
+        if (target.has_gpu_feature()) {
+            Var xo, yo, xi, yi;
+            output.gpu_tile(x, y, xo, yo, xi, yi, 16, 16);
+        }
+    }
+};
+
+}  // namespace
+
+HALIDE_REGISTER_GENERATOR(SimpleMetalPipeline, metal_completion_handler_override)


### PR DESCRIPTION
As discussed in the dev meeting, here is an alternative approach for fixing #7780.  Now, the runtime saves an error during the callback from a failed command buffer, and reports the error back at the next opportunity for reporting.  Note that this means that a pipeline may get an error that should be attributed to the previous pipeline, but additional error information can be added (e.g. prepending the error message with the name of the kernel that caused it) if wanted.