### PR TITLE
Support copying the overlapping region from one buffer to another.

### DIFF
--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -2119,8 +2119,7 @@ public:
     }
 
     HALIDE_ALWAYS_INLINE
-    const not_void_T &
-    operator()() const {
+    const not_void_T &operator()() const {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
         constexpr int expected_dims = 0;

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -1010,7 +1010,9 @@ WEAK int halide_cuda_buffer_copy(void *user_context, struct halide_buffer_t *src
             }
         }
 
-        auto result = cuda_do_multidimensional_copy(user_context, c, c.src + c.src_begin, c.dst, dst->dimensions, from_host, to_host, stream);
+        auto result = cuda_do_multidimensional_copy(
+            user_context, c, c.src + c.src_begin, c.dst + c.dst_begin,
+            dst->dimensions, from_host, to_host, stream);
         if (result) {
             return result;
         }

--- a/src/runtime/d3d12compute.cpp
+++ b/src/runtime/d3d12compute.cpp
@@ -3263,7 +3263,7 @@ WEAK int halide_d3d12compute_buffer_copy(void *user_context, struct halide_buffe
             d3d12_buffer *dsrc = peel_buffer(src);
             d3d12_buffer *ddst = peel_buffer(dst);
             size_t src_offset = dsrc->offsetInBytes + c.src_begin;
-            size_t dst_offset = ddst->offsetInBytes;
+            size_t dst_offset = ddst->offsetInBytes + c.dst_begin;
             D3D12ContextHolder d3d12_context(user_context, true);
             if (d3d12_context.error()) {
                 return d3d12_context.error();

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -301,8 +301,8 @@ namespace {
 void do_device_to_device_copy(void *user_context, mtl_blit_command_encoder *encoder,
                               const device_copy &c, uint64_t src_offset, uint64_t dst_offset, int d) {
     if (d == 0) {
-        buffer_to_buffer_1d_copy(encoder, ((device_handle *)c.src)->buf, c.src_begin + src_offset,
-                                 ((device_handle *)c.dst)->buf, dst_offset, c.chunk_size);
+        buffer_to_buffer_1d_copy(encoder, ((device_handle *)c.src)->buf, c.src_begin,
+                                 ((device_handle *)c.dst)->buf, c.dst_begin, c.chunk_size);
     } else {
         // TODO: deal with negative strides. Currently the code in
         // device_buffer_utils.h does not do so either.
@@ -1108,8 +1108,8 @@ WEAK int halide_metal_buffer_copy(void *user_context, struct halide_buffer_t *sr
             const char *buffer_label = "halide_metal_buffer_copy";
             mtl_command_buffer *blit_command_buffer = new_command_buffer(metal_context.queue, buffer_label, strlen(buffer_label));
             mtl_blit_command_encoder *blit_encoder = new_blit_command_encoder(blit_command_buffer);
-            do_device_to_device_copy(user_context, blit_encoder, c, ((device_handle *)c.src)->offset,
-                                     ((device_handle *)c.dst)->offset, dst->dimensions);
+            do_device_to_device_copy(user_context, blit_encoder, c, ((device_handle *)c.src)->offset + c.src_begin,
+                                     ((device_handle *)c.dst)->offset + c.dst_begin, dst->dimensions);
             end_encoding(blit_encoder);
             commit_command_buffer(blit_command_buffer);
         } else {

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -301,8 +301,8 @@ namespace {
 void do_device_to_device_copy(void *user_context, mtl_blit_command_encoder *encoder,
                               const device_copy &c, uint64_t src_offset, uint64_t dst_offset, int d) {
     if (d == 0) {
-        buffer_to_buffer_1d_copy(encoder, ((device_handle *)c.src)->buf, c.src_begin,
-                                 ((device_handle *)c.dst)->buf, c.dst_begin, c.chunk_size);
+        buffer_to_buffer_1d_copy(encoder, ((device_handle *)c.src)->buf, src_offset,
+                                 ((device_handle *)c.dst)->buf, dst_offset, c.chunk_size);
     } else {
         // TODO: deal with negative strides. Currently the code in
         // device_buffer_utils.h does not do so either.
@@ -1108,7 +1108,8 @@ WEAK int halide_metal_buffer_copy(void *user_context, struct halide_buffer_t *sr
             const char *buffer_label = "halide_metal_buffer_copy";
             mtl_command_buffer *blit_command_buffer = new_command_buffer(metal_context.queue, buffer_label, strlen(buffer_label));
             mtl_blit_command_encoder *blit_encoder = new_blit_command_encoder(blit_command_buffer);
-            do_device_to_device_copy(user_context, blit_encoder, c, ((device_handle *)c.src)->offset + c.src_begin,
+            do_device_to_device_copy(user_context, blit_encoder, c,
+                                     ((device_handle *)c.src)->offset + c.src_begin,
                                      ((device_handle *)c.dst)->offset + c.dst_begin, dst->dimensions);
             end_encoding(blit_encoder);
             commit_command_buffer(blit_command_buffer);

--- a/src/runtime/vulkan.cpp
+++ b/src/runtime/vulkan.cpp
@@ -478,7 +478,7 @@ WEAK int halide_vulkan_copy_to_device(void *user_context, halide_buffer_t *halid
     copy_helper.src = (uint64_t)(staging_buffer);
     copy_helper.dst = (uint64_t)(device_buffer);
     uint64_t src_offset = copy_helper.src_begin;
-    uint64_t dst_offset = device_region->range.head_offset;
+    uint64_t dst_offset = copy_helper.dst_begin + device_region->range.head_offset;
 
     // enqueue the copy operation, using the allocated buffers
     error_code = vk_do_multidimensional_copy(user_context, cmds.command_buffer, copy_helper,
@@ -647,7 +647,7 @@ WEAK int halide_vulkan_copy_to_host(void *user_context, halide_buffer_t *halide_
     copy_helper.src = (uint64_t)(device_buffer);
     copy_helper.dst = (uint64_t)(staging_buffer);
     uint64_t src_offset = copy_helper.src_begin + device_region->range.head_offset;
-    uint64_t dst_offset = 0;
+    uint64_t dst_offset = copy_helper.dst_begin;
 
     // enqueue the copy operation, using the allocated buffers
     int error_code = vk_do_multidimensional_copy(user_context, cmds.command_buffer, copy_helper,
@@ -927,11 +927,7 @@ WEAK int halide_vulkan_buffer_copy(void *user_context, struct halide_buffer_t *s
         copy_helper.src = (uint64_t)(src_device_buffer);
         copy_helper.dst = (uint64_t)(dst_device_buffer);
         uint64_t src_offset = copy_helper.src_begin + src_buffer_region->range.head_offset;
-        uint64_t dst_offset = dst_buffer_region->range.head_offset;
-        if (!from_host && !to_host) {
-            src_offset = src_buffer_region->range.head_offset;
-            dst_offset = dst_buffer_region->range.head_offset;
-        }
+        uint64_t dst_offset = copy_helper.dst_begin + dst_buffer_region->range.head_offset;
 
         debug(user_context) << " src region=" << (void *)src_memory_region << " buffer=" << (void *)src_device_buffer << " crop_offset=" << (uint64_t)src_buffer_region->range.head_offset << " copy_offset=" << src_offset << "\n";
         debug(user_context) << " dst region=" << (void *)dst_memory_region << " buffer=" << (void *)dst_device_buffer << " crop_offset=" << (uint64_t)dst_buffer_region->range.head_offset << " copy_offset=" << dst_offset << "\n";

--- a/src/runtime/vulkan_resources.h
+++ b/src/runtime/vulkan_resources.h
@@ -1716,9 +1716,9 @@ int vk_do_multidimensional_copy(void *user_context, VkCommandBuffer command_buff
             (!from_host && !to_host)) {
 
             VkBufferCopy buffer_copy = {
-                c.src_begin + src_offset,  // srcOffset
-                dst_offset,                // dstOffset
-                c.chunk_size               // size
+                src_offset,   // srcOffset
+                dst_offset,   // dstOffset
+                c.chunk_size  // size
             };
 
             VkBuffer *src_buffer = reinterpret_cast<VkBuffer *>(c.src);

--- a/src/runtime/webgpu.cpp
+++ b/src/runtime/webgpu.cpp
@@ -720,7 +720,7 @@ WEAK int halide_webgpu_buffer_copy(void *user_context,
         ErrorScope error_scope(user_context, context.device);
 
         err = do_multidimensional_copy(user_context, &context, c,
-                                       c.src_begin, 0, dst->dimensions,
+                                       c.src_begin, c.dst_begin, dst->dimensions,
                                        from_host, to_host);
         if (err == halide_error_code_success) {
             err = error_scope.wait();


### PR DESCRIPTION
TLDR: This PR makes it possible to copy from a smaller buffer to a bigger buffer as well (i.e. blit a buffer onto another buffer). Use case: workaround for #8235: realize pipeline to a buffer that acts as a crop, and then copy the result back.

---

This PR makes it possible to copy from any buffer to any other buffer with the same number of dimensions. This is in contrast to the original functionality where it tries to copy from src to the entire number of elements in the dst buffer (even if src is smaller).

 - Added a `dst_begin` in `device_copy`.
 - @derek-gerstmann I modified a few things in the Vulkan backend cleaning up those multidimensional copies (the tests passed on my machine, but please have a look at what I did in that backend if you can). I also brought it more in line with the other backends.
 - I brought the Metal backend also more in line with the others regarding how we deal with the `src_begin` and `dst_begin` values.
 - I added tests to test this behavior.
 - I validated it myself for my own pipelines, as a application-side workaround to deal with #8235 where I make new a new buffer that acts as a crop (but is not), and copy the result back to the original buffer after the pipeline is done.

Irrelevant: my clang-format for some reason wanted to move two things in Halide::Runtime::Buffer, which is compatible with the one on the automatic test here. It seems to be the difference between clang-format-17 (github test) and clang-format-18 (my machine).
