### PR TITLE
Emit `vscale_range()` fn attribute in correct syntax

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -560,7 +560,7 @@ Expr lower_round_to_nearest_ties_to_even(const Expr &x) {
 }
 
 namespace {
-bool get_md_bool(llvm::Metadata *value, bool &result) {
+bool get_md_int(llvm::Metadata *value, int64_t &result) {
     if (!value) {
         return false;
     }
@@ -572,10 +572,16 @@ bool get_md_bool(llvm::Metadata *value, bool &result) {
     if (!c) {
         return false;
     }
-    result = !c->isZero();
+    result = c->getSExtValue();
     return true;
 }
-
+bool get_md_bool(llvm::Metadata *value, bool &result) {
+    int64_t r;
+    if (!get_md_int(value, r)) {
+        return false;
+    }
+    return r != 0;
+}
 bool get_md_string(llvm::Metadata *value, std::string &result) {
     if (!value) {
         result = "";
@@ -698,11 +704,14 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 void set_function_attributes_from_halide_target_options(llvm::Function &fn) {
     llvm::Module &module = *fn.getParent();
 
-    std::string mcpu_target, mcpu_tune, mattrs, vscale_range;
+    std::string mcpu_target, mcpu_tune, mattrs;
     get_md_string(module.getModuleFlag("halide_mcpu_target"), mcpu_target);
     get_md_string(module.getModuleFlag("halide_mcpu_tune"), mcpu_tune);
     get_md_string(module.getModuleFlag("halide_mattrs"), mattrs);
-    get_md_string(module.getModuleFlag("halide_vscale_range"), vscale_range);
+    int64_t vscale_range;
+    if (!get_md_int(module.getModuleFlag("halide_effective_vscale"), vscale_range)) {
+        vscale_range = 0;
+    }
 
     fn.addFnAttr("target-cpu", mcpu_target);
     fn.addFnAttr("tune-cpu", mcpu_tune);
@@ -723,8 +732,9 @@ void set_function_attributes_from_halide_target_options(llvm::Function &fn) {
     fn.addFnAttr("reciprocal-estimates", "none");
 
     // If a fixed vscale is asserted, add it as an attribute on the function.
-    if (!vscale_range.empty()) {
-        fn.addFnAttr("vscale_range", vscale_range);
+    if (vscale_range != 0) {
+        fn.addFnAttr(llvm::Attribute::getWithVScaleRangeArgs(
+            module.getContext(), vscale_range, vscale_range));
     }
 }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -420,8 +420,7 @@ void CodeGen_LLVM::init_codegen(const std::string &name, bool any_strict_float) 
     module->addModuleFlag(llvm::Module::Warning, "halide_use_large_code_model", llvm_large_code_model ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_per_instruction_fast_math_flags", any_strict_float);
     if (effective_vscale != 0) {
-        module->addModuleFlag(llvm::Module::Warning, "halide_vscale_range",
-                              MDString::get(*context, std::to_string(effective_vscale) + ", " + std::to_string(effective_vscale)));
+        module->addModuleFlag(llvm::Module::Warning, "halide_effective_vscale", effective_vscale);
     }
 
     // Ensure some types we need are defined


### PR DESCRIPTION
Per comments on https://github.com/llvm/llvm-project/issues/114900, we emit the vscale_range attribute in slightly malformed fashion; this emits in the preferred fashion.