### PR TITLE
Fix two warnings on GCC 14.2.1.

### DIFF
--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -1816,8 +1816,8 @@ void ReverseAccumulationVisitor::propagate_halide_function_call(
         }
         // If previous update has a different set of reduction variables,
         // don't merge
-        const vector<ReductionVariable> &rvars =
-            func_to_update.function().update(update_id).schedule().rvars();
+        Function func = func_to_update.function();
+        const vector<ReductionVariable> &rvars = func.update(update_id).schedule().rvars();
         if (!merged_r.defined()) {
             return rvars.empty();
         }

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -1431,23 +1431,23 @@ public:
         // into a static dispatch to the right-sized copy.)
         if (T_is_void ? (type().bytes() == 1) : (sizeof(not_void_T) == 1)) {
             using MemType = uint8_t;
-            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
-            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
+            auto &typed_dst = reinterpret_cast<Buffer<MemType, Dims, InClassDimStorage> &>(dst);
+            auto &typed_src = reinterpret_cast<Buffer<const MemType, D2, S2> &>(src);
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 2) : (sizeof(not_void_T) == 2)) {
             using MemType = uint16_t;
-            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
-            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
+            auto &typed_dst = reinterpret_cast<Buffer<MemType, Dims, InClassDimStorage> &>(dst);
+            auto &typed_src = reinterpret_cast<Buffer<const MemType, D2, S2> &>(src);
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 4) : (sizeof(not_void_T) == 4)) {
             using MemType = uint32_t;
-            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
-            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
+            auto &typed_dst = reinterpret_cast<Buffer<MemType, Dims, InClassDimStorage> &>(dst);
+            auto &typed_src = reinterpret_cast<Buffer<const MemType, D2, S2> &>(src);
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else if (T_is_void ? (type().bytes() == 8) : (sizeof(not_void_T) == 8)) {
             using MemType = uint64_t;
-            auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
-            auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
+            auto &typed_dst = reinterpret_cast<Buffer<MemType, Dims, InClassDimStorage> &>(dst);
+            auto &typed_src = reinterpret_cast<Buffer<const MemType, D2, S2> &>(src);
             typed_dst.for_each_value([&](MemType &dst, MemType src) { dst = src; }, typed_src);
         } else {
             assert(false && "type().bytes() must be 1, 2, 4, or 8");


### PR DESCRIPTION
# Cast doesn't use copy-constructor
The cast is nasty and reinterprets the datatype template argument `T`. Simply casting that no longer works without a warning. 

https://github.com/halide/Halide/blob/e55bd6f42bcfc0420adc393c29bf052a7609e041/src/runtime/HalideBuffer.h#L1432-L1454

Being explicit about this silences the compiler.

```
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h: In instantiation of ‘void Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::copy_from(Halide::Runtime::Buffer<T2, D2, S2>) [with T2 = void; int D2 = -1; int S2 = 4; T = void; int Dims = -1; int InClassDimStorage = 4]’:
/home/martijn/zec/3rd/Halide/src/Buffer.h:548:32:   required from ‘void Halide::Buffer<T, Dims>::copy_from(const Halide::Buffer<T2, D2>&) [with T2 = void; int D2 = -1; T = void; int Dims = -1]’
  548 |         contents->buf.copy_from(*other.get());
      |         ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/Deserialization.cpp:1345:24:   required from here
 1345 |     hl_buffer.copy_from(dense_buffer);
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1434:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<unsigned char, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = unsigned char; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1434 |             auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1435:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<const unsigned char, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = const unsigned char; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1435 |             auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1439:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<short unsigned int, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = short unsigned int; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1439 |             auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1440:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<const short unsigned int, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = const short unsigned int; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1440 |             auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1444:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<unsigned int, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = unsigned int; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1444 |             auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1445:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<const unsigned int, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = const unsigned int; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1445 |             auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1449:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<long unsigned int, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = long unsigned int; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1449 |             auto &typed_dst = (Buffer<MemType, Dims, InClassDimStorage> &)dst;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/martijn/zec/3rd/Halide/src/runtime/HalideBuffer.h:1450:31: error: casting ‘Halide::Runtime::Buffer<>’ to ‘Halide::Runtime::Buffer<const long unsigned int, -1, 4>&’ does not use ‘Halide::Runtime::Buffer<T, Dims, InClassDimStorage>::Buffer(const Halide::Runtime::Buffer<T2, D2, S2>&) [with T2 = void; int D2 = -1; int S2 = 4; T = const long unsigned int; int Dims = -1; int InClassDimStorage = 4]’ [-Werror=cast-user-defined]
 1450 |             auto &typed_src = (Buffer<const MemType, D2, S2> &)src;
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

---
# Dangling reference

While probably not true, for the line here:

https://github.com/halide/Halide/blob/e55bd6f42bcfc0420adc393c29bf052a7609e041/src/Derivative.cpp#L1819-L1820

the compiler notices that the Function object is immediately destroyed, and the chain of functions called on it are returning references. So it assumes (incorrectly??) that the final returned reference is dangling. (I'm not sure how the analysis works, and if it actually knows what it's doing when it makes an error phrasing this assertive).


```
/home/martijn/zec/3rd/Halide/src/Derivative.cpp: In lambda function:
/home/martijn/zec/3rd/Halide/src/Derivative.cpp:1819:42: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
 1819 |         const vector<ReductionVariable> &rvars =
      |                                          ^~~~~
/home/martijn/zec/3rd/Halide/src/Derivative.cpp:1820:73: note: the temporary was destroyed at the end of the full expression ‘(&(& Halide::Func::function() const().Halide::Internal::Function::update(update_id))->Halide::Internal::Definition::schedule())->Halide::Internal::StageSchedule::rvars()’
 1820 |             func_to_update.function().update(update_id).schedule().rvars();
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```