### PR TITLE
Backport: Fix Debian packaging (#8524)

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # TODO: detect this from repo somehow: https://github.com/halide/Halide/issues/8406
-  LLVM_VERSION: 19.1.4
+  LLVM_VERSION: 19.1.6
   FLATBUFFERS_VERSION: 23.5.26
   WABT_VERSION: 1.0.36
 

--- a/cmake/HalidePackageConfigHelpers.cmake
+++ b/cmake/HalidePackageConfigHelpers.cmake
@@ -80,7 +80,7 @@ function(_Halide_install_pkgdeps)
     set(depFile "${CMAKE_CURRENT_BINARY_DIR}/${ARG_FILE_NAME}")
 
     _Halide_install_code(
-        "file(READ \"\${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${ARG_EXPORT_FILE}\" target_cmake)"
+        "file(READ \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${ARG_EXPORT_FILE}\" target_cmake)"
         "file(WRITE \"${depFile}.in\" \"\")"
     )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,8 +18,10 @@ set(Halide_VERSION_OVERRIDE "${Halide_VERSION}"
     CACHE STRING "VERSION to set for custom Halide packaging")
 mark_as_advanced(Halide_VERSION_OVERRIDE)
 
-if (Halide_VERSION_OVERRIDE)
-    # Empty is considered a value distinct from not-defined
+if (NOT Halide_VERSION_OVERRIDE STREQUAL "")
+    # CMake treats an empty VERSION property differently from leaving it unset.
+    # We also can't check the boolean-ness of Halide_VERSION_OVERRIDE because
+    # VERSION 0 is valid. See: https://github.com/halide/Halide/issues/8522
     set_target_properties(Halide PROPERTIES VERSION "${Halide_VERSION_OVERRIDE}")
 endif ()
 
@@ -27,8 +29,7 @@ set(Halide_SOVERSION_OVERRIDE "${Halide_VERSION_MAJOR}"
     CACHE STRING "SOVERSION to set for custom Halide packaging")
 mark_as_advanced(Halide_SOVERSION_OVERRIDE)
 
-if (Halide_SOVERSION_OVERRIDE)
-    # Empty is considered a value distinct from not-defined
+if (NOT Halide_SOVERSION_OVERRIDE STREQUAL "")
     set_target_properties(Halide PROPERTIES SOVERSION "${Halide_SOVERSION_OVERRIDE}")
 endif ()
 


### PR DESCRIPTION
* Handle DESTDIR in HalidePackageConfigHelpers.cmake

Fixes #8521

* Fix Halide_[SO]VERSION_OVERRIDE when value is 0

Fixes #8522

* Upgrade LLVM to 19.1.6

(cherry picked from commit ac2cd23951aff9ac3b765e51938f1e576f1f0ee9)