### PR TITLE
Partially apply clang-tidy fixes we don't enforce yet

### DIFF
--- a/python_bindings/src/halide/halide_/PyRDom.cpp
+++ b/python_bindings/src/halide/halide_/PyRDom.cpp
@@ -5,6 +5,7 @@
 namespace Halide {
 namespace PythonBindings {
 
+namespace {
 void define_rvar(py::module &m) {
     auto rvar_class =
         py::class_<RVar>(m, "RVar")
@@ -24,6 +25,7 @@ void define_rvar(py::module &m) {
 
     add_binary_operators(rvar_class);
 }
+}  // namespace
 
 void define_rdom(py::module &m) {
     define_rvar(m);

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -526,7 +526,7 @@ Stmt add_image_checks_inner(Stmt s,
                         << "as the first output buffer.\n";
 
                     stride_constrained = param.stride_constraint(i);
-                } else if (image.defined() && (int)i < image.dimensions()) {
+                } else if (image.defined() && i < image.dimensions()) {
                     stride_constrained = image.dim(i).stride();
                 }
 
@@ -543,7 +543,7 @@ Stmt add_image_checks_inner(Stmt s,
                 } else {
                     extent_constrained = Variable::make(Int(32), extent0_name);
                 }
-            } else if (image.defined() && (int)i < image.dimensions()) {
+            } else if (image.defined() && i < image.dimensions()) {
                 stride_constrained = image.dim(i).stride();
                 extent_constrained = image.dim(i).extent();
                 min_constrained = image.dim(i).min();

--- a/src/BoundaryConditions.cpp
+++ b/src/BoundaryConditions.cpp
@@ -14,7 +14,7 @@ Func repeat_edge(const Func &source,
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {
-        Var arg_var = args[i];
+        const Var &arg_var = args[i];
         Expr min = bounds[i].min;
         Expr extent = bounds[i].extent;
 
@@ -39,16 +39,15 @@ Func repeat_edge(const Func &source,
 
 Func constant_exterior(const Func &source, const Tuple &value,
                        const Region &bounds) {
-    std::vector<Var> source_args = source.args();
-    std::vector<Var> args(source_args);
+    std::vector<Var> args(source.args());
     user_assert(args.size() >= bounds.size())
         << "constant_exterior called with more bounds (" << bounds.size()
-        << ") than dimensions (" << source_args.size()
+        << ") than dimensions (" << args.size()
         << ") Func " << source.name() << " has.\n";
 
     Expr out_of_bounds = cast<bool>(false);
     for (size_t i = 0; i < bounds.size(); i++) {
-        Var arg_var = source_args[i];
+        const Var &arg_var = args[i];
         Expr min = bounds[i].min;
         Expr extent = bounds[i].extent;
 
@@ -91,7 +90,7 @@ Func repeat_image(const Func &source,
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {
-        Var arg_var = args[i];
+        const Var &arg_var = args[i];
         Expr min = bounds[i].min;
         Expr extent = bounds[i].extent;
 
@@ -146,7 +145,7 @@ Func mirror_image(const Func &source,
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {
-        Var arg_var = args[i];
+        const Var &arg_var = args[i];
 
         Expr min = bounds[i].min;
         Expr extent = bounds[i].extent;
@@ -187,7 +186,7 @@ Func mirror_interior(const Func &source,
 
     std::vector<Expr> actuals;
     for (size_t i = 0; i < bounds.size(); i++) {
-        Var arg_var = args[i];
+        const Var &arg_var = args[i];
 
         Expr min = bounds[i].min;
         Expr extent = bounds[i].extent;

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1857,12 +1857,6 @@ Interval bounds_of_expr_in_scope_with_indent(const Expr &expr, const Scope<Inter
     return b.interval;
 }
 
-}  // namespace
-
-Interval bounds_of_expr_in_scope(const Expr &expr, const Scope<Interval> &scope, const FuncValueBounds &fb, bool const_bound) {
-    return bounds_of_expr_in_scope_with_indent(expr, scope, fb, const_bound, 0);
-}
-
 Region region_union(const Region &a, const Region &b) {
     internal_assert(a.size() == b.size()) << "Mismatched dimensionality in region union\n";
     Region result;
@@ -1875,6 +1869,12 @@ Region region_union(const Region &a, const Region &b) {
         result.emplace_back(simplify(min), simplify(extent));
     }
     return result;
+}
+
+}  // namespace
+
+Interval bounds_of_expr_in_scope(const Expr &expr, const Scope<Interval> &scope, const FuncValueBounds &fb, bool const_bound) {
+    return bounds_of_expr_in_scope_with_indent(expr, scope, fb, const_bound, 0);
 }
 
 void merge_boxes(Box &a, const Box &b) {
@@ -3085,8 +3085,6 @@ private:
     }
 };
 
-}  // namespace
-
 map<string, Box> boxes_touched(const Expr &e, Stmt s, bool consider_calls, bool consider_provides,
                                const string &fn, const Scope<Interval> &scope, const FuncValueBounds &fb) {
     if (!fn.empty() && s.defined()) {
@@ -3275,6 +3273,7 @@ Box box_touched(const Expr &e, Stmt s, bool consider_calls, bool consider_provid
     internal_assert(boxes.size() <= 1);
     return boxes[fn];
 }
+}  // namespace
 
 map<string, Box> boxes_required(const Expr &e, const Scope<Interval> &scope, const FuncValueBounds &fb) {
     return boxes_touched(e, Stmt(), true, false, "", scope, fb);
@@ -3324,6 +3323,7 @@ Box box_touched(Stmt s, const string &fn, const Scope<Interval> &scope, const Fu
     return box_touched(Expr(), std::move(s), true, true, fn, scope, fb);
 }
 
+namespace {
 // Compute interval of all possible function's values (default + specialized values)
 Interval compute_pure_function_definition_value_bounds(
     const Definition &def, const Scope<Interval> &scope, const FuncValueBounds &fb, int dim) {
@@ -3338,6 +3338,7 @@ Interval compute_pure_function_definition_value_bounds(
     }
     return result;
 }
+}  // namespace
 
 FuncValueBounds compute_function_value_bounds(const vector<string> &order,
                                               const map<string, Function> &env) {
@@ -3345,7 +3346,7 @@ FuncValueBounds compute_function_value_bounds(const vector<string> &order,
 
     for (const auto &func_name : order) {
         Function f = env.find(func_name)->second;
-        const vector<string> f_args = f.args();
+        const vector<string> &f_args = f.args();
         for (int j = 0; j < f.outputs(); j++) {
             pair<string, int> key = {f.name(), j};
 

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -44,8 +44,6 @@ Type non_null_void_star_type() {
     return Handle(1, &t);
 }
 
-}  // namespace
-
 namespace WindowsMangling {
 
 struct PreviousDeclarations {
@@ -614,6 +612,8 @@ std::string cplusplus_function_mangled_name(const std::string &name, const std::
 }
 
 }  // namespace ItaniumABIMangling
+
+}  // namespace
 
 std::string cplusplus_function_mangled_name(const std::string &name, const std::vector<std::string> &namespaces,
                                             Type return_type, const std::vector<ExternFuncArgument> &args,

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -762,7 +762,7 @@ void CodeGen_C::emit_metadata_getter(const std::string &function_name,
                 constants.push_back(emit_constant_int64(extent));
             }
 
-            stream << get_indent() << "static const int64_t * const buffer_estimates_" << legalized_name << "[" << (int)arg.dimensions * 2 << "] = {\n";
+            stream << get_indent() << "static const int64_t * const buffer_estimates_" << legalized_name << "[" << arg.dimensions * 2 << "] = {\n";
             indent += 1;
             for (const auto &c : constants) {
                 stream << get_indent() << c << ",\n";
@@ -795,9 +795,9 @@ void CodeGen_C::emit_metadata_getter(const std::string &function_name,
         stream << get_indent() << "\"" << name << "\",\n";
         internal_assert(arg.kind < sizeof(kind_names) / sizeof(kind_names[0]));
         stream << get_indent() << kind_names[arg.kind] << ",\n";
-        stream << get_indent() << (int)arg.dimensions << ",\n";
+        stream << get_indent() << arg.dimensions << ",\n";
         internal_assert(arg.type.code() < sizeof(type_code_names) / sizeof(type_code_names[0]));
-        stream << get_indent() << "{" << type_code_names[arg.type.code()] << ", " << (int)arg.type.bits() << ", " << (int)arg.type.lanes() << "},\n";
+        stream << get_indent() << "{" << type_code_names[arg.type.code()] << ", " << arg.type.bits() << ", " << arg.type.lanes() << "},\n";
         stream << get_indent() << "scalar_def_" << legalized_name << ",\n";
         stream << get_indent() << "scalar_min_" << legalized_name << ",\n";
         stream << get_indent() << "scalar_max_" << legalized_name << ",\n";
@@ -872,9 +872,9 @@ void CodeGen_C::emit_constexpr_function_info(const std::string &function_name,
 
         const auto name = map_name(arg.name);
 
-        stream << get_indent() << "{\"" << name << "\", " << kind_names[arg.kind] << ", " << (int)arg.dimensions
-               << ", halide_type_t{" << type_code_names[arg.type.code()] << ", " << (int)arg.type.bits()
-               << ", " << (int)arg.type.lanes() << "}},\n";
+        stream << get_indent() << "{\"" << name << "\", " << kind_names[arg.kind] << ", " << arg.dimensions
+               << ", halide_type_t{" << type_code_names[arg.type.code()] << ", " << arg.type.bits()
+               << ", " << arg.type.lanes() << "}},\n";
     }
     indent -= 1;
     stream << get_indent() << "}};\n";

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -762,7 +762,7 @@ void CodeGen_C::emit_metadata_getter(const std::string &function_name,
                 constants.push_back(emit_constant_int64(extent));
             }
 
-            stream << get_indent() << "static const int64_t * const buffer_estimates_" << legalized_name << "[" << arg.dimensions * 2 << "] = {\n";
+            stream << get_indent() << "static const int64_t * const buffer_estimates_" << legalized_name << "[" << (int)arg.dimensions * 2 << "] = {\n";
             indent += 1;
             for (const auto &c : constants) {
                 stream << get_indent() << c << ",\n";
@@ -795,7 +795,7 @@ void CodeGen_C::emit_metadata_getter(const std::string &function_name,
         stream << get_indent() << "\"" << name << "\",\n";
         internal_assert(arg.kind < sizeof(kind_names) / sizeof(kind_names[0]));
         stream << get_indent() << kind_names[arg.kind] << ",\n";
-        stream << get_indent() << arg.dimensions << ",\n";
+        stream << get_indent() << (int)arg.dimensions << ",\n";
         internal_assert(arg.type.code() < sizeof(type_code_names) / sizeof(type_code_names[0]));
         stream << get_indent() << "{" << type_code_names[arg.type.code()] << ", " << arg.type.bits() << ", " << arg.type.lanes() << "},\n";
         stream << get_indent() << "scalar_def_" << legalized_name << ",\n";
@@ -872,7 +872,7 @@ void CodeGen_C::emit_constexpr_function_info(const std::string &function_name,
 
         const auto name = map_name(arg.name);
 
-        stream << get_indent() << "{\"" << name << "\", " << kind_names[arg.kind] << ", " << arg.dimensions
+        stream << get_indent() << "{\"" << name << "\", " << kind_names[arg.kind] << ", " << (int)arg.dimensions
                << ", halide_type_t{" << type_code_names[arg.type.code()] << ", " << arg.type.bits()
                << ", " << arg.type.lanes() << "}},\n";
     }

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -958,7 +958,7 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::visit(const FloatImm *op)
     // have seen division-by-zero shader warnings, and we postulated that it
     // could be indirectly related to compiler assumptions on signed integer
     // overflow when float_from_bits() is called, but we don't know for sure
-    return CodeGen_GPU_C::visit(op);
+    CodeGen_GPU_C::visit(op);
 }
 
 void CodeGen_D3D12Compute_Dev::add_kernel(Stmt s,
@@ -1146,10 +1146,12 @@ void CodeGen_D3D12Compute_Dev::CodeGen_D3D12Compute_C::add_kernel(Stmt s,
         using IRVisitor::visit;
         void visit(const For *loop) override {
             if (!is_gpu(loop->for_type)) {
-                return loop->body.accept(this);
+                loop->body.accept(this);
+                return;
             }
             if (loop->for_type != ForType::GPUThread) {
-                return loop->body.accept(this);
+                loop->body.accept(this);
+                return;
             }
             internal_assert(is_const_zero(loop->min));
             int index = thread_loop_workgroup_index(loop->name);

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -1044,7 +1044,7 @@ Value *CodeGen_Hexagon::interleave_vectors(const vector<llvm::Value *> &v) {
             // Break them into native vectors, use vshuffvdd, and
             // concatenate the shuffled results.
             llvm::Type *native2_ty = get_vector_type(element_ty, native_elements * 2);
-            Value *bytes = codegen(-static_cast<int>(element_bits / 8));
+            Value *bytes = codegen(-(element_bits / 8));
             vector<Value *> ret;
             for (int i = 0; i < result_elements / 2; i += native_elements) {
                 Value *a_i = slice_vector(a, i, native_elements);
@@ -1147,7 +1147,7 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
     llvm::Type *b_ty = b->getType();
     internal_assert(a_ty == b_ty);
 
-    int a_elements = static_cast<int>(get_vector_num_elements(a_ty));
+    int a_elements = get_vector_num_elements(a_ty);
 
     llvm::Type *element_ty = get_vector_element_type(a->getType());
     internal_assert(element_ty);

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -292,6 +292,7 @@ Expr lower_int_uint_mod(const Expr &a, const Expr &b) {
     }
 }
 
+namespace {
 std::pair<Expr, Expr> unsigned_long_div_mod_round_to_zero(Expr &num, const Expr &den,
                                                           const uint64_t *upper_bound) {
     internal_assert(num.type() == den.type());
@@ -329,6 +330,7 @@ std::pair<Expr, Expr> unsigned_long_div_mod_round_to_zero(Expr &num, const Expr 
     }
     return {q, r};
 }
+}  // namespace
 
 std::pair<Expr, Expr> long_div_mod_round_to_zero(const Expr &num, const Expr &den,
                                                  const uint64_t *max_abs) {
@@ -557,6 +559,7 @@ Expr lower_round_to_nearest_ties_to_even(const Expr &x) {
     return common_subexpression_elimination(a - correction);
 }
 
+namespace {
 bool get_md_bool(llvm::Metadata *value, bool &result) {
     if (!value) {
         return false;
@@ -585,6 +588,7 @@ bool get_md_string(llvm::Metadata *value, std::string &result) {
     }
     return false;
 }
+}  // namespace
 
 void get_target_options(const llvm::Module &module, llvm::TargetOptions &options) {
     bool use_soft_float_abi = false;

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -576,7 +576,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
     // Define all functions
     int idx = 0;
     for (const auto &f : input.functions()) {
-        const auto names = function_names[idx++];
+        const auto &names = function_names[idx++];
 
         run_with_large_stack([&]() {
             compile_func(f, names.simple_name, names.extern_name);
@@ -3234,7 +3234,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         builder->SetInsertPoint(global_not_inited_bb);
         llvm::Value *selected_value = nullptr;
         for (int i = sub_fns.size() - 1; i >= 0; i--) {
-            const auto sub_fn = sub_fns[i];
+            const auto &sub_fn = sub_fns[i];
             if (!selected_value) {
                 selected_value = sub_fn.fn_ptr;
             } else {

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -20,14 +20,6 @@
 
 #include <fstream>
 
-// This is declared in NVPTX.h, which is not exported. Ugly, but seems better than
-// hardcoding a path to the .h file.
-#ifdef WITH_NVPTX
-namespace llvm {
-FunctionPass *createNVVMReflectPass(const StringMap<int> &Mapping);
-}
-#endif
-
 namespace Halide {
 namespace Internal {
 

--- a/src/CodeGen_PowerPC.cpp
+++ b/src/CodeGen_PowerPC.cpp
@@ -129,7 +129,7 @@ void CodeGen_PowerPC::visit(const Min *op) {
             return;
         }
     }
-    return CodeGen_Posix::visit(op);
+    CodeGen_Posix::visit(op);
 }
 
 void CodeGen_PowerPC::visit(const Max *op) {
@@ -139,7 +139,7 @@ void CodeGen_PowerPC::visit(const Max *op) {
             return;
         }
     }
-    return CodeGen_Posix::visit(op);
+    CodeGen_Posix::visit(op);
 }
 
 string CodeGen_PowerPC::mcpu_target() const {

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -1261,10 +1261,10 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Call *op) {
                 one_constant_id = builder.declare_constant(op->type, &one_value);
             }
         } else if (op->type.is_float() && op->type.bits() == 32) {
-            float one_value = float(1.0f);
+            float one_value = 1.0f;
             one_constant_id = builder.declare_constant(op->type, &one_value);
         } else if (op->type.is_float() && op->type.bits() == 64) {
-            double one_value = double(1.0);
+            double one_value = 1.0;
             one_constant_id = builder.declare_constant(op->type, &one_value);
         } else {
             internal_error << "Vulkan: Unhandled float type in fast_inverse intrinsic!\n";
@@ -1832,7 +1832,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Allocate *op) {
             array_size = op->constant_allocation_size();
             array_type_id = builder.declare_type(op->type, array_size);
             builder.add_symbol(variable_name + "_array_type", array_type_id, builder.current_module().id());
-            debug(2) << "Vulkan: Allocate (fixed-size) " << op->name << " type=" << op->type << " array_size=" << (uint32_t)array_size << " in shared memory on device in global scope\n";
+            debug(2) << "Vulkan: Allocate (fixed-size) " << op->name << " type=" << op->type << " array_size=" << array_size << " in shared memory on device in global scope\n";
 
         } else {
             // dynamic allocation with unknown size at compile time ...
@@ -1844,7 +1844,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Allocate *op) {
             array_type_id = builder.add_array_with_default_size(storage_type_id, array_size_id);
             builder.add_symbol(variable_name + "_array_type", array_type_id, builder.current_module().id());
 
-            debug(2) << "Vulkan: Allocate (dynamic size) " << op->name << " type=" << op->type << " default_size=" << (uint32_t)array_size << " in shared memory on device in global scope\n";
+            debug(2) << "Vulkan: Allocate (dynamic size) " << op->name << " type=" << op->type << " default_size=" << array_size << " in shared memory on device in global scope\n";
 
             // bind the specialization constant to the next slot
             std::string constant_name = variable_name + "_array_size";
@@ -1876,7 +1876,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Allocate *op) {
             << "Allocation " << op->name << " has a dynamic size. "
             << "Only fixed-size local allocations are supported with Vulkan.";
 
-        debug(2) << "Vulkan: Allocate " << op->name << " type=" << op->type << " size=" << (uint32_t)array_size << " on device in function scope\n";
+        debug(2) << "Vulkan: Allocate " << op->name << " type=" << op->type << " size=" << array_size << " on device in function scope\n";
 
         array_type_id = builder.declare_type(op->type, array_size);
         storage_class = SpvStorageClassFunction;  // function scope
@@ -2705,7 +2705,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::declare_device_args(const Stmt &s, uint3
 
             // Set descriptor set and binding indices
             SpvBuilder::Literals dset_index = {entry_point_index};
-            SpvBuilder::Literals binding_index = {uint32_t(binding_counter++)};
+            SpvBuilder::Literals binding_index = {binding_counter++};
             builder.add_annotation(buffer_block_var_id, SpvDecorationDescriptorSet, dset_index);
             builder.add_annotation(buffer_block_var_id, SpvDecorationBinding, binding_index);
             symbol_table.push(arg.name, {buffer_block_var_id, storage_class});

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -408,7 +408,7 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::add_kernel(
 
     close_scope("shader " + name);
 
-    for (auto [name, alloc] : workgroup_allocations) {
+    for (const auto &[name, alloc] : workgroup_allocations) {
         std::stringstream length;
         if (is_const(alloc->extents[0])) {
             length << alloc->extents[0];

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -397,11 +397,11 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                     }
                     // Now we check all previous updates, see if the left hand
                     // side arguments overlap.
-                    Box current_box = boxes[update_id];
+                    const Box &current_box = boxes[update_id];
                     for (int prev_update_id = 0; prev_update_id < update_id;
                          prev_update_id++) {
                         // Gather two boxes from current update and previous update
-                        Box prev_box = boxes[prev_update_id];
+                        const Box &prev_box = boxes[prev_update_id];
                         internal_assert(current_box.size() == prev_box.size());
                         // If any of the boxes overlap, we need to throw an error
                         if (boxes_overlap(current_box, prev_box)) {
@@ -1369,7 +1369,7 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
     // Prepare a set of new substitution variables for func_to_update
     vector<Var> new_args;
     new_args.reserve(func_to_update.dimensions());
-    for (int arg_id = 0; arg_id < (int)func_to_update.dimensions(); arg_id++) {
+    for (int arg_id = 0; arg_id < func_to_update.dimensions(); arg_id++) {
         new_args.emplace_back(unique_name("u" + std::to_string(arg_id)));
     }
 
@@ -1805,7 +1805,7 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
             return !rdom.defined();
         }
         int update_id = func_to_update.num_update_definitions() - 1;
-        vector<Expr> prev_lhs =
+        const vector<Expr> &prev_lhs =
             func_to_update.update_args(update_id);
         internal_assert(prev_lhs.size() == lhs.size());
         // If previous update has different left hand side, don't merge

--- a/src/DistributeShifts.cpp
+++ b/src/DistributeShifts.cpp
@@ -195,7 +195,7 @@ private:
 
 }  // namespace
 
-Stmt distribute_shifts(const Stmt &s, const bool multiply_adds) {
+Stmt distribute_shifts(const Stmt &s, bool multiply_adds) {
     return DistributeShiftsAsMuls(multiply_adds).mutate(s);
 }
 

--- a/src/Elf.cpp
+++ b/src/Elf.cpp
@@ -521,6 +521,8 @@ Object::section_iterator Object::merge_text_sections() {
     return text;
 }
 
+namespace {
+
 template<typename T>
 std::vector<char> write_shared_object_internal(Object &obj, Linker *linker, const std::vector<std::string> &dependencies,
                                                const std::string &soname) {
@@ -1036,6 +1038,7 @@ std::vector<char> write_shared_object_internal(Object &obj, Linker *linker, cons
 
     return output;
 }
+}  // namespace
 
 std::vector<char> Object::write_shared_object(Linker *linker, const std::vector<std::string> &dependencies,
                                               const std::string &soname) {

--- a/src/EliminateBoolVectors.cpp
+++ b/src/EliminateBoolVectors.cpp
@@ -1,3 +1,4 @@
+#include "EliminateBoolVectors.h"
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "Scope.h"

--- a/src/FlattenNestedRamps.cpp
+++ b/src/FlattenNestedRamps.cpp
@@ -91,7 +91,7 @@ class FlattenRamps : public IRMutator {
                         c /= stride;
                     }
                     // Compute the number of elements loaded
-                    extent = (int)((max_constant_offset / stride) + 1);
+                    extent = (max_constant_offset / stride) + 1;
                 }
 
                 // If we're gathering from a very large range, it

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2425,7 +2425,7 @@ Stage Func::specialize(const Expr &c) {
 
 void Func::specialize_fail(const std::string &message) {
     invalidate_cache();
-    (void)Stage(func, func.definition(), 0).specialize_fail(message);
+    Stage(func, func.definition(), 0).specialize_fail(message);
 }
 
 Func &Func::serial(const VarOrRVar &var) {

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -168,9 +168,7 @@ class NormalizeDimensionality : public IRMutator {
         if (op->for_type == ForType::GPUThread ||
             op->for_type == ForType::GPULane) {
             depth++;
-            if (depth > max_depth) {
-                max_depth = depth;
-            }
+            max_depth = std::max(max_depth, depth);
             Stmt stmt = IRMutator::visit(op);
             depth--;
             return stmt;

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -1647,15 +1647,15 @@ public:
 // types in question satisfy the property of copies referring to the same underlying
 // structure (returning references is just an optimization). Since this is verbose
 // and used in several places, we'll use a helper macro:
-#define HALIDE_FORWARD_METHOD(Class, Method)                                                                                                        \
-    template<typename... Args>                                                                                                                      \
-    inline auto Method(Args &&...args)->typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
-        return this->template as<Class>().Method(std::forward<Args>(args)...);                                                                      \
+#define HALIDE_FORWARD_METHOD(Class, Method)                                                                                                          \
+    template<typename... Args>                                                                                                                        \
+    inline auto Method(Args &&...args) -> typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
+        return this->template as<Class>().Method(std::forward<Args>(args)...);                                                                        \
     }
 
 #define HALIDE_FORWARD_METHOD_CONST(Class, Method)                                                                  \
     template<typename... Args>                                                                                      \
-    inline auto Method(Args &&...args) const->                                                                      \
+    inline auto Method(Args &&...args) const ->                                                                     \
         typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
         this->check_gio_access();                                                                                   \
         return this->template as<Class>().Method(std::forward<Args>(args)...);                                      \

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -397,7 +397,7 @@ public:
     explicit GeneratorParamBase(const std::string &name);
     virtual ~GeneratorParamBase();
 
-    inline const std::string &name() const {
+    const std::string &name() const {
         return name_;
     }
 
@@ -489,12 +489,12 @@ public:
 template<typename FROM, typename TO>
 struct Convert {
     template<typename TO2 = TO, typename std::enable_if<!std::is_same<TO2, bool>::value>::type * = nullptr>
-    inline static TO2 value(const FROM &from) {
+    static TO2 value(const FROM &from) {
         return static_cast<TO2>(from);
     }
 
     template<typename TO2 = TO, typename std::enable_if<std::is_same<TO2, bool>::value>::type * = nullptr>
-    inline static TO2 value(const FROM &from) {
+    static TO2 value(const FROM &from) {
         return from != 0;
     }
 };
@@ -1647,15 +1647,15 @@ public:
 // types in question satisfy the property of copies referring to the same underlying
 // structure (returning references is just an optimization). Since this is verbose
 // and used in several places, we'll use a helper macro:
-#define HALIDE_FORWARD_METHOD(Class, Method)                                                                                                          \
-    template<typename... Args>                                                                                                                        \
-    inline auto Method(Args &&...args) -> typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
-        return this->template as<Class>().Method(std::forward<Args>(args)...);                                                                        \
+#define HALIDE_FORWARD_METHOD(Class, Method)                                                                                                        \
+    template<typename... Args>                                                                                                                      \
+    inline auto Method(Args &&...args)->typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
+        return this->template as<Class>().Method(std::forward<Args>(args)...);                                                                      \
     }
 
 #define HALIDE_FORWARD_METHOD_CONST(Class, Method)                                                                  \
     template<typename... Args>                                                                                      \
-    inline auto Method(Args &&...args) const ->                                                                     \
+    inline auto Method(Args &&...args) const->                                                                      \
         typename std::remove_reference<decltype(std::declval<Class>().Method(std::forward<Args>(args)...))>::type { \
         this->check_gio_access();                                                                                   \
         return this->template as<Class>().Method(std::forward<Args>(args)...);                                      \
@@ -1683,7 +1683,7 @@ protected:
     }
 
     template<typename T2>
-    inline T2 as() const {
+    T2 as() const {
         return (T2) * this;
     }
 
@@ -1836,7 +1836,7 @@ protected:
     }
 
     template<typename T2>
-    inline T2 as() const {
+    T2 as() const {
         return (T2) * this;
     }
 
@@ -3031,11 +3031,11 @@ public:
     GeneratorContext with_target(const Target &t) const;
 
     template<typename T>
-    inline std::unique_ptr<T> create() const {
+    std::unique_ptr<T> create() const {
         return T::create(*this);
     }
     template<typename T, typename... Args>
-    inline std::unique_ptr<T> apply(const Args &...args) const {
+    std::unique_ptr<T> apply(const Args &...args) const {
         auto t = this->create<T>();
         t->apply(args...);
         return t;
@@ -3074,7 +3074,7 @@ protected:
     static Expr cast(Expr e) {
         return Halide::cast<T>(e);
     }
-    static inline Expr cast(Halide::Type t, Expr e) {
+    static Expr cast(Halide::Type t, Expr e) {
         return Halide::cast(t, std::move(e));
     }
     template<typename T>
@@ -3083,16 +3083,16 @@ protected:
     using Buffer = Halide::Buffer<T, D>;
     template<typename T>
     using Param = Halide::Param<T>;
-    static inline Type Bool(int lanes = 1) {
+    static Type Bool(int lanes = 1) {
         return Halide::Bool(lanes);
     }
-    static inline Type Float(int bits, int lanes = 1) {
+    static Type Float(int bits, int lanes = 1) {
         return Halide::Float(bits, lanes);
     }
-    static inline Type Int(int bits, int lanes = 1) {
+    static Type Int(int bits, int lanes = 1) {
         return Halide::Int(bits, lanes);
     }
-    static inline Type UInt(int bits, int lanes = 1) {
+    static Type UInt(int bits, int lanes = 1) {
         return Halide::UInt(bits, lanes);
     }
 };
@@ -3347,7 +3347,7 @@ public:
 
     template<typename... Args,
              typename = typename std::enable_if<Internal::all_are_printable_args<Args...>::value>::type>
-    inline HALIDE_NO_USER_CODE_INLINE void add_requirement(const Expr &condition, Args &&...error_args) {
+    HALIDE_NO_USER_CODE_INLINE void add_requirement(const Expr &condition, Args &&...error_args) {
         std::vector<Expr> collected_args;
         Internal::collect_print_args(collected_args, std::forward<Args>(error_args)...);
         add_requirement(condition, collected_args);
@@ -3775,7 +3775,7 @@ public:
     }
 
     template<typename T2, typename... Args>
-    inline std::unique_ptr<T2> apply(const Args &...args) const {
+    std::unique_ptr<T2> apply(const Args &...args) const {
         auto t = this->create<T2>();
         t->apply(args...);
         return t;

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -364,7 +364,7 @@ void do_reloc(char *addr, uint32_t mask, uintptr_t val, bool is_signed, bool ver
                 consumed_every_bit |= ((intptr_t)val) == -1;
                 val = ((intptr_t)val) >> 1;
             } else {
-                val = ((uintptr_t)val) >> 1;
+                val = val >> 1;
             }
             consumed_every_bit |= (val == 0);
             inst |= (next_bit << i);

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -66,6 +66,7 @@ Expr native_deinterleave(const Expr &x) {
     return Call::make(x.type(), fn, {x}, Call::PureExtern);
 }
 
+namespace {
 bool is_native_interleave_op(const Expr &x, const char *name) {
     const Call *c = x.as<Call>();
     if (!c || c->args.size() != 1) {
@@ -73,6 +74,7 @@ bool is_native_interleave_op(const Expr &x, const char *name) {
     }
     return starts_with(c->name, name);
 }
+}  // namespace
 
 bool is_native_interleave(const Expr &x) {
     return is_native_interleave_op(x, "halide.hexagon.interleave");

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1318,7 +1318,7 @@ HALIDE_ALWAYS_INLINE double constant_fold_bin_op<And>(halide_type_t &t, double a
     return 0;
 }
 
-constexpr inline uint32_t bitwise_or_reduce() {
+constexpr uint32_t bitwise_or_reduce() {
     return 0;
 }
 
@@ -1327,7 +1327,7 @@ constexpr uint32_t bitwise_or_reduce(uint32_t first, Args... rest) {
     return first | bitwise_or_reduce(rest...);
 }
 
-constexpr inline bool and_reduce() {
+constexpr bool and_reduce() {
     return true;
 }
 

--- a/src/IRMutator.h
+++ b/src/IRMutator.h
@@ -128,8 +128,8 @@ std::pair<Region, bool> mutate_region(Mutator *mutator, const Region &bounds, Ar
     for (size_t i = 0; i < bounds.size(); i++) {
         Expr old_min = bounds[i].min;
         Expr old_extent = bounds[i].extent;
-        Expr new_min = mutator->mutate(old_min, std::forward<Args>(args)...);
-        Expr new_extent = mutator->mutate(old_extent, std::forward<Args>(args)...);
+        Expr new_min = mutator->mutate(old_min, args...);
+        Expr new_extent = mutator->mutate(old_extent, args...);
         if (!new_min.same_as(old_min)) {
             bounds_changed = true;
         }

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -586,7 +586,7 @@ void print_handler(JITUserContext *context, const char *msg) {
     if (context && context->handlers.custom_print) {
         context->handlers.custom_print(context, msg);
     } else {
-        return active_handlers.custom_print(context, msg);
+        active_handlers.custom_print(context, msg);
     }
 }
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -342,8 +342,6 @@ std::unique_ptr<llvm::Module> clone_module(const llvm::Module &module_in) {
     return std::move(cloned_module.get());
 }
 
-}  // namespace
-
 void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
                llvm::CodeGenFileType file_type) {
     Internal::debug(1) << "emit_file.Compiling to native code...\n";
@@ -406,6 +404,8 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
     // If -time-passes is in HL_LLVM_ARGS, this will print llvm passes time statstics otherwise its no-op.
     llvm::reportAndResetTimings();
 }
+
+}  // namespace
 
 std::unique_ptr<llvm::Module> compile_module_to_llvm_module(const Module &module, llvm::LLVMContext &context) {
     return codegen_llvm(module, context);

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -741,10 +741,6 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
     }
 }
 
-}  // namespace
-
-namespace Internal {
-
 /** When JIT-compiling on 32-bit windows, we need to rewrite calls
  *  to name-mangled win32 api calls to non-name-mangled versions.
  */
@@ -753,7 +749,7 @@ void undo_win32_name_mangling(llvm::Module *m) {
     // For every function prototype...
     for (llvm::Module::iterator iter = m->begin(); iter != m->end(); ++iter) {
         llvm::Function &f = *iter;
-        string n = get_llvm_function_name(f);
+        string n = Internal::get_llvm_function_name(f);
         // if it's a __stdcall call that starts with \01_, then we're making a win32 api call
         if (f.getCallingConv() == llvm::CallingConv::X86_StdCall &&
             f.empty() &&
@@ -825,6 +821,10 @@ void add_underscores_to_posix_calls_on_windows(llvm::Module *m) {
         }
     }
 }
+
+}  // namespace
+
+namespace Internal {
 
 std::unique_ptr<llvm::Module> link_with_wasm_jit_runtime(llvm::LLVMContext *c, const Target &t,
                                                          std::unique_ptr<llvm::Module> extra_module) {

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -482,13 +482,13 @@ class LoopCarryOverLoop : public IRMutator {
 
             // Wrap them in the appropriate lets
             for (size_t i = initial_lets.size(); i > 0; i--) {
-                auto l = initial_lets[i - 1];
+                const auto &l = initial_lets[i - 1];
                 initial_stores = LetStmt::make(l.first, l.second, initial_stores);
             }
             // We may be lifting the initial stores out of let stmts,
             // so rewrap them in the necessary ones.
             for (size_t i = containing_lets.size(); i > 0; i--) {
-                auto l = containing_lets[i - 1];
+                const auto &l = containing_lets[i - 1];
                 if (stmt_uses_var(initial_stores, l.first)) {
                     initial_stores = LetStmt::make(l.first, l.second, initial_stores);
                 }

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -165,9 +165,7 @@ class KeyInfo {
         // Find maximum natural alignment needed.
         for (const ConstDependencyKeyInfoPair &i : dependencies.dependency_info) {
             int alignment = i.second.type.bytes();
-            if (alignment > max_alignment) {
-                max_alignment = alignment;
-            }
+            max_alignment = std::max(max_alignment, alignment);
         }
         // Make sure max_alignment is a power of two and has maximum value of 32
         int i = 0;

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -268,7 +268,8 @@ bool Parameter::defined() const {
 // parameter itself, to avoid creating a reference count cycle and causing a
 // leak. Note that it's still possible to create a cycle by having two different
 // Parameters each have constraints that reference the other.
-namespace Internal {
+namespace {
+using namespace Halide::Internal;
 
 Expr remove_self_references(const Parameter &p, const Expr &e) {
     class RemoveSelfReferences : public IRMutator {
@@ -316,36 +317,36 @@ Expr restore_self_references(const Parameter &p, const Expr &e) {
     return mutator.mutate(e);
 }
 
-}  // namespace Internal
+}  // namespace
 
 void Parameter::set_min_constraint(int dim, const Expr &e) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->buffer_constraints[dim].min = Internal::remove_self_references(*this, e);
+    contents->buffer_constraints[dim].min = remove_self_references(*this, e);
 }
 
 void Parameter::set_extent_constraint(int dim, const Expr &e) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->buffer_constraints[dim].extent = Internal::remove_self_references(*this, e);
+    contents->buffer_constraints[dim].extent = remove_self_references(*this, e);
 }
 
 void Parameter::set_stride_constraint(int dim, const Expr &e) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->buffer_constraints[dim].stride = Internal::remove_self_references(*this, e);
+    contents->buffer_constraints[dim].stride = remove_self_references(*this, e);
 }
 
 void Parameter::set_min_constraint_estimate(int dim, const Expr &min) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->buffer_constraints[dim].min_estimate = Internal::remove_self_references(*this, min);
+    contents->buffer_constraints[dim].min_estimate = remove_self_references(*this, min);
 }
 
 void Parameter::set_extent_constraint_estimate(int dim, const Expr &extent) {
     check_is_buffer();
     check_dim_ok(dim);
-    contents->buffer_constraints[dim].extent_estimate = Internal::remove_self_references(*this, extent);
+    contents->buffer_constraints[dim].extent_estimate = remove_self_references(*this, extent);
 }
 
 void Parameter::set_host_alignment(int bytes) {
@@ -356,31 +357,31 @@ void Parameter::set_host_alignment(int bytes) {
 Expr Parameter::min_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return Internal::restore_self_references(*this, contents->buffer_constraints[dim].min);
+    return restore_self_references(*this, contents->buffer_constraints[dim].min);
 }
 
 Expr Parameter::extent_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return Internal::restore_self_references(*this, contents->buffer_constraints[dim].extent);
+    return restore_self_references(*this, contents->buffer_constraints[dim].extent);
 }
 
 Expr Parameter::stride_constraint(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return Internal::restore_self_references(*this, contents->buffer_constraints[dim].stride);
+    return restore_self_references(*this, contents->buffer_constraints[dim].stride);
 }
 
 Expr Parameter::min_constraint_estimate(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return Internal::restore_self_references(*this, contents->buffer_constraints[dim].min_estimate);
+    return restore_self_references(*this, contents->buffer_constraints[dim].min_estimate);
 }
 
 Expr Parameter::extent_constraint_estimate(int dim) const {
     check_is_buffer();
     check_dim_ok(dim);
-    return Internal::restore_self_references(*this, contents->buffer_constraints[dim].extent_estimate);
+    return restore_self_references(*this, contents->buffer_constraints[dim].extent_estimate);
 }
 
 int Parameter::host_alignment() const {

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -484,7 +484,7 @@ public:
 
     template<typename... Args,
              typename = typename std::enable_if<Internal::all_are_printable_args<Args...>::value>::type>
-    inline HALIDE_NO_USER_CODE_INLINE void add_requirement(const Expr &condition, Args &&...error_args) {
+    HALIDE_NO_USER_CODE_INLINE void add_requirement(const Expr &condition, Args &&...error_args) {
         std::vector<Expr> collected_args;
         Internal::collect_print_args(collected_args, std::forward<Args>(error_args)...);
         add_requirement(condition, collected_args);

--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -66,12 +66,14 @@ const std::string &RVar::name() const {
     }
 }
 
+namespace {
 template<int N>
 ReductionDomain build_domain(ReductionVariable (&vars)[N]) {
     vector<ReductionVariable> d(&vars[0], &vars[N]);
     ReductionDomain dom(d);
     return dom;
 }
+}  // namespace
 
 // This just initializes the predefined x, y, z, w members of RDom.
 void RDom::init_vars(const string &name) {

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -282,8 +282,6 @@ void sort_funcs_by_name_and_counter(vector<string> *funcs,
     }
 }
 
-}  // anonymous namespace
-
 map<string, uint64_t> compute_visitation_order(const vector<Function> &outputs) {
     vector<Function> funcs = called_funcs_in_order_found(outputs);
     map<string, uint64_t> result;
@@ -292,6 +290,8 @@ map<string, uint64_t> compute_visitation_order(const vector<Function> &outputs) 
     }
     return result;
 }
+
+}  // anonymous namespace
 
 pair<vector<string>, vector<vector<string>>> realization_order(
     const vector<Function> &outputs, map<string, Function> &env) {

--- a/src/RegionCosts.h
+++ b/src/RegionCosts.h
@@ -32,7 +32,7 @@ struct Cost {
     }
     Cost() = default;
 
-    inline bool defined() const {
+    bool defined() const {
         return arith.defined() && memory.defined();
     }
     void simplify();

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -2551,7 +2551,9 @@ bool group_should_be_inlined(const vector<Function> &funcs) {
 
 }  // namespace
 
-static std::ostream &operator<<(std::ostream &out, const std::vector<Function> &v) {
+// We want this to have internal linkage, but putting it in an anonymous
+// namespace doesn't work due to two-phase lookup peculiarities.
+static std::ostream &operator<<(std::ostream &out, const std::vector<Function> &v) {  // NOLINT
     out << "{ ";
     for (size_t i = 0; i < v.size(); ++i) {
         out << v[i].name();

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1311,7 +1311,7 @@ protected:
 
         // Reinstate the let/if statements
         for (size_t i = containers.size(); i > 0; i--) {
-            auto p = containers[i - 1];
+            const auto &p = containers[i - 1];
             if (p.first.empty()) {
                 body = IfThenElse::make(p.second, body);
             } else {
@@ -2551,7 +2551,7 @@ bool group_should_be_inlined(const vector<Function> &funcs) {
 
 }  // namespace
 
-std::ostream &operator<<(std::ostream &out, const std::vector<Function> &v) {
+static std::ostream &operator<<(std::ostream &out, const std::vector<Function> &v) {
     out << "{ ";
     for (size_t i = 0; i < v.size(); ++i) {
         out << v[i].name();

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -311,6 +311,7 @@ void Simplify::ScopedFact::learn_true(const Expr &fact) {
     }
 }
 
+namespace {
 template<typename T>
 T substitute_facts_impl(const T &t,
                         const std::set<Expr, IRDeepCompare> &truths,
@@ -340,6 +341,7 @@ T substitute_facts_impl(const T &t,
 
     return substitutor.mutate(t);
 }
+}  // namespace
 
 Expr Simplify::ScopedFact::substitute_facts(const Expr &e) {
     return substitute_facts_impl(e, truths, falsehoods);

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -657,7 +657,7 @@ class Dependencies : public IRVisitor {
 
     void visit(const ProducerConsumer *op) override {
         ScopedValue<bool> old_finding_a(in_producer, in_producer || (op->is_producer && op->name == producer));
-        return IRVisitor::visit(op);
+        IRVisitor::visit(op);
     }
 
     void visit(const Call *op) override {

--- a/src/StmtToHTML.cpp
+++ b/src/StmtToHTML.cpp
@@ -784,7 +784,7 @@ public:
         scope.pop(m.name());
     }
 
-    inline std::string escape_html(std::string src) {
+    std::string escape_html(std::string src) {
         src = replace_all(src, "&", "&amp;");
         src = replace_all(src, "<", "&lt;");
         src = replace_all(src, ">", "&gt;");
@@ -902,7 +902,7 @@ public:
                 std::vector<std::string> operands = split_string(operands_str, ", ");
                 operands_str = "";
                 for (size_t opidx = 0; opidx < operands.size(); ++opidx) {
-                    std::string op = operands[opidx];
+                    const std::string &op = operands[opidx];
                     internal_assert(!op.empty());
                     if (opidx != 0) {
                         operands_str += ", ";

--- a/src/Target.h
+++ b/src/Target.h
@@ -223,7 +223,7 @@ struct Target {
 
     bool has_feature(Feature f) const;
 
-    inline bool has_feature(halide_target_feature_t f) const {
+    bool has_feature(halide_target_feature_t f) const {
         return has_feature((Feature)f);
     }
 

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -43,7 +43,7 @@ struct TraceEventBuilder {
         // special-casing of this call to get appropriate results.
         vector<Expr> args = {Expr(func),
                              values, coords,
-                             (int)type.code(), (int)type.bits(), (int)type.lanes(),
+                             (int)type.code(), type.bits(), type.lanes(),
                              (int)event,
                              parent_id, idx, (int)coordinates.size(),
                              trace_tag_expr};

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -172,6 +172,7 @@ Stmt uniquify_variable_names(const Stmt &s) {
     return u.mutate(s);
 }
 
+namespace {
 void check(vector<pair<Var, Expr>> in,
            vector<pair<Var, Expr>> out) {
     Stmt in_stmt = Evaluate::make(0), out_stmt = Evaluate::make(0);
@@ -193,6 +194,7 @@ void check(vector<pair<Var, Expr>> in,
         << "Correct output:\n"
         << out_stmt << "\n";
 }
+}  // namespace
 
 void uniquify_variable_names_test() {
     Var x("x"), x_1("x_1"), x_2("x_2"), x_3{"x_3"};

--- a/src/Util.h
+++ b/src/Util.h
@@ -426,7 +426,7 @@ void halide_toc_impl(const char *file, int line);
 template<typename TO>
 struct StaticCast {
     template<typename FROM>
-    inline constexpr static TO value(const FROM &from) {
+    constexpr static TO value(const FROM &from) {
         if constexpr (std::is_same<TO, bool>::value) {
             return from != 0;
         } else {
@@ -441,7 +441,7 @@ struct StaticCast {
 template<typename TO>
 struct IsRoundtrippable {
     template<typename FROM>
-    inline constexpr static bool value(const FROM &from) {
+    constexpr static bool value(const FROM &from) {
         if constexpr (std::is_convertible<FROM, TO>::value) {
             if constexpr (std::is_arithmetic<TO>::value &&
                           std::is_arithmetic<FROM>::value &&

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -828,7 +828,9 @@ class VectorSubs : public IRMutator {
         if (predicate.same_as(op->predicate) && value.same_as(op->value) && index.same_as(op->index)) {
             return op;
         } else {
-            int lanes = std::max(predicate.type().lanes(), std::max(value.type().lanes(), index.type().lanes()));
+            int lanes = std::max({predicate.type().lanes(),
+                                  value.type().lanes(),
+                                  index.type().lanes()});
             return Store::make(op->name, widen(value, lanes), widen(index, lanes),
                                op->param, widen(predicate, lanes), op->alignment);
         }

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -82,7 +82,7 @@ struct debug_sink {
     debug_sink() = default;
 
     template<typename T>
-    inline debug_sink &operator<<(T &&x) {
+    debug_sink &operator<<(T &&x) {
         return *this;
     }
 };
@@ -163,7 +163,7 @@ public:
 
         // alignment and min-block-size are the same for our purposes here.
         constexpr uint32_t kAlignment = 32;
-        const uint32_t size = std::max(align_up((uint32_t)requested_size, kAlignment), kAlignment);
+        const uint32_t size = std::max(align_up(requested_size, kAlignment), kAlignment);
 
         constexpr uint32_t kMaxAllocSize = 0x7fffffff;
         internal_assert(size <= kMaxAllocSize);
@@ -822,7 +822,7 @@ void copy_hostbuf_to_existing_wasmbuf(WabtContext &wabt_context, const halide_bu
 
 template<typename T>
 struct LoadValue {
-    inline wabt::interp::Value operator()(const void *src) {
+    wabt::interp::Value operator()(const void *src) {
         const T val = *(const T *)(src);
         return wabt::interp::Value::Make(val);
     }
@@ -867,7 +867,7 @@ inline wabt::interp::Value load_value(const T &val) {
 
 template<typename T>
 struct StoreValue {
-    inline void operator()(const wabt::interp::Value &src, void *dst) {
+    void operator()(const wabt::interp::Value &src, void *dst) {
         *(T *)dst = src.Get<T>();
     }
 };
@@ -2134,8 +2134,6 @@ void add_extern_callbacks(const Local<Context> &context,
 
 #endif  // WITH_V8
 
-}  // namespace
-
 // clang-format off
 
 #if WITH_WABT
@@ -2226,6 +2224,8 @@ const HostCallbackMap &get_host_callback_map() {
 
     return m;
 }
+
+}  // namespace
 
 #undef DEFINE_CALLBACK
 #undef DEFINE_POSIX_MATH_CALLBACK

--- a/src/autoschedulers/adams2019/AutoSchedule.cpp
+++ b/src/autoschedulers/adams2019/AutoSchedule.cpp
@@ -80,6 +80,8 @@ namespace Halide {
 namespace Internal {
 namespace Autoscheduler {
 
+namespace {
+
 using std::string;
 using std::vector;
 
@@ -498,9 +500,6 @@ IntrusivePtr<State> optimal_schedule(FunctionDAG &dag,
     return best;
 }
 
-// Keep track of how many times we evaluated a state.
-int State::cost_calculations = 0;
-
 // The main entrypoint to generate a schedule for a pipeline.
 void generate_schedule(const std::vector<Function> &outputs,
                        const Target &target,
@@ -607,6 +606,8 @@ struct Adams2019 {
 };
 
 REGISTER_AUTOSCHEDULER(Adams2019)
+
+}  // namespace
 
 // An alternative entrypoint for other uses
 void find_and_apply_schedule(FunctionDAG &dag,

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -554,6 +554,7 @@ void FunctionDAG::Edge::expand_footprint(const Span *consumer_loop, Span *produc
     }
 }
 
+namespace {
 class DependsOnEstimate : public IRVisitor {
 public:
     bool found_estimate = false;
@@ -571,6 +572,7 @@ bool depends_on_estimate(const Expr &expr) {
     expr.accept(&dependency_checker);
     return dependency_checker.found_estimate;
 }
+}  // namespace
 
 FunctionDAG::FunctionDAG(const vector<Function> &outputs, const Target &target) {
     map<string, Function> env = build_environment(outputs);

--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -11,7 +11,7 @@ namespace Autoscheduler {
 // How small should an innermost loop cluster be before you just
 // entirely unroll the thing. Sized for an architecture with 16 vector
 // registers.
-const int kUnrollLimit = 12;
+constexpr static int kUnrollLimit = 12;
 
 // Given a multi-dimensional box of dimensionality d, generate a list
 // of candidate tile sizes for it, logarithmically spacing the sizes

--- a/src/autoschedulers/adams2019/State.cpp
+++ b/src/autoschedulers/adams2019/State.cpp
@@ -686,6 +686,9 @@ void State::apply_schedule(const FunctionDAG &dag, const Adams2019Params &params
     }
 }
 
+// Keep track of how many times we evaluated a state.
+int State::cost_calculations = 0;
+
 }  // namespace Autoscheduler
 }  // namespace Internal
 }  // namespace Halide

--- a/src/autoschedulers/adams2019/Weights.cpp
+++ b/src/autoschedulers/adams2019/Weights.cpp
@@ -12,7 +12,7 @@ namespace Internal {
 
 using Halide::Runtime::Buffer;
 
-constexpr uint32_t kSignature = 0x68776631;
+constexpr static uint32_t kSignature = 0x68776631;
 
 void Weights::randomize(uint32_t seed) {
     std::mt19937 rng(seed);
@@ -70,7 +70,7 @@ bool Weights::load(std::istream &i) {
         for (uint32_t d = 0; d < dimension_count; d++) {
             uint32_t extent;
             i.read((char *)&extent, sizeof(extent));
-            if (i.fail() || (int)extent != (int)buf.extent(d)) {
+            if (i.fail() || (int)extent != buf.extent(d)) {
                 return false;
             }
         }

--- a/src/autoschedulers/anderson2021/AutoSchedule.cpp
+++ b/src/autoschedulers/anderson2021/AutoSchedule.cpp
@@ -79,6 +79,8 @@ namespace Halide {
 namespace Internal {
 namespace Autoscheduler {
 
+namespace {
+
 using std::string;
 using std::vector;
 
@@ -712,6 +714,7 @@ struct Anderson2021 {
 };
 
 REGISTER_AUTOSCHEDULER(Anderson2021)
+}  // namespace
 
 // An alternative entrypoint for other uses
 void find_and_apply_schedule(FunctionDAG &dag,

--- a/src/autoschedulers/anderson2021/LoopNest.cpp
+++ b/src/autoschedulers/anderson2021/LoopNest.cpp
@@ -32,7 +32,7 @@ std::string stringify(GPU_parallelism label) {
 
 // How small should an innermost loop cluster be before you just
 // entirely unroll the thing
-const int kUnrollLimitGPU = 16;
+constexpr static int kUnrollLimitGPU = 16;
 
 bool may_subtile(const Anderson2021Params &params) {
     return params.disable_subtiling == 0;

--- a/src/autoschedulers/anderson2021/LoopNest.h
+++ b/src/autoschedulers/anderson2021/LoopNest.h
@@ -53,6 +53,8 @@ bool may_subtile(const Anderson2021Params &params);
 
 int64_t get_shared_memory_limit(const Anderson2021Params &params);
 
+int64_t get_shared_memory_sm_limit(const Anderson2021Params &params);
+
 int64_t get_active_block_hardware_limit(const Anderson2021Params &params);
 
 int64_t get_active_warp_hardware_limit(const Anderson2021Params &params);

--- a/src/autoschedulers/anderson2021/LoopNestParser.h
+++ b/src/autoschedulers/anderson2021/LoopNestParser.h
@@ -58,7 +58,7 @@ class LoopNestParser {
             }
 
             if (tokens.back() == "gpu_simd" && compute_root_stages.count(stage) == 1 && compute_root_stages[stage] == -1) {
-                std::string vector_dim = tokens[tokens.size() - 3];
+                const std::string &vector_dim = tokens[tokens.size() - 3];
                 compute_root_stages[stage] = std::stoi(vector_dim.substr(0, vector_dim.size() - 1));
             }
 

--- a/src/autoschedulers/anderson2021/State.cpp
+++ b/src/autoschedulers/anderson2021/State.cpp
@@ -7,9 +7,11 @@ namespace Halide {
 namespace Internal {
 namespace Autoscheduler {
 
+namespace {
 int64_t get_stack_memory_limit(const Anderson2021Params &params) {
     return params.stack_factor * 103232;
 }
+}  // namespace
 
 uint64_t State::structural_hash(int depth) const {
     uint64_t h = num_decisions_made;

--- a/src/autoschedulers/anderson2021/Weights.cpp
+++ b/src/autoschedulers/anderson2021/Weights.cpp
@@ -12,7 +12,7 @@ namespace Internal {
 
 using Halide::Runtime::Buffer;
 
-constexpr uint32_t kSignature = 0x68776631;
+constexpr static uint32_t kSignature = 0x68776631;
 
 void Weights::randomize(uint32_t seed) {
     std::mt19937 rng(seed);
@@ -70,7 +70,7 @@ bool Weights::load(std::istream &i) {
         for (uint32_t d = 0; d < dimension_count; d++) {
             uint32_t extent;
             i.read((char *)&extent, sizeof(extent));
-            if (i.fail() || (int)extent != (int)buf.extent(d)) {
+            if (i.fail() || (int)extent != buf.extent(d)) {
                 return false;
             }
         }

--- a/src/autoschedulers/common/cmdline.h
+++ b/src/autoschedulers/common/cmdline.h
@@ -484,7 +484,7 @@ public:
             return false;
         }
 
-        if (buf.length() > 0) {
+        if (!buf.empty()) {
             args.push_back(buf);
         }
 
@@ -520,7 +520,7 @@ public:
 
         std::map<char, std::string> lookup;
         for (auto &option : options) {
-            if (option.first.length() == 0) {
+            if (option.first.empty()) {
                 continue;
             }
             char initial = option.second->short_name();

--- a/src/autoschedulers/li2018/GradientAutoscheduler.cpp
+++ b/src/autoschedulers/li2018/GradientAutoscheduler.cpp
@@ -737,7 +737,7 @@ void apply_schedule(const GradientAutoschedulerParams &params,
         pure_arg_bounds.reserve(update_args.size());
         int parallelism = 1;
         for (int arg_id = 0; arg_id < (int)update_args.size(); arg_id++) {
-            Expr arg = update_args[arg_id];
+            const Expr &arg = update_args[arg_id];
             const Variable *var = arg.as<Variable>();
             if (var != nullptr &&
                 !var->param.defined() &&
@@ -818,8 +818,6 @@ void apply_schedule(const GradientAutoschedulerParams &params,
     }
     schedule_source << ";\n";
 }
-
-}  // namespace
 
 void generate_schedule(const std::vector<Function> &outputs,
                        const Target &target,
@@ -950,6 +948,7 @@ struct Li2018 {
 
 REGISTER_AUTOSCHEDULER(Li2018)
 
+}  // namespace
 }  // namespace Autoscheduler
 }  // namespace Internal
 }  // namespace Halide

--- a/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
+++ b/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
@@ -1023,7 +1023,7 @@ struct Partitioner {
             : cost(c), parallelism(std::move(p)) {
         }
 
-        inline bool defined() const {
+        bool defined() const {
             return cost.defined() && parallelism.defined();
         }
 
@@ -3200,8 +3200,6 @@ bool inline_unbounded(const vector<Function> &outputs,
     return inlined;
 }
 
-}  // anonymous namespace
-
 // Generate schedules for all functions in the pipeline required to compute the
 // outputs. This applies the schedules and returns a string representation of
 // the schedules. The target architecture is specified by 'target'.
@@ -3450,6 +3448,7 @@ struct Mullapudi2016 {
 };
 
 REGISTER_AUTOSCHEDULER(Mullapudi2016)
+}  // anonymous namespace
 
 }  // namespace Autoscheduler
 }  // namespace Internal

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -422,6 +422,7 @@ private:
             buf.dim = other.buf.dim;
             other.buf.dim = nullptr;
         }
+        other.buf = halide_buffer_t();
     }
 
     /** Initialize the shape from a halide_buffer_t. */
@@ -793,7 +794,6 @@ public:
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
         move_shape_from(std::forward<Buffer<T, Dims, InClassDimStorage>>(other));
-        other.buf = halide_buffer_t();
     }
 
     /** Move-construct a Buffer from a Buffer of different
@@ -808,7 +808,6 @@ public:
         other.dev_ref_count = nullptr;
         other.alloc = nullptr;
         move_shape_from(std::forward<Buffer<T2, D2, S2>>(other));
-        other.buf = halide_buffer_t();
     }
 
     /** Assign from another Buffer of possibly-different
@@ -860,7 +859,6 @@ public:
         free_shape_storage();
         buf = other.buf;
         move_shape_from(std::forward<Buffer<T2, D2, S2>>(other));
-        other.buf = halide_buffer_t();
         return *this;
     }
 
@@ -874,7 +872,6 @@ public:
         free_shape_storage();
         buf = other.buf;
         move_shape_from(std::forward<Buffer<T, Dims, InClassDimStorage>>(other));
-        other.buf = halide_buffer_t();
         return *this;
     }
 
@@ -1158,8 +1155,8 @@ public:
     /** Initialize a Buffer from a pointer to the min coordinate and
      * a vector describing the shape.  Does not take ownership of the
      * data, and does not set the host_dirty flag. */
-    explicit inline Buffer(halide_type_t t, add_const_if_T_is_const<void> *data,
-                           const std::vector<halide_dimension_t> &shape)
+    explicit Buffer(halide_type_t t, add_const_if_T_is_const<void> *data,
+                    const std::vector<halide_dimension_t> &shape)
         : Buffer(t, data, (int)shape.size(), shape.data()) {
     }
 
@@ -1178,7 +1175,7 @@ public:
     /** Initialize a Buffer from a pointer to the min coordinate and
      * a vector describing the shape.  Does not take ownership of the
      * data, and does not set the host_dirty flag. */
-    explicit inline Buffer(T *data, const std::vector<halide_dimension_t> &shape)
+    explicit Buffer(T *data, const std::vector<halide_dimension_t> &shape)
         : Buffer(data, (int)shape.size(), shape.data()) {
     }
 
@@ -1391,7 +1388,7 @@ public:
      *     my_func(input.alias(), output);
      * }\endcode
      */
-    inline Buffer<T, Dims, InClassDimStorage> alias() const {
+    Buffer<T, Dims, InClassDimStorage> alias() const {
         return *this;
     }
 
@@ -1706,7 +1703,7 @@ public:
     }
 
     /** Slice a buffer in-place at the dimension's minimum. */
-    inline void slice(int d) {
+    void slice(int d) {
         slice(d, dim(d).min());
     }
 

--- a/util/HalideTraceDump.cpp
+++ b/util/HalideTraceDump.cpp
@@ -80,12 +80,9 @@ struct FuncInfo {
 
         for (int lane = 0; lane < lanes; lane++) {
             for (int i = 0; i < real_dims; i++) {
-                if (p->coordinates()[lanes * i + lane] < min_coords[i]) {
-                    min_coords[i] = p->coordinates()[lanes * i + lane];
-                }
-                if (p->coordinates()[lanes * i + lane] > max_coords[i]) {
-                    max_coords[i] = p->coordinates()[lanes * i + lane];
-                }
+                const int coord = p->coordinates()[lanes * i + lane];
+                min_coords[i] = std::min(min_coords[i], coord);
+                max_coords[i] = std::max(max_coords[i], coord);
             }
         }
     }

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1175,9 +1175,7 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
                     int frames_since_first_draw = (halide_clock - first_draw_clock) / state.globals.timestep;
                     if (frames_since_first_draw < label.fade_in_frames) {
                         uint32_t color = ((1 + frames_since_first_draw) * 255) / std::max(1, label.fade_in_frames);
-                        if (color > 255) {
-                            color = 255;
-                        }
+                        color = std::min<uint32_t>(color, 255);
                         color *= 0x10101;
                         surface->draw_text(label.text, label.pos, color, label.h_scale);
                         ++it;


### PR DESCRIPTION
Many of these come from clang-tidy-19, which we don't yet use

- Put a bunch of stuff into anonymous namespaces
- Delete some redundant casts (e.g. casting an int to int)
- Add some const refs to avoid copies
- Remove meaningless inline qualifiers on in-class definitions and constexpr functions
- Remove return-with-value from functions returning void
- Delete a little dead code
- Use std::min/max where appropriate
- Don't use a variable after std::forwarding it. It may have been moved from.
- Use std::string::empty instead of comparing length to zero