### PR TITLE
[xtensa] Added a new optimize rule

### DIFF
--- a/src/CodeGen_Xtensa.cpp
+++ b/src/CodeGen_Xtensa.cpp
@@ -144,6 +144,8 @@ CodeGen_Xtensa::CodeGen_Xtensa(ostream &s, const Target &t, OutputKind k, const 
 
           {"halide_xtensa_sat_left_shift_i16", "IVP_SLSNX16"},
           {"halide_xtensa_sat_left_shift_i32", "IVP_SLSN_2X32"},
+
+          {"halide_xtensa_sat_right_shift_i32", "IVP_SRSN_2X32"},
       } {
 }
 

--- a/src/CodeGen_Xtensa.cpp
+++ b/src/CodeGen_Xtensa.cpp
@@ -145,6 +145,7 @@ CodeGen_Xtensa::CodeGen_Xtensa(ostream &s, const Target &t, OutputKind k, const 
           {"halide_xtensa_sat_left_shift_i16", "IVP_SLSNX16"},
           {"halide_xtensa_sat_left_shift_i32", "IVP_SLSN_2X32"},
 
+          // The shift should be in the range [-31, 31].
           {"halide_xtensa_sat_right_shift_i32", "IVP_SRSN_2X32"},
       } {
 }

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -1079,6 +1079,7 @@ private:
 
             {"halide_xtensa_sat_left_shift_i32", i32_sat(widening_shift_left(wild_i32x, wild_i32x))},
             {"halide_xtensa_sat_left_shift_i32", i32_sat(widening_shift_left(wild_i32x, wild_u32x))},
+            {"halide_xtensa_sat_right_shift_i32", i32_sat(widening_shift_right(wild_i32x, wild_i32x))},
             {"halide_xtensa_sat_right_shift_i32", i32_sat(widening_shift_right(wild_i32x, wild_u32x))},
 
             {"halide_xtensa_sat_narrow_shift_i32", i32_sat(wild_i64x >> bc(wild_i64))},

--- a/src/XtensaOptimize.cpp
+++ b/src/XtensaOptimize.cpp
@@ -809,14 +809,14 @@ private:
 
     Expr visit(const Min *op) override {
         if (op->type.is_vector()) {
-            static const std::vector<Pattern> maxes = {
+            static const std::vector<Pattern> mins = {
                 // NOTE(vksnk): patterns below are for predicated instructions and look like they may
                 // be more efficient, but they are not according to simulator. We will need to check with
                 // Cadence about this.
                 // {"halide_xtensa_pred_min_i16", max(wild_i16x, select(wild_u1x, wild_i16x, wild_i16x))}
             };
 
-            Expr new_expr = apply_commutative_patterns(op, maxes, this);
+            Expr new_expr = apply_commutative_patterns(op, mins, this);
             if (!new_expr.same_as(op)) {
                 return new_expr;
             }
@@ -1079,6 +1079,7 @@ private:
 
             {"halide_xtensa_sat_left_shift_i32", i32_sat(widening_shift_left(wild_i32x, wild_i32x))},
             {"halide_xtensa_sat_left_shift_i32", i32_sat(widening_shift_left(wild_i32x, wild_u32x))},
+            {"halide_xtensa_sat_right_shift_i32", i32_sat(widening_shift_right(wild_i32x, wild_u32x))},
 
             {"halide_xtensa_sat_narrow_shift_i32", i32_sat(wild_i64x >> bc(wild_i64))},
             {"halide_xtensa_sat_narrow_shift_i32", i32_sat(wild_i64x / bc(wild_i64)), Pattern::ExactLog2Op1},

--- a/test/correctness/simd_op_check_xtensa.cpp
+++ b/test/correctness/simd_op_check_xtensa.cpp
@@ -125,6 +125,8 @@ public:
         check("IVP_SLLINX16U", vector_width / 2, u16_1 * 4);
         check("IVP_SLLN_2X32U", vector_width / 4, u32_1 << min(max(i32_2, -31), 31));
         check("IVP_SLLIN_2X32U", vector_width / 4, u32_1 * 4);
+        check("IVP_SLSN_2X32", vector_width / 4, i32_sat(widening_shift_left(i32_1, u32_2)));
+        check("IVP_SRSN_2X32", vector_width / 4, i32_sat(widening_shift_right(i32_1, u32_2)));
 
         // Casts.
         // Note: we deliberately leave out the spaces here, to keep the symbols

--- a/test/correctness/simd_op_check_xtensa.cpp
+++ b/test/correctness/simd_op_check_xtensa.cpp
@@ -125,8 +125,8 @@ public:
         check("IVP_SLLINX16U", vector_width / 2, u16_1 * 4);
         check("IVP_SLLN_2X32U", vector_width / 4, u32_1 << min(max(i32_2, -31), 31));
         check("IVP_SLLIN_2X32U", vector_width / 4, u32_1 * 4);
-        check("IVP_SLSN_2X32", vector_width / 4, i32_sat(widening_shift_left(i32_1, u32_2)));
-        check("IVP_SRSN_2X32", vector_width / 4, i32_sat(widening_shift_right(i32_1, u32_2)));
+        check("IVP_SLSN_2X32", vector_width / 4, i32_sat(widening_shift_left(i32_1, min(max(i32_1, -31), 31))));
+        check("IVP_SRSN_2X32", vector_width / 4, i32_sat(widening_shift_right(i32_1, min(max(i32_1, -31), 31))));
 
         // Casts.
         // Note: we deliberately leave out the spaces here, to keep the symbols


### PR DESCRIPTION
This is to avoid int32->int64->int32 path for a saturated cast of widening shift right