### PR TITLE
Support using vcpkg to build dependencies on all platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,9 @@ install_manifest.txt
 # Ninja files
 *.ninja*
 
+# Package managers
+vcpkg_installed/
+
 ################################################################################
 ## IDE directories and metadata
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,16 @@ if (Halide_USE_FETCHCONTENT)
     list(APPEND CMAKE_PROJECT_TOP_LEVEL_INCLUDES "${CMAKE_CURRENT_LIST_DIR}/cmake/dependencies.cmake")
 endif ()
 
+# TODO: remove this after updating build bots.
+if (NOT DEFINED VCPKG_OVERLAY_PORTS)
+    set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/cmake/vcpkg")
+endif ()
+
+# TODO: remove this after updating build bots.
+if (NOT DEFINED VCPKG_MANIFEST_FEATURES)
+    set(VCPKG_MANIFEST_FEATURES developer)
+endif ()
+
 project(Halide
         VERSION 19.0.0
         DESCRIPTION "Halide compiler and libraries"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 6,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 22,
+    "minor": 28,
     "patch": 0
   },
   "configurePresets": [
@@ -18,30 +18,42 @@
       "inherits": "base",
       "toolchainFile": "${sourceDir}/cmake/toolchain.${presetName}.cmake",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      }
-    },
-    {
-      "name": "windows-only",
-      "hidden": true,
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "Halide_LLVM_SHARED_LIBS": false
       }
     },
     {
       "name": "vcpkg",
-      "hidden": true,
-      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      "inherits": "base",
+      "displayName": "vcpkg deps",
+      "description": "Build dependencies (with Halide exclusions) with vcpkg",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+      "cacheVariables": {
+        "VCPKG_MANIFEST_FEATURES": "developer",
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/cmake/vcpkg",
+        "Halide_USE_FETCHCONTENT": false
+      }
+    },
+    {
+      "name": "vcpkg-full",
+      "inherits": "vcpkg",
+      "displayName": "vcpkg deps (all dependencies)",
+      "description": "Build ALL dependencies with vcpkg",
+      "cacheVariables": {
+        "VCPKG_OVERLAY_PORTS": ""
+      }
     },
     {
       "name": "vs2022",
       "hidden": true,
       "inherits": [
-        "vcpkg",
-        "windows-only"
+        "vcpkg"
       ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
       "generator": "Visual Studio 17 2022",
       "toolset": "host=x64"
     },
@@ -64,41 +76,73 @@
       }
     },
     {
-      "name": "debian-debug",
-      "inherits": "debug",
-      "displayName": "Debian (Debug)",
-      "description": "Debug build assuming Debian-provided dependencies",
-      "cacheVariables": {
-        "Halide_LLVM_SHARED_LIBS": "ON"
-      }
+      "name": "debug-vcpkg",
+      "inherits": [
+        "debug",
+        "vcpkg"
+      ],
+      "displayName": "Debug (vcpkg)",
+      "description": "Debug build for a single-config generator, vcpkg dependencies"
     },
     {
-      "name": "debian-release",
-      "inherits": "debian-debug",
-      "displayName": "Debian (Release)",
-      "description": "Release build assuming Debian-provided dependencies",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      }
+      "name": "release-vcpkg",
+      "inherits": [
+        "release",
+        "vcpkg"
+      ],
+      "displayName": "Release (vcpkg)",
+      "description": "Release build for a single-config generator, vcpkg dependencies"
+    },
+    {
+      "name": "debug-vcpkg-full",
+      "inherits": [
+        "debug",
+        "vcpkg-full"
+      ],
+      "displayName": "Debug (vcpkg-full)",
+      "description": "Debug build for a single-config generator, vcpkg-full dependencies"
+    },
+    {
+      "name": "release-vcpkg-full",
+      "inherits": [
+        "release",
+        "vcpkg-full"
+      ],
+      "displayName": "Release (vcpkg-full)",
+      "description": "Release build for a single-config generator, vcpkg-full dependencies"
     },
     {
       "name": "win32",
-      "inherits": [
-        "vs2022",
-        "base"
-      ],
+      "inherits": "vs2022",
       "displayName": "Win32 (Visual Studio)",
       "description": "Visual Studio-based Win32 build with vcpkg dependencies.",
       "architecture": "Win32"
     },
     {
       "name": "win64",
-      "inherits": [
-        "vs2022",
-        "base"
-      ],
+      "inherits": "vs2022",
       "displayName": "Win64 (Visual Studio)",
       "description": "Visual Studio-based x64 build with vcpkg dependencies.",
+      "architecture": "x64"
+    },
+    {
+      "name": "win32-vcpkg-full",
+      "inherits": [
+        "vcpkg-full",
+        "vs2022"
+      ],
+      "displayName": "Win32 (Visual Studio/vcpkg-full)",
+      "description": "Visual Studio-based Win32 build with vcpkg-full dependencies.",
+      "architecture": "Win32"
+    },
+    {
+      "name": "win64-vcpkg-full",
+      "inherits": [
+        "vcpkg-full",
+        "vs2022"
+      ],
+      "displayName": "Win64 (Visual Studio/vcpkg-full)",
+      "description": "Visual Studio-based x64 build with vcpkg-full dependencies.",
       "architecture": "x64"
     },
     {
@@ -107,9 +151,37 @@
       "description": "macOS build using Apple Clang and Homebrew LLVM",
       "generator": "Ninja",
       "inherits": "release",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
       "cacheVariables": {
-        "CMAKE_PREFIX_PATH": "/opt/homebrew;/opt/homebrew/opt/llvm;/opt/homebrew/opt/jpeg",
-        "Halide_LLVM_SHARED_LIBS": "YES"
+        "CMAKE_PREFIX_PATH": "/opt/homebrew;/opt/homebrew/opt/llvm;/opt/homebrew/opt/jpeg"
+      }
+    },
+    {
+      "name": "macOS-vcpkg",
+      "inherits": [
+        "macOS",
+        "vcpkg"
+      ],
+      "displayName": "macOS (vcpkg)",
+      "description": "macOS build with vcpkg dependencies",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "/opt/homebrew/opt/llvm"
+      }
+    },
+    {
+      "name": "macOS-vcpkg-full",
+      "inherits": [
+        "macOS",
+        "vcpkg-full"
+      ],
+      "displayName": "macOS (vcpkg-full)",
+      "description": "macOS build with vcpkg-full dependencies",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": ""
       }
     },
     {
@@ -182,7 +254,6 @@
       "description": "Build everything with fuzzing enabled",
       "cacheVariables": {
         "LLVM_ROOT": "$penv{LLVM_ROOT}",
-        "TARGET_WEBASSEMBLY": "NO",
         "WITH_TUTORIALS": "NO",
         "WITH_UTILS": "NO",
         "WITH_PYTHON_BINDINGS": "NO",

--- a/cmake/vcpkg/llvm/portfile.cmake
+++ b/cmake/vcpkg/llvm/portfile.cmake
@@ -1,0 +1,3 @@
+# This instructs vcpkg to do nothing, which causes find_package
+# to search the system for LLVM, rather than the vcpkg trees.
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/cmake/vcpkg/llvm/vcpkg.json
+++ b/cmake/vcpkg/llvm/vcpkg.json
@@ -1,0 +1,468 @@
+{
+  "name": "llvm",
+  "version": "18.1.6",
+  "port-version": 1,
+  "description": "The LLVM Compiler Infrastructure.",
+  "homepage": "https://llvm.org",
+  "license": "Apache-2.0",
+  "supports": "!uwp & !(arm & windows)",
+  "dependencies": [
+    {
+      "name": "atl",
+      "platform": "windows & !mingw"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "clang",
+    "default-targets",
+    "enable-bindings",
+    "enable-terminfo",
+    "enable-zlib",
+    "enable-zstd",
+    "lld",
+    "tools"
+  ],
+  "features": {
+    "bolt": {
+      "description": "BOLT is a post-link optimizer developed to speed up large applications.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "clang": {
+      "description": "Include C Language Family Front-end.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "clang-tools-extra": {
+      "description": "Include Clang tools.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang"
+          ]
+        }
+      ]
+    },
+    "compiler-rt": {
+      "description": "Include compiler's runtime libraries.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang"
+          ]
+        }
+      ]
+    },
+    "default-targets": {
+      "description": "Build with platform-specific default targets.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-aarch64"
+          ],
+          "platform": "arm64"
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-x86"
+          ],
+          "platform": "x86 | x64"
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-arm"
+          ],
+          "platform": "arm & !arm64"
+        }
+      ]
+    },
+    "enable-abi-breaking-checks": {
+      "description": "Build LLVM with LLVM_ABI_BREAKING_CHECKS=FORCE_ON."
+    },
+    "enable-assertions": {
+      "description": "Build LLVM with assertions."
+    },
+    "enable-bindings": {
+      "description": "Build bindings."
+    },
+    "enable-eh": {
+      "description": "Build LLVM with exception handler.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "enable-rtti"
+          ]
+        }
+      ]
+    },
+    "enable-ffi": {
+      "description": "Build LLVM with FFI.",
+      "dependencies": [
+        "libffi"
+      ]
+    },
+    "enable-ios": {
+      "description": "Build compiler-rt for iOS SDK.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-arm"
+          ]
+        }
+      ]
+    },
+    "enable-libxml2": {
+      "description": "Build with LibXml2.",
+      "dependencies": [
+        "libxml2"
+      ]
+    },
+    "enable-mlir-python-bindings": {
+      "description": "Build MLIR Python bindings.",
+      "supports": "!(windows & static)",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "mlir"
+          ]
+        },
+        "pybind11",
+        "python3"
+      ]
+    },
+    "enable-rtti": {
+      "description": "Build LLVM with run-time type information."
+    },
+    "enable-terminfo": {
+      "description": "Use terminfo database if available."
+    },
+    "enable-zlib": {
+      "description": "Build with ZLib.",
+      "dependencies": [
+        "zlib"
+      ]
+    },
+    "enable-zstd": {
+      "description": "Build with zstd.",
+      "dependencies": [
+        "zstd"
+      ]
+    },
+    "flang": {
+      "description": "Include Fortran front end.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang",
+            "mlir",
+            "tools"
+          ]
+        }
+      ]
+    },
+    "libc": {
+      "description": "Include libc library.",
+      "supports": "linux",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang",
+            "tools"
+          ]
+        }
+      ]
+    },
+    "libclc": {
+      "description": "Include OpenCL library."
+    },
+    "libcxx": {
+      "description": "Include libcxx library.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang",
+            "libcxxabi",
+            "tools"
+          ]
+        }
+      ]
+    },
+    "libcxxabi": {
+      "description": "Include libcxxabi library.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang",
+            "libcxx",
+            "tools"
+          ]
+        }
+      ]
+    },
+    "libunwind": {
+      "description": "Include libunwind library.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "lld": {
+      "description": "Include LLVM linker.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "lldb": {
+      "description": "Include LLVM debugger.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang",
+            "enable-terminfo",
+            "tools"
+          ]
+        }
+      ]
+    },
+    "mlir": {
+      "description": "Include MLIR (Multi-Level IR Compiler Framework) project.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools",
+            "utils"
+          ]
+        }
+      ]
+    },
+    "openmp": {
+      "description": "Include LLVM OpenMP libraries.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang",
+            "utils"
+          ]
+        }
+      ]
+    },
+    "polly": {
+      "description": "Include Polly (Polyhedral optimizations for LLVM) project.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools",
+            "utils"
+          ]
+        }
+      ]
+    },
+    "pstl": {
+      "description": "Include pstl (Parallel STL) library.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "target-aarch64": {
+      "description": "Build with AArch64 backend."
+    },
+    "target-all": {
+      "description": "Build with all backends.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-aarch64",
+            "target-amdgpu",
+            "target-arc",
+            "target-arm",
+            "target-avr",
+            "target-bpf",
+            "target-csky",
+            "target-directx",
+            "target-hexagon",
+            "target-lanai",
+            "target-loongarch",
+            "target-m68k",
+            "target-mips",
+            "target-msp430",
+            "target-nvptx",
+            "target-powerpc",
+            "target-riscv",
+            "target-sparc",
+            "target-spirv",
+            "target-systemz",
+            "target-ve",
+            "target-webassembly",
+            "target-x86",
+            "target-xcore",
+            "target-xtensa"
+          ]
+        }
+      ]
+    },
+    "target-amdgpu": {
+      "description": "Build with AMDGPU backend."
+    },
+    "target-arc": {
+      "description": "Build with ARC backend (experimental)."
+    },
+    "target-arm": {
+      "description": "Build with ARM backend."
+    },
+    "target-avr": {
+      "description": "Build with AVR backend."
+    },
+    "target-bpf": {
+      "description": "Build with BPF backend."
+    },
+    "target-csky": {
+      "description": "Build with CSKY backend (experimental)."
+    },
+    "target-directx": {
+      "description": "Build with DirectX backend (experimental)."
+    },
+    "target-hexagon": {
+      "description": "Build with Hexagon backend."
+    },
+    "target-lanai": {
+      "description": "Build with Lanai backend."
+    },
+    "target-loongarch": {
+      "description": "Build with LoongArch backend."
+    },
+    "target-m68k": {
+      "description": "Build with M68k backend (experimental)."
+    },
+    "target-mips": {
+      "description": "Build with Mips backend."
+    },
+    "target-msp430": {
+      "description": "Build with MSP430 backend."
+    },
+    "target-nvptx": {
+      "description": "Build with NVPTX backend."
+    },
+    "target-powerpc": {
+      "description": "Build with PowerPC backend."
+    },
+    "target-riscv": {
+      "description": "Build with RISC-V backend."
+    },
+    "target-sparc": {
+      "description": "Build with Sparc backend."
+    },
+    "target-spirv": {
+      "description": "Build with SPIRV backend (experimental)."
+    },
+    "target-systemz": {
+      "description": "Build with SystemZ backend."
+    },
+    "target-ve": {
+      "description": "Build with VE backend."
+    },
+    "target-webassembly": {
+      "description": "Build with WebAssembly backend."
+    },
+    "target-x86": {
+      "description": "Build with X86 backend."
+    },
+    "target-xcore": {
+      "description": "Build with XCore backend."
+    },
+    "target-xtensa": {
+      "description": "Build with Xtensa backend (experimental)."
+    },
+    "tools": {
+      "description": "Build LLVM tools."
+    },
+    "utils": {
+      "description": "Build LLVM utils.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/cmake/vcpkg/python3/portfile.cmake
+++ b/cmake/vcpkg/python3/portfile.cmake
@@ -1,0 +1,3 @@
+# This instructs vcpkg to do nothing, which causes find_package
+# to search the system for Python, rather than the vcpkg trees.
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)

