### PR TITLE
Print constants in scientific precision

### DIFF
--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -594,6 +594,11 @@ void IRPrinter::visit(const UIntImm *op) {
 }
 
 void IRPrinter::visit(const FloatImm *op) {
+    const bool use_scientific_format = (op->value != 0.0) && (std::log10(std::abs(op->value)) < -6);
+    if (use_scientific_format) {
+        stream << std::scientific;
+    }
+
     switch (op->type.bits()) {
     case 64:
         stream << op->value;
@@ -606,6 +611,10 @@ void IRPrinter::visit(const FloatImm *op) {
         break;
     default:
         internal_error << "Bad bit-width for float: " << op->type << "\n";
+    }
+
+    if (use_scientific_format) {
+        stream << std::fixed;
     }
 }
 


### PR DESCRIPTION
When the absolute value of a floating point number is smaller than then default IRPrinter precision (6 decimal points), print the value in scientific format.

Use cases:

- Normalizing the 2D/3D fft image by the total pixel count.
- Algorithm problem scaling.
- SI unit conversions, i.e. from nanometer to meter.