### PR TITLE
Fix #8455 (in combination with #8457)

### DIFF
--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -489,7 +489,9 @@ protected:
     /** Concatenate a bunch of llvm vectors. Must be of the same type. */
     virtual llvm::Value *concat_vectors(const std::vector<llvm::Value *> &);
 
-    /** Create an LLVM shuffle vectors instruction. */
+    /** Create an LLVM shuffle vectors instruction. Takes a combination of
+     * fixed or scalable vectors as input, so long as the effective lengths match,
+     * but always returns a fixed vector. */
     virtual llvm::Value *shuffle_vectors(llvm::Value *a, llvm::Value *b,
                                          const std::vector<int> &indices);
     /** Shorthand for shuffling a single vector. */


### PR DESCRIPTION
In slice_vector(), only check for type equality after vectors have been normalized to fixed (i.e., it's ok for some original input to be vscale)