### PR TITLE
Remove type inspection helpers from ApplySplitResult and Split

### DIFF
--- a/src/ApplySplit.h
+++ b/src/ApplySplit.h
@@ -46,31 +46,6 @@ struct ApplySplitResult {
     ApplySplitResult(Expr val, Type t = Predicate)
         : name(""), value(std::move(val)), type(t) {
     }
-
-    bool is_substitution() const {
-        return (type == Substitution);
-    }
-    bool is_substitution_in_calls() const {
-        return (type == SubstitutionInCalls);
-    }
-    bool is_substitution_in_provides() const {
-        return (type == SubstitutionInProvides);
-    }
-    bool is_let() const {
-        return (type == LetStmt);
-    }
-    bool is_predicate() const {
-        return (type == Predicate);
-    }
-    bool is_predicate_calls() const {
-        return (type == PredicateCalls);
-    }
-    bool is_predicate_provides() const {
-        return (type == PredicateProvides);
-    }
-    bool is_blend_provides() const {
-        return (type == BlendProvides);
-    }
 };
 
 /** Given a Split schedule on a definition (init or update), return a list of

--- a/src/Inline.cpp
+++ b/src/Inline.cpp
@@ -55,16 +55,19 @@ void validate_schedule_inlined_function(Function f) {
     }
 
     for (const auto &split : stage_s.splits()) {
-        if (split.is_rename()) {
+        switch (split.split_type) {
+        case Split::RenameVar:
             user_warning << "It is meaningless to rename variable "
                          << split.old_var << " of function "
                          << f.name() << " to " << split.outer
                          << " because " << f.name() << " is scheduled inline.\n";
-        } else if (split.is_fuse()) {
+            break;
+        case Split::FuseVars:
             user_warning << "It is meaningless to fuse variables "
                          << split.inner << " and " << split.outer
                          << " because " << f.name() << " is scheduled inline.\n";
-        } else {
+            break;
+        case Split::SplitVar:
             user_warning << "It is meaningless to split variable "
                          << split.old_var << " of function "
                          << f.name() << " into "
@@ -72,6 +75,10 @@ void validate_schedule_inlined_function(Function f) {
                          << split.factor << " + "
                          << split.inner << " because "
                          << f.name() << " is scheduled inline.\n";
+
+            break;
+        case Split::PurifyRVar:
+            break;
         }
     }
 

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -348,19 +348,6 @@ struct Split {
     // If split_type is Fuse, then this does the opposite of a
     // split, it joins the outer and inner into the old_var.
     SplitType split_type;
-
-    bool is_rename() const {
-        return split_type == RenameVar;
-    }
-    bool is_split() const {
-        return split_type == SplitVar;
-    }
-    bool is_fuse() const {
-        return split_type == FuseVars;
-    }
-    bool is_purify() const {
-        return split_type == PurifyRVar;
-    }
 };
 
 /** Each Dim below has a dim_type, which tells you what


### PR DESCRIPTION
They hide bugs where a case hasn't been considered.