--- a/cmake/vcpkg/python3/vcpkg.json
+++ b/cmake/vcpkg/python3/vcpkg.json
@@ -1,0 +1,63 @@
+{
+  "name": "python3",
+  "version": "3.11.8",
+  "port-version": 4,
+  "description": "The Python programming language",
+  "homepage": "https://github.com/python/cpython",
+  "license": "Python-2.0",
+  "supports": "!uwp & !mingw",
+  "dependencies": [
+    {
+      "name": "bzip2",
+      "platform": "!(windows & static)"
+    },
+    "expat",
+    {
+      "name": "gettext",
+      "platform": "osx"
+    },
+    {
+      "name": "libffi",
+      "platform": "!(windows & static)"
+    },
+    {
+      "name": "libiconv",
+      "platform": "osx"
+    },
+    {
+      "name": "liblzma",
+      "platform": "!(windows & static)"
+    },
+    {
+      "name": "libuuid",
+      "platform": "!osx & !windows"
+    },
+    {
+      "name": "openssl",
+      "platform": "!(windows & static)"
+    },
+    {
+      "name": "python3",
+      "host": true
+    },
+    {
+      "name": "sqlite3",
+      "platform": "!(windows & static)"
+    },
+    {
+      "name": "vcpkg-get-python",
+      "host": true
+    },
+    {
+      "name": "vcpkg-msbuild",
+      "host": true,
+      "platform": "windows"
+    },
+    "zlib"
+  ],
+  "features": {
+    "deprecated-win7-support": {
+      "description": "Deprecated support for the Windows 7 platform -- may be removed at any time."
+    }
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,207 @@
+{
+  "name": "halide",
+  "version": "19.0.0",
+  "description": "Halide is a programming language designed to make it easier to write high-performance image and array processing code on modern machines.",
+  "homepage": "https://github.com/halide/Halide",
+  "license": "MIT",
+  "supports": "!uwp",
+  "builtin-baseline": "4fa096bce24561bf869e56384e655f4b2bab71a8",
+  "default-features": [
+    "jit",
+    "serialization"
+  ],
+  "dependencies": [
+    {
+      "name": "llvm",
+      "default-features": false,
+      "features": [
+        "clang",
+        "enable-eh",
+        "enable-rtti",
+        "lld",
+        "target-webassembly",
+        "target-x86",
+        "tools"
+      ]
+    },
+    "spirv-headers"
+  ],
+  "features": {
+    "developer": {
+      "description": "Include all Halide features to facilitate development",
+      "dependencies": [
+        {
+          "name": "halide",
+          "default-features": false,
+          "features": [
+            "python-bindings",
+            "serialization",
+            "target-all",
+            "tests",
+            "wasm-executor"
+          ]
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang-tools-extra",
+            "enable-assertions"
+          ]
+        }
+      ]
+    },
+    "jit": {
+      "description": "Include targets needed to compile for the library architecture",
+      "dependencies": [
+        {
+          "name": "halide",
+          "default-features": false,
+          "features": [
+            "target-arm"
+          ],
+          "platform": "arm32"
+        },
+        {
+          "name": "halide",
+          "default-features": false,
+          "features": [
+            "target-aarch64"
+          ],
+          "platform": "arm64"
+        },
+        {
+          "name": "halide",
+          "default-features": false,
+          "features": [
+            "target-all"
+          ],
+          "platform": "!x86 & !x64 & !arm"
+        }
+      ]
+    },
+    "python-bindings": {
+      "description": "Halide's native Python module (not the whole pip package)",
+      "dependencies": [
+        "pybind11"
+      ]
+    },
+    "serialization": {
+      "description": "Include experimental Serialization/Deserialization code",
+      "dependencies": [
+        "flatbuffers"
+      ]
+    },
+    "target-aarch64": {
+      "description": "Include AArch64 target",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-aarch64"
+          ]
+        }
+      ]
+    },
+    "target-all": {
+      "description": "Include all targets",
+      "dependencies": [
+        {
+          "name": "halide",
+          "default-features": false,
+          "features": [
+            "target-aarch64",
+            "target-arm",
+            "target-hexagon",
+            "target-powerpc",
+            "target-riscv"
+          ]
+        }
+      ]
+    },
+    "target-arm": {
+      "description": "Include ARM target",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-arm"
+          ]
+        }
+      ]
+    },
+    "target-hexagon": {
+      "description": "Include Hexagon target",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-hexagon"
+          ]
+        }
+      ]
+    },
+    "target-nvptx": {
+      "description": "Include NVPTX target",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-nvptx"
+          ]
+        }
+      ]
+    },
+    "target-powerpc": {
+      "description": "Include PowerPC target",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-powerpc"
+          ]
+        }
+      ]
+    },
+    "target-riscv": {
+      "description": "Include RISCV target",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-riscv"
+          ]
+        }
+      ]
+    },
+    "tests": {
+      "description": "Include dependencies needed for testing Halide",
+      "dependencies": [
+        {
+          "name": "cuda",
+          "platform": "(windows & x64 & !uwp & !xbox) | (linux & x64) | (linux & arm64)"
+        },
+        "eigen3",
+        "libjpeg-turbo",
+        "libpng",
+        "openblas",
+        {
+          "name": "opencl",
+          "platform": "(windows & x64 & !uwp & !xbox) | (linux & x64) | (linux & arm64)"
+        }
+      ]
+    },
+    "wasm-executor": {
+      "description": "Include built-in WASM executor",
+      "dependencies": [
+        "wabt"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for using vcpkg to acquire and build Halide's dependencies on all platforms.

It adds a top-level `vcpkg.json` file that explains the relationship between Halide's features and its dependencies. These features include the various LLVM `target-`s (which merely imply a dependency on the corresponding LLVM backend), `serialization` (flatbuffers), the `python-bindings` (pybind11), the `wasm-executor` (wabt), and a few meta-features:

* `jit`: enables LLVM targets corresponding to the host system
* `target-all`: enables all LLVM targets
* `tests`: depends on everything needed for the tests and apps
* `developer`: includes all other features

All of these are optional (since x86 and WebAssembly are forced), but `jit` and `serialization` are on by default.

vcpkg is intended to be an eventual replacement for FetchContent, at least on the buildbots. It will accelerate builds beyond ccache by directly restoring binary caches for our dependencies. Unlike FetchContent, it does not pollute our build with third-party CMake code. Indeed, our build has no idea at all when vcpkg is in use.

The primary drawback is that vcpkg installation happens during (or ahead of) configuration time, so there is some initial wait.

## Try it!

I have provided many CMake presets to ease adoption. As long as you have `VCPKG_ROOT` set to a fresh clone of `vcpkg`, they should work. They come in two flavors:

* `vcpkg`: this acquires dependencies from the main vcpkg registry, but applies our own overlay, which disables building Python 3 (really!) and LLVM. The system is searched for these as usual.
* `vcpkg-full`: this disables the Halide overlay and attempts to build ALL dependencies.

All these presets enable the `developer` feature in `VCPKG_MANIFEST_FEATURES`, which can be overridden in the usual way.

Here are the commands you should use to try it locally:

* On Linux or Windows: `cmake --preset release-vcpkg`
* On macOS: `cmake --preset macOS-vcpkg`
* To use Visual Studio: `cmake --preset win32`. Here, `vcpkg` is implied and `-vcpkg-full` can be added to build LLVM.

## Buildbot adjustments

We should adjust the buildbots to use vcpkg on all platforms and to set up the overlay and feature settings so we can remove the only bit of vcpkg-aware code in the build.