### PR TITLE
Quick CMake fixes enabled by 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,17 @@ project(Halide
 enable_testing()
 
 ##
+# Disable find_package(Halide) inside the build
+##
+
+file(CONFIGURE OUTPUT "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/HalideConfig.cmake"
+     CONTENT [[set(Halide_FOUND 1)
+               set(Halide_VERSION @Halide_VERSION@)]])
+
+file(CONFIGURE OUTPUT "${CMAKE_FIND_PACKAGE_REDIRECTS_DIR}/HalideHelpersConfig.cmake"
+     CONTENT "set(HalideHelpers_FOUND 1)\n")
+
+##
 # Set up project-wide properties
 ##
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard to use. Halide requires
 option(CMAKE_CXX_STANDARD_REQUIRED "When enabled, the value of CMAKE_CXX_STANDARD is a requirement." ON)
 option(CMAKE_CXX_EXTENSIONS "When enabled, compiler-specific language extensions are enabled (e.g. -std=gnu++17)" OFF)
 
-if(CMAKE_CXX_STANDARD LESS 17)
+if (CMAKE_CXX_STANDARD LESS 17)
     message(FATAL_ERROR "Halide requires C++17 or newer but CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
-endif()
+endif ()
 
 # Build Halide with ccache if the package is present
 option(Halide_CCACHE_BUILD "Set to ON for a ccache enabled build" OFF)
@@ -79,12 +79,12 @@ if (Halide_CCACHE_BUILD)
 
     # Per https://ccache.dev/manual/latest.html#_precompiled_headers,
     # we must set -fno-pch-timestamp when using Clang + CCache + PCH
-    if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    if (CMAKE_C_COMPILER_ID MATCHES "Clang")
         string(APPEND CMAKE_C_FLAGS " -Xclang -fno-pch-timestamp")
-    endif()
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    endif ()
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         string(APPEND CMAKE_CXX_FLAGS " -Xclang -fno-pch-timestamp")
-    endif()
+    endif ()
 
     message(STATUS "Enabling ccache usage for building.")
 endif ()

--- a/apps/cuda_mat_mul/CMakeLists.txt
+++ b/apps/cuda_mat_mul/CMakeLists.txt
@@ -3,13 +3,13 @@ project(cuda_mat_mul)
 
 # This just checks whether CUDA is available ahead of time to allow
 # skipping this app when CUDA/cuBLAS are not installed on the system.
-find_package(CUDA)
-if (NOT CUDA_FOUND)
+find_package(CUDAToolkit)
+if (NOT CUDAToolkit_FOUND)
     message(WARNING "Could NOT find CUDA")
     return()
 endif ()
 
-if (NOT CUDA_CUBLAS_LIBRARIES)
+if (NOT TARGET CUDA::cublas)
     message(WARNING "Could NOT find cuBLAS")
     return()
 endif ()
@@ -35,8 +35,7 @@ add_halide_library(mat_mul FROM mat_mul.generator
 
 # Main executable
 add_executable(runner runner.cpp)
-target_include_directories(runner PRIVATE ${CUDA_INCLUDE_DIRS})
-target_link_libraries(runner PRIVATE Halide::Tools mat_mul ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})
+target_link_libraries(runner PRIVATE mat_mul Halide::Tools CUDA::cudart CUDA::cublas)
 
 # Test that the app actually works!
 add_test(NAME mat_mul COMMAND runner)

--- a/cmake/FindHalide.cmake
+++ b/cmake/FindHalide.cmake
@@ -1,6 +1,0 @@
-# This file should NOT be installed.
-# It is used by python_bindings (and future externalizable projects) to satisfy
-# calls to `find_package(Halide)` when used in-tree.
-
-message(VERBOSE "Spoofing find_package(Halide) since in-tree builds already have Halide available.")
-set(Halide_FOUND 1)

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_dependent_option(WITH_V8 "Include V8 for WASM testing" OFF "TARGET_WEBASSE
 
 if (WITH_WABT AND WITH_V8)
     message(FATAL_ERROR "Cannot use both WABT and V8 at the same time, disable one of them.")
-endif()
+endif ()
 
 if ("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
     if (WITH_WABT)

--- a/python_bindings/src/halide/CMakeLists.txt
+++ b/python_bindings/src/halide/CMakeLists.txt
@@ -66,14 +66,9 @@ target_link_libraries(Halide_Python PRIVATE Halide::Halide)
 #   Ref: https://stackoverflow.com/questions/59860465/pybind11-importerror-dll-not-found-when-trying-to-import-pyd-in-python-int
 #   Ref: https://bugs.python.org/issue36085
 #   Ref: https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
-# TODO: copying a dummy file here works around a CMake limitation. The issue is that if $<TARGET_RUNTIME_DLLS:...> is
-#   empty, then copy_if_different errors out, thinking it doesn't have enough arguments.
-#   Ref: https://gitlab.kitware.com/cmake/cmake/-/issues/23543
-set(dummy_file "${CMAKE_CURRENT_BINARY_DIR}/.dummy_file")
-file(TOUCH "${dummy_file}")
 add_custom_command(
     TARGET Halide_Python POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${dummy_file}" $<TARGET_RUNTIME_DLLS:Halide_Python> $<TARGET_FILE_DIR:Halide_Python>
+    COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:Halide_Python> $<TARGET_RUNTIME_DLLS:Halide_Python>
     COMMAND_EXPAND_LISTS
     VERBATIM
 )

--- a/python_bindings/stub/CMakeLists.txt
+++ b/python_bindings/stub/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(Halide::PyStubs ALIAS Halide_PyStubs)
 # Don't add a direct dependency on pybind11::pybind11 here: that will add a
 # phantom dependency which gets propagated into our install setup. All we
 # really need here is a path to the include directories for pybind11, which
-# BUILD_INTERFACE will accomplish,
-target_link_libraries(Halide_PyStubs PRIVATE Halide::Halide $<BUILD_INTERFACE:pybind11::pybind11>)
+# BUILD_LOCAL_INTERFACE will accomplish,
+target_link_libraries(Halide_PyStubs PRIVATE Halide::Halide $<BUILD_LOCAL_INTERFACE:pybind11::pybind11>)
 
 set_target_properties(Halide_PyStubs PROPERTIES
                       EXPORT_NAME PyStubs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -417,13 +417,13 @@ endforeach ()
 
 set(HALIDE_H "${Halide_BINARY_DIR}/include/Halide.h")
 set(LICENSE_PATH "${Halide_SOURCE_DIR}/LICENSE.txt")
-add_custom_command(OUTPUT "${Halide_BINARY_DIR}/include/Halide.h"
+add_custom_command(OUTPUT "${HALIDE_H}"
                    COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${Halide_BINARY_DIR}/include>"
                    COMMAND build_halide_h "$<SHELL_PATH:${LICENSE_PATH}>" ${HEADER_FILES} > "$<SHELL_PATH:${HALIDE_H}>"
                    DEPENDS build_halide_h "${LICENSE_PATH}" ${HEADER_FILES}
                    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
                    VERBATIM)
-add_custom_target(HalideIncludes ALL DEPENDS "${Halide_BINARY_DIR}/include/Halide.h")
+add_custom_target(HalideIncludes DEPENDS "${HALIDE_H}")
 
 ##
 # Define the Halide library target.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -533,8 +533,10 @@ add_library(Halide::Halide ALIAS Halide)
 
 target_link_libraries(Halide PRIVATE Halide::LLVM)
 target_link_libraries(Halide PUBLIC Halide::LanguageOptions)
-target_compile_definitions(Halide PRIVATE $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,STATIC_LIBRARY>:Halide_STATIC_DEFINE>)
 target_compile_features(Halide PUBLIC cxx_std_17)
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(Halide PRIVATE Halide_STATIC_DEFINE)
+endif ()
 
 include(TargetExportScript)
 ## TODO: implement something similar for Windows/link.exe

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -338,6 +338,7 @@ set(SOURCE_FILES
     SlidingWindow.cpp
     Solve.cpp
     SpirvIR.cpp
+    SpirvIR.h
     SplitTuples.cpp
     StageStridedLoads.cpp
     StmtToHTML.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -630,7 +630,7 @@ if (TARGET_SPIRV)
         HINTS "${Halide_SOURCE_DIR}/dependencies/spirv"
     )
     target_compile_definitions(Halide PRIVATE WITH_SPIRV)
-    target_link_libraries(Halide PRIVATE "$<BUILD_INTERFACE:SPIRV-Headers::SPIRV-Headers>")
+    target_link_libraries(Halide PRIVATE "$<BUILD_LOCAL_INTERFACE:SPIRV-Headers::SPIRV-Headers>")
 endif ()
 
 option(TARGET_WEBGPU "Include WebGPU target" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -548,9 +548,11 @@ set(Halide_SOVERSION_OVERRIDE "${Halide_VERSION_MAJOR}"
 mark_as_advanced(Halide_SOVERSION_OVERRIDE)
 
 set_target_properties(Halide PROPERTIES
-                      POSITION_INDEPENDENT_CODE ON
-                      VERSION ${Halide_VERSION}
-                      SOVERSION ${Halide_SOVERSION_OVERRIDE})
+                      VERSION "${Halide_VERSION}"
+                      SOVERSION "${Halide_SOVERSION_OVERRIDE}")
+
+# Always build with PIC, even when static
+set_target_properties(Halide PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Note that we (deliberately) redeclare these versions here, even though the macros
 # with identical versions are expected to be defined in source; this allows us to

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -367,13 +367,13 @@ set(SOURCE_FILES
 set(C_TEMPLATE_FILES
     CodeGen_C_prologue
     CodeGen_C_vectors
-    )
+)
 
 set(HTML_TEMPLATE_FILES
     StmtToHTML_dependencies.html
     StmtToHTML.js
     StmtToHTML.css
-    )
+)
 
 ##
 # Build and import the runtime.
@@ -576,6 +576,7 @@ endif ()
 ##
 # Set compiler options for libHalide
 ##
+
 set_halide_compiler_warnings(Halide)
 
 if (CMAKE_GENERATOR MATCHES "Visual Studio")
@@ -592,7 +593,7 @@ target_compile_definitions(Halide
                            # in the Windows API.
                            $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
                            $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>
-                           )
+)
 
 ##
 # Set up additional backend options for Halide
@@ -631,7 +632,6 @@ option(TARGET_WEBGPU "Include WebGPU target" ON)
 if (TARGET_WEBGPU)
     target_compile_definitions(Halide PRIVATE WITH_WEBGPU)
 endif()
-
 
 ##
 # Add autoschedulers to the build.


### PR DESCRIPTION
Trying to carve out pieces of #8360 that are easy to review/land individually. Here are a few quick fixes:

1. A few inconsistent-formatting tweaks, improved comments
2. Using the package-redirects feature to disable in-tree `find_package(Halide)`, rather than polluting our source tree with a dummy file.
3. Replacing another dummy file in the Python bindings with a better cmake -E command
4. Using `find_package(CUDAToolkit)` in apps/cuda_mat_mul
5. Add `SpirvIR.h` to the list of _sources_, not public headers. This won't put it in `Halide.h`, but it will put it in IDE file lists.
6. Use `BUILD_LOCAL_INTERFACE` instead of `BUILD_INTERFACE` (this is even more private)