### PR TITLE
Replace FetchContent with a custom dependency provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
 cmake_minimum_required(VERSION 3.28)
+
+option(Halide_USE_FETCHCONTENT "When Halide is top-level, use FetchContent for build-time dependencies." ON)
+if (Halide_USE_FETCHCONTENT)
+    list(APPEND CMAKE_PROJECT_TOP_LEVEL_INCLUDES "${CMAKE_CURRENT_LIST_DIR}/cmake/dependencies.cmake")
+endif ()
+
 project(Halide
         VERSION 19.0.0
         DESCRIPTION "Halide compiler and libraries"

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,0 +1,64 @@
+include(FetchContent)
+
+FetchContent_Declare(
+    flatbuffers
+    GIT_REPOSITORY https://github.com/google/flatbuffers.git
+    GIT_TAG 0100f6a5779831fa7a651e4b67ef389a8752bd9b # v23.5.26
+    GIT_SHALLOW TRUE
+)
+
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG 5b0a6fc2017fcc176545afe3e09c9f9885283242 # v2.10.4
+    GIT_SHALLOW TRUE
+)
+
+FetchContent_Declare(
+    wabt
+    GIT_REPOSITORY https://github.com/WebAssembly/wabt.git
+    GIT_TAG 3e826ecde1adfba5f88d10d361131405637e65a3 # 1.0.36
+    GIT_SHALLOW TRUE
+)
+
+macro(Halide_provide_dependency method dep_name)
+    set(${dep_name}_FOUND 1)
+
+    ## Set up sub-builds for Halide's requirements
+    if ("${dep_name}" STREQUAL "flatbuffers")
+        set(FLATBUFFERS_BUILD_TESTS OFF)
+        set(FLATBUFFERS_INSTALL OFF)
+    elseif ("${dep_name}" STREQUAL "pybind11")
+        # No special build options necessary
+    elseif ("${dep_name}" STREQUAL "wabt")
+        set(WITH_EXCEPTIONS "${Halide_ENABLE_EXCEPTIONS}")
+        set(BUILD_TESTS OFF)
+        set(BUILD_TOOLS OFF)
+        set(BUILD_LIBWASM OFF)
+        set(USE_INTERNAL_SHA256 ON)
+    else ()
+        set(${dep_name}_FOUND 0)
+    endif ()
+
+    if (${dep_name}_FOUND)
+        list(APPEND Halide_provide_dependency_args "${method}" "${dep_name}")
+        FetchContent_MakeAvailable(${dep_name})
+        list(POP_BACK Halide_provide_dependency_args method dep_name)
+
+        ## Patches for broken packages
+        if ("${dep_name}" STREQUAL "flatbuffers")
+            if (NOT TARGET flatbuffers::flatbuffers)
+                add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
+                add_executable(flatbuffers::flatc ALIAS flatc)
+            endif ()
+        endif ()
+        if ("${dep_name}" STREQUAL "wabt")
+            set_target_properties(wabt PROPERTIES POSITION_INDEPENDENT_CODE ON)
+        endif ()
+    endif ()
+endmacro()
+
+cmake_language(
+    SET_DEPENDENCY_PROVIDER Halide_provide_dependency
+    SUPPORTED_METHODS FIND_PACKAGE
+)

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -37,7 +37,7 @@ if (TARGET Halide_Adams2019)
 endif ()
 
 # Halide_LLVM
-foreach (dep IN ITEMS Halide_LLVM Halide_wabt)
+foreach (dep IN ITEMS Halide_LLVM)
     if (TARGET ${dep})
         install(TARGETS ${dep} EXPORT Halide_Targets)
     endif ()

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -32,10 +32,6 @@ cmake_dependent_option(
     WITH_TESTS OFF
 )
 
-# Set the expected (downloaded) version of pybind11
-option(PYBIND11_USE_FETCHCONTENT "Enable to download pybind11 via FetchContent" ON)
-set(PYBIND11_VER 2.10.4 CACHE STRING "The pybind11 version to use (or download)")
-
 ##
 # Dependencies
 ##
