### PR TITLE
Don't allow internal_error to pass an error test

### DIFF
--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -29,6 +29,7 @@ if (NOT TARGET Halide::ExpectAbort)
     # Add an OBJECT (not static) library to convert abort calls into exit(1).
     add_library(Halide_expect_abort OBJECT ${Halide_SOURCE_DIR}/test/common/expect_abort.cpp)
     add_library(Halide::ExpectAbort ALIAS Halide_expect_abort)
+    target_link_libraries(Halide_expect_abort PRIVATE Halide::Halide)
 endif ()
 
 if (NOT TARGET Halide::TerminateHandler)


### PR DESCRIPTION
Pulling out changes from my rfactor work...

I had written a test that was "passing" but only because it was an error test and it was hitting an `internal_error`... this shouldn't be considered a "pass". This PR modifies our death tests to check if they are dying because a `Halide::InternalError` was uncaught and, if so, report failure.