### PR TITLE
Select condition vector lanes must match the true and false value

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2038,7 +2038,7 @@ void CodeGen_C::visit(const Select *op) {
 
     // clang doesn't support the ternary operator on OpenCL style vectors.
     // See: https://bugs.llvm.org/show_bug.cgi?id=33103
-    if (op->condition.type().is_scalar()) {
+    if (op->type.is_scalar()) {
         rhs << "(" << type << ")"
             << "(" << cond
             << " ? " << true_val

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2104,10 +2104,11 @@ void CodeGen_Hexagon::visit(const Min *op) {
 }
 
 void CodeGen_Hexagon::visit(const Select *op) {
-    if (op->condition.type().is_scalar() && op->type.is_vector()) {
+    const Broadcast *b = op->condition.as<Broadcast>();
+    if (op->type.is_vector() && b && b->type.is_scalar()) {
         // Implement scalar conditions on vector values with if-then-else.
         value = codegen(Call::make(op->type, Call::if_then_else,
-                                   {op->condition, op->true_value, op->false_value},
+                                   {b->value, op->true_value, op->false_value},
                                    Call::PureIntrinsic));
     } else {
         CodeGen_Posix::visit(op);

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1880,12 +1880,6 @@ void CodeGen_LLVM::visit(const Not *op) {
 
 void CodeGen_LLVM::visit(const Select *op) {
     Value *cmp = codegen(op->condition);
-    if (use_llvm_vp_intrinsics &&
-        op->type.is_vector() &&
-        op->condition.type().is_scalar()) {
-        cmp = create_broadcast(cmp, op->type.lanes());
-    }
-
     Value *a = codegen(op->true_value);
     Value *b = codegen(op->false_value);
     if (a->getType()->isVectorTy()) {

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -753,7 +753,7 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Cast *op) {
 }
 
 void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Select *op) {
-    if (!op->condition.type().is_scalar()) {
+    if (op->type.is_vector()) {
         // A vector of bool was recursively introduced while
         // performing codegen. Eliminate it.
         Expr equiv = eliminate_bool_vectors(op);

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -484,7 +484,7 @@ void CodeGen_X86::visit(const NE *op) {
 }
 
 void CodeGen_X86::visit(const Select *op) {
-    if (op->condition.type().is_vector()) {
+    if (op->type.is_vector()) {
         // LLVM handles selects on vector conditions much better at native width
         Value *cond = codegen(op->condition);
         Value *true_val = codegen(op->true_value);

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -236,9 +236,8 @@ Expr Select::make(Expr condition, Expr true_value, Expr false_value) {
     internal_assert(false_value.defined()) << "Select of undefined\n";
     internal_assert(condition.type().is_bool()) << "First argument to Select is not a bool: " << condition.type() << "\n";
     internal_assert(false_value.type() == true_value.type()) << "Select of mismatched types\n";
-    internal_assert(condition.type().is_scalar() ||
-                    condition.type().lanes() == true_value.type().lanes())
-        << "In Select, vector lanes of condition must either be 1, or equal to vector lanes of arguments\n";
+    internal_assert(condition.type().lanes() == true_value.type().lanes())
+        << "In Select, vector lanes of condition must be equal to vector lanes of arguments\n";
 
     Select *node = new Select;
     node->type = true_value.type();

--- a/src/Simplify_Mod.cpp
+++ b/src/Simplify_Mod.cpp
@@ -63,10 +63,18 @@ Expr Simplify::visit(const Mod *op, ExprInfo *info) {
                rewrite(ramp(x, c0, lanes) % broadcast(c1, lanes), ramp(x % c1, c0, lanes),
                        // First and last lanes are the same when...
                        can_prove((x % c1 + c0 * (lanes - 1)) / c1 == 0, this)) ||
-               rewrite(ramp(x * c0, c2, c3) % broadcast(c1, c3), ramp(x * fold(c0 % c1), fold(c2 % c1), c3) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||
-               rewrite(ramp(x + c0, c2, c3) % broadcast(c1, c3), ramp(x + fold(c0 % c1), fold(c2 % c1), c3) % c1, c1 > 0 && (c0 >= c1 || c0 < 0)) ||
-               rewrite(ramp(x * c0 + y, c2, c3) % broadcast(c1, c3), ramp(y, fold(c2 % c1), c3) % c1, c0 % c1 == 0) ||
-               rewrite(ramp(y + x * c0, c2, c3) % broadcast(c1, c3), ramp(y, fold(c2 % c1), c3) % c1, c0 % c1 == 0))))) {
+               rewrite(ramp(x * c0, c2, c3) % broadcast(c1, c3),
+                       ramp(x * fold(c0 % c1), fold(c2 % c1), c3) % broadcast(c1, c3),
+                       c1 > 0 && (c0 >= c1 || c0 < 0)) ||
+               rewrite(ramp(x + c0, c2, c3) % broadcast(c1, c3),
+                       ramp(x + fold(c0 % c1), fold(c2 % c1), c3) % broadcast(c1, c3),
+                       c1 > 0 && (c0 >= c1 || c0 < 0)) ||
+               rewrite(ramp(x * c0 + y, c2, c3) % broadcast(c1, c3),
+                       ramp(y, fold(c2 % c1), c3) % broadcast(c1, c3),
+                       c0 % c1 == 0) ||
+               rewrite(ramp(y + x * c0, c2, c3) % broadcast(c1, c3),
+                       ramp(y, fold(c2 % c1), c3) % broadcast(c1, c3),
+                       c0 % c1 == 0))))) {
             return mutate(rewrite.result, info);
         }
         // clang-format on

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -17,7 +17,6 @@ Expr Simplify::visit(const Select *op, ExprInfo *info) {
     }
 
     if (may_simplify(op->type)) {
-        int lanes = op->type.lanes();
         auto rewrite = IRMatcher::rewriter(IRMatcher::select(condition, true_value, false_value), op->type);
 
         // clang-format off
@@ -40,8 +39,7 @@ Expr Simplify::visit(const Select *op, ExprInfo *info) {
 
         // clang-format off
         if (EVAL_IN_LAMBDA
-            (rewrite(select(broadcast(x, lanes), y, z), select(x, y, z)) ||
-             rewrite(select(x != y, z, w), select(x == y, w, z)) ||
+            (rewrite(select(x != y, z, w), select(x == y, w, z)) ||
              rewrite(select(x <= y, z, w), select(y < x, w, z)) ||
              rewrite(select(x, select(y, z, w), z), select(x && !y, w, z)) ||
              rewrite(select(x, select(y, z, w), w), select(x && y, z, w)) ||

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -622,6 +622,7 @@ class VectorSubs : public IRMutator {
             // Widen the true and false values, but we don't have to widen the condition
             true_value = widen(true_value, lanes);
             false_value = widen(false_value, lanes);
+            condition = widen(condition, lanes);
             return Select::make(condition, true_value, false_value);
         }
     }

--- a/test/correctness/fuzz_simplify.cpp
+++ b/test/correctness/fuzz_simplify.cpp
@@ -136,7 +136,7 @@ Expr random_expr(std::mt19937 &rng, Type t, int depth, bool overflow_undef) {
             auto c = random_condition(rng, t, depth, true);
             auto e1 = random_expr(rng, t, depth, overflow_undef);
             auto e2 = random_expr(rng, t, depth, overflow_undef);
-            return Select::make(c, e1, e2);
+            return select(c, e1, e2);
         },
         [&]() {
             if (t.lanes() != 1) {


### PR DESCRIPTION
In our Select node, I believe the ability for the condition to be a scalar while the value is a vector was a mistake that just adds complexity. It's easy enough to just check if the condition is a broadcast if you really care about that case.

One place it added a bunch of complexity is that it meant in the RHS of the simplifier rules, sometimes you needed an implicit broadcast. These checks for an implicit broadcast on every binary node construction were responsible for about a third of the code size in Simplify_Sub.o! It's also unclear if it respects the reduction order we use to prove the simplifier terminates, because those rules were turning an implicit broadcast in the IR into a new actual Broadcast node, which may increase the total number of IR nodes, which the simplifier is not supposed to do. Now the Broadcast node is there explicitly in the input.

The select helper in IROperator.h can still take scalar conditions - but it now broadcasts them before calling Select::make. This matches the type-matching behavior of the other helpers in IROperator.h.

This shaves ~600k of code size from the compiler, and speeds up compilation of Simplify_Sub.o (and presumably other large simplifier modules) by 20%.