@@ -44,25 +40,10 @@ set(PYBIND11_VER 2.10.4 CACHE STRING "The pybind11 version to use (or download)"
 # Development.Module and Development.Embed. We don't need the Embed
 # part, so only requesting Module avoids failures when Embed is not
 # available, as is the case in the manylinux Docker images.
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
-if (Python3_VERSION VERSION_LESS "3.8")
-    message(FATAL_ERROR "Halide requires Python v3.8 or later, but found ${Python3_VERSION}.")
-endif ()
-message(STATUS "Found Python ${Python3_VERSION} at ${Python3_EXECUTABLE}")
+find_package(Python3 3.8 REQUIRED Interpreter Development.Module)
 
 if (WITH_PYTHON_BINDINGS)
-    # If we are actually going to build the bindings, we need pybind11.
-    if (PYBIND11_USE_FETCHCONTENT)
-        include(FetchContent)
-        FetchContent_Declare(
-            pybind11
-            GIT_REPOSITORY https://github.com/pybind/pybind11.git
-            GIT_TAG v${PYBIND11_VER}
-        )
-        FetchContent_MakeAvailable(pybind11)
-    else ()
-        find_package(pybind11 ${PYBIND11_VER} REQUIRED)
-    endif ()
+    find_package(pybind11 2.10.4 REQUIRED)
 endif ()
 
 # Note: this must happen, especially when WITH_PYTHON_BINDINGS is OFF.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -459,40 +459,18 @@ target_sources(
 # Build serialization, enabled by default
 option(WITH_SERIALIZATION "Include experimental Serialization/Deserialization code" ON)
 if (WITH_SERIALIZATION)
-    # flatbuffers is small and compiles quickly, but if you want/need to use
-    # a local version (via find_package), configure with FLATBUFFERS_USE_FETCHCONTENT=OFF
-    option(FLATBUFFERS_USE_FETCHCONTENT "Enable to download the Flatbuffers library via FetchContent" ON)
-    set(FLATBUFFERS_VER 23.5.26 CACHE STRING "The Flatbuffers version to use (or download) ")
+    # Sadly, there seem to be at least three variations of the Flatbuffer
+    # package in terms of the case of the relevant CMake files. Fortunately,
+    # the IMPORTED targets appear to be consistently named `flatbuffers`.
+    find_package(
+        flatbuffers 23.5.26 REQUIRED
+        NAMES flatbuffers Flatbuffers FlatBuffers
+    )
 
-    if (FLATBUFFERS_USE_FETCHCONTENT)
-        include(FetchContent)
-        FetchContent_Declare(
-            flatbuffers
-            GIT_REPOSITORY https://github.com/google/flatbuffers.git
-            GIT_TAG v${FLATBUFFERS_VER}
-            GIT_SHALLOW TRUE
-            SYSTEM
-        )
-        # configuration for flatbuffers
-        set(FLATBUFFERS_BUILD_TESTS OFF)
-        set(FLATBUFFERS_INSTALL OFF)
-        FetchContent_MakeAvailable(flatbuffers)
-        set_target_properties(flatbuffers PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-        add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
-        add_executable(flatbuffers::flatc ALIAS flatc)
-
-        message(STATUS "Using fetched-and-built flatbuffers, version ${FLATBUFFERS_VER}")
+    get_target_property(vendored_flatbuffers flatbuffers::flatbuffers ALIASED_TARGET)
+    if (vendored_flatbuffers)
         set(flatbuffers_target "$<BUILD_LOCAL_INTERFACE:flatbuffers::flatbuffers>")
     else ()
-        # Sadly, there seem to be at least three variations of the Flatbuffer
-        # package in terms of the case of the relevant CMake files. Fortunately,
-        # the IMPORTED targets appear to be consistently named `flatbuffers`.
-        find_package(
-            flatbuffers ${FLATBUFFERS_VER}
-            NAMES flatbuffers Flatbuffers FlatBuffers
-            REQUIRED
-        )
         set(flatbuffers_target flatbuffers::flatbuffers)
     endif ()
 
@@ -592,42 +570,8 @@ if (TARGET_WEBASSEMBLY)
     endif ()
 
     if (Halide_WASM_BACKEND STREQUAL "wabt")
-        set(WABT_VER 1.0.33)
-
-        message(STATUS "Fetching WABT ${WABT_VER}...")
-        FetchContent_Declare(wabt
-                             GIT_REPOSITORY https://github.com/WebAssembly/wabt.git
-                             GIT_TAG ${WABT_VER}
-                             GIT_SHALLOW TRUE)
-
-        # configuration for wabt
-        set(WITH_EXCEPTIONS ${Halide_ENABLE_EXCEPTIONS})
-        set(BUILD_TESTS OFF)
-        set(BUILD_TOOLS OFF)
-        set(BUILD_LIBWASM OFF)
-        set(USE_INTERNAL_SHA256 ON)
-        FetchContent_MakeAvailable(wabt)
-
-        set_target_properties(wabt PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
-        # Disable this very-noisy warning in GCC
-        target_compile_options(wabt
-                               PRIVATE
-                               $<$<CXX_COMPILER_ID:GNU>:-Wno-alloca-larger-than>)
-
-        # TODO: we want to require unique prefixes to include these files, to avoid ambiguity;
-        # this means we have to prefix with "wabt-src/...", which is less bad than other alternatives,
-        # but perhaps we could do better (esp. if wabt was smarter about what it exposed?)
-        add_library(Halide_wabt INTERFACE)
-        target_sources(Halide_wabt INTERFACE $<BUILD_LOCAL_INTERFACE:$<TARGET_OBJECTS:wabt>>)
-        target_include_directories(Halide_wabt
-                                   SYSTEM # Use -isystem instead of -I; this is a trick so that clang-tidy won't analyze these includes
-                                   INTERFACE
-                                   $<BUILD_INTERFACE:${wabt_SOURCE_DIR}>/include
-                                   $<BUILD_INTERFACE:${wabt_BINARY_DIR}>/include)
-        set_target_properties(Halide_wabt PROPERTIES EXPORT_NAME wabt)
-
-        target_link_libraries(Halide PRIVATE Halide_wabt)
+        find_package(wabt 1.0.36 REQUIRED)
+        target_link_libraries(Halide PRIVATE wabt::wabt)
         target_compile_definitions(Halide PRIVATE WITH_WABT)
     elseif (Halide_WASM_BACKEND STREQUAL "V8")
         find_package(V8 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -467,11 +467,11 @@ if (WITH_SERIALIZATION)
         NAMES flatbuffers Flatbuffers FlatBuffers
     )
 
-    get_target_property(vendored_flatbuffers flatbuffers::flatbuffers ALIASED_TARGET)
-    if (vendored_flatbuffers)
-        set(flatbuffers_target "$<BUILD_LOCAL_INTERFACE:flatbuffers::flatbuffers>")
+    if (Halide_USE_FETCHCONTENT AND NOT BUILD_SHARED_LIBS)
+        target_sources(Halide PRIVATE "$<TARGET_OBJECTS:flatbuffers::flatbuffers>")
+        target_link_libraries(Halide PRIVATE "$<BUILD_LOCAL_INTERFACE:$<COMPILE_ONLY:flatbuffers::flatbuffers>>")
     else ()
-        set(flatbuffers_target flatbuffers::flatbuffers)
+        target_link_libraries(Halide PRIVATE flatbuffers::flatbuffers)
     endif ()
 
     set(fb_def "${CMAKE_CURRENT_SOURCE_DIR}/halide_ir.fbs")
@@ -493,7 +493,6 @@ if (WITH_SERIALIZATION)
         BASE_DIRS "${fb_dir}"
         FILES "${fb_header}"
     )
-    target_link_libraries(Halide PRIVATE ${flatbuffers_target})
     target_compile_definitions(Halide PRIVATE WITH_SERIALIZATION)
 endif ()
 
@@ -569,7 +568,14 @@ if (TARGET_WEBASSEMBLY)
 
     if (Halide_WASM_BACKEND STREQUAL "wabt")
         find_package(wabt 1.0.36 REQUIRED)
-        target_link_libraries(Halide PRIVATE wabt::wabt)
+
+        if (Halide_USE_FETCHCONTENT AND NOT BUILD_SHARED_LIBS)
+            target_sources(Halide PRIVATE "$<TARGET_OBJECTS:wabt::wabt>")
+            target_link_libraries(Halide PRIVATE "$<BUILD_LOCAL_INTERFACE:$<COMPILE_ONLY:wabt::wabt>>")
+        else ()
+            target_link_libraries(Halide PRIVATE wabt::wabt)
+        endif ()
+
         target_compile_definitions(Halide PRIVATE WITH_WABT)
     elseif (Halide_WASM_BACKEND STREQUAL "V8")
         find_package(V8 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -545,8 +545,6 @@ target_compile_definitions(Halide PUBLIC
 ##
 
 if (TARGET_WEBASSEMBLY)
-    include(FetchContent)
-
     set(Halide_WASM_BACKEND "wabt"
         CACHE STRING "Which backend to use for Halide's WASM testing.")
     set_property(CACHE Halide_WASM_BACKEND PROPERTY STRINGS "wabt;V8;OFF")


### PR DESCRIPTION
This is the first _big_ change from #8360 

The build no longer uses `FetchContent`, instead using `find_package` always and everywhere. When Halide is the top-level project, it will (by default) inject a _dependency provider_ that overrides the `wabt`, `flatbuffers`, and `pybind11` packages with `FetchContent`. Users can opt-out by setting `Halide_USE_FETCHCONTENT=NO`.

This also bumps the required `wabt` version to the latest release (1.0.36). This version includes a patch I submitted that fixes the CMake package when `wabt` is built with OpenSSL rather than picosha2.

---

Here are relevant links to the docs:

* https://cmake.org/cmake/help/latest/guide/using-dependencies/index.html#dependency-providers
* https://cmake.org/cmake/help/latest/command/cmake_language.html#dependency-providers