### PR TITLE
Make pybind11 minimum version check compatible with pybind11 v3.

### DIFF
--- a/python_bindings/src/halide/halide_/PyHalide.cpp
+++ b/python_bindings/src/halide/halide_/PyHalide.cpp
@@ -26,11 +26,14 @@
 #include "PyType.h"
 #include "PyVar.h"
 
-static_assert(PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6,
-              "Halide requires PyBind 2.6+");
+#if !defined(PYBIND11_VERSION_HEX) || PYBIND11_VERSION_HEX < 0x02060000
+#error "Halide requires PyBind 2.6+"
+#endif
 
-static_assert(PY_VERSION_HEX >= 0x03000000,
-              "We appear to be compiling against Python 2.x rather than 3.x, which is not supported.");
+// Note: This check will be redundant when PyBind 2.10 becomes the minimum version.
+#if PY_VERSION_HEX < 0x03000000
+#error "We appear to be compiling against Python 2.x rather than 3.x, which is not supported."
+#endif
 
 #ifndef HALIDE_PYBIND_MODULE_NAME
 #define HALIDE_PYBIND_MODULE_NAME halide_

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -8,11 +8,14 @@
 
 #include "Halide.h"
 
-static_assert(PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR >= 6,
-              "Halide requires PyBind 2.6+");
+#if !defined(PYBIND11_VERSION_HEX) || PYBIND11_VERSION_HEX < 0x02060000
+#error "Halide requires PyBind 2.6+"
+#endif
 
-static_assert(PY_VERSION_HEX >= 0x03000000,
-              "We appear to be compiling against Python 2.x rather than 3.x, which is not supported.");
+// Note: This check will be redundant when PyBind 2.10 becomes the minimum version.
+#if PY_VERSION_HEX < 0x03000000
+#error "We appear to be compiling against Python 2.x rather than 3.x, which is not supported."
+#endif
 
 namespace py = pybind11;
 


### PR DESCRIPTION
Concretely:

https://github.com/pybind/pybind11/blob/48f25275c44d52d0ceade122e328dc1f2e48ef44/include/pybind11/detail/common.h#L12-L14

This is needed for a Google-internal deployment, but is a useful fix regardless.