### PR TITLE
Clean up autoscheduler dependencies

### DIFF
--- a/src/autoschedulers/adams2019/CMakeLists.txt
+++ b/src/autoschedulers/adams2019/CMakeLists.txt
@@ -81,7 +81,7 @@ if (WITH_UTILS)
                    retrain_cost_model.cpp
                    $<TARGET_OBJECTS:adams2019_weights_obj>)
     target_include_directories(adams2019_retrain_cost_model PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/adams2019")
-    target_link_libraries(adams2019_retrain_cost_model PRIVATE Halide::ASLog adams2019_cost_model adams2019_train_cost_model Halide::Halide Halide::Plugin)
+    target_link_libraries(adams2019_retrain_cost_model PRIVATE adams2019_cost_model adams2019_train_cost_model Halide::Plugin)
 endif ()
 
 # =================================================================
@@ -103,7 +103,7 @@ add_autoscheduler(
 )
 
 target_include_directories(Halide_Adams2019 PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/adams2019")
-target_link_libraries(Halide_Adams2019 PRIVATE Halide::ASLog adams2019_cost_model adams2019_train_cost_model)
+target_link_libraries(Halide_Adams2019 PRIVATE adams2019_cost_model adams2019_train_cost_model)
 
 # ====================================================
 # Auto-tuning support utilities.
@@ -120,7 +120,8 @@ endif ()
 
 if (WITH_TESTS)
     add_executable(adams2019_test_function_dag test_function_dag.cpp FunctionDAG.cpp)
-    target_link_libraries(adams2019_test_function_dag PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(adams2019_test_function_dag PRIVATE Halide::Plugin)
+
     add_test(NAME adams2019_test_function_dag COMMAND adams2019_test_function_dag)
     set_tests_properties(adams2019_test_function_dag PROPERTIES LABELS "adams2019;autoschedulers_cpu")
 endif()

--- a/src/autoschedulers/anderson2021/CMakeLists.txt
+++ b/src/autoschedulers/anderson2021/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(anderson2021_weights_obj OBJECT ${WF_CPP})
 
 # cost_model, train_cost_model
 add_executable(anderson2021_cost_model.generator cost_model_generator.cpp)
-target_link_libraries(anderson2021_cost_model.generator PRIVATE Halide::Halide Halide::Generator)
+target_link_libraries(anderson2021_cost_model.generator PRIVATE Halide::Generator)
 
 add_halide_library(anderson2021_cost_model FROM anderson2021_cost_model.generator
                    GENERATOR cost_model
@@ -36,8 +36,13 @@ if (WITH_UTILS)
                    retrain_cost_model.cpp
                    $<TARGET_OBJECTS:anderson2021_weights_obj>)
     target_include_directories(anderson2021_retrain_cost_model PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_retrain_cost_model PRIVATE Halide::ASLog anderson2021_cost_model
-        anderson2021_train_cost_model Halide::Halide Halide::Plugin)
+    target_link_libraries(
+        anderson2021_retrain_cost_model
+        PRIVATE
+        anderson2021_cost_model
+        anderson2021_train_cost_model
+        Halide::Plugin
+    )
 endif ()
 
 ###
@@ -60,8 +65,7 @@ add_autoscheduler(
 )
 
 target_include_directories(Halide_Anderson2021 PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-target_link_libraries(Halide_Anderson2021 PRIVATE Halide::ASLog
-    anderson2021_cost_model anderson2021_train_cost_model)
+target_link_libraries(Halide_Anderson2021 PRIVATE anderson2021_cost_model anderson2021_train_cost_model)
 
 ## ====================================================
 if (WITH_UTILS)
@@ -75,8 +79,6 @@ endif ()
 # which is handled in tests/autoschedulers/anderson2021)
 
 if (WITH_TESTS)
-    ##
-
     function(_add_test TARGET)
         add_test(NAME ${TARGET} COMMAND ${TARGET})
         add_dependencies(${TARGET} Halide::Anderson2021)
@@ -90,44 +92,44 @@ if (WITH_TESTS)
 
     add_executable(anderson2021_test_function_dag test_function_dag.cpp FunctionDAG.cpp)
     target_include_directories(anderson2021_test_function_dag PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_function_dag PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_function_dag PRIVATE Halide::Plugin)
 
     _add_test(anderson2021_test_function_dag)
 
     add_executable(anderson2021_test_bounds test/bounds.cpp FunctionDAG.cpp LoopNest.cpp GPULoopInfo.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_bounds PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_bounds PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_bounds PRIVATE Halide::Plugin)
 
     _add_test(anderson2021_test_bounds)
 
     add_executable(anderson2021_test_parser test/parser.cpp)
     target_include_directories(anderson2021_test_parser PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_parser PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_parser PRIVATE Halide::Plugin)
 
     _add_test(anderson2021_test_parser)
 
     add_executable(anderson2021_test_state test/state.cpp FunctionDAG.cpp LoopNest.cpp GPULoopInfo.cpp State.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_state PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_state PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_state PRIVATE Halide::Plugin)
 
     _add_test(anderson2021_test_state)
 
     add_executable(anderson2021_test_storage_strides test/storage_strides.cpp FunctionDAG.cpp LoopNest.cpp GPULoopInfo.cpp State.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_storage_strides PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_storage_strides PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_storage_strides PRIVATE Halide::Plugin)
 
     _add_test(anderson2021_test_storage_strides)
 
     add_executable(anderson2021_test_thread_info test/thread_info.cpp LoopNest.cpp
         FunctionDAG.cpp GPULoopInfo.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_thread_info PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_thread_info PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_thread_info PRIVATE Halide::Plugin)
 
     _add_test(anderson2021_test_thread_info)
 
     add_executable(anderson2021_test_tiling test/tiling.cpp Tiling.cpp)
     target_include_directories(anderson2021_test_tiling PRIVATE "${Halide_SOURCE_DIR}/src/autoschedulers/anderson2021")
-    target_link_libraries(anderson2021_test_tiling PRIVATE Halide::ASLog Halide::Halide Halide::Tools Halide::Plugin)
+    target_link_libraries(anderson2021_test_tiling PRIVATE Halide::Plugin)
 
     _add_test(anderson2021_test_tiling)
 endif()


### PR DESCRIPTION
After #8370 the `Halide::Plugin` target covers the common autoscheduler code.