### PR TITLE
Fix Apple libtool detection in bundle_static

### DIFF
--- a/cmake/BundleStatic.cmake
+++ b/cmake/BundleStatic.cmake
@@ -24,7 +24,7 @@ endfunction()
 
 function(_bundle_static_is_apple_libtool result_var item)
     _bundle_static_check_output(version_info "${item}" -V)
-    if (NOT version_info MATCHES "Apple, Inc.")
+    if (NOT version_info MATCHES "Apple,? Inc\\.")
         set(${result_var} 0 PARENT_SCOPE)
     endif ()
 endfunction()


### PR DESCRIPTION
At some point, Apple changed their `libtool -V` output to exclude the comma.

Skipping buildbots because this only runs during packaging.