### PR TITLE
Use a Find module for NodeJS

### DIFF
--- a/cmake/FindNodeJS.cmake
+++ b/cmake/FindNodeJS.cmake
@@ -1,0 +1,35 @@
+if (EXISTS "${NODE_JS_EXECUTABLE}")
+    message(DEPRECATION "NODE_JS_EXECUTABLE has been renamed to NodeJS_EXECUTABLE")
+    set(NodeJS_EXECUTABLE "${NODE_JS_EXECUTABLE}")
+    set(NodeJS_EXECUTABLE "${NODE_JS_EXECUTABLE}" CACHE PATH "")
+endif ()
+
+find_program(
+    NodeJS_EXECUTABLE
+    NAMES node nodejs
+)
+
+set(NodeJS_VERSION "")
+if (NodeJS_EXECUTABLE)
+    execute_process(
+        COMMAND "${NodeJS_EXECUTABLE}" --version
+        OUTPUT_VARIABLE NodeJS_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    string(REPLACE "v" "" NodeJS_VERSION "${NodeJS_VERSION}")
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    NodeJS
+    REQUIRED_VARS NodeJS_EXECUTABLE
+    VERSION_VAR NodeJS_VERSION
+    HANDLE_COMPONENTS
+)
+
+if (NodeJS_FOUND AND NOT TARGET NodeJS::node)
+    add_executable(NodeJS::node IMPORTED)
+    set_target_properties(
+        NodeJS::node PROPERTIES IMPORTED_LOCATION "${NodeJS_EXECUTABLE}"
+    )
+endif ()

--- a/dependencies/wasm/CMakeLists.txt
+++ b/dependencies/wasm/CMakeLists.txt
@@ -153,25 +153,10 @@ function(add_wasm_halide_test TARGET)
         return()
     endif ()
 
-    add_halide_test("${TARGET}"
-                    GROUPS ${args_GROUPS}
-                    COMMAND ${NODE_JS_EXECUTABLE} "${Halide_SOURCE_DIR}/tools/launch_wasm_test.js" "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.js" "${Halide_TARGET}")
+    find_package(NodeJS 16.13 REQUIRED)
+    add_halide_test(
+        "${TARGET}"
+        GROUPS ${args_GROUPS}
+        COMMAND "${NodeJS_EXECUTABLE}" "${Halide_SOURCE_DIR}/tools/launch_wasm_test.js" "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}.js" "${Halide_TARGET}"
+    )
 endfunction()
-
-function(find_node_js)
-    find_program(NODE_JS_EXECUTABLE node nodejs REQUIRED)
-
-    execute_process(COMMAND "${NODE_JS_EXECUTABLE}" --version
-                    OUTPUT_VARIABLE NODE_JS_VERSION_RAW
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(REPLACE "v" "" NODE_JS_VERSION "${NODE_JS_VERSION_RAW}")
-
-    if (NODE_JS_VERSION VERSION_LESS "16.13")
-        message(FATAL_ERROR "Halide requires Node v16.13 or later, but found ${NODE_JS_VERSION_RAW} at ${NODE_JS_EXECUTABLE}. Please set NODE_JS_EXECUTABLE on the CMake command line.")
-    endif ()
-endfunction()
-
-if (Halide_TARGET MATCHES "wasm")
-    # Check and warn up front if a suitable Node.js isn't found
-    find_node_js()
-endif ()


### PR DESCRIPTION
Also renames `NODE_JS_EXECUTABLE` to `NodeJS_EXECUTABLE` with a deprecation warning.