### PR TITLE
List headers with target_sources FILE_SETS

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -27,7 +27,7 @@ install(TARGETS Halide Halide_Generator Halide_GenGen Halide_LanguageOptions
         LIBRARY COMPONENT Halide_Runtime
         NAMELINK_COMPONENT Halide_Development
         ARCHIVE COMPONENT Halide_Development
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        FILE_SET HEADERS COMPONENT Halide_Development)
 
 if (TARGET Halide_Adams2019)
     install(TARGETS Halide_Adams2019 Halide_Li2018 Halide_Mullapudi2016 Halide_Anderson2021
@@ -44,24 +44,26 @@ foreach (dep IN ITEMS Halide_LLVM Halide_wabt)
 endforeach ()
 
 ##
+# Runtime headers
+##
+
+install(TARGETS Halide_Runtime
+        EXPORT Halide_Interfaces
+        FILE_SET HEADERS COMPONENT Halide_Development)
+
+##
 # Library-type-agnostic interface targets
 ##
 
 target_sources(Halide_RunGenMain INTERFACE $<INSTALL_INTERFACE:${Halide_INSTALL_TOOLSDIR}/RunGenMain.cpp>)
 
+install(FILES ${Halide_SOURCE_DIR}/tools/RunGenMain.cpp
+        DESTINATION ${Halide_INSTALL_TOOLSDIR}
+        COMPONENT Halide_Development)
+
 install(TARGETS Halide_Tools Halide_ImageIO Halide_RunGenMain Halide_ThreadPool
         EXPORT Halide_Interfaces
-        INCLUDES DESTINATION ${Halide_INSTALL_TOOLSDIR})
-
-install(TARGETS Halide_Runtime
-        EXPORT Halide_Interfaces
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-# Captures both the runtime and Halide.h
-install(DIRECTORY ${Halide_BINARY_DIR}/include/
-        TYPE INCLUDE
-        COMPONENT Halide_Development
-        FILES_MATCHING PATTERN "include/*.h")
+        FILE_SET HEADERS COMPONENT Halide_Development DESTINATION ${Halide_INSTALL_TOOLSDIR})
 
 ##
 # Patch RPATH for executable targets
@@ -112,17 +114,6 @@ install(FILES
 ##
 # Tools
 ##
-
-install(DIRECTORY ${Halide_SOURCE_DIR}/tools/
-        DESTINATION ${Halide_INSTALL_TOOLSDIR}
-        COMPONENT Halide_Development
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "*.cpp"
-        PATTERN "*.m"
-        PATTERN "binary2cpp.cpp" EXCLUDE
-        PATTERN "build_halide_h.cpp" EXCLUDE
-        PATTERN "find_inverse.cpp" EXCLUDE)
 
 install(PROGRAMS ${Halide_SOURCE_DIR}/src/autoschedulers/adams2019/adams2019_autotune_loop.sh
                  ${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021/anderson2021_autotune_loop.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,23 @@
 ##
+# Declare the Halide library target.
+##
+
+add_library(Halide)
+add_library(Halide::Halide ALIAS Halide)
+
+##
 # Lists of source files. Keep ALL lists sorted in alphabetical order.
 ##
 
 # The externally-visible header files that go into making Halide.h.
 # Don't include anything here that includes llvm headers.
 # Also *don't* include anything that's only used internally (eg SpirvIR.h).
-set(HEADER_FILES
+target_sources(
+    Halide
+    PRIVATE
+    FILE_SET private_headers
+    TYPE HEADERS
+    FILES
     AbstractGenerator.h
     AddAtomicMutex.h
     AddImageChecks.h
@@ -175,9 +187,13 @@ set(HEADER_FILES
     VectorizeLoops.h
     WasmExecutor.h
     WrapCalls.h
-    )
+)
 
-set(SOURCE_FILES
+# The sources that go into libHalide. For the sake of IDE support, headers that
+# exist in src/ but are not public should be included here.
+target_sources(
+    Halide
+    PRIVATE
     AbstractGenerator.cpp
     AddAtomicMutex.cpp
     AddImageChecks.cpp
@@ -363,7 +379,7 @@ set(SOURCE_FILES
     VectorizeLoops.cpp
     WasmExecutor.cpp
     WrapCalls.cpp
-    )
+)
 
 set(C_TEMPLATE_FILES
     CodeGen_C_prologue
@@ -381,12 +397,13 @@ set(HTML_TEMPLATE_FILES
 ##
 
 add_subdirectory(runtime)
+target_link_libraries(Halide PRIVATE "$<BUILD_LOCAL_INTERFACE:Halide::initmod>")
+target_link_libraries(Halide INTERFACE Halide::Runtime)
 
 ##
 # Build the template files via binary2cpp.
 ##
 
-add_library(Halide_c_templates OBJECT)
 foreach (f IN LISTS C_TEMPLATE_FILES)
     set(SRC "$<SHELL_PATH:${CMAKE_CURRENT_SOURCE_DIR}/${f}.template.cpp>")
     set(DST "c_template.${f}.template.cpp")
@@ -395,7 +412,7 @@ foreach (f IN LISTS C_TEMPLATE_FILES)
                        COMMAND binary2cpp "halide_c_template_${f}" < "${SRC}" > "${DST}"
                        DEPENDS "${SRC}" binary2cpp
                        VERBATIM)
-    target_sources(Halide_c_templates PRIVATE ${DST})
+    target_sources(Halide PRIVATE ${DST})
 endforeach ()
 
 foreach (f IN LISTS HTML_TEMPLATE_FILES)
@@ -407,9 +424,8 @@ foreach (f IN LISTS HTML_TEMPLATE_FILES)
                        COMMAND binary2cpp "${VARNAME}" < "${SRC}" > "${DST}"
                        DEPENDS "${SRC}" binary2cpp
                        VERBATIM)
-    target_sources(Halide_c_templates PRIVATE ${DST})
+    target_sources(Halide PRIVATE ${DST})
 endforeach ()
-
 
 ##
 # Build the Halide mono-header.
@@ -417,24 +433,24 @@ endforeach ()
 
 set(HALIDE_H "${Halide_BINARY_DIR}/include/Halide.h")
 set(LICENSE_PATH "${Halide_SOURCE_DIR}/LICENSE.txt")
+set(headers "$<TARGET_PROPERTY:Halide,HEADER_SET_private_headers>")
 add_custom_command(OUTPUT "${HALIDE_H}"
                    COMMAND ${CMAKE_COMMAND} -E make_directory "$<SHELL_PATH:${Halide_BINARY_DIR}/include>"
-                   COMMAND build_halide_h "$<SHELL_PATH:${LICENSE_PATH}>" ${HEADER_FILES} > "$<SHELL_PATH:${HALIDE_H}>"
-                   DEPENDS build_halide_h "${LICENSE_PATH}" ${HEADER_FILES}
+                   COMMAND build_halide_h "$<SHELL_PATH:${LICENSE_PATH}>" "${headers}" > "$<SHELL_PATH:${HALIDE_H}>"
+                   DEPENDS build_halide_h "${LICENSE_PATH}" "${headers}"
                    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+                   COMMAND_EXPAND_LISTS
                    VERBATIM)
 add_custom_target(HalideIncludes DEPENDS "${HALIDE_H}")
+add_dependencies(Halide HalideIncludes)
 
-##
-# Define the Halide library target.
-##
-
-add_library(Halide
-            ${SOURCE_FILES}
-            ${HEADER_FILES}
-            # Including these as sources works around the need to "install" Halide_initmod
-            $<TARGET_OBJECTS:Halide_initmod>
-            $<TARGET_OBJECTS:Halide_c_templates>)
+target_sources(
+    Halide
+    INTERFACE
+    FILE_SET HEADERS
+    BASE_DIRS "${Halide_BINARY_DIR}/include"
+    FILES "${Halide_BINARY_DIR}/include/Halide.h"
+)
 
 ##
 # Flatbuffers and Serialization dependencies.
@@ -491,8 +507,14 @@ if (WITH_SERIALIZATION)
     )
     add_custom_target(generate_fb_header DEPENDS "${fb_header}")
 
-    add_dependencies(Halide generate_fb_header)
-    target_include_directories(Halide PRIVATE "$<BUILD_INTERFACE:${fb_dir}>")
+    target_sources(
+        Halide
+        PRIVATE
+        FILE_SET fb_headers
+        TYPE HEADERS
+        BASE_DIRS "${fb_dir}"
+        FILES "${fb_header}"
+    )
     target_link_libraries(Halide PRIVATE ${flatbuffers_target})
     target_compile_definitions(Halide PRIVATE WITH_SERIALIZATION)
 endif ()
@@ -506,8 +528,6 @@ cmake_dependent_option(
 if (WITH_SERIALIZATION_JIT_ROUNDTRIP_TESTING)
     target_compile_definitions(Halide PRIVATE WITH_SERIALIZATION_JIT_ROUNDTRIP_TESTING)
 endif ()
-
-add_library(Halide::Halide ALIAS Halide)
 
 target_link_libraries(Halide PRIVATE Halide::LLVM)
 target_link_libraries(Halide PUBLIC Halide::LanguageOptions)
@@ -541,10 +561,6 @@ target_compile_definitions(Halide PUBLIC
                            HALIDE_VERSION_MAJOR=${Halide_VERSION_MAJOR}
                            HALIDE_VERSION_MINOR=${Halide_VERSION_MINOR}
                            HALIDE_VERSION_PATCH=${Halide_VERSION_PATCH})
-
-
-target_include_directories(Halide INTERFACE "$<BUILD_INTERFACE:${Halide_BINARY_DIR}/include>")
-add_dependencies(Halide HalideIncludes)
 
 if (TARGET Halide_wabt)
     target_link_libraries(Halide PRIVATE Halide_wabt)

--- a/src/autoschedulers/adams2019/CMakeLists.txt
+++ b/src/autoschedulers/adams2019/CMakeLists.txt
@@ -103,7 +103,7 @@ add_autoscheduler(
 )
 
 target_include_directories(Halide_Adams2019 PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/adams2019")
-target_link_libraries(Halide_Adams2019 PRIVATE ASLog ParamParser adams2019_cost_model adams2019_train_cost_model)
+target_link_libraries(Halide_Adams2019 PRIVATE Halide::ASLog adams2019_cost_model adams2019_train_cost_model)
 
 # ====================================================
 # Auto-tuning support utilities.

--- a/src/autoschedulers/adams2019/CMakeLists.txt
+++ b/src/autoschedulers/adams2019/CMakeLists.txt
@@ -81,7 +81,7 @@ if (WITH_UTILS)
                    retrain_cost_model.cpp
                    $<TARGET_OBJECTS:adams2019_weights_obj>)
     target_include_directories(adams2019_retrain_cost_model PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/adams2019")
-    target_link_libraries(adams2019_retrain_cost_model PRIVATE ASLog adams2019_cost_model adams2019_train_cost_model Halide::Halide Halide::Plugin)
+    target_link_libraries(adams2019_retrain_cost_model PRIVATE Halide::ASLog adams2019_cost_model adams2019_train_cost_model Halide::Halide Halide::Plugin)
 endif ()
 
 # =================================================================
@@ -120,7 +120,7 @@ endif ()
 
 if (WITH_TESTS)
     add_executable(adams2019_test_function_dag test_function_dag.cpp FunctionDAG.cpp)
-    target_link_libraries(adams2019_test_function_dag PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(adams2019_test_function_dag PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
     add_test(NAME adams2019_test_function_dag COMMAND adams2019_test_function_dag)
     set_tests_properties(adams2019_test_function_dag PROPERTIES LABELS "adams2019;autoschedulers_cpu")
 endif()

--- a/src/autoschedulers/anderson2021/CMakeLists.txt
+++ b/src/autoschedulers/anderson2021/CMakeLists.txt
@@ -60,7 +60,7 @@ add_autoscheduler(
 )
 
 target_include_directories(Halide_Anderson2021 PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-target_link_libraries(Halide_Anderson2021 PRIVATE ASLog ParamParser
+target_link_libraries(Halide_Anderson2021 PRIVATE Halide::ASLog
     anderson2021_cost_model anderson2021_train_cost_model)
 
 ## ====================================================

--- a/src/autoschedulers/anderson2021/CMakeLists.txt
+++ b/src/autoschedulers/anderson2021/CMakeLists.txt
@@ -36,7 +36,7 @@ if (WITH_UTILS)
                    retrain_cost_model.cpp
                    $<TARGET_OBJECTS:anderson2021_weights_obj>)
     target_include_directories(anderson2021_retrain_cost_model PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_retrain_cost_model PRIVATE ASLog anderson2021_cost_model
+    target_link_libraries(anderson2021_retrain_cost_model PRIVATE Halide::ASLog anderson2021_cost_model
         anderson2021_train_cost_model Halide::Halide Halide::Plugin)
 endif ()
 
@@ -90,44 +90,44 @@ if (WITH_TESTS)
 
     add_executable(anderson2021_test_function_dag test_function_dag.cpp FunctionDAG.cpp)
     target_include_directories(anderson2021_test_function_dag PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_function_dag PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_function_dag PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
     _add_test(anderson2021_test_function_dag)
 
     add_executable(anderson2021_test_bounds test/bounds.cpp FunctionDAG.cpp LoopNest.cpp GPULoopInfo.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_bounds PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_bounds PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_bounds PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
     _add_test(anderson2021_test_bounds)
 
     add_executable(anderson2021_test_parser test/parser.cpp)
     target_include_directories(anderson2021_test_parser PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_parser PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_parser PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
     _add_test(anderson2021_test_parser)
 
     add_executable(anderson2021_test_state test/state.cpp FunctionDAG.cpp LoopNest.cpp GPULoopInfo.cpp State.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_state PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_state PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_state PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
     _add_test(anderson2021_test_state)
 
     add_executable(anderson2021_test_storage_strides test/storage_strides.cpp FunctionDAG.cpp LoopNest.cpp GPULoopInfo.cpp State.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_storage_strides PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_storage_strides PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_storage_strides PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
     _add_test(anderson2021_test_storage_strides)
 
     add_executable(anderson2021_test_thread_info test/thread_info.cpp LoopNest.cpp
         FunctionDAG.cpp GPULoopInfo.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_thread_info PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_thread_info PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_thread_info PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
     _add_test(anderson2021_test_thread_info)
 
     add_executable(anderson2021_test_tiling test/tiling.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_tiling PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_tiling PRIVATE ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_tiling PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
 
     _add_test(anderson2021_test_tiling)
 endif()

--- a/src/autoschedulers/common/CMakeLists.txt
+++ b/src/autoschedulers/common/CMakeLists.txt
@@ -1,16 +1,28 @@
 add_library(Halide_Plugin INTERFACE)
 add_library(Halide::Plugin ALIAS Halide_Plugin)
-target_include_directories(Halide_Plugin INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-target_link_libraries(Halide_Plugin INTERFACE Halide::Halide)
+target_sources(
+    Halide_Plugin
+    INTERFACE
+    FILE_SET HEADERS
+    FILES
+    Errors.h
+    HalidePlugin.h
+    ParamParser.h
+    cmdline.h
+    PerfectHashMap.h
+)
+target_link_libraries(Halide_Plugin INTERFACE Halide::Halide Halide::ASLog)
 
-add_library(ASLog STATIC ASLog.cpp)
-target_include_directories(ASLog PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-set_property(TARGET ASLog PROPERTY POSITION_INDEPENDENT_CODE YES)
-
-# Sigh, header-only libraries shouldn't be special
-add_library(ParamParser INTERFACE)
-target_include_directories(ParamParser INTERFACE
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+add_library(Halide_ASLog STATIC)
+add_library(Halide::ASLog ALIAS Halide_ASLog)
+target_sources(
+    Halide_ASLog
+    PRIVATE ASLog.cpp
+    PUBLIC
+    FILE_SET HEADERS
+    FILES ASLog.h
+)
+set_property(TARGET Halide_ASLog PROPERTY POSITION_INDEPENDENT_CODE YES)
 
 if (WITH_UTILS)
     add_executable(featurization_to_sample featurization_to_sample.cpp)

--- a/src/autoschedulers/li2018/CMakeLists.txt
+++ b/src/autoschedulers/li2018/CMakeLists.txt
@@ -1,3 +1,1 @@
 add_autoscheduler(NAME Li2018 SOURCES GradientAutoscheduler.cpp)
-target_link_libraries(Halide_Li2018 PRIVATE ParamParser)
-

--- a/src/autoschedulers/mullapudi2016/CMakeLists.txt
+++ b/src/autoschedulers/mullapudi2016/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_autoscheduler(NAME Mullapudi2016 SOURCES AutoSchedule.cpp)
-target_link_libraries(Halide_Mullapudi2016 PRIVATE ParamParser)

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -146,6 +146,7 @@ set(RUNTIME_HEADER_FILES
 # in a different directory ONLY IF that source was created
 # by add_custom_command, as is the case in this directory.
 add_library(Halide_initmod OBJECT)
+add_library(Halide::initmod ALIAS Halide_initmod)
 
 # Note: ensure that these flags match the flags in the Makefile.
 # Note: this always uses Clang-from-LLVM for compilation, so none of these flags should need conditionalization.
@@ -337,8 +338,6 @@ foreach (i IN LISTS RUNTIME_HEADER_FILES)
                        DEPENDS "${i}" binary2cpp
                        VERBATIM)
     target_sources(Halide_initmod PRIVATE "_initmod_${SYM_NAME}.cpp")
-
-    configure_file(${i} "${Halide_BINARY_DIR}/include/${i}" COPYONLY)
 endforeach ()
 
 ##
@@ -347,10 +346,14 @@ endforeach ()
 
 add_library(Halide_Runtime INTERFACE)
 add_library(Halide::Runtime ALIAS Halide_Runtime)
-target_include_directories(Halide_Runtime INTERFACE $<BUILD_INTERFACE:${Halide_BINARY_DIR}/include>)
 set_target_properties(Halide_Runtime PROPERTIES EXPORT_NAME Runtime)
-option(Halide_BUILD_HEXAGON_REMOTE_RUNTIME "Build the hexagon remote runtime for offloading to Hexagon (HVX)" OFF)
 
+target_sources(Halide_Runtime
+               INTERFACE
+               FILE_SET HEADERS
+               FILES ${RUNTIME_HEADER_FILES})
+
+option(Halide_BUILD_HEXAGON_REMOTE_RUNTIME "Build the hexagon remote runtime for offloading to Hexagon (HVX)" OFF)
 if (Halide_BUILD_HEXAGON_REMOTE_RUNTIME AND NOT Halide_CLANG_TIDY_BUILD)
   add_subdirectory(hexagon_remote)
 endif ()

--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -177,10 +177,10 @@ function(_add_halide_aot_tests NAME)
     set(TARGET_CPP "generator_aotcpp_${NAME}")
 
     if (${_USING_WASM})
+        # for runtime, mini_webgpu.h
+        list(APPEND args_INCLUDES "${Halide_SOURCE_DIR}/src/runtime")
         if ("${Halide_TARGET}" MATCHES "webgpu")
             set(OPTIONS "-DTEST_WEBGPU")
-            # for mini_webgpu.h
-            list(APPEND args_INCLUDES "${Halide_SOURCE_DIR}/src/runtime")
         endif ()
         add_wasm_executable("${TARGET}"
                             SRCS "${args_SRCS}"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,25 +21,33 @@ target_compile_options(regexp_replace PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/wd4996>
 add_library(Halide_ImageIO INTERFACE)
 add_library(Halide::ImageIO ALIAS Halide_ImageIO)
 set_target_properties(Halide_ImageIO PROPERTIES EXPORT_NAME ImageIO)
+
 target_link_libraries(Halide_ImageIO
                       INTERFACE
+                      Halide::Runtime
                       $<TARGET_NAME_IF_EXISTS:PNG::PNG>
                       $<TARGET_NAME_IF_EXISTS:JPEG::JPEG>)
 target_compile_definitions(Halide_ImageIO
                            INTERFACE
                            $<$<NOT:$<TARGET_EXISTS:PNG::PNG>>:HALIDE_NO_PNG>
                            $<$<NOT:$<TARGET_EXISTS:JPEG::JPEG>>:HALIDE_NO_JPEG>)
-target_include_directories(Halide_ImageIO INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+target_sources(Halide_ImageIO INTERFACE FILE_SET HEADERS FILES halide_image_io.h)
 
 ##
-# Utility targets meant for users
+# RunGenMain
 ##
 
 add_library(Halide_RunGenMain INTERFACE)
 add_library(Halide::RunGenMain ALIAS Halide_RunGenMain)
-target_sources(Halide_RunGenMain INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/RunGenMain.cpp>)
-target_link_libraries(Halide_RunGenMain INTERFACE Halide::Runtime Halide::ImageIO Halide::Tools)
 set_target_properties(Halide_RunGenMain PROPERTIES EXPORT_NAME RunGenMain)
+
+target_sources(Halide_RunGenMain INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/RunGenMain.cpp>)
+target_sources(Halide_RunGenMain INTERFACE FILE_SET HEADERS FILES RunGen.h)
+target_link_libraries(Halide_RunGenMain INTERFACE Halide::Runtime Halide::ImageIO Halide::Tools)
+
+##
+# Generator meta-target
+##
 
 add_library(Halide_GenGen STATIC GenGen.cpp)
 add_library(Halide::GenGen ALIAS Halide_GenGen)
@@ -55,13 +63,34 @@ target_link_libraries(
     Halide_Generator INTERFACE "$<LINK_LIBRARY:WHOLE_ARCHIVE,Halide::GenGen>"
 )
 
+##
+# Dependency-free header-only libs
+##
+
 add_library(Halide_Tools INTERFACE)
 add_library(Halide::Tools ALIAS Halide_Tools)
-target_include_directories(Halide_Tools INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 set_target_properties(Halide_Tools PROPERTIES EXPORT_NAME Tools)
+
+target_sources(
+    Halide_Tools
+    INTERFACE
+    FILE_SET HEADERS
+    FILES
+    halide_benchmark.h
+    halide_image.h
+    halide_image_info.h
+    halide_malloc_trace.h
+    halide_trace_config.h
+)
+
+##
+# Simple thread pool
+##
 
 add_library(Halide_ThreadPool INTERFACE)
 add_library(Halide::ThreadPool ALIAS Halide_ThreadPool)
-target_link_libraries(Halide_ThreadPool INTERFACE Threads::Threads)
-target_include_directories(Halide_Tools INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 set_target_properties(Halide_ThreadPool PROPERTIES EXPORT_NAME ThreadPool)
+
+target_link_libraries(Halide_ThreadPool INTERFACE Threads::Threads)
+target_sources(Halide_ThreadPool INTERFACE FILE_SET HEADERS FILES halide_thread_pool.h)
+


### PR DESCRIPTION
Removes instances of `target_include_directories` and installation rules based on those directories. These are now automatically computed from the `BASE_DIRS` (defaults to current source dir) argument to `target_sources`.

This models the build more accurately and avoids accidental installation of unwanted headers. Also forces us to think about the linking relationships between components; ideally this will result in a more accurate build graph.