### PR TITLE
Drop support for LLVM 16 in main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,7 @@ LLVM_CXX_FLAGS += -DLLVM_VERSION=$(LLVM_VERSION_TIMES_10)
 WITH_X86 ?= $(findstring x86, $(LLVM_COMPONENTS))
 WITH_ARM ?= $(findstring arm, $(LLVM_COMPONENTS))
 WITH_HEXAGON ?= $(findstring hexagon, $(LLVM_COMPONENTS))
-ifeq ($(shell test $(LLVM_VERSION_TIMES_10) -ge 170; echo $$?),0)
 WITH_RISCV ?= $(findstring riscv, $(LLVM_COMPONENTS))
-else
-# leave WITH_RISCV undefined
-endif
 WITH_AARCH64 ?= $(findstring aarch64, $(LLVM_COMPONENTS))
 WITH_POWERPC ?= $(findstring powerpc, $(LLVM_COMPONENTS))
 WITH_NVPTX ?= $(findstring nvptx, $(LLVM_COMPONENTS))

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1491,15 +1491,10 @@ void CodeGen_ARM::visit(const Store *op) {
         std::ostringstream instr;
         vector<llvm::Type *> arg_types;
         llvm::Type *intrin_llvm_type = llvm_type_with_constraint(intrin_type, false, is_sve ? VectorTypeConstraint::VScale : VectorTypeConstraint::Fixed);
-#if LLVM_VERSION >= 170
-        const bool is_opaque = true;
-#else
-        const bool is_opaque = llvm::PointerType::get(intrin_llvm_type, 0)->isOpaque();
-#endif
         if (target.bits == 32) {
             instr << "llvm.arm.neon.vst"
                   << num_vecs
-                  << (is_opaque ? ".p0" : ".p0i8")
+                  << ".p0"
                   << ".v"
                   << intrin_type.lanes()
                   << (t.is_float() ? 'f' : 'i')
@@ -1526,9 +1521,6 @@ void CodeGen_ARM::visit(const Store *op) {
                       << (t.is_float() ? 'f' : 'i')
                       << t.bits()
                       << ".p0";
-                if (!is_opaque) {
-                    instr << (t.is_float() ? 'f' : 'i') << t.bits();
-                }
                 arg_types = vector<llvm::Type *>(num_vecs + 1, intrin_llvm_type);
                 arg_types.back() = llvm_type_of(intrin_type.element_of())->getPointerTo();
             }

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -143,9 +143,6 @@ CodeGen_RISCV::CodeGen_RISCV(const Target &t)
     user_assert(native_vector_bits() > 0) << "No vector_bits was specified for RISCV codegen; "
                                           << "this is almost certainly a mistake. You should add -rvv-vector_bits_N "
                                           << "to your Target string, where N is the SIMD width in bits (e.g. 128).";
-#if LLVM_VERSION < 170
-    user_warning << "RISCV codegen is only tested with LLVM 17.0 or later; it is unlikely to work well with earlier versions of LLVM.\n";
-#endif
 }
 
 string CodeGen_RISCV::mcpu_target() const {
@@ -349,11 +346,9 @@ bool CodeGen_RISCV::call_riscv_vector_intrinsic(const RISCVIntrinsic &intrin, co
         left_arg->getType(),
         right_arg->getType(),
     };
-#if LLVM_VERSION >= 170
     if (round_any) {
         llvm_arg_types.push_back(xlen_type);
     }
-#endif
     if (intrin.flags & AddVLArg) {
         llvm_arg_types.push_back(xlen_type);
     }

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -361,7 +361,6 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
         for (auto const &iter : module.exports()) {
             orc::SymbolStringPtr name = symbolStringPool->intern(iter.first);
             orc::SymbolStringPtr _name = symbolStringPool->intern("_" + iter.first);
-#if LLVM_VERSION >= 170
             auto symbol = llvm::orc::ExecutorAddr::fromPtr(iter.second.address);
             if (!newSymbols.count(name)) {
                 newSymbols.insert({name, {symbol, JITSymbolFlags::Exported}});
@@ -369,15 +368,6 @@ void JITModule::compile_module(std::unique_ptr<llvm::Module> m, const string &fu
             if (!newSymbols.count(_name)) {
                 newSymbols.insert({_name, {symbol, JITSymbolFlags::Exported}});
             }
-#else
-            auto symbol = llvm::JITEvaluatedSymbol::fromPointer(iter.second.address);
-            if (!newSymbols.count(name)) {
-                newSymbols.insert({name, symbol});
-            }
-            if (!newSymbols.count(_name)) {
-                newSymbols.insert({_name, symbol});
-            }
-#endif
         }
     }
     err = JIT->getMainJITDylib().define(orc::absoluteSymbols(std::move(newSymbols)));

--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -1,10 +1,10 @@
 #ifndef HALIDE_LLVM_HEADERS_H
 #define HALIDE_LLVM_HEADERS_H
 
-#if LLVM_VERSION >= 160
+#if LLVM_VERSION >= 170
 // We're good to go
 #else
-#error "Compiling Halide requires LLVM 16.0 or newer"
+#error "Compiling Halide requires LLVM 17.0 or newer"
 #endif
 
 // No msvc warnings from llvm headers please
@@ -22,18 +22,13 @@
 
 #if WITH_WABT || WITH_V8
 #include <lld/Common/Driver.h>
-#if LLVM_VERSION >= 170
 #include <lld/Common/ErrorHandler.h>
-#endif
 #endif
 #include <llvm/ADT/APFloat.h>
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringMap.h>
 #include <llvm/ADT/StringRef.h>
-#if LLVM_VERSION < 170
-#include <llvm/ADT/Triple.h>
-#endif
 #include <llvm/ADT/Twine.h>
 #include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
@@ -86,15 +81,10 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
-#if LLVM_VERSION >= 170
 #include <llvm/TargetParser/Triple.h>
-#endif
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/IPO/Inliner.h>
-#if LLVM_VERSION < 170
-#include <llvm/Transforms/IPO/PassManagerBuilder.h>
-#endif
 #include <llvm/Transforms/Instrumentation.h>
 #include <llvm/Transforms/Instrumentation/AddressSanitizer.h>
 #include <llvm/Transforms/Instrumentation/SanitizerCoverage.h>

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -384,25 +384,6 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
     // Make sure things marked as always-inline get inlined
     pass_manager.add(llvm::createAlwaysInlinerLegacyPass());
 
-#if LLVM_VERSION < 170
-    // Remove any stale debug info
-    //
-    // Note: this pass was added in https://github.com/halide/Halide/pull/2060;
-    // based on the comments, it looks like it was an attempt to fix an error,
-    // but didn't actually fix it, and (apparently) just got left in?
-    //
-    // There is a 'new' equivalent that we could add in the optimization pass
-    // in Codegen_LLVM.cpp, but since this seems to be have added in error,
-    // we're just going to elide it for LLVM >= 17.0
-    pass_manager.add(llvm::createStripDeadDebugInfoPass());
-
-    // Enable symbol rewriting. This allows code outside libHalide to
-    // use symbol rewriting when compiling Halide code (for example, by
-    // using cl::ParseCommandLineOption and then passing the appropriate
-    // rewrite options via -mllvm flags).
-    pass_manager.add(llvm::createRewriteSymbolsPass());
-#endif
-
     if (target_machine->isPositionIndependent()) {
         Internal::debug(1) << "Target machine is Position Independent!\n";
     }

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -410,17 +410,9 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
         }
     } else if (target.arch == Target::POWERPC) {
         if (target.bits == 32) {
-#if LLVM_VERSION >= 170
             return llvm::DataLayout("E-m:e-p:32:32-Fn32-i64:64-n32");
-#else
-            return llvm::DataLayout("E-m:e-p:32:32-i64:64-n32");
-#endif
         } else {
-#if LLVM_VERSION >= 170
             return llvm::DataLayout("e-m:e-Fn32-i64:64-n32:64-S128-v256:256:256-v512:512:512");
-#else
-            return llvm::DataLayout("e-m:e-i64:64-n32:64-S128-v256:256:256-v512:512:512");
-#endif
         }
     } else if (target.arch == Target::Hexagon) {
         return llvm::DataLayout(

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -46,9 +46,7 @@
 // clang-format on
 
 #if WITH_WABT || WITH_V8
-#if LLVM_VERSION >= 170
 LLD_HAS_DRIVER(wasm)
-#endif
 #endif
 
 namespace Halide {
@@ -336,10 +334,7 @@ std::vector<char> compile_to_wasm(const Module &module, const std::string &fn_na
 
     std::string lld_arg_strs[] = {
         "HalideJITLinker",
-#if LLVM_VERSION >= 170
-        "-flavor",
-        "wasm",
-#endif
+        "-flavor", "wasm",
         // For debugging purposes:
         // "--verbose",
         // "-error-limit=0",
@@ -359,7 +354,6 @@ std::vector<char> compile_to_wasm(const Module &module, const std::string &fn_na
         lld_args[i] = lld_arg_strs[i].c_str();
     }
 
-#if LLVM_VERSION >= 170
     // lld will temporarily hijack the signal handlers to ensure that temp files get cleaned up,
     // but rather than preserving custom handlers in place, it restores the default handlers.
     // This conflicts with some of our testing infrastructure, which relies on a SIGABRT handler
@@ -383,21 +377,6 @@ std::vector<char> compile_to_wasm(const Module &module, const std::string &fn_na
     }
 
     std::signal(SIGABRT, old_abort_handler);
-#else
-    // lld will temporarily hijack the signal handlers to ensure that temp files get cleaned up,
-    // but rather than preserving custom handlers in place, it restores the default handlers.
-    // This conflicts with some of our testing infrastructure, which relies on a SIGABRT handler
-    // set at global-ctor time to stay set. Therefore we'll save and restore this ourselves.
-    // Note that we must restore it before using internal_error (and also on the non-error path).
-    auto old_abort_handler = std::signal(SIGABRT, SIG_DFL);
-
-    if (!lld::wasm::link(lld_args, llvm::outs(), llvm::errs(), /*canExitEarly*/ false, /*disableOutput*/ false)) {
-        std::signal(SIGABRT, old_abort_handler);
-        internal_error << "lld::wasm::link failed\n";
-    }
-
-    std::signal(SIGABRT, old_abort_handler);
-#endif
 
 #if WASM_DEBUG_LEVEL
     wasm_output.detach();

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -345,8 +345,7 @@ std::vector<char> compile_to_wasm(const Module &module, const std::string &fn_na
         obj_file.pathname(),
         "--entry=" + fn_name,
         "-o",
-        wasm_output.pathname()
-    };
+        wasm_output.pathname()};
 
     constexpr int c = sizeof(lld_arg_strs) / sizeof(lld_arg_strs[0]);
     const char *lld_args[c];

--- a/test/correctness/simd_op_check_riscv.cpp
+++ b/test/correctness/simd_op_check_riscv.cpp
@@ -135,10 +135,6 @@ private:
 }  // namespace
 
 int main(int argc, char **argv) {
-    if (Halide::Internal::get_llvm_version() < 160) {
-        std::cout << "[SKIP] simd_op_check_riscv requires LLVM 16 or later.\n";
-        return 0;
-    }
     return SimdOpCheckTest::main<SimdOpCheckRISCV>(
         argc, argv,
         {

--- a/test/correctness/simd_op_check_sve2.cpp
+++ b/test/correctness/simd_op_check_sve2.cpp
@@ -298,7 +298,7 @@ private:
                 add_8_16_32_widen(sel_op("vmovl.u", "ushll"), widen_i(u_1));
 
                 // VMOVN    I       -       Move and Narrow
-                if (Halide::Internal::get_llvm_version() >= 140 && total_bits >= 128) {
+                if (total_bits >= 128) {
                     if (is_arm32()) {
                         add_16_32_64_narrow("vmovn.i", narrow_i(i_1));
                         add_16_32_64_narrow("vmovn.i", narrow_u(u_1));
@@ -460,12 +460,10 @@ private:
                 add_8_16_32(sel_op("vrshr.u", "urshr", "urshl"), cast_u((widen_u(u_1) + 1) >> 1));
 
                 // VRSHRN   I       -       Rounding Shift Right Narrow
-                if (Halide::Internal::get_llvm_version() >= 140) {
-                    // LLVM14 converts RSHRN/RSHRN2 to RADDHN/RADDHN2 when the shift amount is half the width of the vector element
-                    // See https://reviews.llvm.org/D116166
-                    add_16_32_narrow(sel_op("vrshrn.i", "raddhn"), narrow_i((widen_i(i_1) + (cast_i(1) << (bits / 2 - 1))) >> (bits / 2)));
-                    add_16_32_narrow(sel_op("vrshrn.i", "raddhn"), narrow_u((widen_u(u_1) + (cast_u(1) << (bits / 2 - 1))) >> (bits / 2)));
-                }
+                // LLVM14 converts RSHRN/RSHRN2 to RADDHN/RADDHN2 when the shift amount is half the width of the vector element
+                // See https://reviews.llvm.org/D116166
+                add_16_32_narrow(sel_op("vrshrn.i", "raddhn"), narrow_i((widen_i(i_1) + (cast_i(1) << (bits / 2 - 1))) >> (bits / 2)));
+                add_16_32_narrow(sel_op("vrshrn.i", "raddhn"), narrow_u((widen_u(u_1) + (cast_u(1) << (bits / 2 - 1))) >> (bits / 2)));
                 add_16_32_64_narrow(sel_op("vrshrn.i", "rshrn"), narrow_i((widen_i(i_1) + (1 << (bits / 4))) >> (bits / 4 + 1)));
                 add_16_32_narrow(sel_op("vrshrn.i", "rshrn"), narrow_u((widen_u(u_1) + (1 << (bits / 4))) >> (bits / 4 + 1)));
 


### PR DESCRIPTION
Per policy, Halide 19 will support LLVM 17, 18, 19 (plus top-of-tree which is 20)