### PR TITLE
Fix classifier spelling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA",
     "Environment :: WebAssembly",
     "Intended Audience :: Developers",
-    "Intended Audience :: Science / Research",
+    "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: MacOS",


### PR DESCRIPTION
PyPI rejected this because of a spacing issue. Whee. Wish something would have caught this while building the wheel...