### PR TITLE
[vulkan] Fixes to address outstanding validation failures 

### DIFF
--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -1569,6 +1569,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Store *op) {
     user_assert(is_const_one(op->predicate)) << "Predicated stores not supported by SPIR-V codegen!\n";
 
     debug(2) << "    value_type=" << op->value.type() << " value=" << op->value << "\n";
+    debug(2) << "    index_type=" << op->index.type() << " index=" << op->index << "\n";
     op->value.accept(this);
     SpvId value_id = builder.current_id();
 
@@ -2682,7 +2683,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::declare_device_args(const Stmt &s, uint3
             SpvId runtime_arr_type_id = builder.add_runtime_array(array_element_type_id);
 
             // Annotate the array with its stride
-            SpvBuilder::Literals array_stride = {(uint32_t)(arg.type.bytes())};
+            SpvBuilder::Literals array_stride = {(uint32_t)(arg.type.bytes() * lanes)};
             builder.add_annotation(runtime_arr_type_id, SpvDecorationArrayStride, array_stride);
 
             // Wrap the runtime array in a struct (required with SPIR-V buffer block semantics)

--- a/src/runtime/internal/block_allocator.h
+++ b/src/runtime/internal/block_allocator.h
@@ -137,7 +137,7 @@ BlockAllocator *BlockAllocator::create(void *user_context, const Config &cfg, co
 
 void BlockAllocator::destroy(void *user_context, BlockAllocator *instance) {
     halide_abort_if_false(user_context, instance != nullptr);
-    const MemoryAllocators &allocators = instance->allocators;
+    MemoryAllocators allocators = instance->allocators;
     instance->destroy(user_context);
     halide_abort_if_false(user_context, allocators.system.deallocate != nullptr);
     allocators.system.deallocate(user_context, instance);

--- a/src/runtime/internal/memory_arena.h
+++ b/src/runtime/internal/memory_arena.h
@@ -114,7 +114,7 @@ MemoryArena *MemoryArena::create(void *user_context, const Config &cfg, const Sy
 
 void MemoryArena::destroy(void *user_context, MemoryArena *instance) {
     halide_debug_assert(user_context, instance != nullptr);
-    const SystemMemoryAllocatorFns &system_allocator = instance->blocks.current_allocator();
+    SystemMemoryAllocatorFns system_allocator = instance->blocks.current_allocator();
     instance->destroy(user_context);
     halide_debug_assert(user_context, system_allocator.deallocate != nullptr);
     system_allocator.deallocate(user_context, instance);

--- a/src/runtime/internal/region_allocator.h
+++ b/src/runtime/internal/region_allocator.h
@@ -126,7 +126,7 @@ RegionAllocator *RegionAllocator::create(void *user_context, BlockResource *bloc
 
 int RegionAllocator::destroy(void *user_context, RegionAllocator *instance) {
     halide_abort_if_false(user_context, instance != nullptr);
-    const MemoryAllocators &allocators = instance->allocators;
+    MemoryAllocators allocators = instance->allocators;
     instance->destroy(user_context);
     halide_abort_if_false(user_context, allocators.system.deallocate != nullptr);
     allocators.system.deallocate(user_context, instance);

--- a/src/runtime/internal/string_storage.h
+++ b/src/runtime/internal/string_storage.h
@@ -148,7 +148,7 @@ StringStorage *StringStorage::create(void *user_context, const SystemMemoryAlloc
 
 void StringStorage::destroy(void *user_context, StringStorage *instance) {
     halide_abort_if_false(user_context, instance != nullptr);
-    const SystemMemoryAllocatorFns &system_allocator = instance->current_allocator();
+    SystemMemoryAllocatorFns system_allocator = instance->current_allocator();
     instance->destroy(user_context);
     halide_abort_if_false(user_context, system_allocator.deallocate != nullptr);
     system_allocator.deallocate(user_context, instance);

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -163,11 +163,7 @@ int VulkanMemoryAllocator::destroy(void *user_context, VulkanMemoryAllocator *in
     }
     BlockAllocator::MemoryAllocators allocators = instance->block_allocator->current_allocators();
     instance->destroy(user_context);
-    BlockAllocator::destroy(user_context, instance->block_allocator);
-    if (allocators.system.deallocate == nullptr) {
-        error(user_context) << "VulkanBlockAllocator: Unable to destroy instance! Missing system allocator interface!\n";
-        return halide_error_code_internal_error;
-    }
+    halide_abort_if_false(user_context, allocators.system.deallocate != nullptr);
     allocators.system.deallocate(user_context, instance);
     return halide_error_code_success;
 }
@@ -521,7 +517,8 @@ int VulkanMemoryAllocator::destroy(void *user_context) {
                    << "user_context=" << user_context << ") ... \n";
 #endif
     if (block_allocator != nullptr) {
-        block_allocator->destroy(this);
+        BlockAllocator::destroy(user_context, block_allocator);
+        block_allocator = nullptr;
     }
     region_count = 0;
     region_byte_count = 0;

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -161,7 +161,7 @@ int VulkanMemoryAllocator::destroy(void *user_context, VulkanMemoryAllocator *in
         error(user_context) << "VulkanBlockAllocator: Unable to destroy instance! Invalide instance pointer!\n";
         return halide_error_code_internal_error;
     }
-    const BlockAllocator::MemoryAllocators &allocators = instance->block_allocator->current_allocators();
+    BlockAllocator::MemoryAllocators allocators = instance->block_allocator->current_allocators();
     instance->destroy(user_context);
     BlockAllocator::destroy(user_context, instance->block_allocator);
     if (allocators.system.deallocate == nullptr) {

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -163,7 +163,10 @@ int VulkanMemoryAllocator::destroy(void *user_context, VulkanMemoryAllocator *in
     }
     BlockAllocator::MemoryAllocators allocators = instance->block_allocator->current_allocators();
     instance->destroy(user_context);
-    halide_abort_if_false(user_context, allocators.system.deallocate != nullptr);
+    if (allocators.system.deallocate == nullptr) {
+        error(user_context) << "VulkanBlockAllocator: Unable to destroy instance! Missing system allocator interface!\n";
+        return halide_error_code_internal_error;
+    }
     allocators.system.deallocate(user_context, instance);
     return halide_error_code_success;
 }


### PR DESCRIPTION
- Fix ArrayStride for arrays of vectors bound to buffer blocks.
- Make a local copy of allocators to avoid dangling references during destruction
- Cleanup Vulkan Memory Allocator destruction to avoid duplicate calls to destroy block allocator

Fixes #8291
Fixes #8287 
Fixes #8293