### PR TITLE
Require an autoscheduler for build_gradient_module()/GRADIENT_DESCENT

### DIFF
--- a/doc/HalideCMakePackage.md
+++ b/doc/HalideCMakePackage.md
@@ -474,7 +474,9 @@ verbatim.
 If `GRADIENT_DESCENT` is set, then the module will be built suitably for
 gradient descent calculation in TensorFlow or PyTorch. See
 `Generator::build_gradient_module()` for more documentation. This corresponds to
-passing `-d 1` at the generator command line.
+passing `-d 1` at the generator command line. Note that you *must* also specify
+an autoscheduler (via the `AUTOSCHEDULER` argument) when specifying this
+argument.
 
 If the `C_BACKEND` option is set, this command will invoke the configured C++
 compiler on a generated source. Note that a `<target>.runtime` target is _not_

--- a/src/AbstractGenerator.cpp
+++ b/src/AbstractGenerator.cpp
@@ -218,8 +218,7 @@ Module AbstractGenerator::build_gradient_module(const std::string &function_name
     if (!asp.name.empty()) {
         auto_schedule_results = grad_pipeline.apply_autoscheduler(context.target(), asp);
     } else {
-        user_warning << "Autoscheduling is not enabled in build_gradient_module(), so the resulting "
-                        "gradient module will be unscheduled; this is very unlikely to be what you want.\n";
+        user_error << "An autoscheduler must be specified when producing a gradient-descent module().\n";
     }
 
     Module result = grad_pipeline.compile_to_module(gradient_inputs, function_name, context.target(), linkage_type);


### PR DESCRIPTION
Currently we just emit a warning... which may be hidden by CMake/Bazel. This really needs to be an error, though, because an unscheduled gradient-descent module can be immense and take ~forever to compile. (Addresses part of #8393 but not a complete fix.)