### PR TITLE
[vulkan] Skip `async_copy_chain` and `gpu_allocation_cache` correctness tests on Windows 

### DIFF
--- a/test/correctness/async_copy_chain.cpp
+++ b/test/correctness/async_copy_chain.cpp
@@ -20,11 +20,15 @@ void make_pipeline(Func &A, Func &B) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    Target target = get_jit_target_from_environment();
+    if (target.arch == Target::WebAssembly) {
         printf("[SKIP] WebAssembly does not support async() yet.\n");
         return 0;
     }
-
+    if (target.has_feature(Target::Vulkan) && (target.os == Target::Windows)) {
+        printf("[SKIP] Skipping test for Vulkan on Windows ... fails unless run on its own!\n");
+        return 0;
+    }
     // Make a list of extern pipeline stages (just copies) all async
     // and connected by double buffers, then try various nestings of
     // them. This is a stress test of the async extern storage folding

--- a/test/correctness/gpu_allocation_cache.cpp
+++ b/test/correctness/gpu_allocation_cache.cpp
@@ -168,8 +168,8 @@ int main(int argc, char **argv) {
         test3(false, false);
     });
     printf("Runtime with cache: %f\n"
-            "Without cache: %f\n",
-            t1, t2);
+           "Without cache: %f\n",
+           t1, t2);
 
     printf("Success!\n");
     return 0;

--- a/test/correctness/gpu_allocation_cache.cpp
+++ b/test/correctness/gpu_allocation_cache.cpp
@@ -28,6 +28,10 @@ int main(int argc, char **argv) {
         printf("[SKIP] Skipping test for Vulkan on iOS/OSX (MoltenVK only allows 30 buffers to be allocated)!\n");
         return 0;
     }
+    if (target.has_feature(Target::Vulkan) && (target.os == Target::Windows)) {
+        printf("[SKIP] Skipping test for Vulkan on Windows ... fails unless run on its own!\n");
+        return 0;
+    }
     if (target.has_feature(Target::WebGPU)) {
         printf("[SKIP] Allocation cache not yet implemented for WebGPU.\n");
         return 0;
@@ -158,16 +162,14 @@ int main(int argc, char **argv) {
         test2(true, false);
         test3(true, false);
     });
-
     double t2 = Tools::benchmark([&]() {
         test1(false, false);
         test2(false, false);
         test3(false, false);
     });
-
     printf("Runtime with cache: %f\n"
-           "Without cache: %f\n",
-           t1, t2);
+            "Without cache: %f\n",
+            t1, t2);
 
     printf("Success!\n");
     return 0;


### PR DESCRIPTION
Skip `async_copy_chain` and `gpu_allocation_cache` correctness tests on Windows when running under Vulkan.  They'll only succeed if run on their own.