### PR TITLE
Detect ARM CPU features for host target and in runtime

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -180,13 +180,17 @@ DECLARE_NO_INITMOD(metal_objc_x86)
 #endif  // WITH_METAL
 
 #ifdef WITH_ARM
+DECLARE_CPP_INITMOD(android_arm_cpu_features)
 DECLARE_LL_INITMOD(arm)
 DECLARE_LL_INITMOD(arm_no_neon)
 DECLARE_CPP_INITMOD(arm_cpu_features)
+DECLARE_CPP_INITMOD(osx_arm_cpu_features)
 #else
+DECLARE_CPP_INITMOD(android_arm_cpu_features)
 DECLARE_NO_INITMOD(arm)
 DECLARE_NO_INITMOD(arm_no_neon)
 DECLARE_NO_INITMOD(arm_cpu_features)
+DECLARE_NO_INITMOD(osx_arm_cpu_features)
 #endif  // WITH_ARM
 
 #ifdef WITH_AARCH64
@@ -1181,7 +1185,13 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 if (t.bits == 64) {
                     modules.push_back(get_initmod_aarch64_cpu_features(c, bits_64, debug));
                 } else {
-                    modules.push_back(get_initmod_arm_cpu_features(c, bits_64, debug));
+                    if (t.os == Target::Android) {
+                        modules.push_back(get_initmod_android_arm_cpu_features(c, bits_64, debug));
+                    } else if (t.os == Target::OSX || t.os == Target::IOS) {
+                        modules.push_back(get_initmod_osx_arm_cpu_features(c, bits_64, debug));
+                    } else {
+                        modules.push_back(get_initmod_arm_cpu_features(c, bits_64, debug));
+                    }
                 }
             }
             if (t.arch == Target::POWERPC) {

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -5,6 +5,7 @@ set(RUNTIME_CPP
     alignment_32
     alignment_64
     allocation_cache
+    android_arm_cpu_features
     android_clock
     android_host_cpu_count
     android_io
@@ -43,6 +44,7 @@ set(RUNTIME_CPP
     msan
     msan_stubs
     opencl
+    osx_arm_cpu_features
     osx_clock
     osx_get_symbol
     osx_host_cpu_count

--- a/src/runtime/android_arm_cpu_features.cpp
+++ b/src/runtime/android_arm_cpu_features.cpp
@@ -1,0 +1,2 @@
+#define ANDROID 1
+#include "arm_cpu_features.cpp"

--- a/src/runtime/arm_cpu_features.cpp
+++ b/src/runtime/arm_cpu_features.cpp
@@ -5,12 +5,41 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-WEAK CpuFeatures halide_get_cpu_features() {
-    CpuFeatures features;
-    // All ARM architectures support "No Neon".
-    features.set_known(halide_target_feature_no_neon);
-    features.set_available(halide_target_feature_no_neon);
+#if ANDROID
 
+extern unsigned long getauxval(unsigned long type);
+#define AT_HWCAP 16
+//#define AT_HWCAP2 26
+
+#define HWCAP_VFPv4 (1 << 16)
+#define HWCAP_ASIMDDP (1 << 20)
+
+static void set_platform_features(CpuFeatures &features) {
+    unsigned long hwcaps = getauxval(AT_HWCAP);
+
+    // runtime detection for ARMDotProd extension
+    if (hwcaps & HWCAP_ASIMDDP) {
+        features.set_available(halide_target_feature_arm_dot_prod);
+    }
+
+    // runtime detection for ARMFp16 extension
+    if (hwcaps & HWCAP_VFPv4) {
+        // VFPv4 is the only 32-bit arm-fp revision to support fp16
+        features.set_available(halide_target_feature_arm_fp16);
+    }
+}
+
+#elif OSX
+
+extern int sysctlbyname(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
+
+static bool sysctl_is_set(const char *name) {
+    int enabled = 0;
+    size_t enabled_len = sizeof(enabled);
+    return sysctlbyname(name, &enabled, &enabled_len, nullptr, 0) == 0 && enabled;
+}
+
+static void set_platform_features(CpuFeatures &features) {
     // TODO: add runtime detection for ARMv7s. AFAICT Apple doesn't
     // provide an Officially Approved Way to detect this at runtime.
     // Could probably use some variant of sysctl() to detect, but would
@@ -20,11 +49,40 @@ WEAK CpuFeatures halide_get_cpu_features() {
     //    features.set_available(halide_target_feature_armv7s);
     // }
 
+    // runtime detection for ARMDotProd extension
+    if (sysctl_is_set("hw.optional.arm.FEAT_DotProd")) {
+        features.set_available(halide_target_feature_arm_dot_prod);
+    }
+
+    // runtime detection for ARMFp16 extension
+    if (sysctl_is_set("hw.optional.arm.FEAT_FP16")) {
+        features.set_available(halide_target_feature_arm_fp16);
+    }
+}
+
+#else
+
+static void set_platform_features(CpuFeatures &) {
     // TODO: add runtime detection for ARMDotProd extension
     // https://github.com/halide/Halide/issues/4727
 
     // TODO: add runtime detection for ARMFp16 extension
     // https://github.com/halide/Halide/issues/6106
+}
+
+#endif
+
+WEAK CpuFeatures halide_get_cpu_features() {
+    CpuFeatures features;
+    // All ARM architectures support "No Neon".
+    features.set_known(halide_target_feature_no_neon);
+    features.set_available(halide_target_feature_no_neon);
+
+    features.set_known(halide_target_feature_arm_dot_prod);
+    features.set_known(halide_target_feature_arm_fp16);
+
+    set_platform_features(features);
+
     return features;
 }
 

--- a/src/runtime/arm_cpu_features.cpp
+++ b/src/runtime/arm_cpu_features.cpp
@@ -31,6 +31,14 @@ static void set_platform_features(CpuFeatures &features) {
 
 #elif OSX
 
+typedef int integer_t;
+
+typedef integer_t cpu_type_t;
+typedef integer_t cpu_subtype_t;
+
+#define CPU_TYPE_ARM ((cpu_type_t)12)
+#define CPU_SUBTYPE_ARM_V7S ((cpu_subtype_t)11) /* Swift */
+
 extern int sysctlbyname(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
 
 static bool sysctl_is_set(const char *name) {
@@ -39,15 +47,28 @@ static bool sysctl_is_set(const char *name) {
     return sysctlbyname(name, &enabled, &enabled_len, nullptr, 0) == 0 && enabled;
 }
 
+static bool is_armv7s() {
+    cpu_type_t type;
+    size_t type_len = sizeof(type);
+    if (sysctlbyname("hw.cputype", &type, &type_len, nullptr, 0)) {
+        return false;
+    }
+
+    cpu_subtype_t subtype;
+    size_t subtype_len = sizeof(subtype);
+    if (sysctlbyname("hw.cpusubtype", &subtype, &subtype_len, nullptr, 0)) {
+        return false;
+    }
+
+    return type == CPU_TYPE_ARM && subtype == CPU_SUBTYPE_ARM_V7S;
+}
+
 static void set_platform_features(CpuFeatures &features) {
-    // TODO: add runtime detection for ARMv7s. AFAICT Apple doesn't
-    // provide an Officially Approved Way to detect this at runtime.
-    // Could probably use some variant of sysctl() to detect, but would
-    // need some experimentation and testing to get right.
-    // features.set_known(halide_target_feature_armv7s);
-    // if () {
-    //    features.set_available(halide_target_feature_armv7s);
-    // }
+    // runtime detection for ARMv7s
+    features.set_known(halide_target_feature_armv7s);
+    if (is_armv7s()) {
+        features.set_available(halide_target_feature_armv7s);
+    }
 
     // runtime detection for ARMDotProd extension
     if (sysctl_is_set("hw.optional.arm.FEAT_DotProd")) {

--- a/src/runtime/osx_arm_cpu_features.cpp
+++ b/src/runtime/osx_arm_cpu_features.cpp
@@ -1,0 +1,2 @@
+#define OSX 1
+#include "arm_cpu_features.cpp"


### PR DESCRIPTION
Adds feature detection to the runtime library and to the `host` target feature computation.

Not sure what the best way is to share code here. Not sure how best to test on Android, either.
  
Fixes #4727
Fixes #6106
Fixes #7901
Fixes #7979