### PR TITLE
Fix _Float16 detection on ARM64 GCC<13

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -117,7 +117,7 @@ extern "C" {
 // For now, we say that if >= v12, and compiling on x86 or arm,
 // we assume support. This may need revision.
 #if defined(__GNUC__) && (__GNUC__ >= 12)
-#if defined(__x86_64__) || (defined(__i386__) && (__GNUC__ >= 14) && defined(__SSE2__)) || defined(__arm__) || defined(__aarch64__)
+#if defined(__x86_64__) || (defined(__i386__) && (__GNUC__ >= 14) && defined(__SSE2__)) || ((defined(__arm__) || defined(__aarch64__)) && (__GNUC__ >= 13))
 #define HALIDE_CPP_COMPILER_HAS_FLOAT16
 #endif
 #endif


### PR DESCRIPTION
GCC 12 only supports `_Float16` on x86. Support for ARM was added in GCC 13. This causes a build failure in the `manylinux_2_28` images.

[See Godbolt output here](https://gcc.godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGIAMwArKSuADJ4DJgAcj4ARpjEegAOqAqETgwe3r4BwSlpjgLhkTEs8Ylctpj2hQxCBEzEBFk%2BfkFVNRn1jQTF0XEJegoNTS057cM9faXlEgCUtqhexMjsHAD6AGK0qEwEXABsANQsTADWmOsAXgmoEHNHJgDsFkfEmATLDEcaJv6vzwAIhwFrROIFeH5uLxUJw3NZrEcFEsVphHmZ/DxSARNCCFmcQIEuAA6A4YswATg0AA5JFwuBSzNIwRxJJDcaRYRxeAoQBpsbiFnBYDBEChUCwknQEuRKGhJdLEo0WAdJMAuJj%2BTRaAQEryILEObEIo0AJ6cLHG5jEU0AeVi2kwDgtvHlbEEtoYtHNHC0pCwsS8wDcYlovOh/swpyM4l9vHw7wceAAbphw37MKonV5dS7yIJqhzaHhYsQzR4sByCMQ8Cw86niLFUphAVHDMBi0ZBXwDMAFAA1PCYADutqSjDz/EEIjE7CkMkEihU6jjpF0lQMXdMlms%2BhLvMgC1QSVq4ZhDZrWAP9w6TtqLgY7k8rQkZhCj%2BmA0S/lI%2BXSAjGPwuDfP9ak/MpBh/Ow7y6EZmmfHJgNvJMBG6JpwNmKC4MA19bDgjDIIWZFllWeZ9HBdlVy5I4AEEACUAFlVSOYBkGQI4NWJEkNCOCBcEIEh0UxOZeBxOM5nxEBJGpYl/CeA4ng0CkuECalqQ0eT5xZNlSDrQJ%2BShP0uR5PkBXE0hhTFeUpXoMgKAgazFRAZVVXVJktToXViH1Q1VytM0838m17UdZ0IzdRgCE9b0OQDIMQ1oMM8ywaMOzWP0Exg1N014TNs1zCMIl1Fk/WLUtywwdLRJrOsIwbJslFbVLO1AcyqF7Ach1HccoSxKdhFEcR536pc1A5XQ303YwEUsPdYmvI8TwyM9OQvPAr3gIjqhg5wIFcHCqXfdACMSaRQIyA7%2BXOooIn6CDTuQ2o0Pg7I/EO6CULqfDbpmQZpEmUYELe/kAd6H6vykoiUVIrhQQo0hDJhThaMY5jWPY4DiUkYkeL4/AiGIITYdEwUFgQTAmCwRIb203g9IMjljNsUyxK0CTSAJaTZPkxTlNU9TNOZTh/EoozOBJ8S4Y4MxRaR7kzLZhYGzSZxJCAA%3D%3D%3D)