### PR TITLE
Reflow src/CMakeLists.txt in logical groups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,26 @@
 add_library(Halide)
 add_library(Halide::Halide ALIAS Halide)
 
+# Language standard
+target_compile_features(Halide PUBLIC cxx_std_17)
+
+# Inform the sources if we're building a static or shared library
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(Halide PRIVATE Halide_STATIC_DEFINE)
+endif ()
+
+# Set the (shared) library version
+set(Halide_SOVERSION_OVERRIDE "${Halide_VERSION_MAJOR}"
+    CACHE STRING "SOVERSION to set for custom Halide packaging")
+mark_as_advanced(Halide_SOVERSION_OVERRIDE)
+
+set_target_properties(Halide PROPERTIES
+                      VERSION "${Halide_VERSION}"
+                      SOVERSION "${Halide_SOVERSION_OVERRIDE}")
+
+# Always build with PIC, even when static
+set_target_properties(Halide PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 ##
 # CodeGen backends
 
@@ -516,28 +536,12 @@ if (WITH_SERIALIZATION_JIT_ROUNDTRIP_TESTING)
     target_compile_definitions(Halide PRIVATE WITH_SERIALIZATION_JIT_ROUNDTRIP_TESTING)
 endif ()
 
-target_compile_features(Halide PUBLIC cxx_std_17)
-if (NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(Halide PRIVATE Halide_STATIC_DEFINE)
-endif ()
-
 include(TargetExportScript)
 ## TODO: implement something similar for Windows/link.exe
 # https://github.com/halide/Halide/issues/4651
 target_export_script(Halide
                      APPLE_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.osx"
                      GNU_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.ldscript")
-
-set(Halide_SOVERSION_OVERRIDE "${Halide_VERSION_MAJOR}"
-    CACHE STRING "SOVERSION to set for custom Halide packaging")
-mark_as_advanced(Halide_SOVERSION_OVERRIDE)
-
-set_target_properties(Halide PROPERTIES
-                      VERSION "${Halide_VERSION}"
-                      SOVERSION "${Halide_SOVERSION_OVERRIDE}")
-
-# Always build with PIC, even when static
-set_target_properties(Halide PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Note that we (deliberately) redeclare these versions here, even though the macros
 # with identical versions are expected to be defined in source; this allows us to

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -536,13 +536,6 @@ if (WITH_SERIALIZATION_JIT_ROUNDTRIP_TESTING)
     target_compile_definitions(Halide PRIVATE WITH_SERIALIZATION_JIT_ROUNDTRIP_TESTING)
 endif ()
 
-include(TargetExportScript)
-## TODO: implement something similar for Windows/link.exe
-# https://github.com/halide/Halide/issues/4651
-target_export_script(Halide
-                     APPLE_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.osx"
-                     GNU_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.ldscript")
-
 # Note that we (deliberately) redeclare these versions here, even though the macros
 # with identical versions are expected to be defined in source; this allows us to
 # ensure that the versions defined between all build systems are identical.
@@ -595,6 +588,17 @@ elseif (Halide_WASM_BACKEND STREQUAL "V8")
 elseif (Halide_WASM_BACKEND)
     message(FATAL_ERROR "Unknown Halide_WASM_BACKEND `${Halide_WASM_BACKEND}`")
 endif ()
+
+##
+# Attach symbol export scripts
+##
+
+## TODO: implement something similar for Windows/link.exe
+# https://github.com/halide/Halide/issues/4651
+include(TargetExportScript)
+target_export_script(Halide
+                     APPLE_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.osx"
+                     GNU_LD "${CMAKE_CURRENT_LIST_DIR}/exported_symbols.ldscript")
 
 ##
 # Set compiler options for libHalide

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,16 +26,6 @@ set_target_properties(Halide PROPERTIES
 set_target_properties(Halide PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 ##
-# CodeGen backends
-
-# LLVM
-foreach (backend IN LISTS Halide_LLVM_COMPONENTS)
-    string(TOUPPER "WITH_${backend}" definition)
-    target_compile_definitions(Halide PRIVATE "${definition}")
-    target_link_libraries(Halide PRIVATE Halide_LLVM::${backend})
-endforeach ()
-
-##
 # Lists of source files. Keep ALL lists sorted in alphabetical order.
 ##
 
@@ -483,6 +473,34 @@ target_sources(
 )
 
 ##
+# CodeGen backends
+##
+
+# LLVM backends
+foreach (backend IN LISTS Halide_LLVM_COMPONENTS)
+    string(TOUPPER "WITH_${backend}" definition)
+    target_compile_definitions(Halide PRIVATE "${definition}")
+    target_link_libraries(Halide PRIVATE Halide_LLVM::${backend})
+endforeach ()
+
+# GPU backends
+find_package(
+    SPIRV-Headers 1.5.5 REQUIRED
+    HINTS "${Halide_SOURCE_DIR}/dependencies/spirv"
+)
+
+target_link_libraries(
+    Halide PRIVATE "$<BUILD_LOCAL_INTERFACE:SPIRV-Headers::SPIRV-Headers>"
+)
+
+target_compile_definitions(Halide PRIVATE WITH_D3D12)
+target_compile_definitions(Halide PRIVATE WITH_METAL)
+target_compile_definitions(Halide PRIVATE WITH_OPENCL)
+target_compile_definitions(Halide PRIVATE WITH_SPIRV)
+target_compile_definitions(Halide PRIVATE WITH_VULKAN)
+target_compile_definitions(Halide PRIVATE WITH_WEBGPU)
+
+##
 # Flatbuffers and Serialization dependencies.
 ##
 
@@ -654,23 +672,6 @@ else ()
         Halide PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:_HAS_EXCEPTIONS=0>"
     )
 endif ()
-
-##
-# GPU CodeGen backends
-
-find_package(
-    SPIRV-Headers 1.5.5 REQUIRED
-    HINTS "${Halide_SOURCE_DIR}/dependencies/spirv"
-)
-
-target_link_libraries(Halide PRIVATE "$<BUILD_LOCAL_INTERFACE:SPIRV-Headers::SPIRV-Headers>")
-
-target_compile_definitions(Halide PRIVATE WITH_D3D12)
-target_compile_definitions(Halide PRIVATE WITH_METAL)
-target_compile_definitions(Halide PRIVATE WITH_OPENCL)
-target_compile_definitions(Halide PRIVATE WITH_SPIRV)
-target_compile_definitions(Halide PRIVATE WITH_VULKAN)
-target_compile_definitions(Halide PRIVATE WITH_WEBGPU)
 
 ##
 # Add autoschedulers to the build.


### PR DESCRIPTION
1. Move core features closer to Halide library definition.
2. Move target export script to its own section.
3. Group LLVM backends and GPU backends together.

The next four PRs are all real/functional, I promise.