### PR TITLE
Backport reverse_view to clean up some code

### DIFF
--- a/src/BoundConstantExtentLoops.cpp
+++ b/src/BoundConstantExtentLoops.cpp
@@ -61,8 +61,8 @@ class BoundLoops : public IRMutator {
             if (e == nullptr) {
                 // We're about to hard fail. Get really aggressive
                 // with the simplifier.
-                for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-                    extent = Let::make(it->first, it->second, extent);
+                for (const auto &[var, value] : reverse_view(lets)) {
+                    extent = Let::make(var, value, extent);
                 }
                 extent = remove_likelies(extent);
                 extent = substitute_in_all_lets(extent);

--- a/src/BoundSmallAllocations.cpp
+++ b/src/BoundSmallAllocations.cpp
@@ -38,8 +38,8 @@ class BoundSmallAllocations : public IRMutator {
 
         result = mutate(result);
 
-        for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-            result = T::make(it->op->name, it->op->value, result);
+        for (const auto &frame : reverse_view(frames)) {
+            result = T::make(frame.op->name, frame.op->value, result);
         }
 
         return result;

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -328,7 +328,7 @@ public:
                 }
             }
 
-            for (const auto &s : def.specializations()) {
+            for (const auto &s : reverse_view(def.specializations())) {
                 const Expr s_cond = s.condition;
                 const Definition &s_def = s.definition;
 

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -328,10 +328,9 @@ public:
                 }
             }
 
-            const vector<Specialization> &specializations = def.specializations();
-            for (size_t i = specializations.size(); i > 0; i--) {
-                Expr s_cond = specializations[i - 1].condition;
-                const Definition &s_def = specializations[i - 1].definition;
+            for (const auto &s : def.specializations()) {
+                const Expr s_cond = s.condition;
+                const Definition &s_def = s.definition;
 
                 // Else case (i.e. specialization condition is false)
                 for (auto &vec : result) {
@@ -1309,12 +1308,11 @@ public:
                                  old_inner_productions.end());
 
         // Rewrap the let/if statements
-        for (size_t i = wrappers.size(); i > 0; i--) {
-            const auto &p = wrappers[i - 1];
-            if (p.first.empty()) {
-                body = IfThenElse::make(p.second, body);
+        for (const auto &[var, value] : reverse_view(wrappers)) {
+            if (var.empty()) {
+                body = IfThenElse::make(value, body);
             } else {
-                body = LetStmt::make(p.first, p.second, body);
+                body = LetStmt::make(var, value, body);
             }
         }
 

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -216,14 +216,14 @@ MangledNamePart mangle_inner_name(const Type &type, const Target &target, Previo
         result.full_name = quals + code + type.handle_type->inner_name.name + "@";
         result.with_substitutions = quals + code + prev_decls.check_and_enter_name(type.handle_type->inner_name.name);
 
-        for (size_t i = type.handle_type->enclosing_types.size(); i > 0; i--) {
-            result.full_name += type.handle_type->enclosing_types[i - 1].name + "@";
-            result.with_substitutions += prev_decls.check_and_enter_name(type.handle_type->enclosing_types[i - 1].name);
+        for (const auto &enclosing_type : reverse_view(type.handle_type->enclosing_types)) {
+            result.full_name += enclosing_type.name + "@";
+            result.with_substitutions += prev_decls.check_and_enter_name(enclosing_type.name);
         }
 
-        for (size_t i = type.handle_type->namespaces.size(); i > 0; i--) {
-            result.full_name += type.handle_type->namespaces[i - 1] + "@";
-            result.with_substitutions += prev_decls.check_and_enter_name(type.handle_type->namespaces[i - 1]);
+        for (const auto &ns : reverse_view(type.handle_type->namespaces)) {
+            result.full_name += ns + "@";
+            result.with_substitutions += prev_decls.check_and_enter_name(ns);
         }
 
         result.full_name += "@";
@@ -288,8 +288,8 @@ std::string cplusplus_function_mangled_name(const std::string &name, const std::
     PreviousDeclarations prev_decls;
     result += prev_decls.check_and_enter_name(name);
 
-    for (size_t i = namespaces.size(); i > 0; i--) {
-        result += prev_decls.check_and_enter_name(namespaces[i - 1]);
+    for (const auto &ns : reverse_view(namespaces)) {
+        result += prev_decls.check_and_enter_name(ns);
     }
     result += "@";
 

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -336,13 +336,11 @@ Expr common_subexpression_elimination(const Expr &e_in, bool lift_all) {
     debug(4) << "With variables " << e << "\n";
 
     // Wrap the final expr in the lets.
-    for (size_t i = lets.size(); i > 0; i--) {
-        Expr value = lets[i - 1].second;
+    for (const auto &[var, value] : reverse_view(lets)) {
         // Drop this variable as an acceptable replacement for this expr.
         replacer.erase(value);
         // Use containing lets in the value.
-        value = replacer.mutate(lets[i - 1].second);
-        e = Let::make(lets[i - 1].first, value, e);
+        e = Let::make(var, replacer.mutate(value), e);
     }
 
     debug(4) << "With lets: " << e << "\n";

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -239,8 +239,8 @@ class CSEEveryExprInStmt : public IRMutator {
         internal_assert(bundle && bundle->args.size() == 2);
         Stmt s = Store::make(op->name, bundle->args[0], bundle->args[1],
                              op->param, mutate(op->predicate), op->alignment);
-        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-            s = LetStmt::make(it->first, it->second, s);
+        for (const auto &[var, value] : reverse_view(lets)) {
+            s = LetStmt::make(var, value, s);
         }
         return s;
     }

--- a/src/CanonicalizeGPUVars.cpp
+++ b/src/CanonicalizeGPUVars.cpp
@@ -156,13 +156,13 @@ class CanonicalizeGPUVars : public IRMutator {
 
         result = mutate(result);
 
-        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-            std::string name = canonicalize_let(it->first);
-            if (name != it->first) {
+        for (const auto &[var, value] : reverse_view(lets)) {
+            std::string name = canonicalize_let(var);
+            if (name != var) {
                 Expr new_var = Variable::make(Int(32), name);
-                result = substitute(it->first, new_var, result);
+                result = substitute(var, new_var, result);
             }
-            result = LetStmt::make(name, it->second, result);
+            result = LetStmt::make(name, value, result);
         }
 
         return result;

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1123,8 +1123,8 @@ void CodeGen_C::compile(const LoweredFunc &f, const MetadataNameMap &metadata_na
 
     if (!namespaces.empty()) {
         stream << "\n";
-        for (size_t i = namespaces.size(); i > 0; i--) {
-            stream << "}  // namespace " << namespaces[i - 1] << "\n";
+        for (const auto &ns : reverse_view(namespaces)) {
+            stream << "}  // namespace " << ns << "\n";
         }
         stream << "\n";
     }

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3245,8 +3245,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         // Build the not-already-inited case
         builder->SetInsertPoint(global_not_inited_bb);
         llvm::Value *selected_value = nullptr;
-        for (int i = sub_fns.size() - 1; i >= 0; i--) {
-            const auto &sub_fn = sub_fns[i];
+        for (const auto &sub_fn : reverse_view(sub_fns)) {
             if (!selected_value) {
                 selected_value = sub_fn.fn_ptr;
             } else {

--- a/src/CodeGen_PyTorch.cpp
+++ b/src/CodeGen_PyTorch.cpp
@@ -210,8 +210,8 @@ void CodeGen_PyTorch::compile(const LoweredFunc &f, bool is_cuda) {
 
     if (!namespaces.empty()) {
         stream << "\n";
-        for (size_t i = namespaces.size(); i > 0; i--) {
-            stream << "}  // namespace " << namespaces[i - 1] << "\n";
+        for (const auto &ns : reverse_view(namespaces)) {
+            stream << "}  // namespace " << ns << "\n";
         }
         stream << "\n";
     }

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -481,21 +481,21 @@ class Interleaver : public IRMutator {
 
         result = mutate(result);
 
-        for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-            Expr value = std::move(it->new_value);
+        for (const auto &frame : reverse_view(frames)) {
+            Expr value = std::move(frame.new_value);
 
-            result = T::make(it->op->name, value, result);
+            result = T::make(frame.op->name, value, result);
 
             // For vector lets, we may additionally need a let defining the even and odd lanes only
             if (value.type().is_vector()) {
                 if (value.type().lanes() % 2 == 0) {
-                    result = T::make(it->op->name + ".even_lanes", extract_even_lanes(value, vector_lets), result);
-                    result = T::make(it->op->name + ".odd_lanes", extract_odd_lanes(value, vector_lets), result);
+                    result = T::make(frame.op->name + ".even_lanes", extract_even_lanes(value, vector_lets), result);
+                    result = T::make(frame.op->name + ".odd_lanes", extract_odd_lanes(value, vector_lets), result);
                 }
                 if (value.type().lanes() % 3 == 0) {
-                    result = T::make(it->op->name + ".lanes_0_of_3", extract_mod3_lanes(value, 0, vector_lets), result);
-                    result = T::make(it->op->name + ".lanes_1_of_3", extract_mod3_lanes(value, 1, vector_lets), result);
-                    result = T::make(it->op->name + ".lanes_2_of_3", extract_mod3_lanes(value, 2, vector_lets), result);
+                    result = T::make(frame.op->name + ".lanes_0_of_3", extract_mod3_lanes(value, 0, vector_lets), result);
+                    result = T::make(frame.op->name + ".lanes_1_of_3", extract_mod3_lanes(value, 1, vector_lets), result);
+                    result = T::make(frame.op->name + ".lanes_2_of_3", extract_mod3_lanes(value, 2, vector_lets), result);
                 }
             }
         }

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -554,8 +554,7 @@ void ReverseAccumulationVisitor::propagate_adjoints(
     }
 
     // Traverse functions from producers to consumers for reverse accumulation
-    for (int func_id = funcs.size() - 1; func_id >= 0; func_id--) {
-        const Func &func = funcs[func_id];
+    for (const auto &func : reverse_view(funcs)) {
         current_func = func;
 
         FuncKey func_key{func.name(), func.num_update_definitions() - 1};

--- a/src/Derivative.cpp
+++ b/src/Derivative.cpp
@@ -353,13 +353,12 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                 expr_adjoints[output_expr] = 1.f;
             }
 
-            // Traverse the expressions in reverse order
-            for (auto it = expr_list.rbegin(); it != expr_list.rend(); it++) {
-                if (it->type().is_handle()) {
+            for (Expr &e : reverse_view(expr_list)) {
+                if (e.type().is_handle()) {
                     // Ignore pointer types
                     continue;
                 }
-                it->accept(this);
+                e.accept(this);
             }
 
             auto error = [&]() {
@@ -700,14 +699,13 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                     }
                 }
 
-                // Traverse the expressions in reverse order
-                for (auto it = expr_list.rbegin(); it != expr_list.rend(); it++) {
-                    if (it->type().is_handle()) {
+                for (Expr &e : reverse_view(expr_list)) {
+                    if (e.type().is_handle()) {
                         // Ignore pointer types
                         continue;
                     }
                     // Propagate adjoints
-                    it->accept(this);
+                    e.accept(this);
                 }
             }
             if (is_current_non_overwriting_scan) {
@@ -742,14 +740,13 @@ void ReverseAccumulationVisitor::propagate_adjoints(
                                    update_args, i);
                 }
 
-                // Traverse the expressions in reverse order
-                for (auto it = expr_list.rbegin(); it != expr_list.rend(); it++) {
-                    if (it->type().is_handle()) {
+                for (Expr &e : reverse_view(expr_list)) {
+                    if (e.type().is_handle()) {
                         // Ignore pointer types
                         continue;
                     }
                     // Propagate adjoints
-                    it->accept(this);
+                    e.accept(this);
                 }
             }
         }

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -250,11 +250,11 @@ map<string, Box> inference_bounds(const vector<Func> &funcs,
         bounds[func.name()] = output_bounds[i];
     }
     // Traverse from the consumers to the producers
-    for (auto it = order.rbegin(); it != order.rend(); it++) {
-        Func func = Func(env[*it]);
+    for (const auto &func_name : reverse_view(order)) {
+        auto func = Func(env[func_name]);
         // We should already have the bounds of this function
-        internal_assert(bounds.find(*it) != bounds.end()) << *it << "\n";
-        const Box &current_bounds = bounds[*it];
+        internal_assert(bounds.find(func_name) != bounds.end()) << func_name << "\n";
+        const Box &current_bounds = bounds[func_name];
         internal_assert(func.args().size() == current_bounds.size());
         // We know the range for each argument of this function
         for (int i = 0; i < (int)current_bounds.size(); i++) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -576,8 +576,8 @@ void StubEmitter::emit() {
     stream << get_indent() << "};\n";
     stream << "\n";
 
-    for (int i = (int)namespaces.size() - 1; i >= 0; --i) {
-        stream << get_indent() << "}  // namespace " << namespaces[i] << "\n";
+    for (const auto &ns : reverse_view(namespaces)) {
+        stream << get_indent() << "}  // namespace " << ns << "\n";
     }
     stream << "\n";
 

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -132,11 +132,11 @@ class LiftLoopInvariants : public IRMutator {
 
         result = mutate(result);
 
-        for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-            if (it->new_value.same_as(it->op->value) && result.same_as(it->op->body)) {
-                result = it->op;
+        for (const auto &frame : reverse_view(frames)) {
+            if (frame.new_value.same_as(frame.op->value) && result.same_as(frame.op->body)) {
+                result = frame.op;
             } else {
-                result = T::make(it->op->name, std::move(it->new_value), result);
+                result = T::make(frame.op->name, std::move(frame.new_value), result);
             }
         }
 
@@ -502,11 +502,11 @@ class GroupLoopInvariants : public IRMutator {
 
         result = mutate(result);
 
-        for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-            if (it->new_value.same_as(it->op->value) && result.same_as(it->op->body)) {
-                result = it->op;
+        for (const auto &frame : reverse_view(frames)) {
+            if (frame.new_value.same_as(frame.op->value) && result.same_as(frame.op->body)) {
+                result = frame.op;
             } else {
-                result = T::make(it->op->name, it->new_value, result);
+                result = T::make(frame.op->name, frame.new_value, result);
             }
         }
 

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -481,16 +481,14 @@ class LoopCarryOverLoop : public IRMutator {
             Stmt initial_stores = Block::make(initial_scratch_stores);
 
             // Wrap them in the appropriate lets
-            for (size_t i = initial_lets.size(); i > 0; i--) {
-                const auto &l = initial_lets[i - 1];
-                initial_stores = LetStmt::make(l.first, l.second, initial_stores);
+            for (const auto &[var, value] : reverse_view(initial_lets)) {
+                initial_stores = LetStmt::make(var, value, initial_stores);
             }
             // We may be lifting the initial stores out of let stmts,
             // so rewrap them in the necessary ones.
-            for (size_t i = containing_lets.size(); i > 0; i--) {
-                const auto &l = containing_lets[i - 1];
-                if (stmt_uses_var(initial_stores, l.first)) {
-                    initial_stores = LetStmt::make(l.first, l.second, initial_stores);
+            for (const auto &[var, value] : reverse_view(containing_lets)) {
+                if (stmt_uses_var(initial_stores, var)) {
+                    initial_stores = LetStmt::make(var, value, initial_stores);
                 }
             }
 

--- a/src/Memoization.cpp
+++ b/src/Memoization.cpp
@@ -537,11 +537,7 @@ private:
             Expr value = mutate(let->value);
             Stmt body = mutate(let->body);
 
-            std::vector<const Allocate *> &allocations = pending_memoized_allocations[innermost_realization_name];
-
-            for (size_t i = allocations.size(); i > 0; i--) {
-                const Allocate *allocation = allocations[i - 1];
-
+            for (const auto *allocation : reverse_view(pending_memoized_allocations[innermost_realization_name])) {
                 // Make the allocation node
                 body = Allocate::make(allocation->name, allocation->type, allocation->memory_type, allocation->extents, allocation->condition, body,
                                       Call::make(Handle(), Call::buffer_get_host,

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -218,8 +218,7 @@ private:
             // If there are multiple prefetches of the same Func or ImageParam,
             // use the most recent one
             set<string> seen;
-            for (int i = prefetch_list.size() - 1; i >= 0; --i) {
-                const PrefetchDirective &p = prefetch_list[i];
+            for (const PrefetchDirective &p : reverse_view(prefetch_list)) {
                 if (!ends_with(op->name, "." + p.at) || (seen.find(p.name) != seen.end())) {
                     continue;
                 }
@@ -231,9 +230,9 @@ private:
                 // Note that it is not good enough to just prepend use 'prefix + from', as there may be splits involved, e.g.,
                 // prefix = g.s0, from = xo, but the var we seek is actually g.s0.x.xo (because 'g' was split at x).
                 string from_var;
-                for (int j = (int)loop_nest.size() - 1; j >= 0; --j) {
-                    if (starts_with(loop_nest[j], prefix) && ends_with(loop_nest[j], "." + p.from)) {
-                        from_var = loop_nest[j];
+                for (const auto &var : reverse_view(loop_nest)) {
+                    if (starts_with(var, prefix) && ends_with(var, "." + p.from)) {
+                        from_var = var;
                         debug(5) << "Prefetch from " << p.from << " -> from_var " << from_var << "\n";
                         break;
                     }

--- a/src/RemoveUndef.cpp
+++ b/src/RemoveUndef.cpp
@@ -264,15 +264,15 @@ private:
         result = mutate(result);
 
         if (result.defined()) {
-            for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-                if (!it->new_value.defined()) {
+            for (const auto &frame : reverse_view(frames)) {
+                if (!frame.new_value.defined()) {
                     continue;
                 }
-                predicate = substitute(it->op->name, it->new_value, predicate);
-                if (it->new_value.same_as(it->op->value) && result.same_as(it->op->body)) {
-                    result = it->op;
+                predicate = substitute(frame.op->name, frame.new_value, predicate);
+                if (frame.new_value.same_as(frame.op->value) && result.same_as(frame.op->body)) {
+                    result = frame.op;
                 } else {
-                    result = T::make(it->op->name, std::move(it->new_value), result);
+                    result = T::make(frame.op->name, std::move(frame.new_value), result);
                 }
             }
         }
@@ -540,13 +540,12 @@ private:
 
         result = mutate(result);
 
-        for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-            op = it->first;
-            Stmt new_first = std::move(it->second);
+        for (const auto &[block, stmt] : reverse_view(frames)) {
+            Stmt new_first = stmt;
             if (!result.defined()) {
                 result = new_first;
-            } else if (new_first.same_as(op->first) && result.same_as(op->rest)) {
-                result = op;
+            } else if (new_first.same_as(block->first) && result.same_as(block->rest)) {
+                result = block;
             } else {
                 result = Block::make(new_first, result);
             }

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -391,28 +391,26 @@ Stmt build_loop_nest(
     }
 
     // Rewrap the statement in the containing lets and fors.
-    for (int i = (int)nest.size() - 1; i >= 0; i--) {
-        if (nest[i].type == Container::Let) {
-            internal_assert(nest[i].value.defined());
-            stmt = LetStmt::make(nest[i].name, nest[i].value, stmt);
-        } else if ((nest[i].type == Container::If) || (nest[i].type == Container::IfInner)) {
-            internal_assert(nest[i].value.defined());
-            stmt = IfThenElse::make(nest[i].value, stmt, Stmt());
+    for (const auto &container : reverse_view(nest)) {
+        if (container.type == Container::Let) {
+            internal_assert(container.value.defined());
+            stmt = LetStmt::make(container.name, container.value, stmt);
+        } else if ((container.type == Container::If) || (container.type == Container::IfInner)) {
+            internal_assert(container.value.defined());
+            stmt = IfThenElse::make(container.value, stmt, Stmt());
         } else {
-            internal_assert(nest[i].type == Container::For);
-            const Dim &dim = stage_s.dims()[nest[i].dim_idx];
-            Expr min = Variable::make(Int(32), nest[i].name + ".loop_min");
-            Expr extent = Variable::make(Int(32), nest[i].name + ".loop_extent");
-            stmt = For::make(nest[i].name, min, extent, dim.for_type, dim.partition_policy, dim.device_api, stmt);
+            internal_assert(container.type == Container::For);
+            const Dim &dim = stage_s.dims()[container.dim_idx];
+            Expr min = Variable::make(Int(32), container.name + ".loop_min");
+            Expr extent = Variable::make(Int(32), container.name + ".loop_extent");
+            stmt = For::make(container.name, min, extent, dim.for_type, dim.partition_policy, dim.device_api, stmt);
         }
     }
 
     // Define the bounds on the split dimensions using the bounds
     // on the function args. If it is a purify, we should use the bounds
     // from the dims instead.
-    for (size_t i = splits.size(); i > 0; i--) {
-        const Split &split = splits[i - 1];
-
+    for (const Split &split : reverse_view(splits)) {
         vector<std::pair<string, Expr>> let_stmts = compute_loop_bounds_after_split(split, prefix);
         for (const auto &let_stmt : let_stmts) {
             stmt = LetStmt::make(let_stmt.first, let_stmt.second, stmt);
@@ -1310,12 +1308,11 @@ protected:
         }
 
         // Reinstate the let/if statements
-        for (size_t i = containers.size(); i > 0; i--) {
-            const auto &p = containers[i - 1];
-            if (p.first.empty()) {
-                body = IfThenElse::make(p.second, body);
+        for (const auto &[var, value] : reverse_view(containers)) {
+            if (var.empty()) {
+                body = IfThenElse::make(value, body);
             } else {
-                body = LetStmt::make(p.first, p.second, body);
+                body = LetStmt::make(var, value, body);
             }
         }
 
@@ -1839,9 +1836,8 @@ private:
         internal_assert(producer.defined());
 
         // Rewrap the loop in the containing lets.
-        for (size_t i = add_lets.size(); i > 0; --i) {
-            const auto &b = add_lets[i - 1];
-            producer = LetStmt::make(b.first, b.second, producer);
+        for (const auto &[var, value] : reverse_view(add_lets)) {
+            producer = LetStmt::make(var, value, producer);
         }
 
         // The original bounds of the loop nests (without any loop-fusion)
@@ -2234,14 +2230,14 @@ bool validate_schedule(Function f, const Stmt &s, const Target &target, bool is_
         // (@abadams comments: "I acknowledge that this is gross and should be refactored.")
 
         // (Note that the splits are ordered, so a single reverse-pass catches all these cases.)
-        for (auto split = s.splits().rbegin(); split != s.splits().rend(); split++) {
-            if (split->is_split() && (parallel_vars.count(split->outer) || parallel_vars.count(split->inner))) {
-                parallel_vars.insert(split->old_var);
-            } else if (split->is_fuse() && parallel_vars.count(split->old_var)) {
-                parallel_vars.insert(split->inner);
-                parallel_vars.insert(split->outer);
-            } else if ((split->is_rename() || split->is_purify()) && parallel_vars.count(split->outer)) {
-                parallel_vars.insert(split->old_var);
+        for (const auto &split : reverse_view(s.splits())) {
+            if (split.is_split() && (parallel_vars.count(split.outer) || parallel_vars.count(split.inner))) {
+                parallel_vars.insert(split.old_var);
+            } else if (split.is_fuse() && parallel_vars.count(split.old_var)) {
+                parallel_vars.insert(split.inner);
+                parallel_vars.insert(split.outer);
+            } else if ((split.is_rename() || split.is_purify()) && parallel_vars.count(split.outer)) {
+                parallel_vars.insert(split.old_var);
             }
         }
 
@@ -2577,8 +2573,7 @@ Stmt schedule_functions(const vector<Function> &outputs,
 
     validate_fused_groups_schedule(fused_groups, env);
 
-    for (size_t i = fused_groups.size(); i > 0; --i) {
-        const vector<string> &group = fused_groups[i - 1];
+    for (const auto &group : reverse_view(fused_groups)) {
         vector<Function> funcs;
         vector<bool> is_output_list;
 

--- a/src/SimplifySpecializations.cpp
+++ b/src/SimplifySpecializations.cpp
@@ -118,9 +118,9 @@ vector<Definition> propagate_specialization_in_definition(Definition &def, const
         specializations.insert(specializations.end(), s_def.specializations().begin(), s_def.specializations().end());
     }
 
-    for (size_t i = specializations.size(); i > 0; i--) {
-        Expr c = specializations[i - 1].condition;
-        Definition &s_def = specializations[i - 1].definition;
+    for (auto &s : reverse_view(specializations)) {
+        Expr c = s.condition;
+        Definition &s_def = s.definition;
         const EQ *eq = c.as<EQ>();
         const Variable *var = eq ? eq->a.as<Variable>() : c.as<Variable>();
 

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -280,33 +280,33 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *info) {
     }
     find_var_uses(result, unused_vars);
 
-    for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-        if (it->value_bounds_tracked) {
-            bounds_and_alignment_info.pop(it->op->name);
+    for (const auto &frame : reverse_view(frames)) {
+        if (frame.value_bounds_tracked) {
+            bounds_and_alignment_info.pop(frame.op->name);
         }
-        if (it->new_value_bounds_tracked) {
-            bounds_and_alignment_info.pop(it->new_name);
+        if (frame.new_value_bounds_tracked) {
+            bounds_and_alignment_info.pop(frame.new_name);
         }
 
-        if (it->new_value.defined() && (it->info.new_uses > 0 && !unused_vars.count(it->new_name))) {
+        if (frame.new_value.defined() && (frame.info.new_uses > 0 && !unused_vars.count(frame.new_name))) {
             // The new name/value may be used
-            result = LetOrLetStmt::make(it->new_name, it->new_value, result);
-            find_var_uses(it->new_value, unused_vars);
+            result = LetOrLetStmt::make(frame.new_name, frame.new_value, result);
+            find_var_uses(frame.new_value, unused_vars);
         }
 
         if ((!remove_dead_code && std::is_same<LetOrLetStmt, LetStmt>::value) ||
-            (it->info.old_uses > 0 && !unused_vars.count(it->op->name))) {
+            (frame.info.old_uses > 0 && !unused_vars.count(frame.op->name))) {
             // The old name is still in use. We'd better keep it as well.
-            result = LetOrLetStmt::make(it->op->name, it->value, result);
-            find_var_uses(it->value, unused_vars);
+            result = LetOrLetStmt::make(frame.op->name, frame.value, result);
+            find_var_uses(frame.value, unused_vars);
         }
 
         const LetOrLetStmt *new_op = result.template as<LetOrLetStmt>();
         if (new_op &&
-            new_op->name == it->op->name &&
-            new_op->body.same_as(it->op->body) &&
-            new_op->value.same_as(it->op->value)) {
-            result = it->op;
+            new_op->name == frame.op->name &&
+            new_op->body.same_as(frame.op->body) &&
+            new_op->value.same_as(frame.op->value)) {
+            result = frame.op;
         }
     }
 

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -422,8 +422,8 @@ Stmt Simplify::visit(const Evaluate *op) {
     } else {
         // Rewrap the lets outside the evaluate node
         Stmt stmt = Evaluate::make(value);
-        for (size_t i = lets.size(); i > 0; i--) {
-            stmt = LetStmt::make(lets[i - 1].first, lets[i - 1].second, stmt);
+        for (const auto &[var, value] : reverse_view(lets)) {
+            stmt = LetStmt::make(var, value, stmt);
         }
         return stmt;
     }

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -543,10 +543,10 @@ protected:
         }
 
         // Rewrap any uninteresting lets
-        for (auto it = containing_lets.rbegin(); it != containing_lets.rend(); it++) {
-            mutate(it->second);  // Visit the value of each let
+        for (auto &[var, value] : reverse_view(containing_lets)) {
+            mutate(value);  // Visit the value of each let
             if (changed) {
-                body = T::make(it->first, std::move(it->second), std::move(body));
+                body = T::make(var, std::move(value), std::move(body));
             }
         }
 

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -202,9 +202,9 @@ class SplitTuples : public IRMutator {
                         aliases = aliases && (a[i] == b[i]);
                     }
                     // Might need some of the containing lets
-                    for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-                        if (expr_uses_var(aliases, it->first)) {
-                            aliases = Let::make(it->first, it->second, aliases);
+                    for (const auto &[var, value] : reverse_view(lets)) {
+                        if (expr_uses_var(aliases, var)) {
+                            aliases = Let::make(var, value, aliases);
                         }
                     }
                     return !can_prove(!aliases);
@@ -443,8 +443,8 @@ class SplitScatterGather : public IRMutator {
         body = substitute(op->name, gather_replacement, body);
         body = mutate(body);
 
-        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-            body = LetStmt::make(it->first, it->second, body);
+        for (const auto &[var, value] : reverse_view(lets)) {
+            body = LetStmt::make(var, value, body);
         }
 
         return body;
@@ -472,8 +472,8 @@ class SplitScatterGather : public IRMutator {
             body = mutate(body);
         }
 
-        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-            body = LetStmt::make(it->first, it->second, body);
+        for (const auto &[var, value] : reverse_view(lets)) {
+            body = LetStmt::make(var, value, body);
         }
 
         return body;
@@ -536,8 +536,8 @@ class SplitScatterGather : public IRMutator {
             }
         }
 
-        for (auto it = lets.rbegin(); it != lets.rend(); it++) {
-            s = LetStmt::make(it->first, it->second, s);
+        for (const auto &[var, value] : reverse_view(lets)) {
+            s = LetStmt::make(var, value, s);
         }
 
         return s;

--- a/src/Substitute.cpp
+++ b/src/Substitute.cpp
@@ -66,8 +66,8 @@ public:
             new_body.same_as(body)) {
             return orig;
         } else {
-            for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-                new_body = T::make(it->op->name, it->new_value, new_body);
+            for (const auto &frame : reverse_view(frames)) {
+                new_body = T::make(frame.op->name, frame.new_value, new_body);
             }
             return new_body;
         }

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -386,10 +386,10 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name, bool trace_pipeline,
             builder.func = trace_tags.first;  // func name
             builder.event = halide_trace_tag;
             // We must reverse-iterate to preserve order
-            for (auto it = trace_tags.second.rbegin(); it != trace_tags.second.rend(); ++it) {
-                user_assert(it->find('\0') == string::npos)
+            for (const auto &tag : reverse_view(trace_tags.second)) {
+                user_assert(tag.find('\0') == string::npos)
                     << "add_trace_tag() may not contain the null character.";
-                builder.trace_tag_expr = Expr(*it);
+                builder.trace_tag_expr = Expr(tag);
                 s = Block::make(Evaluate::make(builder.build()), s);
             }
         }
@@ -409,9 +409,8 @@ Stmt inject_tracing(Stmt s, const string &pipeline_name, bool trace_pipeline,
         Expr space = Expr(" ");
 
         std::map<std::string, Box> bt = boxes_touched(s);
-        for (auto topo_it = order.rbegin(); topo_it != order.rend(); ++topo_it) {
-            const string &o = *topo_it;
-            auto p = tracing.funcs_touched.find(*topo_it);
+        for (const auto &o : reverse_view(order)) {
+            auto p = tracing.funcs_touched.find(o);
             if (p == tracing.funcs_touched.end() && ends_with(o, "_im")) {
                 p = tracing.funcs_touched.find(o.substr(0, o.size() - 3));
             }

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -64,14 +64,14 @@ class UniquifyVariableNames : public IRMutator {
 
         result = mutate(result);
 
-        for (auto it = frames.rbegin(); it != frames.rend(); it++) {
-            renaming.pop(it->op->name);
-            if (it->new_name == it->op->name &&
-                result.same_as(it->op->body) &&
-                it->op->value.same_as(it->value)) {
-                result = it->op;
+        for (const auto &frame : reverse_view(frames)) {
+            renaming.pop(frame.op->name);
+            if (frame.new_name == frame.op->name &&
+                result.same_as(frame.op->body) &&
+                frame.op->value.same_as(frame.value)) {
+                result = frame.op;
             } else {
-                result = LetOrLetStmt::make(it->new_name, it->value, result);
+                result = LetOrLetStmt::make(frame.new_name, frame.value, result);
             }
         }
 
@@ -176,11 +176,11 @@ namespace {
 void check(vector<pair<Var, Expr>> in,
            vector<pair<Var, Expr>> out) {
     Stmt in_stmt = Evaluate::make(0), out_stmt = Evaluate::make(0);
-    for (auto it = in.rbegin(); it != in.rend(); it++) {
-        in_stmt = LetStmt::make(it->first.name(), it->second, in_stmt);
+    for (const auto &[var, value] : reverse_view(in)) {
+        in_stmt = LetStmt::make(var.name(), value, in_stmt);
     }
-    for (auto it = out.rbegin(); it != out.rend(); it++) {
-        out_stmt = LetStmt::make(it->first.name(), it->second, out_stmt);
+    for (const auto &[var, value] : reverse_view(out)) {
+        out_stmt = LetStmt::make(var.name(), value, out_stmt);
     }
 
     Stmt s = uniquify_variable_names(in_stmt);

--- a/src/Util.h
+++ b/src/Util.h
@@ -458,6 +458,30 @@ struct IsRoundtrippable {
     }
 };
 
+template<typename T>
+struct reverse_adaptor {
+    T &range;
+};
+
+template<typename T>
+auto begin(reverse_adaptor<T> i) {
+    return std::rbegin(i.range);
+}
+
+template<typename T>
+auto end(reverse_adaptor<T> i) {
+    return std::rend(i.range);
+}
+
+/**
+ * Reverse-order adaptor for range-based for-loops.
+ * TODO: Replace with std::ranges::reverse_view when upgrading to C++20.
+ */
+template<typename T>
+reverse_adaptor<T> reverse_view(T &&range) {
+    return {range};
+}
+
 /** Emit a version of a string that is a valid identifier in C (. is replaced with _)
  * If prefix_underscore is true (the default), an underscore will be prepended if the
  * input starts with an alphabetic character to avoid reserved word clashes.

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1000,12 +1000,12 @@ class VectorSubs : public IRMutator {
             body = mutate(body);
 
             // Append vectorized lets for this loop level.
-            for (auto let = containing_lets.rbegin(); let != containing_lets.rend(); let++) {
+            for (const auto &[var, _] : reverse_view(containing_lets)) {
                 // Skip if this var wasn't vectorized.
-                if (!scope.contains(let->first)) {
+                if (!scope.contains(var)) {
                     continue;
                 }
-                string vectorized_name = get_widened_var_name(let->first);
+                string vectorized_name = get_widened_var_name(var);
                 Expr vectorized_value = vector_scope.get(vectorized_name);
                 vector_scope.pop(vectorized_name);
                 InterleavedRamp ir;

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1310,9 +1310,8 @@ class VectorSubs : public IRMutator {
             s = SerializeLoops().mutate(s);
         }
         // We'll need the original scalar versions of any containing lets.
-        for (size_t i = containing_lets.size(); i > 0; i--) {
-            const auto &l = containing_lets[i - 1];
-            s = LetStmt::make(l.first, l.second, s);
+        for (const auto &[var, value] : reverse_view(containing_lets)) {
+            s = LetStmt::make(var, value, s);
         }
 
         for (int ix = vectorized_vars.size() - 1; ix >= 0; ix--) {

--- a/src/autoschedulers/adams2019/DefaultCostModel.cpp
+++ b/src/autoschedulers/adams2019/DefaultCostModel.cpp
@@ -62,9 +62,10 @@ void DefaultCostModel::set_pipeline_features(const Internal::Autoscheduler::Func
     Runtime::Buffer<float> pipeline_features(head1_w, head1_h, num_stages);
     int stage = 0;
     for (const auto &n : dag.nodes) {
-        if (n.is_input) continue;
-        for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
-            const auto &s = *it;
+        if (n.is_input) {
+            continue;
+        }
+        for (const auto &s : Internal::reverse_view(n.stages)) {
             const int *pipeline_feats = (const int *)(&(s.features)) + 7;
             // skip the first 7 features
             for (int i = 0; i < pipeline_feat_size; i++) {
@@ -119,9 +120,9 @@ void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
         if (stage >= num_stages) break;
 
         // Load up the schedule features for all stages of this Func.
-        for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
-            internal_assert(schedule_feats.contains(&*it)) << n.func.name() << "\n";
-            const auto &feat = schedule_feats.get(&*it);
+        for (const auto &s : Internal::reverse_view(n.stages)) {
+            internal_assert(schedule_feats.contains(&s)) << n.func.name() << "\n";
+            const auto &feat = schedule_feats.get(&s);
             for (size_t i = 0; i < ScheduleFeatures::num_features(); i++) {
                 schedule_features(i, stage) = feat[i];
             }

--- a/src/autoschedulers/adams2019/State.cpp
+++ b/src/autoschedulers/adams2019/State.cpp
@@ -585,46 +585,46 @@ void State::apply_schedule(const FunctionDAG &dag, const Adams2019Params &params
         }
     }
 
-    for (auto &p : state_map) {
-        if (p.first->node->is_input) {
+    for (auto &[stage_ptr, schedule] : state_map) {
+        if (stage_ptr->node->is_input) {
             continue;
         }
 
-        Stage stage(p.first->stage);
+        Stage stage(stage_ptr->stage);
 
         // Do all the reorders and pick which vars to
         // parallelize.
         vector<VarOrRVar> vars;
         vector<VarOrRVar> parallel_vars;
         bool any_parallel_vars = false, any_parallel_rvars = false;
-        for (auto it = p.second->vars.rbegin(); it != p.second->vars.rend(); it++) {
-            if (!it->exists || it->extent == 1) {
+        for (const auto &func_var : reverse_view(schedule->vars)) {
+            if (!func_var.exists || func_var.extent == 1) {
                 continue;
             }
-            if (!it->parallel) {
+            if (!func_var.parallel) {
                 break;
             }
-            any_parallel_rvars |= it->var.is_rvar;
-            any_parallel_vars |= !it->var.is_rvar;
-            parallel_vars.push_back(it->var);
+            any_parallel_rvars |= func_var.var.is_rvar;
+            any_parallel_vars |= !func_var.var.is_rvar;
+            parallel_vars.push_back(func_var.var);
         }
 
-        if (p.second->vars.size() > 1) {
-            p.second->schedule_source << "\n    .reorder(";
+        if (schedule->vars.size() > 1) {
+            schedule->schedule_source << "\n    .reorder(";
             bool first = true;
-            for (auto &v : p.second->vars) {
+            for (auto &v : schedule->vars) {
                 if (v.exists) {
                     vars.push_back(v.var);
                     if (!first) {
-                        p.second->schedule_source << ", ";
+                        schedule->schedule_source << ", ";
                     } else {
-                        p.second->schedule_source << "{";
+                        schedule->schedule_source << "{";
                     }
                     first = false;
-                    p.second->schedule_source << v.var.name();
+                    schedule->schedule_source << v.var.name();
                 }
             }
-            p.second->schedule_source << "})";
+            schedule->schedule_source << "})";
             stage.reorder(vars);
         }
 
@@ -635,44 +635,44 @@ void State::apply_schedule(const FunctionDAG &dag, const Adams2019Params &params
             for (size_t i = 1; i < parallel_vars.size(); i++) {
                 // Outermost, and next outermost. Preserve the inner
                 // name to not invalidate any compute_ats.
-                p.second->schedule_source << "\n    .fuse(" << parallel_vars[i].name()
+                schedule->schedule_source << "\n    .fuse(" << parallel_vars[i].name()
                                           << ", " << parallel_vars[i - 1].name()
                                           << ", " << parallel_vars[i].name() << ")";
                 stage.fuse(parallel_vars[i], parallel_vars[i - 1], parallel_vars[i]);
             }
             if (!parallel_vars.empty()) {
-                p.second->schedule_source << "\n    .parallel(" << parallel_vars.back().name() << ")";
+                schedule->schedule_source << "\n    .parallel(" << parallel_vars.back().name() << ")";
                 stage.parallel(parallel_vars.back());
             }
         } else {
             for (const auto &v : parallel_vars) {
-                p.second->schedule_source << "\n    .parallel(" << v.name() << ")";
+                schedule->schedule_source << "\n    .parallel(" << v.name() << ")";
                 stage.parallel(v);
             }
         }
 
         // Reorder the vector dimension innermost
-        if (p.first->index == 0 && p.second->vector_dim > 0) {
-            vector<Var> storage_vars = Func(p.first->node->func).args();
-            for (int i = p.second->vector_dim; i > 0; i--) {
+        if (stage_ptr->index == 0 && schedule->vector_dim > 0) {
+            vector<Var> storage_vars = Func(stage_ptr->node->func).args();
+            for (int i = schedule->vector_dim; i > 0; i--) {
                 std::swap(storage_vars[i], storage_vars[i - 1]);
             }
-            p.second->schedule_source << "\n    .reorder_storage(";
+            schedule->schedule_source << "\n    .reorder_storage(";
             bool first = true;
             for (const auto &v : storage_vars) {
                 if (!first) {
-                    p.second->schedule_source << ", ";
+                    schedule->schedule_source << ", ";
                 }
                 first = false;
-                p.second->schedule_source << v.name();
+                schedule->schedule_source << v.name();
             }
-            p.second->schedule_source << ")";
-            Func(p.first->node->func).reorder_storage(storage_vars);
+            schedule->schedule_source << ")";
+            Func(stage_ptr->node->func).reorder_storage(storage_vars);
         }
 
         // Dump the schedule source string
-        src << p.first->name
-            << p.second->schedule_source.str()
+        src << stage_ptr->name
+            << schedule->schedule_source.str()
             << ";\n";
     }
     // Sanitize the names of things to make them legal source code.

--- a/src/autoschedulers/anderson2021/DefaultCostModel.cpp
+++ b/src/autoschedulers/anderson2021/DefaultCostModel.cpp
@@ -65,8 +65,7 @@ void DefaultCostModel::set_pipeline_features(const Internal::Autoscheduler::Func
         if (n.is_input) {
             continue;
         }
-        for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
-            const auto &s = *it;
+        for (const auto &s : Internal::reverse_view(n.stages)) {
             const int *pipeline_feats = (const int *)(&(s.features)) + 7;
             // skip the first 7 features
             for (int i = 0; i < pipeline_feat_size; i++) {
@@ -130,9 +129,9 @@ void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
         }
 
         // Load up the schedule features for all stages of this Func.
-        for (auto it = n.stages.rbegin(); it != n.stages.rend(); it++) {
-            internal_assert(schedule_feats.contains(&*it)) << n.func.name() << "\n";
-            const auto &feat = schedule_feats.get(&*it);
+        for (const auto &s : Internal::reverse_view(n.stages)) {
+            internal_assert(schedule_feats.contains(&s)) << n.func.name() << "\n";
+            const auto &feat = schedule_feats.get(&s);
             for (size_t i = 0; i < ScheduleFeatures::num_features(); i++) {
                 schedule_features(i, stage) = feat[i];
             }

--- a/src/autoschedulers/li2018/GradientAutoscheduler.cpp
+++ b/src/autoschedulers/li2018/GradientAutoscheduler.cpp
@@ -908,11 +908,11 @@ void generate_schedule(const std::vector<Function> &outputs,
 
     std::ostringstream schedule_source;
     // Traverse from the consumers to the producers
-    for (auto it = order.rbegin(); it != order.rend(); it++) {
-        Func func(env[*it]);
-        debug(1) << "[gradient_autoscheduler] Processing function:" << *it << "\n";
+    for (const auto &func_name : reverse_view(order)) {
+        Func func(env[func_name]);
+        debug(1) << "[gradient_autoscheduler] Processing function:" << func_name << "\n";
         // Get the bounds in integer constant by substitute all the parameters' estimates.
-        Box bounds = func_bounds[*it];
+        Box bounds = func_bounds[func_name];
         std::vector<int> int_bounds = get_int_bounds(bounds);
         // Scheduling pure definition
         apply_schedule(params, target, func, -1, int_bounds, target.has_gpu_feature(), schedule_source);


### PR DESCRIPTION
I found it very useful to backport `reverse_view` from C++20 for the sake of writing readable backwards loops. Here, I add `reverse_view` to `Util.h`. This allows us to simplify code in a lot of places.