### PR TITLE
Backport #8259 to release/17.x

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1159,8 +1159,9 @@ void CodeGen_C::compile(const Buffer<> &buffer) {
     bool is_constant = buffer.dimensions() != 0;
 
     // If it is an GPU source kernel, we would like to see the actual output, not the
-    // uint8 representation. We use a string literal for this.
-    if (ends_with(name, "gpu_source_kernels")) {
+    // uint8 representation. We use a string literal for this. Since the Vulkan backend
+    // actually generates a SPIR-V binary, keep it as raw data to avoid textual reformatting.
+    if (ends_with(name, "gpu_source_kernels") && !target.has_feature(Target::Vulkan)) {
         stream << "static const char *" << name << "_string = R\"BUFCHARSOURCE(";
         stream.write((char *)b.host, num_elems);
         stream << ")BUFCHARSOURCE\";\n";

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2521,7 +2521,7 @@ namespace {
 class FindIntrinsicsUsed : public IRVisitor {
     using IRVisitor::visit;
     void visit(const For *op) override {
-        if (CodeGen_GPU_Dev::is_gpu_var(op->for_type)) {
+        if (CodeGen_GPU_Dev::is_gpu_var(op->name)) {
 
             // map the block or thread id name to the SIMT intrinsic definition
             auto intrinsic = simt_intrinsic(op->name);

--- a/src/runtime/internal/block_allocator.h
+++ b/src/runtime/internal/block_allocator.h
@@ -127,7 +127,7 @@ BlockAllocator *BlockAllocator::create(void *user_context, const Config &cfg, co
         allocators.system.allocate(user_context, sizeof(BlockAllocator)));
 
     if (result == nullptr) {
-        error(user_context) << "BlockAllocator: Failed to create instance! Out of memory!\n";
+        error(user_context) << "BlockAllocator: Failed to create instance! Out of memory\n";
         return nullptr;
     }
 
@@ -161,13 +161,13 @@ MemoryRegion *BlockAllocator::reserve(void *user_context, const MemoryRequest &r
                         << "dedicated=" << (request.dedicated ? "true" : "false") << " "
                         << "usage=" << halide_memory_usage_name(request.properties.usage) << " "
                         << "caching=" << halide_memory_caching_name(request.properties.caching) << " "
-                        << "visibility=" << halide_memory_visibility_name(request.properties.visibility) << ") ...\n";
+                        << "visibility=" << halide_memory_visibility_name(request.properties.visibility) << ") ...";
 #endif
     // Reserve a block entry for use
     BlockEntry *block_entry = reserve_block_entry(user_context, request);
     if (block_entry == nullptr) {
         error(user_context) << "BlockAllocator: Failed to allocate new empty block of requested size ("
-                            << (int32_t)(request.size) << " bytes)!\n";
+                            << (int32_t)(request.size) << " bytes)\n";
         return nullptr;
     }
 
@@ -183,7 +183,7 @@ MemoryRegion *BlockAllocator::reserve(void *user_context, const MemoryRequest &r
         block_entry = create_block_entry(user_context, request);
         if (block_entry == nullptr) {
             error(user_context) << "BlockAllocator: Out of memory! Failed to allocate empty block of size ("
-                                << (int32_t)(request.size) << " bytes)!\n";
+                                << (int32_t)(request.size) << " bytes)\n";
             return nullptr;
         }
 
@@ -291,7 +291,7 @@ MemoryRegion *BlockAllocator::reserve_memory_region(void *user_context, RegionAl
     if (result == nullptr) {
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "BlockAllocator: Failed to allocate region of size ("
-                            << (int32_t)(request.size) << " bytes)!\n";
+                            << (int32_t)(request.size) << " bytes)\n";
 #endif
         // allocator has enough free space, but not enough contiguous space
         // -- collect and try to reallocate
@@ -323,20 +323,20 @@ bool BlockAllocator::is_block_suitable_for_request(void *user_context, const Blo
 
     if (request.dedicated && (block->reserved > 0)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "BlockAllocator: skipping block ... can be used for dedicated allocation!\n"
-                            << " block_resource=" << (void *)block << "\n"
-                            << " block_size=" << (uint32_t)block->memory.size << "\n"
-                            << " block_reserved=" << (uint32_t)block->reserved << "\n";
+        debug(user_context) << "BlockAllocator: skipping block ... can be used for dedicated allocation! ("
+                            << "block_resource=" << (void *)block << " "
+                            << "block_size=" << (uint32_t)block->memory.size << " "
+                            << "block_reserved=" << (uint32_t)block->reserved << ")";
 #endif
         // skip blocks that can't be dedicated to a single allocation
         return false;
 
     } else if (block->memory.dedicated && (block->reserved > 0)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "BlockAllocator: skipping block ... already dedicated to an allocation!\n"
-                            << " block_resource=" << (void *)block << "\n"
-                            << " block_size=" << (uint32_t)block->memory.size << "\n"
-                            << " block_reserved=" << (uint32_t)block->reserved << "\n";
+        debug(user_context) << "BlockAllocator: skipping block ... already dedicated to an allocation! ("
+                            << "block_resource=" << (void *)block << " "
+                            << "block_size=" << (uint32_t)block->memory.size << " "
+                            << "block_reserved=" << (uint32_t)block->reserved << ")";
 #endif
         // skip dedicated blocks that are already allocated
         return false;
@@ -425,14 +425,14 @@ BlockAllocator::create_region_allocator(void *user_context, BlockResource *block
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "BlockAllocator: Creating region allocator ("
                         << "user_context=" << (void *)(user_context) << " "
-                        << "block_resource=" << (void *)(block) << ")...\n";
+                        << "block_resource=" << (void *)(block) << ")...";
 #endif
     halide_abort_if_false(user_context, block != nullptr);
     RegionAllocator *region_allocator = RegionAllocator::create(
         user_context, block, {allocators.system, allocators.region});
 
     if (region_allocator == nullptr) {
-        error(user_context) << "BlockAllocator: Failed to create new region allocator!\n";
+        error(user_context) << "BlockAllocator: Failed to create new region allocator\n";
         return nullptr;
     }
 
@@ -443,7 +443,7 @@ int BlockAllocator::destroy_region_allocator(void *user_context, RegionAllocator
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "BlockAllocator: Destroying region allocator ("
                         << "user_context=" << (void *)(user_context) << " "
-                        << "region_allocator=" << (void *)(region_allocator) << ")...\n";
+                        << "region_allocator=" << (void *)(region_allocator) << ")...";
 #endif
     if (region_allocator == nullptr) {
         return 0;
@@ -462,13 +462,13 @@ BlockAllocator::create_block_entry(void *user_context, const MemoryRequest &requ
 
     if (config.maximum_block_count && (block_count() >= config.maximum_block_count)) {
         error(user_context) << "BlockAllocator: No free blocks found! Maximum block count reached ("
-                            << (int32_t)(config.maximum_block_count) << ")!\n";
+                            << (int32_t)(config.maximum_block_count) << ")\n";
         return nullptr;
     }
 
     BlockEntry *block_entry = block_list.append(user_context);
     if (block_entry == nullptr) {
-        debug(user_context) << "BlockAllocator: Failed to allocate new block entry!\n";
+        debug(user_context) << "BlockAllocator: Failed to allocate new block entry\n";
         return nullptr;
     }
 
@@ -476,7 +476,7 @@ BlockAllocator::create_block_entry(void *user_context, const MemoryRequest &requ
     debug(user_context) << "BlockAllocator: Creating block entry ("
                         << "block_entry=" << (void *)(block_entry) << " "
                         << "block=" << (void *)(block_entry->value) << " "
-                        << "allocator=" << (void *)(allocators.block.allocate) << ")...\n";
+                        << "allocator=" << (void *)(allocators.block.allocate) << ")...";
 #endif
 
     // Constrain the request to the a valid block allocation
@@ -499,7 +499,7 @@ int BlockAllocator::release_block_entry(void *user_context, BlockAllocator::Bloc
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "BlockAllocator: Releasing block entry ("
                         << "block_entry=" << (void *)(block_entry) << " "
-                        << "block=" << (void *)(block_entry->value) << ")...\n";
+                        << "block=" << (void *)(block_entry->value) << ")...";
 #endif
     BlockResource *block = static_cast<BlockResource *>(block_entry->value);
     if (block->allocator) {
@@ -513,7 +513,7 @@ int BlockAllocator::destroy_block_entry(void *user_context, BlockAllocator::Bloc
     debug(user_context) << "BlockAllocator: Destroying block entry ("
                         << "block_entry=" << (void *)(block_entry) << " "
                         << "block=" << (void *)(block_entry->value) << " "
-                        << "deallocator=" << (void *)(allocators.block.deallocate) << ")...\n";
+                        << "deallocator=" << (void *)(allocators.block.deallocate) << ")...";
 #endif
     BlockResource *block = static_cast<BlockResource *>(block_entry->value);
     if (block->allocator) {
@@ -527,7 +527,7 @@ int BlockAllocator::destroy_block_entry(void *user_context, BlockAllocator::Bloc
 
 int BlockAllocator::alloc_memory_block(void *user_context, BlockResource *block) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "BlockAllocator: Allocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.allocate << ")...\n";
+    debug(user_context) << "BlockAllocator: Allocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.allocate << ")...";
 #endif
     halide_abort_if_false(user_context, allocators.block.allocate != nullptr);
     MemoryBlock *memory_block = &(block->memory);
@@ -538,7 +538,7 @@ int BlockAllocator::alloc_memory_block(void *user_context, BlockResource *block)
 
 int BlockAllocator::free_memory_block(void *user_context, BlockResource *block) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "BlockAllocator: Deallocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.deallocate << ")...\n";
+    debug(user_context) << "BlockAllocator: Deallocating block (ptr=" << (void *)block << " allocator=" << (void *)allocators.block.deallocate << ")...";
 #endif
     halide_abort_if_false(user_context, allocators.block.deallocate != nullptr);
     MemoryBlock *memory_block = &(block->memory);

--- a/src/runtime/internal/memory_arena.h
+++ b/src/runtime/internal/memory_arena.h
@@ -271,7 +271,7 @@ void *MemoryArena::create_entry(void *user_context, Block *block, uint32_t index
     void *entry_ptr = lookup_entry(user_context, block, index);
     block->free_index = block->indices[index];
     block->status[index] = AllocationStatus::InUse;
-#if DEBUG_RUNTIME_INTERNAL
+#ifdef DEBUG_RUNTIME_INTERNAL
     memset(entry_ptr, 0, config.entry_size);
 #endif
     return entry_ptr;

--- a/src/runtime/internal/memory_resources.h
+++ b/src/runtime/internal/memory_resources.h
@@ -127,7 +127,7 @@ ALWAYS_INLINE bool is_power_of_two_alignment(size_t x) {
 // -- Alignment must be power of two!
 ALWAYS_INLINE size_t aligned_offset(size_t offset, size_t alignment) {
     halide_abort_if_false(nullptr, is_power_of_two_alignment(alignment));
-    return (offset + (alignment - 1)) & ~(alignment - 1);
+    return (alignment == 0) ? (offset) : (offset + (alignment - 1)) & ~(alignment - 1);
 }
 
 // Returns a suitable alignment such that requested alignment is a suitable

--- a/src/runtime/internal/memory_resources.h
+++ b/src/runtime/internal/memory_resources.h
@@ -202,18 +202,22 @@ struct HalideSystemAllocatorFns {
 
 typedef int (*AllocateBlockFn)(void *, MemoryBlock *);
 typedef int (*DeallocateBlockFn)(void *, MemoryBlock *);
+typedef int (*ConformBlockRequestFn)(void *, MemoryRequest *);
 
 struct MemoryBlockAllocatorFns {
     AllocateBlockFn allocate = nullptr;
     DeallocateBlockFn deallocate = nullptr;
+    ConformBlockRequestFn conform = nullptr;
 };
 
 typedef int (*AllocateRegionFn)(void *, MemoryRegion *);
 typedef int (*DeallocateRegionFn)(void *, MemoryRegion *);
+typedef int (*ConformBlockRegionFn)(void *, MemoryRequest *);
 
 struct MemoryRegionAllocatorFns {
     AllocateRegionFn allocate = nullptr;
     DeallocateRegionFn deallocate = nullptr;
+    ConformBlockRegionFn conform = nullptr;
 };
 
 // --

--- a/src/runtime/internal/region_allocator.h
+++ b/src/runtime/internal/region_allocator.h
@@ -46,10 +46,11 @@ public:
 
     // Public interface methods
     MemoryRegion *reserve(void *user_context, const MemoryRequest &request);
-    int release(void *user_context, MemoryRegion *memory_region);  //< unmark and cache the region for reuse
-    int reclaim(void *user_context, MemoryRegion *memory_region);  //< free the region and consolidate
-    int retain(void *user_context, MemoryRegion *memory_region);   //< retain the region and increase usage count
-    bool collect(void *user_context);                              //< returns true if any blocks were removed
+    int conform(void *user_context, MemoryRequest *request) const;  //< conform the given request into a suitable allocation
+    int release(void *user_context, MemoryRegion *memory_region);   //< unmark and cache the region for reuse
+    int reclaim(void *user_context, MemoryRegion *memory_region);   //< free the region and consolidate
+    int retain(void *user_context, MemoryRegion *memory_region);    //< retain the region and increase usage count
+    bool collect(void *user_context);                               //< returns true if any blocks were removed
     int release(void *user_context);
     int destroy(void *user_context);
 
@@ -73,13 +74,13 @@ private:
     BlockRegion *coalesce_block_regions(void *user_context, BlockRegion *region);
 
     // Returns true if the given region can be split to accomodate the given size
-    bool can_split(const BlockRegion *region, size_t size) const;
+    bool can_split(const BlockRegion *region, const MemoryRequest &request) const;
 
     // Splits the given block region into a smaller region to accomodate the given size, followed by empty space for the remaining
-    BlockRegion *split_block_region(void *user_context, BlockRegion *region, size_t size, size_t alignment);
+    BlockRegion *split_block_region(void *user_context, BlockRegion *region, const MemoryRequest &request);
 
     // Creates a new block region and adds it to the region list
-    BlockRegion *create_block_region(void *user_context, const MemoryProperties &properties, size_t offset, size_t size, bool dedicated);
+    BlockRegion *create_block_region(void *user_context, const MemoryRequest &request);
 
     // Creates a new block region and adds it to the region list
     int destroy_block_region(void *user_context, BlockRegion *region);
@@ -137,30 +138,55 @@ int RegionAllocator::initialize(void *user_context, BlockResource *mb, const Mem
     allocators = ma;
     arena = MemoryArena::create(user_context, {sizeof(BlockRegion), MemoryArena::default_capacity, 0}, allocators.system);
     halide_abort_if_false(user_context, arena != nullptr);
+    MemoryRequest block_request = {};
+    block_request.size = block->memory.size;
+    block_request.offset = 0;
+    block_request.alignment = block->memory.properties.alignment;
+    block_request.properties = block->memory.properties;
+    block_request.dedicated = block->memory.dedicated;
     block->allocator = this;
-    block->regions = create_block_region(
-        user_context,
-        block->memory.properties,
-        0, block->memory.size,
-        block->memory.dedicated);
+    block->regions = create_block_region(user_context, block_request);
+    return 0;
+}
+
+int RegionAllocator::conform(void *user_context, MemoryRequest *request) const {
+    if (allocators.region.conform) {
+        return allocators.region.conform(user_context, request);
+    } else {
+        size_t actual_alignment = conform_alignment(request->alignment, block->memory.properties.alignment);
+        size_t actual_offset = aligned_offset(request->offset, actual_alignment);
+        size_t actual_size = conform_size(actual_offset, request->size, actual_alignment, block->memory.properties.nearest_multiple);
+        request->alignment = actual_alignment;
+        request->offset = actual_offset;
+        request->size = actual_size;
+    }
     return 0;
 }
 
 MemoryRegion *RegionAllocator::reserve(void *user_context, const MemoryRequest &request) {
     halide_abort_if_false(user_context, request.size > 0);
-    size_t actual_alignment = conform_alignment(request.alignment, block->memory.properties.alignment);
-    size_t actual_size = conform_size(request.offset, request.size, actual_alignment, block->memory.properties.nearest_multiple);
-    size_t remaining = block->memory.size - block->reserved;
-    if (remaining < actual_size) {
+
+    MemoryRequest region_request = request;
+
+    int error_code = conform(user_context, &region_request);
+    if (error_code) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "RegionAllocator: Unable to reserve more memory from block "
-                            << "-- requested size (" << (int32_t)(request.size) << " bytes) "
-                            << "greater than available (" << (int32_t)(remaining) << " bytes)!\n";
+        debug(user_context) << "RegionAllocator: Failed to conform region request! Unable to reserve memory ...\n";
 #endif
         return nullptr;
     }
 
-    BlockRegion *block_region = find_block_region(user_context, request);
+    size_t remaining = block->memory.size - block->reserved;
+    if (remaining < region_request.size) {
+#ifdef DEBUG_RUNTIME_INTERNAL
+        debug(user_context) << "RegionAllocator: Unable to reserve more memory from block "
+                            << "-- requested size (" << (int32_t)(region_request.size) << " bytes) "
+                            << "greater than available (" << (int32_t)(remaining) << " bytes)";
+#endif
+        return nullptr;
+    }
+
+    BlockRegion *block_region = find_block_region(user_context, region_request);
     if (block_region == nullptr) {
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "RegionAllocator: Failed to locate region for requested size ("
@@ -169,12 +195,12 @@ MemoryRegion *RegionAllocator::reserve(void *user_context, const MemoryRequest &
         return nullptr;
     }
 
-    if (can_split(block_region, request.size)) {
+    if (can_split(block_region, region_request)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "RegionAllocator: Splitting region of size ( " << (int32_t)(block_region->memory.size) << ") "
-                            << "to accomodate requested size (" << (int32_t)(request.size) << " bytes)!\n";
+                            << "to accomodate requested size (" << (int32_t)(region_request.size) << " bytes)";
 #endif
-        split_block_region(user_context, block_region, request.size, request.alignment);
+        split_block_region(user_context, block_region, region_request);
     }
 
     alloc_block_region(user_context, block_region);
@@ -238,8 +264,17 @@ bool RegionAllocator::is_block_region_suitable_for_request(void *user_context, c
         return false;
     }
 
+    MemoryRequest region_request = request;
+    int error_code = conform(user_context, &region_request);
+    if (error_code) {
+#ifdef DEBUG_RUNTIME_INTERNAL
+        debug(user_context) << "RegionAllocator: Failed to conform region request! Unable to reserve memory ...\n";
+#endif
+        return false;
+    }
+
     // skip incompatible block regions for this request
-    if (!is_compatible_block_region(region, request.properties)) {
+    if (!is_compatible_block_region(region, region_request.properties)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "RegionAllocator: skipping block region ... incompatible properties! "
                             << " block_region=" << (void *)region << "\n";
@@ -247,23 +282,28 @@ bool RegionAllocator::is_block_region_suitable_for_request(void *user_context, c
         return false;
     }
 
-    size_t actual_alignment = conform_alignment(request.alignment, block->memory.properties.alignment);
-    size_t actual_size = conform_size(region->memory.offset, request.size, actual_alignment, block->memory.properties.nearest_multiple);
-
     // is the adjusted size larger than the current region?
-    if (actual_size > region->memory.size) {
+    if (region_request.size > region->memory.size) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "RegionAllocator: skipping block region ... not enough space for adjusted size! "
-                            << " block_region=" << (void *)region << "\n";
+        debug(user_context) << "    skipping block region ... not enough space for adjusted size! ("
+                            << " block_region=" << (void *)region
+                            << " request_size=" << (uint32_t)(request.size)
+                            << " actual_size=" << (uint32_t)(region_request.size)
+                            << " region_size=" << (uint32_t)(region->memory.size)
+                            << ")";
 #endif
         return false;
     }
 
     // will the adjusted size fit within the remaining unallocated space?
-    if ((actual_size + block->reserved) <= block->memory.size) {
+    if ((region_request.size + block->reserved) <= block->memory.size) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "RegionAllocator: found suitable block region! "
-                            << " block_region=" << (void *)region << "\n";
+        debug(user_context) << "    found suitable block region! ("
+                            << " block_region=" << (void *)region
+                            << " request_size=" << (uint32_t)(request.size)
+                            << " actual_size=" << (uint32_t)(region_request.size)
+                            << " region_size=" << (uint32_t)(region->memory.size)
+                            << ")";
 #endif
         return true;  // you betcha
     }
@@ -393,11 +433,11 @@ BlockRegion *RegionAllocator::coalesce_block_regions(void *user_context, BlockRe
     return block_region;
 }
 
-bool RegionAllocator::can_split(const BlockRegion *block_region, size_t size) const {
-    return (block_region && (block_region->memory.size > size) && (block_region->usage_count == 0));
+bool RegionAllocator::can_split(const BlockRegion *block_region, const MemoryRequest &split_request) const {
+    return (block_region && (block_region->memory.size > split_request.size) && (block_region->usage_count == 0));
 }
 
-BlockRegion *RegionAllocator::split_block_region(void *user_context, BlockRegion *block_region, size_t size, size_t alignment) {
+BlockRegion *RegionAllocator::split_block_region(void *user_context, BlockRegion *block_region, const MemoryRequest &request) {
 
     if ((block_region->usage_count == 0) && (block_region->memory.handle != nullptr)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
@@ -414,31 +454,17 @@ BlockRegion *RegionAllocator::split_block_region(void *user_context, BlockRegion
         block_region->memory.handle = nullptr;
     }
 
-    size_t actual_alignment = conform_alignment(alignment, block->memory.properties.alignment);
-    size_t split_size = conform_size(block_region->memory.offset, size, actual_alignment, block->memory.properties.nearest_multiple);
-    size_t split_offset = aligned_offset(block_region->memory.offset + size, actual_alignment);
-    size_t empty_size = block_region->memory.size - split_size;
-
-#ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "RegionAllocator: Conforming size and alignment \n"
-                        << " requested_size=" << (uint32_t)size << "\n"
-                        << " split_size=" << (uint32_t)split_size << "\n"
-                        << " requested_alignment=" << (uint32_t)alignment << " "
-                        << " required_alignment=" << (uint32_t)block->memory.properties.alignment << " "
-                        << " actual_alignment=" << (uint32_t)actual_alignment << ")\n";
-#endif
+    MemoryRequest split_request = request;
+    split_request.size = block_region->memory.size - request.size;
+    split_request.offset = block_region->memory.offset + request.size;
 
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Splitting "
                         << "current region (offset=" << (int32_t)block_region->memory.offset << " size=" << (int32_t)(block_region->memory.size) << " bytes) "
-                        << "to create empty region (offset=" << (int32_t)split_offset << " size=" << (int32_t)(empty_size) << " bytes)!\n";
+                        << "to create empty region (offset=" << (int32_t)split_request.offset << " size=" << (int32_t)(split_request.size) << " bytes)";
 #endif
-
     BlockRegion *next_region = block_region->next_ptr;
-    BlockRegion *empty_region = create_block_region(user_context,
-                                                    block_region->memory.properties,
-                                                    split_offset, empty_size,
-                                                    block_region->memory.dedicated);
+    BlockRegion *empty_region = create_block_region(user_context, split_request);
     halide_abort_if_false(user_context, empty_region != nullptr);
 
     empty_region->next_ptr = next_region;
@@ -447,26 +473,44 @@ BlockRegion *RegionAllocator::split_block_region(void *user_context, BlockRegion
     }
     empty_region->prev_ptr = block_region;
     block_region->next_ptr = empty_region;
-    block_region->memory.size -= empty_size;
+    block_region->memory.size -= empty_region->memory.size;
     return empty_region;
 }
 
-BlockRegion *RegionAllocator::create_block_region(void *user_context, const MemoryProperties &properties, size_t offset, size_t size, bool dedicated) {
+BlockRegion *RegionAllocator::create_block_region(void *user_context, const MemoryRequest &request) {
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Creating block region ("
                         << "user_context=" << (void *)(user_context) << " "
-                        << "offset=" << (uint32_t)offset << " "
-                        << "size=" << (uint32_t)size << " "
-                        << "alignment=" << (uint32_t)properties.alignment << " "
-                        << "dedicated=" << (dedicated ? "true" : "false") << " "
-                        << "usage=" << halide_memory_usage_name(properties.usage) << " "
-                        << "caching=" << halide_memory_caching_name(properties.caching) << " "
-                        << "visibility=" << halide_memory_visibility_name(properties.visibility) << ") ...\n";
+                        << "offset=" << (uint32_t)request.offset << " "
+                        << "size=" << (uint32_t)request.size << " "
+                        << "alignment=" << (uint32_t)request.properties.alignment << " "
+                        << "dedicated=" << (request.dedicated ? "true" : "false") << " "
+                        << "usage=" << halide_memory_usage_name(request.properties.usage) << " "
+                        << "caching=" << halide_memory_caching_name(request.properties.caching) << " "
+                        << "visibility=" << halide_memory_visibility_name(request.properties.visibility) << ") ...";
 #endif
+
+    MemoryRequest region_request = request;
+    int error_code = conform(user_context, &region_request);
+    if (error_code) {
+#ifdef DEBUG_RUNTIME_INTERNAL
+        debug(user_context) << "RegionAllocator: Failed to conform request for new block region!\n";
+#endif
+        return nullptr;
+    }
+
+    if (region_request.size == 0) {
+#ifdef DEBUG_RUNTIME_INTERNAL
+        debug(user_context) << "RegionAllocator: Failed to allocate new block region ... region size was zero!\n";
+#endif
+        return nullptr;
+    }
 
     BlockRegion *block_region = static_cast<BlockRegion *>(arena->reserve(user_context, true));
     if (block_region == nullptr) {
-        error(user_context) << "RegionAllocator: Failed to allocate new block region!\n";
+#ifdef DEBUG_RUNTIME_INTERNAL
+        debug(user_context) << "RegionAllocator: Failed to allocate new block region!\n";
+#endif
         return nullptr;
     }
 
@@ -481,10 +525,10 @@ BlockRegion *RegionAllocator::create_block_region(void *user_context, const Memo
     size_t actual_offset = aligned_offset(offset, actual_alignment);
 
     block_region->memory.handle = nullptr;
-    block_region->memory.offset = actual_offset;
-    block_region->memory.size = actual_size;
-    block_region->memory.properties = properties;
-    block_region->memory.dedicated = dedicated;
+    block_region->memory.offset = region_request.offset;
+    block_region->memory.size = region_request.size;
+    block_region->memory.properties = region_request.properties;
+    block_region->memory.dedicated = region_request.dedicated;
     block_region->status = AllocationStatus::Available;
     block_region->block_ptr = block;
     block_region->usage_count = 0;
@@ -637,7 +681,10 @@ bool RegionAllocator::collect(void *user_context) {
     debug(user_context) << "RegionAllocator: Collecting free block regions ("
                         << "user_context=" << (void *)(user_context) << ") ...\n";
 
-    uint32_t count = 0;
+    uint32_t collected_count = 0;
+    uint32_t remaining_count = 0;
+    uint64_t available_bytes = 0;
+    uint64_t scanned_bytes = 0;
     uint64_t reserved = block->reserved;
     debug(user_context) << "    collecting unused regions ("
                         << "block_ptr=" << (void *)block << " "
@@ -648,6 +695,18 @@ bool RegionAllocator::collect(void *user_context) {
     bool has_collected = false;
     BlockRegion *block_region = block->regions;
     while (block_region != nullptr) {
+#ifdef DEBUG_RUNTIME_INTERNAL
+        scanned_bytes += block_region->memory.size;
+        debug(user_context) << "    checking region ("
+                            << "block_ptr=" << (void *)block_region->block_ptr << " "
+                            << "block_region=" << (void *)block_region << " "
+                            << "usage_count=" << (uint32_t)(block_region->usage_count) << " "
+                            << "status=" << (uint32_t)(block_region->status) << " "
+                            << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
+                            << "block_reserved=" << (uint32_t)block->reserved << " "
+                            << ")";
+#endif
+
         if (can_coalesce(block_region)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
             count++;
@@ -661,11 +720,23 @@ bool RegionAllocator::collect(void *user_context) {
             block_region = coalesce_block_regions(user_context, block_region);
             has_collected = true;
         }
+#ifdef DEBUG_RUNTIME_INTERNAL
+        available_bytes += is_available(block_region) ? block_region->memory.size : 0;
+#endif
         if (is_last_block_region(user_context, block_region)) {
             break;
         }
         block_region = block_region->next_ptr;
     }
+#ifdef DEBUG_RUNTIME_INTERNAL
+    debug(user_context) << "    scanned active regions ("
+                        << "block_ptr=" << (void *)block << " "
+                        << "total_count=" << (uint32_t)(collected_count + remaining_count) << " "
+                        << "block_reserved=" << (uint32_t)(block->reserved) << " "
+                        << "scanned_bytes=" << (uint32_t)(scanned_bytes) << " "
+                        << "available_bytes=" << (uint32_t)(available_bytes) << " "
+                        << ")";
+#endif
 
     if (has_collected) {
 #ifdef DEBUG_RUNTIME_INTERNAL

--- a/src/runtime/internal/region_allocator.h
+++ b/src/runtime/internal/region_allocator.h
@@ -190,7 +190,7 @@ MemoryRegion *RegionAllocator::reserve(void *user_context, const MemoryRequest &
     if (block_region == nullptr) {
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "RegionAllocator: Failed to locate region for requested size ("
-                            << (int32_t)(request.size) << " bytes)!\n";
+                            << (int32_t)(request.size) << " bytes)";
 #endif
         return nullptr;
     }
@@ -226,9 +226,6 @@ int RegionAllocator::reclaim(void *user_context, MemoryRegion *memory_region) {
     }
     release_block_region(user_context, block_region);
     free_block_region(user_context, block_region);
-    if (can_coalesce(block_region)) {
-        block_region = coalesce_block_regions(user_context, block_region);
-    }
     return 0;
 }
 
@@ -258,8 +255,10 @@ bool RegionAllocator::is_last_block_region(void *user_context, const BlockRegion
 bool RegionAllocator::is_block_region_suitable_for_request(void *user_context, const BlockRegion *region, const MemoryRequest &request) const {
     if (!is_available(region)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "RegionAllocator: skipping block region ... not available! "
-                            << " block_region=" << (void *)region << "\n";
+        debug(user_context) << "    skipping block region ... not available! ("
+                            << " block_region=" << (void *)region
+                            << " region_size=" << (uint32_t)(region->memory.size)
+                            << ")";
 #endif
         return false;
     }
@@ -276,8 +275,10 @@ bool RegionAllocator::is_block_region_suitable_for_request(void *user_context, c
     // skip incompatible block regions for this request
     if (!is_compatible_block_region(region, region_request.properties)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "RegionAllocator: skipping block region ... incompatible properties! "
-                            << " block_region=" << (void *)region << "\n";
+        debug(user_context) << "    skipping block region ... incompatible properties! ("
+                            << " block_region=" << (void *)region
+                            << " region_size=" << (uint32_t)(region->memory.size)
+                            << ")";
 #endif
         return false;
     }
@@ -312,20 +313,29 @@ bool RegionAllocator::is_block_region_suitable_for_request(void *user_context, c
 }
 
 BlockRegion *RegionAllocator::find_block_region(void *user_context, const MemoryRequest &request) {
+#ifdef DEBUG_RUNTIME_INTERNAL
+    debug(user_context) << "RegionAllocator: find block region ( "
+                        << "user_context=" << (void *)(user_context) << " "
+                        << "requested_size=" << (uint32_t)request.size << " "
+                        << "requested_is_dedicated=" << (request.dedicated ? "true" : "false") << " "
+                        << "requested_usage=" << halide_memory_usage_name(request.properties.usage) << " "
+                        << "requested_caching=" << halide_memory_caching_name(request.properties.caching) << " "
+                        << "requested_visibility=" << halide_memory_visibility_name(request.properties.visibility) << ")";
+#endif
     BlockRegion *block_region = block->regions;
     while (block_region != nullptr) {
         if (is_block_region_suitable_for_request(user_context, block_region, request)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-            debug(user_context) << "RegionAllocator: found suitable region ...\n"
-                                << " user_context=" << (void *)(user_context) << "\n"
-                                << " block_resource=" << (void *)block << "\n"
-                                << " block_size=" << (uint32_t)block->memory.size << "\n"
-                                << " block_reserved=" << (uint32_t)block->reserved << "\n"
-                                << " requested_size=" << (uint32_t)request.size << "\n"
-                                << " requested_is_dedicated=" << (request.dedicated ? "true" : "false") << "\n"
-                                << " requested_usage=" << halide_memory_usage_name(request.properties.usage) << "\n"
-                                << " requested_caching=" << halide_memory_caching_name(request.properties.caching) << "\n"
-                                << " requested_visibility=" << halide_memory_visibility_name(request.properties.visibility) << "\n";
+            debug(user_context) << "RegionAllocator: found suitable region ( "
+                                << "user_context=" << (void *)(user_context) << " "
+                                << "block_resource=" << (void *)block << " "
+                                << "block_size=" << (uint32_t)block->memory.size << " "
+                                << "block_reserved=" << (uint32_t)block->reserved << " "
+                                << "requested_size=" << (uint32_t)request.size << " "
+                                << "requested_is_dedicated=" << (request.dedicated ? "true" : "false") << " "
+                                << "requested_usage=" << halide_memory_usage_name(request.properties.usage) << " "
+                                << "requested_caching=" << halide_memory_caching_name(request.properties.caching) << " "
+                                << "requested_visibility=" << halide_memory_visibility_name(request.properties.visibility) << ")";
 #endif
             return block_region;
         }
@@ -339,13 +349,13 @@ BlockRegion *RegionAllocator::find_block_region(void *user_context, const Memory
 
     if (block_region == nullptr) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "RegionAllocator: couldn't find suitable region!\n"
-                            << " user_context=" << (void *)(user_context) << "\n"
-                            << " requested_size=" << (uint32_t)request.size << "\n"
-                            << " requested_is_dedicated=" << (request.dedicated ? "true" : "false") << "\n"
-                            << " requested_usage=" << halide_memory_usage_name(request.properties.usage) << "\n"
-                            << " requested_caching=" << halide_memory_caching_name(request.properties.caching) << "\n"
-                            << " requested_visibility=" << halide_memory_visibility_name(request.properties.visibility) << "\n";
+        debug(user_context) << "RegionAllocator: couldn't find suitable region! ("
+                            << "user_context=" << (void *)(user_context) << " "
+                            << "requested_size=" << (uint32_t)request.size << " "
+                            << "requested_is_dedicated=" << (request.dedicated ? "true" : "false") << " "
+                            << "requested_usage=" << halide_memory_usage_name(request.properties.usage) << " "
+                            << "requested_caching=" << halide_memory_caching_name(request.properties.caching) << " "
+                            << "requested_visibility=" << halide_memory_visibility_name(request.properties.visibility) << ")";
 #endif
     }
 
@@ -382,12 +392,12 @@ BlockRegion *RegionAllocator::coalesce_block_regions(void *user_context, BlockRe
 
     if ((block_region->usage_count == 0) && (block_region->memory.handle != nullptr)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "Freeing region ("
+        debug(user_context) << "RegionAllocator: Freeing unused region to coalesce ("
                             << "block_ptr=" << (void *)block_region->block_ptr << " "
                             << "block_region=" << (void *)block_region << " "
                             << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                             << "block_reserved=" << (uint32_t)block->reserved << " "
-                            << ")\n";
+                            << ")";
 #endif
         halide_abort_if_false(user_context, allocators.region.deallocate != nullptr);
         MemoryRegion *memory_region = &(block_region->memory);
@@ -401,7 +411,7 @@ BlockRegion *RegionAllocator::coalesce_block_regions(void *user_context, BlockRe
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "RegionAllocator: Coalescing "
                             << "previous region (offset=" << (int32_t)prev_region->memory.offset << " size=" << (int32_t)(prev_region->memory.size) << " bytes) "
-                            << "into current region (offset=" << (int32_t)block_region->memory.offset << " size=" << (int32_t)(block_region->memory.size) << " bytes)\n!";
+                            << "into current region (offset=" << (int32_t)block_region->memory.offset << " size=" << (int32_t)(block_region->memory.size) << " bytes)!";
 #endif
 
         prev_region->next_ptr = block_region->next_ptr;
@@ -419,7 +429,7 @@ BlockRegion *RegionAllocator::coalesce_block_regions(void *user_context, BlockRe
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "RegionAllocator: Coalescing "
                             << "next region (offset=" << (int32_t)next_region->memory.offset << " size=" << (int32_t)(next_region->memory.size) << " bytes) "
-                            << "into current region (offset=" << (int32_t)block_region->memory.offset << " size=" << (int32_t)(block_region->memory.size) << " bytes)!\n";
+                            << "into current region (offset=" << (int32_t)block_region->memory.offset << " size=" << (int32_t)(block_region->memory.size) << " bytes)";
 #endif
 
         if (next_region->next_ptr) {
@@ -446,7 +456,7 @@ BlockRegion *RegionAllocator::split_block_region(void *user_context, BlockRegion
                             << "block_region=" << (void *)block_region << " "
                             << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                             << "block_reserved=" << (uint32_t)block_region->block_ptr->reserved << " "
-                            << ")\n";
+                            << ")";
 #endif
         halide_abort_if_false(user_context, allocators.region.deallocate != nullptr);
         MemoryRegion *memory_region = &(block_region->memory);
@@ -479,7 +489,7 @@ BlockRegion *RegionAllocator::split_block_region(void *user_context, BlockRegion
 
 BlockRegion *RegionAllocator::create_block_region(void *user_context, const MemoryRequest &request) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "RegionAllocator: Creating block region ("
+    debug(user_context) << "RegionAllocator: Creating block region request ("
                         << "user_context=" << (void *)(user_context) << " "
                         << "offset=" << (uint32_t)request.offset << " "
                         << "size=" << (uint32_t)request.size << " "
@@ -514,16 +524,6 @@ BlockRegion *RegionAllocator::create_block_region(void *user_context, const Memo
         return nullptr;
     }
 
-#ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "RegionAllocator: Added block region ("
-                        << "user_context=" << (void *)(user_context) << " "
-                        << "block_region=" << (void *)(block_region) << ") ...\n";
-#endif
-
-    size_t actual_alignment = conform_alignment(properties.alignment, block->memory.properties.alignment);
-    size_t actual_size = conform_size(offset, size, actual_alignment, block->memory.properties.nearest_multiple);
-    size_t actual_offset = aligned_offset(offset, actual_alignment);
-
     block_region->memory.handle = nullptr;
     block_region->memory.offset = region_request.offset;
     block_region->memory.size = region_request.size;
@@ -534,11 +534,13 @@ BlockRegion *RegionAllocator::create_block_region(void *user_context, const Memo
     block_region->usage_count = 0;
 
 #ifdef DEBUG_RUNTIME_INTERNAL
-    debug(user_context) << "Creating region ("
+    debug(user_context) << "RegionAllocator: Created block region allocation ("
+                        << "user_context=" << (void *)(user_context) << " "
                         << "block_ptr=" << (void *)block_region->block_ptr << " "
                         << "block_region=" << (void *)block_region << " "
+                        << "memory_offset=" << (uint32_t)(block_region->memory.offset) << " "
                         << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
-                        << ")\n";
+                        << ")";
 #endif
 
     return block_region;
@@ -548,7 +550,12 @@ int RegionAllocator::release_block_region(void *user_context, BlockRegion *block
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Releasing block region ("
                         << "user_context=" << (void *)(user_context) << " "
-                        << "block_region=" << (void *)(block_region) << ") ...\n";
+                        << "block_ptr=" << ((block_region) ? ((void *)block_region->block_ptr) : nullptr) << " "
+                        << "block_region=" << (void *)block_region << " "
+                        << "usage_count=" << ((block_region) ? (uint32_t)(block_region->usage_count) : 0) << " "
+                        << "memory_offset=" << ((block_region) ? (uint32_t)(block_region->memory.offset) : 0) << " "
+                        << "memory_size=" << ((block_region) ? (uint32_t)(block_region->memory.size) : 0) << " "
+                        << "block_reserved=" << (uint32_t)(block->reserved) << ") ... ";
 #endif
     if (block_region == nullptr) {
         return 0;
@@ -561,12 +568,13 @@ int RegionAllocator::release_block_region(void *user_context, BlockRegion *block
     if (block_region->status != AllocationStatus::Available) {
 
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "Releasing region ("
+        debug(user_context) << "    releasing region ("
                             << "block_ptr=" << (void *)block_region->block_ptr << " "
                             << "block_region=" << (void *)block_region << " "
+                            << "memory_offset=" << (uint32_t)(block_region->memory.offset) << " "
                             << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                             << "block_reserved=" << (uint32_t)(block->reserved - block_region->memory.size) << " "
-                            << ")\n";
+                            << ")";
 #endif
 
         block->reserved -= block_region->memory.size;
@@ -579,7 +587,7 @@ int RegionAllocator::destroy_block_region(void *user_context, BlockRegion *block
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Destroying block region ("
                         << "user_context=" << (void *)(user_context) << " "
-                        << "block_region=" << (void *)(block_region) << ") ...\n";
+                        << "block_region=" << (void *)(block_region) << ") ...";
 #endif
 
     block_region->usage_count = 0;
@@ -593,7 +601,7 @@ int RegionAllocator::alloc_block_region(void *user_context, BlockRegion *block_r
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Allocating region (user_context=" << (void *)(user_context)
                         << " size=" << (int32_t)(block_region->memory.size)
-                        << " offset=" << (int32_t)block_region->memory.offset << ")!\n";
+                        << " offset=" << (int32_t)block_region->memory.offset << ")";
 #endif
     halide_abort_if_false(user_context, allocators.region.allocate != nullptr);
     halide_abort_if_false(user_context, block_region->status == AllocationStatus::Available);
@@ -604,25 +612,25 @@ int RegionAllocator::alloc_block_region(void *user_context, BlockRegion *block_r
         memory_region->is_owner = true;
 
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "Allocating region ("
+        debug(user_context) << "    allocating region ("
                             << "block_ptr=" << (void *)block_region->block_ptr << " "
                             << "block_region=" << (void *)block_region << " "
                             << "memory_offset=" << (uint32_t)(block_region->memory.offset) << " "
                             << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                             << "block_reserved=" << (uint32_t)block->reserved << " "
-                            << ")\n";
+                            << ")";
 #endif
 
     } else {
 
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "Re-using region  ("
+        debug(user_context) << "    re-using region  ("
                             << "block_ptr=" << (void *)block_region->block_ptr << " "
                             << "block_region=" << (void *)block_region << " "
                             << "memory_offset=" << (uint32_t)(block_region->memory.offset) << " "
                             << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                             << "block_reserved=" << (uint32_t)block->reserved << " "
-                            << ")\n";
+                            << ")";
 #endif
     }
     block_region->status = block_region->memory.dedicated ? AllocationStatus::Dedicated : AllocationStatus::InUse;
@@ -634,24 +642,26 @@ int RegionAllocator::free_block_region(void *user_context, BlockRegion *block_re
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Freeing block region ("
                         << "user_context=" << (void *)(user_context) << " "
+                        << "block_ptr=" << (void *)block_region->block_ptr << " "
                         << "block_region=" << (void *)(block_region) << " "
+                        << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                         << "status=" << (uint32_t)block_region->status << " "
-                        << "usage_count=" << (uint32_t)block_region->usage_count << ") ...\n";
+                        << "usage_count=" << (uint32_t)block_region->usage_count << " "
+                        << "block_reserved=" << (uint32_t)block->reserved << ")";
 #endif
     if ((block_region->usage_count == 0) && (block_region->memory.handle != nullptr)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-        debug(user_context) << "Freeing region ("
+        debug(user_context) << "    deallocating region ("
                             << "block_ptr=" << (void *)block_region->block_ptr << " "
                             << "block_region=" << (void *)block_region << " "
                             << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                             << "block_reserved=" << (uint32_t)block->reserved << " "
-                            << ")\n";
+                            << ")";
 #endif
+        // NOTE: Deallocate but leave memory size as is, so that coalesce can compute region merging sizes
         halide_abort_if_false(user_context, allocators.region.deallocate != nullptr);
         MemoryRegion *memory_region = &(block_region->memory);
         allocators.region.deallocate(user_context, memory_region);
-        block_region->memory.size = 0;
-        block_region->memory.offset = 0;
         block_region->memory.handle = nullptr;
     }
     block_region->usage_count = 0;
@@ -662,7 +672,7 @@ int RegionAllocator::free_block_region(void *user_context, BlockRegion *block_re
 int RegionAllocator::release(void *user_context) {
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Releasing all regions ("
-                        << "user_context=" << (void *)(user_context) << ") ...\n";
+                        << "user_context=" << (void *)(user_context) << ") ...";
 #endif
 
     BlockRegion *block_region = block->regions;
@@ -679,7 +689,7 @@ int RegionAllocator::release(void *user_context) {
 bool RegionAllocator::collect(void *user_context) {
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Collecting free block regions ("
-                        << "user_context=" << (void *)(user_context) << ") ...\n";
+                        << "user_context=" << (void *)(user_context) << ") ...";
 
     uint32_t collected_count = 0;
     uint32_t remaining_count = 0;
@@ -689,7 +699,7 @@ bool RegionAllocator::collect(void *user_context) {
     debug(user_context) << "    collecting unused regions ("
                         << "block_ptr=" << (void *)block << " "
                         << "block_reserved=" << (uint32_t)block->reserved << " "
-                        << ")\n";
+                        << ")";
 #endif
 
     bool has_collected = false;
@@ -709,16 +719,20 @@ bool RegionAllocator::collect(void *user_context) {
 
         if (can_coalesce(block_region)) {
 #ifdef DEBUG_RUNTIME_INTERNAL
-            count++;
+            collected_count++;
             debug(user_context) << "    collecting region ("
                                 << "block_ptr=" << (void *)block_region->block_ptr << " "
                                 << "block_region=" << (void *)block_region << " "
                                 << "memory_size=" << (uint32_t)(block_region->memory.size) << " "
                                 << "block_reserved=" << (uint32_t)block->reserved << " "
-                                << ")\n";
+                                << ")";
 #endif
             block_region = coalesce_block_regions(user_context, block_region);
             has_collected = true;
+        } else {
+#ifdef DEBUG_RUNTIME_INTERNAL
+            remaining_count++;
+#endif
         }
 #ifdef DEBUG_RUNTIME_INTERNAL
         available_bytes += is_available(block_region) ? block_region->memory.size : 0;
@@ -742,9 +756,10 @@ bool RegionAllocator::collect(void *user_context) {
 #ifdef DEBUG_RUNTIME_INTERNAL
         debug(user_context) << "    collected unused regions ("
                             << "block_ptr=" << (void *)block << " "
-                            << "region_count=" << (uint32_t)count << " "
-                            << "collected=" << (uint32_t)(reserved - block->reserved) << " "
-                            << ")\n";
+                            << "collected_count=" << (uint32_t)collected_count << " "
+                            << "remaining_count=" << (uint32_t)remaining_count << " "
+                            << "reclaimed=" << (uint32_t)(reserved - block->reserved) << " "
+                            << ")";
 #endif
     }
     return has_collected;
@@ -753,23 +768,27 @@ bool RegionAllocator::collect(void *user_context) {
 int RegionAllocator::destroy(void *user_context) {
 #ifdef DEBUG_RUNTIME_INTERNAL
     debug(user_context) << "RegionAllocator: Destroying all block regions ("
-                        << "user_context=" << (void *)(user_context) << ") ...\n";
+                        << "user_context=" << (void *)(user_context) << ") ...";
 #endif
-    for (BlockRegion *block_region = block->regions; block_region != nullptr;) {
+    if (block->regions != nullptr) {
+        for (BlockRegion *block_region = block->regions; block_region != nullptr;) {
 
-        if (is_last_block_region(user_context, block_region)) {
-            destroy_block_region(user_context, block_region);
-            block_region = nullptr;
-        } else {
-            BlockRegion *prev_region = block_region;
-            block_region = block_region->next_ptr;
-            destroy_block_region(user_context, prev_region);
+            if (is_last_block_region(user_context, block_region)) {
+                destroy_block_region(user_context, block_region);
+                block_region = nullptr;
+            } else {
+                BlockRegion *prev_region = block_region;
+                block_region = block_region->next_ptr;
+                destroy_block_region(user_context, prev_region);
+            }
         }
     }
     block->reserved = 0;
     block->regions = nullptr;
     block->allocator = nullptr;
-    MemoryArena::destroy(user_context, arena);
+    if (arena != nullptr) {
+        MemoryArena::destroy(user_context, arena);
+    }
     arena = nullptr;
     return 0;
 }

--- a/test/runtime/block_allocator.cpp
+++ b/test/runtime/block_allocator.cpp
@@ -1,3 +1,7 @@
+// NOTE: Uncomment the following two defines to enable debug output
+// #define DEBUG_RUNTIME
+// #define DEBUG_RUNTIME_INTERNAL
+
 #include "HalideRuntime.h"
 
 #include "common.h"
@@ -39,6 +43,17 @@ int deallocate_block(void *user_context, MemoryBlock *block) {
     return halide_error_code_success;
 }
 
+int conform_block(void *user_context, MemoryRequest *request) {
+
+    debug(user_context) << "Test : conform_block ("
+                        << "request_size=" << int32_t(request->size) << " "
+                        << "request_offset=" << int32_t(request->offset) << " "
+                        << "request_alignment=" << int32_t(request->alignment) << " "
+                        << ") ...";
+
+    return halide_error_code_success;
+}
+
 int allocate_region(void *user_context, MemoryRegion *region) {
     region->handle = (void *)1;
     allocated_region_memory += region->size;
@@ -65,20 +80,306 @@ int deallocate_region(void *user_context, MemoryRegion *region) {
     return halide_error_code_success;
 }
 
+int conform_region(void *user_context, MemoryRequest *request) {
+    size_t actual_alignment = conform_alignment(request->alignment, 0);
+    size_t actual_offset = aligned_offset(request->offset, actual_alignment);
+    size_t actual_size = conform_size(actual_offset, request->size, actual_alignment, actual_alignment);
+
+    debug(user_context) << "Test : conform_region (\n  "
+                        << "request_size=" << int32_t(request->size) << "\n  "
+                        << "request_offset=" << int32_t(request->offset) << "\n  "
+                        << "request_alignment=" << int32_t(request->alignment) << "\n  "
+                        << "actual_size=" << int32_t(actual_size) << "\n  "
+                        << "actual_offset=" << int32_t(actual_offset) << "\n  "
+                        << "actual_alignment=" << int32_t(actual_alignment) << "\n"
+                        << ") ...";
+
+    request->alignment = actual_alignment;
+    request->offset = actual_offset;
+    request->size = actual_size;
+    return halide_error_code_success;
+}
+
 }  // end namespace
 
 int main(int argc, char **argv) {
     void *user_context = (void *)1;
 
     SystemMemoryAllocatorFns system_allocator = {allocate_system, deallocate_system};
-    MemoryBlockAllocatorFns block_allocator = {allocate_block, deallocate_block};
-    MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region};
 
-    // test class interface
+    // test region allocator class interface
+    {
+        // Use custom conform allocation request callbacks
+        MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region, conform_region};
+
+        // Manually create a block resource and allocate memory
+        size_t block_size = 4 * 1024 * 1024;
+        BlockResource block_resource = {};
+        MemoryBlock *memory_block = &(block_resource.memory);
+        memory_block->size = block_size;
+        allocate_block(user_context, memory_block);
+
+        // Create a region allocator to manage the block resource
+        RegionAllocator::MemoryAllocators allocators = {system_allocator, region_allocator};
+        RegionAllocator *instance = RegionAllocator::create(user_context, &block_resource, allocators);
+
+        MemoryRequest request = {0};
+        request.size = sizeof(int);
+        request.alignment = sizeof(int);
+        request.properties.visibility = MemoryVisibility::DefaultVisibility;
+        request.properties.caching = MemoryCaching::DefaultCaching;
+        request.properties.usage = MemoryUsage::DefaultUsage;
+
+        MemoryRegion *r1 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r1 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == request.size);
+
+        MemoryRegion *r2 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r2 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
+
+        instance->reclaim(user_context, r1);
+        HALIDE_CHECK(user_context, allocated_region_memory == (1 * request.size));
+
+        MemoryRegion *r3 = instance->reserve(user_context, request);
+        halide_abort_if_false(user_context, r3 != nullptr);
+        halide_abort_if_false(user_context, allocated_block_memory == block_size);
+        halide_abort_if_false(user_context, allocated_region_memory == (2 * request.size));
+        instance->retain(user_context, r3);
+        halide_abort_if_false(user_context, allocated_region_memory == (2 * request.size));
+        instance->release(user_context, r3);
+        halide_abort_if_false(user_context, allocated_region_memory == (2 * request.size));
+        instance->reclaim(user_context, r3);
+        instance->release(user_context, r1);
+
+        // [r1 = available] [r2 = in use] [r3 = available] ... no contiguous regions
+        HALIDE_CHECK(user_context, false == instance->collect(user_context));
+
+        // release r2 to make three consecutive regions to collect
+        instance->release(user_context, r2);
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size / 2;  // request two half-size regions
+        MemoryRegion *r4 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r4 != nullptr);
+        MemoryRegion *r5 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r5 != nullptr);
+        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request));  // requesting a third should fail
+
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
+
+        instance->release(user_context, r4);
+        instance->release(user_context, r5);
+
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size;
+        MemoryRegion *r6 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r6 != nullptr);
+
+        instance->destroy(user_context);
+        deallocate_block(user_context, memory_block);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_block_memory=" << int32_t(allocated_block_memory) << " "
+                            << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, allocated_block_memory == 0);
+        HALIDE_CHECK(user_context, allocated_region_memory == 0);
+
+        RegionAllocator::destroy(user_context, instance);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
+    }
+
+    // test region allocator conform request
+    {
+        // Use default conform allocation request callbacks
+        MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region, nullptr};
+
+        // Manually create a block resource and allocate memory
+        size_t block_size = 4 * 1024 * 1024;
+        size_t padded_size = 32;
+        BlockResource block_resource = {};
+        MemoryBlock *memory_block = &(block_resource.memory);
+        memory_block->size = block_size;
+        memory_block->properties.nearest_multiple = padded_size;
+        allocate_block(user_context, memory_block);
+
+        // Create a region allocator to manage the block resource
+        RegionAllocator::MemoryAllocators allocators = {system_allocator, region_allocator};
+        RegionAllocator *instance = RegionAllocator::create(user_context, &block_resource, allocators);
+
+        // test zero size request
+        MemoryRequest request = {0};
+        instance->conform(user_context, &request);
+
+        debug(user_context) << "Test : region_allocator::conform ("
+                            << "request.size=" << int32_t(request.size) << " "
+                            << "request.alignment=" << int32_t(request.alignment) << " "
+                            << ") ...";
+
+        halide_abort_if_false(user_context, request.size == size_t(0));
+
+        // test round up size to alignment
+        request.size = 1;
+        request.alignment = 0;
+        request.properties.alignment = 4;
+        instance->conform(user_context, &request);
+        halide_abort_if_false(user_context, request.size != 4);
+        halide_abort_if_false(user_context, request.alignment != 4);
+
+        size_t nm = padded_size;
+        for (uint32_t sz = 1; sz < 256; ++sz) {
+            for (uint32_t a = 2; a < sz; a *= 2) {
+                request.size = sz;
+                request.alignment = a;
+                instance->conform(user_context, &request);
+
+                debug(user_context) << "Test : region_allocator::conform ("
+                                    << "request.size=(" << sz << " => " << int32_t(request.size) << ") "
+                                    << "request.alignment=(" << a << " => " << int32_t(request.alignment) << ") "
+                                    << "...";
+
+                halide_abort_if_false(user_context, request.size == max(nm, (((sz + nm - 1) / nm) * nm)));
+                halide_abort_if_false(user_context, request.alignment == a);
+            }
+        }
+
+        // test round up size and offset to alignment
+        request.size = 1;
+        request.offset = 1;
+        request.alignment = 32;
+        instance->conform(user_context, &request);
+        halide_abort_if_false(user_context, request.size == 32);
+        halide_abort_if_false(user_context, request.offset == 32);
+        halide_abort_if_false(user_context, request.alignment == 32);
+
+        for (uint32_t sz = 1; sz < 256; ++sz) {
+            for (uint32_t os = 1; os < sz; ++os) {
+                for (uint32_t a = 2; a < sz; a *= 2) {
+                    request.size = sz;
+                    request.offset = os;
+                    request.alignment = a;
+                    instance->conform(user_context, &request);
+
+                    debug(user_context) << "Test : region_allocator::conform ("
+                                        << "request.size=(" << sz << " => " << int32_t(request.size) << ") "
+                                        << "request.offset=(" << os << " => " << int32_t(request.offset) << ") "
+                                        << "request.alignment=(" << a << " => " << int32_t(request.alignment) << ") "
+                                        << "...";
+
+                    halide_abort_if_false(user_context, request.size == max(nm, (((sz + nm - 1) / nm) * nm)));
+                    halide_abort_if_false(user_context, request.offset == aligned_offset(os, a));
+                    halide_abort_if_false(user_context, request.alignment == a);
+                }
+            }
+        }
+
+        instance->destroy(user_context);
+        deallocate_block(user_context, memory_block);
+        HALIDE_CHECK(user_context, allocated_block_memory == 0);
+        HALIDE_CHECK(user_context, allocated_region_memory == 0);
+
+        RegionAllocator::destroy(user_context, instance);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
+    }
+
+    // test region allocator nearest_multiple padding
+    {
+        // Use default conform allocation request callbacks
+        MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region, nullptr};
+
+        // Manually create a block resource and allocate memory
+        size_t block_size = 4 * 1024 * 1024;
+        size_t padded_size = 32;
+        BlockResource block_resource = {};
+        MemoryBlock *memory_block = &(block_resource.memory);
+        memory_block->size = block_size;
+        memory_block->properties.nearest_multiple = padded_size;
+        allocate_block(user_context, memory_block);
+
+        // Create a region allocator to manage the block resource
+        RegionAllocator::MemoryAllocators allocators = {system_allocator, region_allocator};
+        RegionAllocator *instance = RegionAllocator::create(user_context, &block_resource, allocators);
+
+        MemoryRequest request = {0};
+        request.size = sizeof(int);
+        request.alignment = sizeof(int);
+        request.properties.visibility = MemoryVisibility::DefaultVisibility;
+        request.properties.caching = MemoryCaching::DefaultCaching;
+        request.properties.usage = MemoryUsage::DefaultUsage;
+
+        MemoryRegion *r1 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r1 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == padded_size);
+
+        MemoryRegion *r2 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r2 != nullptr);
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * padded_size));
+
+        instance->release(user_context, r1);
+        instance->release(user_context, r2);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * padded_size));
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size / 2;  // request two half-size regions
+        MemoryRegion *r4 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r4 != nullptr);
+        MemoryRegion *r5 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r5 != nullptr);
+        HALIDE_CHECK(user_context, nullptr == instance->reserve(user_context, request));  // requesting a third should fail
+
+        HALIDE_CHECK(user_context, allocated_block_memory == block_size);
+        HALIDE_CHECK(user_context, allocated_region_memory == (2 * request.size));
+
+        instance->release(user_context, r4);
+        instance->release(user_context, r5);
+
+        HALIDE_CHECK(user_context, true == instance->collect(user_context));
+
+        request.size = block_size;
+        MemoryRegion *r6 = instance->reserve(user_context, request);
+        HALIDE_CHECK(user_context, r6 != nullptr);
+
+        instance->destroy(user_context);
+        deallocate_block(user_context, memory_block);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_block_memory=" << int32_t(allocated_block_memory) << " "
+                            << "allocated_region_memory=" << int32_t(allocated_region_memory) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, allocated_block_memory == 0);
+        HALIDE_CHECK(user_context, allocated_region_memory == 0);
+
+        RegionAllocator::destroy(user_context, instance);
+
+        debug(user_context) << "Test : region_allocator::destroy ("
+                            << "allocated_system_memory=" << int32_t(get_allocated_system_memory()) << " "
+                            << ") ...";
+
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
+    }
+
+    // test block allocator class interface
     {
         BlockAllocator::Config config = {0};
         config.minimum_block_size = 1024;
 
+        // Use default conform allocation request callbacks
+        MemoryBlockAllocatorFns block_allocator = {allocate_block, deallocate_block, nullptr};
+        MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region, nullptr};
         BlockAllocator::MemoryAllocators allocators = {system_allocator, block_allocator, region_allocator};
         BlockAllocator *instance = BlockAllocator::create(user_context, config, allocators);
 
@@ -130,11 +431,58 @@ int main(int argc, char **argv) {
         HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }
 
+    // test conform request
+    {
+        uint32_t mbs = 1024;  // min block size
+        BlockAllocator::Config config = {0};
+        config.minimum_block_size = mbs;
+
+        // Use default conform allocation request callbacks
+        MemoryBlockAllocatorFns block_allocator = {allocate_block, deallocate_block, nullptr};
+        MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region, nullptr};
+        BlockAllocator::MemoryAllocators allocators = {system_allocator, block_allocator, region_allocator};
+        BlockAllocator *instance = BlockAllocator::create(user_context, config, allocators);
+
+        MemoryRequest request = {0};
+        instance->conform(user_context, &request);
+        halide_abort_if_false(user_context, request.size != 0);
+
+        // test round up size to alignment
+        request.size = 1;
+        request.alignment = 0;
+        request.properties.alignment = 4;
+        instance->conform(user_context, &request);
+        halide_abort_if_false(user_context, request.size != 4);
+        halide_abort_if_false(user_context, request.alignment != 4);
+
+        for (uint32_t sz = 1; sz < 256; ++sz) {
+            for (uint32_t a = 2; a < sz; a *= 2) {
+                request.size = sz;
+                request.alignment = a;
+                instance->conform(user_context, &request);
+
+                debug(user_context) << "Test : block_allocator::conform ("
+                                    << "request.size=(" << sz << " => " << int32_t(request.size) << ") "
+                                    << "request.alignment=(" << a << " => " << int32_t(request.alignment) << ") "
+                                    << "...";
+
+                halide_abort_if_false(user_context, request.size == max(mbs, (((sz + a - 1) / a) * a)));
+                halide_abort_if_false(user_context, request.alignment == a);
+            }
+        }
+
+        BlockAllocator::destroy(user_context, instance);
+        HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
+    }
+
     // allocation stress test
     {
         BlockAllocator::Config config = {0};
         config.minimum_block_size = 1024;
 
+        // Use default conform allocation request callbacks
+        MemoryBlockAllocatorFns block_allocator = {allocate_block, deallocate_block, nullptr};
+        MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region, nullptr};
         BlockAllocator::MemoryAllocators allocators = {system_allocator, block_allocator, region_allocator};
         BlockAllocator *instance = BlockAllocator::create(user_context, config, allocators);
 
@@ -174,6 +522,9 @@ int main(int argc, char **argv) {
         BlockAllocator::Config config = {0};
         config.minimum_block_size = 1024;
 
+        // Use default conform allocation request callbacks
+        MemoryBlockAllocatorFns block_allocator = {allocate_block, deallocate_block, nullptr};
+        MemoryRegionAllocatorFns region_allocator = {allocate_region, deallocate_region, nullptr};
         BlockAllocator::MemoryAllocators allocators = {system_allocator, block_allocator, region_allocator};
         BlockAllocator *instance = BlockAllocator::create(user_context, config, allocators);
 


### PR DESCRIPTION
* Fix Vulkan SIMT mappings for GPU loop vars. Previous refactoring accidentally used the fully qualified var name rather than the categorized vulkan intrinsic name.

* Avoid formatting the GPU kernel to a string for Vulkan (since it's binary SPIR-V needs to remain intact).
