### PR TITLE
Link to PyPI from Doxygen index.html

### DIFF
--- a/src/MainPage.h
+++ b/src/MainPage.h
@@ -25,6 +25,11 @@
  * particular check out local_laplacian, bilateral_grid, and
  * interpolate.
  *
+ * If you are looking for a binary release, we suggest using pip to install
+ * either a <a href="https://pypi.org/project/halide">stable release</a> or
+ * a <a href="https://test.pypi.org/project/halide">nightly build</a> from
+ * Test PyPI.
+ *
  * If you plan to build your program with CMake, you might be interested in
  * documentation for <a href="https://github.com/halide/Halide/blob/main/doc/HalideCMakePackage.md">
  * the Halide CMake helpers</a>.


### PR DESCRIPTION
Add links to PyPI from the Doxygen index.html [to mark this link as Verified on PyPI](https://docs.pypi.org/project_metadata/#self-links).

Very open to suggestions for alternate copy.