### PR TITLE
Remove warning for unsupported compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,9 +152,6 @@ function(set_halide_compiler_warnings NAME)
         $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unused-member-function>
         $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unused-template>
 
-        # This warning was removed in Clang 13
-        $<$<AND:$<CXX_COMPILER_ID:Clang,AppleClang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,13.0>>:-Wno-return-std-move-in-c++11>
-
         $<$<CXX_COMPILER_ID:MSVC>:/W3>
         $<$<CXX_COMPILER_ID:MSVC>:/wd4018>  # 4018: disable "signed/unsigned mismatch"
         $<$<CXX_COMPILER_ID:MSVC>:/wd4141>  # 4141: 'inline' used more than once


### PR DESCRIPTION
We haven't supported building with Clang 12 or below in a _long_ time. No need to keep this in our build.