### PR TITLE
Replace all use of getPointerTo() with PointerType::get()

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1500,7 +1500,7 @@ void CodeGen_ARM::visit(const Store *op) {
                   << (t.is_float() ? 'f' : 'i')
                   << t.bits();
             arg_types = vector<llvm::Type *>(num_vecs + 2, intrin_llvm_type);
-            arg_types.front() = i8_t->getPointerTo();
+            arg_types.front() = PointerType::get(i8_t, 0);
             arg_types.back() = i32_t;
         } else {
             if (is_sve) {
@@ -1512,7 +1512,7 @@ void CodeGen_ARM::visit(const Store *op) {
                       << t.bits();
                 arg_types = vector<llvm::Type *>(num_vecs, intrin_llvm_type);
                 arg_types.emplace_back(get_vector_type(i1_t, intrin_type.lanes() / target_vscale(), VectorTypeConstraint::VScale));  // predicate
-                arg_types.emplace_back(llvm_type_of(intrin_type.element_of())->getPointerTo());
+                arg_types.emplace_back(PointerType::get(llvm_type_of(intrin_type.element_of()), 0));
             } else {
                 instr << "llvm.aarch64.neon.st"
                       << num_vecs
@@ -1522,7 +1522,7 @@ void CodeGen_ARM::visit(const Store *op) {
                       << t.bits()
                       << ".p0";
                 arg_types = vector<llvm::Type *>(num_vecs + 1, intrin_llvm_type);
-                arg_types.back() = llvm_type_of(intrin_type.element_of())->getPointerTo();
+                arg_types.back() = PointerType::get(llvm_type_of(intrin_type.element_of()), 0);
             }
         }
         llvm::FunctionType *fn_type = FunctionType::get(llvm::Type::getVoidTy(*context), arg_types, false);
@@ -1546,7 +1546,7 @@ void CodeGen_ARM::visit(const Store *op) {
 
             if (target.bits == 32) {
                 // The arm32 versions take an i8*, regardless of the type stored.
-                ptr = builder->CreatePointerCast(ptr, i8_t->getPointerTo());
+                ptr = builder->CreatePointerCast(ptr, PointerType::get(i8_t, 0));
                 // Set the pointer argument
                 slice_args.insert(slice_args.begin(), ptr);
                 // Set the alignment argument

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2231,7 +2231,7 @@ void CodeGen_Hexagon::visit(const Allocate *alloc) {
 
         // Fix the type to avoid pointless bitcasts later
         call = builder->CreatePointerCast(
-            call, llvm_type_of(alloc->type)->getPointerTo());
+            call, PointerType::get(llvm_type_of(alloc->type), 0));
         allocation.ptr = call;
 
         // Assert that the allocation worked.

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -744,7 +744,7 @@ void embed_bitcode(llvm::Module *M, const string &halide_command) {
     // Save llvm.compiler.used and remote it.
     SmallVector<Constant *, 2> used_array;
     SmallVector<GlobalValue *, 4> used_globals;
-    llvm::Type *used_element_type = llvm::Type::getInt8Ty(M->getContext())->getPointerTo(0);
+    llvm::Type *used_element_type = PointerType::get(llvm::Type::getInt8Ty(M->getContext()), 0);
     GlobalVariable *used = collectUsedGlobalVariables(*M, used_globals, true);
     for (auto *GV : used_globals) {
         if (GV->getName() != "llvm.embedded.module" &&

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -138,7 +138,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
     vector<llvm::Type *> arg_types(args.size());
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].is_buffer) {
-            arg_types[i] = llvm_type_of(UInt(8))->getPointerTo();
+            arg_types[i] = PointerType::get(llvm_type_of(UInt(8)), 0);
         } else {
             arg_types[i] = llvm_type_of(args[i].type);
         }


### PR DESCRIPTION
LLVM's `getPointerTo()` is now marked as `deprecated` and fails to compile on at least some of our build bots; `PointerType::get()` is the recommended replacement.