### PR TITLE
Make the default constructor for ConstantInterval inlinable

### DIFF
--- a/src/ConstantInterval.cpp
+++ b/src/ConstantInterval.cpp
@@ -7,8 +7,6 @@
 namespace Halide {
 namespace Internal {
 
-ConstantInterval::ConstantInterval() = default;
-
 ConstantInterval::ConstantInterval(int64_t min, int64_t max)
     : min(min), max(max), min_defined(true), max_defined(true) {
     internal_assert(min <= max);

--- a/src/ConstantInterval.h
+++ b/src/ConstantInterval.h
@@ -22,7 +22,7 @@ struct ConstantInterval {
     bool min_defined = false, max_defined = false;
 
     /* A default-constructed Interval is everything */
-    ConstantInterval();
+    ConstantInterval() = default;
 
     /** Construct an interval from a lower and upper bound. */
     ConstantInterval(int64_t min, int64_t max);


### PR DESCRIPTION
It's just zero-intialization of the (exposed) struct members, so it's silly to have to call a function in another TU for it.