### PR TITLE
scoped_truth for the loop variable being always less than the loop extent.

### DIFF
--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -247,6 +247,8 @@ Stmt Simplify::visit(const For *op) {
         Expr new_max = mutate(new_min + new_extent, nullptr);
         ScopedFact fact_loop_var_less_than_extent = scoped_truth(loop_var < new_max);
 
+        ScopedFact fact_loop_var_ge_than_min = scoped_truth(new_min <= loop_var);
+
         new_body = mutate(op->body);
     }
 

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -240,7 +240,12 @@ Stmt Simplify::visit(const For *op) {
                                         loop_var_info);
 
         // If we're in the loop, the extent must be greater than 0.
-        ScopedFact fact = scoped_truth(extent_positive);
+        ScopedFact fact_extent_positive = scoped_truth(extent_positive);
+
+        // The loop variable will never exceed the loop bound.
+        Expr loop_var = Variable::make(Int(32), op->name);
+        ScopedFact fact_loop_var_less_than_extent = scoped_truth(loop_var < new_extent);
+
         new_body = mutate(op->body);
     }
 

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -244,7 +244,8 @@ Stmt Simplify::visit(const For *op) {
 
         // The loop variable will never exceed the loop bound.
         Expr loop_var = Variable::make(Int(32), op->name);
-        ScopedFact fact_loop_var_less_than_extent = scoped_truth(loop_var < new_extent);
+        Expr new_max = mutate(new_min + new_extent, nullptr);
+        ScopedFact fact_loop_var_less_than_extent = scoped_truth(loop_var < new_max);
 
         new_body = mutate(op->body);
     }


### PR DESCRIPTION
Fixes #8303 