### PR TITLE
Update pip package metadata

### DIFF
--- a/packaging/pip/README.md
+++ b/packaging/pip/README.md
@@ -1,0 +1,24 @@
+Halide is a programming language designed to make it easier to write
+high-performance image and array processing code on modern machines. Halide
+currently targets:
+
+- CPU architectures: X86, ARM, Hexagon, PowerPC, RISC-V
+- Operating systems: Linux, Windows, macOS, Android, iOS, Qualcomm QuRT
+- GPU Compute APIs: CUDA, OpenCL, Apple Metal, Microsoft Direct X 12, Vulkan
+
+Rather than being a standalone programming language, Halide is embedded in
+Python. This means you write Python code that builds an in-memory representation
+of a Halide pipeline using Halide's Python API. You can then compile this
+representation to an object file, or JIT-compile it and run it in the same
+process.
+
+## Using Halide from C++
+Halide is also available as a C++ library. This package provides the development
+files necessary to use Halide from C++, including a CMake package. On Linux and
+macOS, CMake's `find_package` command should find Halide as long as you're in
+the same virtual environment you installed it in. On Windows, you will need to
+add the virtual environment root directory to `CMAKE_PREFIX_PATH`. This can be
+done by running `set CMAKE_PREFIX_PATH=%VIRTUAL_ENV%` in `cmd`.
+
+Other build systems can find the Halide root path by running `python -c 
+"import halide; print(halide.install_dir())"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,20 +8,65 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "halide"
 authors = [{ name = "The Halide team", email = "halide-dev@lists.csail.mit.edu" }]
+maintainers = [{ name = "Alex Reinking", email = "areinking@adobe.com" }]
 description = "Halide is a programming language designed to make it easier to write high-performance image and array processing code."
 license = { file = "LICENSE.txt" }
-readme = "README.md"
+readme = "./packaging/pip/README.md"
 requires-python = ">=3.8"
 dependencies = [
     "numpy",
     "imageio",
 ]
 dynamic = ['version']
+keywords = [
+    "array",
+    "compiler",
+    "domain-specific language",
+    "dsl",
+    "gpu",
+    "hexagon",
+    "image processing",
+    "machine learning",
+    "performance",
+    "programming language",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: GPU",
+    "Environment :: GPU :: NVIDIA CUDA",
+    "Environment :: WebAssembly",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science / Research",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Programming Language :: C++",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Multimedia :: Graphics",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Image Processing",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Software Development :: Libraries",
+]
 
 [project.urls]
-homepage = "https://halide-lang.org"
-documentation = "https://halide-lang.org/docs"
-repository = "https://github.com/halide/Halide.git"
+Homepage = "https://halide-lang.org"
+Documentation = "https://github.com/halide/Halide/blob/main/doc/Python.md"
+"Documentation (C++)" = "https://halide-lang.org/docs"
+Issues = "https://github.com/halide/Halide/issues"
+Repository = "https://github.com/halide/Halide.git"
 
 [tool.scikit-build]
 cmake.version = ">=3.28"

--- a/src/MainPage.h
+++ b/src/MainPage.h
@@ -25,6 +25,10 @@
  * particular check out local_laplacian, bilateral_grid, and
  * interpolate.
  *
+ * If you plan to build your program with CMake, you might be interested in
+ * documentation for <a href="https://github.com/halide/Halide/blob/main/doc/HalideCMakePackage.md">
+ * the Halide CMake helpers</a>.
+ *
  * Below are links to the documentation for the important classes in Halide.
  *
  * For defining, scheduling, and evaluating basic pipelines:

--- a/src/Serialization.h
+++ b/src/Serialization.h
@@ -8,7 +8,6 @@ namespace Halide {
 /// @brief Serialize a Halide pipeline into the given data buffer.
 /// @param pipeline The Halide pipeline to serialize.
 /// @param data The data buffer to store the serialized Halide pipeline into. Any existing contents will be destroyed.
-/// @param params Map of named parameters which will get populated during serialization (can be used to bind external parameters to objects in the pipeline by name).
 void serialize_pipeline(const Pipeline &pipeline, std::vector<uint8_t> &data);
 
 /// @brief Serialize a Halide pipeline into the given data buffer.


### PR DESCRIPTION
Updates the pip package metadata to include a brief README that will appear on the PyPI website. Open to suggestions for things to add here, but we should avoid being redundant with the other metadata in this file (e.g. no need to include links to the repo, docs, etc.).

Adds keywords and classifiers to the package and lists myself as the package maintainer (that way people don't try emailing the halide-dev list with problems).

Also links to the CMake package documentation from the Doxygen landing page and fixes a warning about a missing parameter when building the docs.