### PR TITLE
Document how to find Halide from a pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Currently, we provide wheels for: Windows x86-64, macOS x86-64, macOS arm64, and
 Linux x86-64. The Linux wheels are built for manylinux_2_28, which makes them
 broadly compatible (Debian 10, Ubuntu 18.10, Fedora 29).
 
-On Linux and macOS, CMake's `find_package` command should find Halide as long as
-you're in the same virtual environment you installed it in. On Windows, you will
-need to add the virtual environment root directory to `CMAKE_PREFIX_PATH`. This
-can be done by running `set CMAKE_PREFIX_PATH=%VIRTUAL_ENV%` in `cmd`.
+*For C++ usage of the pip package:* On Linux and macOS, CMake's `find_package`
+command should find Halide as long as you're in the same virtual environment you
+installed it in. On Windows, you will need to add the virtual environment root
+directory to `CMAKE_PREFIX_PATH`. This can be done by running
+`set CMAKE_PREFIX_PATH=%VIRTUAL_ENV%` in `cmd`.
 
 Other build systems can find the Halide root path by running `python -c 
 "import halide; print(halide.install_dir())"`.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Currently, we provide wheels for: Windows x86-64, macOS x86-64, macOS arm64, and
 Linux x86-64. The Linux wheels are built for manylinux_2_28, which makes them
 broadly compatible (Debian 10, Ubuntu 18.10, Fedora 29).
 
+On Linux and macOS, CMake's `find_package` command should find Halide as long as
+you're in the same virtual environment you installed it in. On Windows, you will
+need to add the virtual environment root directory to `CMAKE_PREFIX_PATH`. This
+can be done by running `set CMAKE_PREFIX_PATH=%VIRTUAL_ENV%` in `cmd`.
+
+Other build systems can find the Halide root path by running `python -c 
+"import halide; print(halide.install_dir())"`.
+
 ## Homebrew
 
 Alternatively, if you use macOS, you can install Halide via

--- a/doc/HalideCMakePackage.md
+++ b/doc/HalideCMakePackage.md
@@ -71,13 +71,17 @@ vendor-specific extensions to C++. This is not necessary to simply use Halide,
 but we do not allow such extensions in the Halide repo.
 
 Finally, we use [`find_package`][find_package] to locate Halide on your system.
-If Halide is not globally installed, you will need to add the root of the Halide
-installation directory to [`CMAKE_PREFIX_PATH`][cmake_prefix_path] at the CMake
-command line.
+When using the pip package on Linux and macOS, CMake's `find_package`
+command should find Halide as long as you're in the same virtual environment you
+installed it in. On Windows, you will need to add the virtual environment root
+directory to [`CMAKE_PREFIX_PATH`][cmake_prefix_path]:
 
 ```shell
-$ cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="/path/to/Halide-install"
+$ cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%VIRTUAL_ENV%
 ```
+
+If `find_package` cannot find Halide, set `CMAKE_PREFIX_PATH` to the Halide
+installation directory.
 
 ## JIT mode
 

--- a/python_bindings/src/halide/__init__.py
+++ b/python_bindings/src/halide/__init__.py
@@ -11,7 +11,15 @@ patch_dll_dirs()
 del patch_dll_dirs
 
 from .halide_ import *
+# noinspection PyUnresolvedReferences
 from .halide_ import _, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9
+
+
+def install_dir():
+    import os
+    return os.path.dirname(__file__)
+
+
 from ._generator_helpers import (
     _create_python_generator,
     _generatorcontext_enter,


### PR DESCRIPTION
Adds a function `install_dir()` to the Python package to aid other build systems in finding the Halide install root.

Documents how to find Halide using CMake from the pip package, too.