### PR TITLE
Disable zstd in llvm in our llvm build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Then build it like so:
         -DLLVM_ENABLE_PROJECTS="clang;lld;clang-tools-extra" \
         -DLLVM_TARGETS_TO_BUILD="X86;ARM;NVPTX;AArch64;Hexagon;WebAssembly;RISCV" \
         -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ASSERTIONS=ON \
+        -DLLVM_ENABLE_ZSTD=OFF \
         -DLLVM_ENABLE_EH=ON -DLLVM_ENABLE_RTTI=ON -DLLVM_BUILD_32_BITS=OFF \
         -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
         -S llvm-project/llvm -B llvm-build


### PR DESCRIPTION
LLVM recently started defaulting ENABLE_ZSTD to on, but on macos brew puts libzstd into a directory that's not in the linker search path, and llvm-config --system-libs declares a dependency on zstd but doesn't add the correct search path.  It's not clear why we need llvm with zstd, so I'm proposing just disabling it in our build instructions to avoid this failure mode.