### PR TITLE
Bump CMake minimum version to 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.23)
+cmake_minimum_required(VERSION 3.28)
 project(Halide
         VERSION 19.0.0
         DESCRIPTION "Halide compiler and libraries"

--- a/README_cmake.md
+++ b/README_cmake.md
@@ -558,7 +558,7 @@ No matter how you intend to use Halide, you will need some basic CMake
 boilerplate.
 
 ```cmake
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(HalideExample)
 
 set(CMAKE_CXX_STANDARD 17)  # or newer

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Test apps from the perspective of a consuming project.
 ##
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(Halide_apps)
 
 enable_testing()

--- a/apps/HelloBaremetal/CMakeLists.txt
+++ b/apps/HelloBaremetal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 project(HelloBaremetal)
 

--- a/apps/HelloBaremetal/cmake-external_project/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-external_project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 # Enable assembly language (.s) support additionally
 project(HelloBaremetal LANGUAGES C CXX ASM)

--- a/apps/HelloBaremetal/cmake-external_project/generator/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-external_project/generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 project(HelloBaremetal-gen)
 

--- a/apps/HelloBaremetal/cmake-super_build/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-super_build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 project(HelloBaremetal-Super)
 

--- a/apps/HelloBaremetal/cmake-super_build/app/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-super_build/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 # Enable assembly language (.s) support additionally
 project(HelloBaremetal-app LANGUAGES C CXX ASM)

--- a/apps/HelloBaremetal/cmake-super_build/generator/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-super_build/generator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 project(HelloBaremetal-gen)
 

--- a/apps/HelloBaremetal/cmake-twice/CMakeLists.txt
+++ b/apps/HelloBaremetal/cmake-twice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 # Enable assembly language (.s) support additionally
 project(HelloBaremetal LANGUAGES C CXX ASM)

--- a/apps/HelloWasm/CMakeLists.txt
+++ b/apps/HelloWasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(HelloWasm)
 
 enable_testing()

--- a/apps/bgu/CMakeLists.txt
+++ b/apps/bgu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(bgu)
 
 enable_testing()

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(bilateral_grid)
 
 enable_testing()

--- a/apps/blur/CMakeLists.txt
+++ b/apps/blur/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(blur)
 
 enable_testing()

--- a/apps/c_backend/CMakeLists.txt
+++ b/apps/c_backend/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(c_backend)
 
 enable_testing()

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(camera_pipe)
 
 enable_testing()

--- a/apps/compositing/CMakeLists.txt
+++ b/apps/compositing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(compositing)
 
 enable_testing()

--- a/apps/conv_layer/CMakeLists.txt
+++ b/apps/conv_layer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(conv_layer)
 
 enable_testing()

--- a/apps/cuda_mat_mul/CMakeLists.txt
+++ b/apps/cuda_mat_mul/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(cuda_mat_mul)
 
 # This just checks whether CUDA is available ahead of time to allow

--- a/apps/depthwise_separable_conv/CMakeLists.txt
+++ b/apps/depthwise_separable_conv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(depthwise_separable_conv)
 
 enable_testing()

--- a/apps/fft/CMakeLists.txt
+++ b/apps/fft/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(fft)
 
 enable_testing()

--- a/apps/hannk/CMakeLists.txt
+++ b/apps/hannk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(hannk)
 
 # We need to set this for some of the subprojects pulled in by TFLite (eg flatbuffers)

--- a/apps/hannk/cmake/superbuild/CMakeLists.txt
+++ b/apps/hannk/cmake/superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.23)
+cmake_minimum_required(VERSION 3.28)
 project(hannk_superbuild LANGUAGES NONE)
 
 ##

--- a/apps/harris/CMakeLists.txt
+++ b/apps/harris/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(harris)
 
 enable_testing()

--- a/apps/hexagon_benchmarks/CMakeLists.txt
+++ b/apps/hexagon_benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(hexagon_benchmarks)
 
 enable_testing()

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(hist)
 
 enable_testing()

--- a/apps/iir_blur/CMakeLists.txt
+++ b/apps/iir_blur/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(iir_blur)
 
 enable_testing()

--- a/apps/interpolate/CMakeLists.txt
+++ b/apps/interpolate/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(interpolate)
 
 enable_testing()

--- a/apps/lens_blur/CMakeLists.txt
+++ b/apps/lens_blur/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(lens_blur)
 
 enable_testing()

--- a/apps/linear_algebra/CMakeLists.txt
+++ b/apps/linear_algebra/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(linear_algebra)
 
 enable_testing()

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(local_laplacian)
 
 enable_testing()

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(max_filter)
 
 enable_testing()

--- a/apps/nl_means/CMakeLists.txt
+++ b/apps/nl_means/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(nl_means)
 
 enable_testing()

--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(resize)
 
 enable_testing()

--- a/apps/stencil_chain/CMakeLists.txt
+++ b/apps/stencil_chain/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(stencil_chain)
 
 enable_testing()

--- a/apps/unsharp/CMakeLists.txt
+++ b/apps/unsharp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(unsharp)
 
 enable_testing()

--- a/apps/wavelet/CMakeLists.txt
+++ b/apps/wavelet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(wavelet)
 
 enable_testing()

--- a/cmake/BundleStatic.cmake
+++ b/cmake/BundleStatic.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 ##
 # This module provides a utility for bundling a set of IMPORTED

--- a/cmake/FindHalide_WebGPU.cmake
+++ b/cmake/FindHalide_WebGPU.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 # tip: uncomment this line to get better debugging information if find_library() fails
 # set(CMAKE_FIND_DEBUG_MODE TRUE)

--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 option(Halide_NO_DEFAULT_FLAGS "When enabled, suppresses recommended flags in add_halide_generator" OFF)
 

--- a/cmake/HalideTargetHelpers.cmake
+++ b/cmake/HalideTargetHelpers.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 ##
 # Utilities for manipulating Halide target triples

--- a/cmake/TargetExportScript.cmake
+++ b/cmake/TargetExportScript.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 include(CheckLinkerFlag)
 

--- a/packaging/common/HalideConfig.cmake
+++ b/packaging/common/HalideConfig.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 macro(Halide_fail message)
     set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "${message}")

--- a/packaging/common/HalideHelpersConfig.cmake
+++ b/packaging/common/HalideHelpersConfig.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 set(Halide_HOST_TARGET @Halide_HOST_TARGET@)
 

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.23)
+cmake_minimum_required(VERSION 3.28)
 project(Halide_Python)
 
 include(CMakeDependentOption)

--- a/src/runtime/hexagon_remote/android/CMakeLists.txt
+++ b/src/runtime/hexagon_remote/android/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(halide-hexagon_remote-android)
 
 set(_aarch64 "")

--- a/src/runtime/hexagon_remote/qurt/CMakeLists.txt
+++ b/src/runtime/hexagon_remote/qurt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 
 # The Hexagon toolchain is broken
 set(ENV{HEXAGON_SDK_ROOT} "${HEXAGON_SDK_ROOT}")

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(integration_tests NONE)
 
 enable_testing()

--- a/test/integration/aot/CMakeLists.txt
+++ b/test/integration/aot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(aot)
 
 enable_testing()

--- a/test/integration/jit/CMakeLists.txt
+++ b/test/integration/jit/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(jit)
 
 enable_testing()

--- a/test/integration/xc/CMakeLists.txt
+++ b/test/integration/xc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28)
 project(xc)
 
 enable_testing()


### PR DESCRIPTION
This is in line with our policy to track the version included in the latest Ubuntu LTS. Version 24.04 LTS now includes CMake 3.28.

Merge after #8362 