### PR TITLE
Fix two trivial build errors

### DIFF
--- a/test/common/halide_test_dirs.h
+++ b/test/common/halide_test_dirs.h
@@ -5,8 +5,8 @@
 // include Halide.h
 
 #include <cassert>
-#include <string>
 #include <stdlib.h>
+#include <string>
 
 #ifdef _WIN32
 #ifndef NOMINMAX

--- a/test/common/halide_test_dirs.h
+++ b/test/common/halide_test_dirs.h
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <string>
+#include <stdlib.h>
 
 #ifdef _WIN32
 #ifndef NOMINMAX

--- a/test/performance/parallel_scenarios.cpp
+++ b/test/performance/parallel_scenarios.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 
         auto bench_one = [&]() {
             auto t1 = std::chrono::high_resolution_clock::now();
-            callable(i, o, memory_limit, in, out);
+            (void)callable(i, o, memory_limit, in, out);
             auto t2 = std::chrono::high_resolution_clock::now();
             return 1e9 * std::chrono::duration<float>(t2 - t1).count() / (i * o);
         };

--- a/test/performance/parallel_scenarios.cpp
+++ b/test/performance/parallel_scenarios.cpp
@@ -37,6 +37,7 @@ int main(int argc, char **argv) {
 
         auto bench_one = [&]() {
             auto t1 = std::chrono::high_resolution_clock::now();
+            // Ignore error code because default halide_error() will abort on failure
             (void)callable(i, o, memory_limit, in, out);
             auto t2 = std::chrono::high_resolution_clock::now();
             return 1e9 * std::chrono::duration<float>(t2 - t1).count() / (i * o);


### PR DESCRIPTION
- Missing #include in halide_test_dirs.h
- ignoring return value of function declared with 'warn_unused_result' attribute [-Werror,-Wunused-result] in parallel_scenarios.cpp