### PR TITLE
Python binding support for int64 literals

### DIFF
--- a/python_bindings/src/halide/halide_/PyExpr.cpp
+++ b/python_bindings/src/halide/halide_/PyExpr.cpp
@@ -29,6 +29,7 @@ void define_expr(py::module &m) {
             // PyBind11 searches in declared order,
             // int should be tried before float conversion
             .def(py::init<int>())
+            .def(py::init<int64_t>())
             // Python float is implemented by double
             // But Halide prohibits implicitly construct by double.
             .def(py::init([](double v) {
@@ -65,6 +66,7 @@ void define_expr(py::module &m) {
     // int should be tried before float conversion
     py::implicitly_convertible<bool, Expr>();
     py::implicitly_convertible<int, Expr>();
+    py::implicitly_convertible<int64_t, Expr>();
     py::implicitly_convertible<float, Expr>();
     py::implicitly_convertible<double, Expr>();
 

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -445,6 +445,11 @@ def test_requirements():
         assert False, "Did not see expected exception!"
 
 
+def test_implicit_convert_int64():
+    assert (hl.i32(0) + 0x7fffffff).type() == hl.Int(32)
+    assert (hl.i32(0) + (0x7fffffff+1)).type() == hl.Int(64)
+
+
 if __name__ == "__main__":
     test_compiletime_error()
     test_runtime_error()
@@ -463,3 +468,4 @@ if __name__ == "__main__":
     test_scalar_funcs()
     test_bool_conversion()
     test_requirements()
+    test_implicit_convert_int64()


### PR DESCRIPTION
This makes >32bit python integers get mapped to `hl.i64` implicitly.

Fixes #8224