### PR TITLE
Use a consistent idiom for visit_let

### DIFF
--- a/src/ClampUnsafeAccesses.cpp
+++ b/src/ClampUnsafeAccesses.cpp
@@ -42,11 +42,11 @@ protected:
     }
 
     Expr visit(const Let *let) override {
-        return visit_let<Let, Expr>(let);
+        return visit_let(let);
     }
 
     Stmt visit(const LetStmt *let) override {
-        return visit_let<LetStmt, Stmt>(let);
+        return visit_let(let);
     }
 
     Expr visit(const Variable *var) override {
@@ -80,15 +80,15 @@ protected:
     }
 
 private:
-    template<typename L, typename Body>
-    Body visit_let(const L *let) {
-        ScopedBinding<bool> binding(let_var_inside_indexing, let->name, false);
-        Body body = mutate(let->body);
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
+        ScopedBinding<bool> binding(let_var_inside_indexing, op->name, false);
+        auto body = mutate(op->body);
 
-        ScopedValue<bool> s(is_inside_indexing, is_inside_indexing || let_var_inside_indexing.get(let->name));
-        Expr value = mutate(let->value);
+        ScopedValue<bool> s(is_inside_indexing, is_inside_indexing || let_var_inside_indexing.get(op->name));
+        Expr value = mutate(op->value);
 
-        return L::make(let->name, std::move(value), std::move(body));
+        return LetOrLetStmt::make(op->name, std::move(value), std::move(body));
     }
 
     bool bounds_smaller_than_type(const Interval &bounds, Type type) {

--- a/src/EliminateBoolVectors.cpp
+++ b/src/EliminateBoolVectors.cpp
@@ -287,8 +287,8 @@ private:
         return expr;
     }
 
-    template<typename NodeType, typename LetType>
-    NodeType visit_let(const LetType *op) {
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
         Expr value = mutate(op->value);
 
         // We changed the type of the let, we need to replace the
@@ -305,17 +305,17 @@ private:
         }
 
         if (!value.same_as(op->value) || !body.same_as(op->body)) {
-            return LetType::make(op->name, value, body);
+            return LetOrLetStmt::make(op->name, value, body);
         } else {
             return op;
         }
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Expr>(op);
+        return visit_let(op);
     }
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt>(op);
+        return visit_let(op);
     }
 };
 

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -1157,9 +1157,9 @@ class ExtractRegisterAllocations : public IRMutator {
                            op->param, mutate(op->predicate), op->alignment);
     }
 
-    template<typename ExprOrStmt, typename LetOrLetStmt>
-    ExprOrStmt visit_let(const LetOrLetStmt *op) {
-        ExprOrStmt body = op->body;
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
+        auto body = op->body;
 
         body = mutate(op->body);
         Expr value = mutate(op->value);
@@ -1178,11 +1178,11 @@ class ExtractRegisterAllocations : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Expr>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt>(op);
+        return visit_let(op);
     }
 
     Scope<int> register_allocations;

--- a/src/HexagonOptimize.cpp
+++ b/src/HexagonOptimize.cpp
@@ -1088,20 +1088,20 @@ class OptimizePatterns : public IRMutator {
         }
     }
 
-    template<typename NodeType, typename T>
-    NodeType visit_let(const T *op) {
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
         bounds.push(op->name, bounds_of_expr_in_scope(op->value, bounds));
-        NodeType node = IRMutator::visit(op);
+        auto node = IRMutator::visit(op);
         bounds.pop(op->name);
         return node;
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Expr>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt>(op);
+        return visit_let(op);
     }
 
     Expr visit(const Div *op) override {
@@ -1599,12 +1599,12 @@ class EliminateInterleaves : public IRMutator {
         }
     }
 
-    template<typename NodeType, typename LetType>
-    NodeType visit_let(const LetType *op) {
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
 
         Expr value = mutate(op->value);
         string deinterleaved_name;
-        NodeType body;
+        decltype(op->body) body;
         // Other code in this mutator needs to be able to tell the
         // difference between a Let that yields a deinterleave, and a
         // let that has a removable deinterleave. Lets that can
@@ -1632,10 +1632,10 @@ class EliminateInterleaves : public IRMutator {
             return op;
         } else if (body.same_as(op->body)) {
             // If the body didn't change, we must not have used the deinterleaved value.
-            return LetType::make(op->name, value, body);
+            return LetOrLetStmt::make(op->name, value, body);
         } else {
             // We need to rewrap the body with new lets.
-            NodeType result = body;
+            auto result = body;
             bool deinterleaved_used = stmt_or_expr_uses_var(result, deinterleaved_name);
             bool interleaved_used = stmt_or_expr_uses_var(result, op->name);
             if (deinterleaved_used && interleaved_used) {
@@ -1653,14 +1653,14 @@ class EliminateInterleaves : public IRMutator {
                     interleaved = native_interleave(interleaved);
                 }
 
-                result = LetType::make(op->name, interleaved, result);
-                return LetType::make(deinterleaved_name, deinterleaved, result);
+                result = LetOrLetStmt::make(op->name, interleaved, result);
+                return LetOrLetStmt::make(deinterleaved_name, deinterleaved, result);
             } else if (deinterleaved_used) {
                 // Only the deinterleaved value is used, we can eliminate the interleave.
-                return LetType::make(deinterleaved_name, remove_interleave(value), result);
+                return LetOrLetStmt::make(deinterleaved_name, remove_interleave(value), result);
             } else if (interleaved_used) {
                 // Only the original value is used, regenerate the let.
-                return LetType::make(op->name, value, result);
+                return LetOrLetStmt::make(op->name, value, result);
             } else {
                 // The let must have been dead.
                 internal_assert(!stmt_or_expr_uses_var(op->body, op->name))
@@ -1671,7 +1671,7 @@ class EliminateInterleaves : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        Expr expr = visit_let<Expr>(op);
+        Expr expr = visit_let(op);
 
         // Lift interleaves out of Let expression bodies.
         const Let *let = expr.as<Let>();
@@ -1682,7 +1682,7 @@ class EliminateInterleaves : public IRMutator {
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt>(op);
+        return visit_let(op);
     }
 
     Expr visit(const Cast *op) override {
@@ -2047,13 +2047,13 @@ class ScatterGatherGenerator : public IRMutator {
         return IRMutator::visit(op);
     }
 
-    template<typename NodeType, typename T>
-    NodeType visit_let(const T *op) {
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
         // We only care about vector lets.
         if (op->value.type().is_vector()) {
             bounds.push(op->name, bounds_of_expr_in_scope(op->value, bounds));
         }
-        NodeType node = IRMutator::visit(op);
+        auto node = IRMutator::visit(op);
         if (op->value.type().is_vector()) {
             bounds.pop(op->name);
         }
@@ -2061,11 +2061,11 @@ class ScatterGatherGenerator : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Expr>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const Allocate *op) override {

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -112,23 +112,23 @@ class LiftLoopInvariants : public IRMutator {
         return true;
     }
 
-    template<typename T, typename Body>
-    Body visit_let(const T *op) {
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
         // Visit an entire chain of lets in a single method to conserve stack space.
         struct Frame {
-            const T *op;
+            const LetOrLetStmt *op;
             Expr new_value;
             ScopedBinding<> binding;
-            Frame(const T *op, Expr v, Scope<> &scope)
+            Frame(const LetOrLetStmt *op, Expr v, Scope<> &scope)
                 : op(op), new_value(std::move(v)), binding(scope, op->name) {
             }
         };
         vector<Frame> frames;
-        Body result;
+        decltype(op->body) result;
         do {
             frames.emplace_back(op, mutate(op->value), varying);
             result = op->body;
-        } while ((op = result.template as<T>()));
+        } while ((op = result.template as<LetOrLetStmt>()));
 
         result = mutate(result);
 
@@ -136,7 +136,7 @@ class LiftLoopInvariants : public IRMutator {
             if (frame.new_value.same_as(frame.op->value) && result.same_as(frame.op->body)) {
                 result = frame.op;
             } else {
-                result = T::make(frame.op->name, std::move(frame.new_value), result);
+                result = LetOrLetStmt::make(frame.op->name, std::move(frame.new_value), result);
             }
         }
 
@@ -144,11 +144,11 @@ class LiftLoopInvariants : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Let, Expr>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<LetStmt, Stmt>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const For *op) override {
@@ -476,20 +476,20 @@ class GroupLoopInvariants : public IRMutator {
         return stmt;
     }
 
-    template<typename T, typename Body>
-    Body visit_let(const T *op) {
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
         struct Frame {
-            const T *op;
+            const LetOrLetStmt *op;
             Expr new_value;
             ScopedBinding<int> binding;
-            Frame(const T *op, Expr v, int depth, Scope<int> &scope)
+            Frame(const LetOrLetStmt *op, Expr v, int depth, Scope<int> &scope)
                 : op(op),
                   new_value(std::move(v)),
                   binding(scope, op->name, depth) {
             }
         };
         std::vector<Frame> frames;
-        Body result;
+        decltype(op->body) result;
 
         do {
             result = op->body;
@@ -498,7 +498,7 @@ class GroupLoopInvariants : public IRMutator {
                 d = expr_depth(op->value);
             }
             frames.emplace_back(op, mutate(op->value), d, var_depth);
-        } while ((op = result.template as<T>()));
+        } while ((op = result.template as<LetOrLetStmt>()));
 
         result = mutate(result);
 
@@ -506,7 +506,7 @@ class GroupLoopInvariants : public IRMutator {
             if (frame.new_value.same_as(frame.op->value) && result.same_as(frame.op->body)) {
                 result = frame.op;
             } else {
-                result = T::make(frame.op->name, frame.new_value, result);
+                result = LetOrLetStmt::make(frame.op->name, frame.new_value, result);
             }
         }
 
@@ -514,11 +514,11 @@ class GroupLoopInvariants : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Let, Expr>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<LetStmt, Stmt>(op);
+        return visit_let(op);
     }
 };
 

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -691,10 +691,10 @@ class HoistWarpShufflesFromSingleIfStmt : public IRMutator {
         }
     }
 
-    template<typename ExprOrStmt, typename LetOrLetStmt>
-    ExprOrStmt visit_let(const LetOrLetStmt *op) {
+    template<typename LetOrLetStmt>
+    auto visit_let(const LetOrLetStmt *op) -> decltype(op->body) {
         Expr value = mutate(op->value);
-        ExprOrStmt body = mutate(op->body);
+        auto body = mutate(op->body);
 
         // If any of the lifted expressions use this, we also need to
         // lift this.
@@ -712,11 +712,11 @@ class HoistWarpShufflesFromSingleIfStmt : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Expr>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const For *op) override {

--- a/src/SimplifyCorrelatedDifferences.cpp
+++ b/src/SimplifyCorrelatedDifferences.cpp
@@ -78,8 +78,8 @@ class SimplifyCorrelatedDifferences : public IRMutator {
     };
     vector<OuterLet> lets;
 
-    template<typename LetStmtOrLet, typename StmtOrExpr>
-    StmtOrExpr visit_let(const LetStmtOrLet *op) {
+    template<typename LetStmtOrLet>
+    auto visit_let(const LetStmtOrLet *op) -> decltype(op->body) {
         // Visit an entire chain of lets in a single method to conserve stack space.
         struct Frame {
             const LetStmtOrLet *op;
@@ -94,7 +94,7 @@ class SimplifyCorrelatedDifferences : public IRMutator {
             }
         };
         std::vector<Frame> frames;
-        StmtOrExpr result;
+        decltype(op->body) result;
 
         // Note that we must add *everything* that depends on the loop
         // var to the monotonic scope and the list of lets, even
@@ -146,11 +146,11 @@ class SimplifyCorrelatedDifferences : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Let, Expr>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<LetStmt, Stmt>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const For *op) override {

--- a/src/TrimNoOps.cpp
+++ b/src/TrimNoOps.cpp
@@ -309,10 +309,10 @@ class SimplifyUsingBounds : public IRMutator {
         return visit_cmp(op);
     }
 
-    template<typename StmtOrExpr, typename LetStmtOrLet>
-    StmtOrExpr visit_let(const LetStmtOrLet *op) {
+    template<typename LetStmtOrLet>
+    auto visit_let(const LetStmtOrLet *op) -> decltype(op->body) {
         Expr value = mutate(op->value);
-        StmtOrExpr body;
+        decltype(op->body) body;
         if (value.type() == Int(32) && is_pure(value)) {
             containing_loops.push_back({op->name, {value, value}});
             body = mutate(op->body);
@@ -324,11 +324,11 @@ class SimplifyUsingBounds : public IRMutator {
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Expr, Let>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt, LetStmt>(op);
+        return visit_let(op);
     }
 
     Stmt visit(const For *op) override {

--- a/src/UniquifyVariableNames.cpp
+++ b/src/UniquifyVariableNames.cpp
@@ -130,15 +130,15 @@ class FindFreeVars : public IRVisitor {
         }
     }
 
-    template<typename T>
-    void visit_let(const T *op) {
+    template<typename LetOrLetStmt>
+    void visit_let(const LetOrLetStmt *op) {
         vector<ScopedBinding<>> frame;
         decltype(op->body) body;
         do {
             op->value.accept(this);
             frame.emplace_back(scope, op->name);
             body = op->body;
-            op = body.template as<T>();
+            op = body.template as<LetOrLetStmt>();
         } while (op);
         body.accept(this);
     }

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1411,8 +1411,8 @@ class FindVectorizableExprsInAtomicNode : public IRMutator {
 
     using IRMutator::visit;
 
-    template<typename T>
-    const T *visit_let(const T *op) {
+    template<typename LetOrLetStmt>
+    const LetOrLetStmt *visit_let(const LetOrLetStmt *op) {
         mutate(op->value);
         ScopedBinding<> bind_if(poison, poisoned_names, op->name);
         mutate(op->body);
@@ -1498,8 +1498,8 @@ class LiftVectorizableExprsOutOfSingleAtomicNode : public IRMutator {
 
     using IRMutator::visit;
 
-    template<typename StmtOrExpr, typename LetStmtOrLet>
-    StmtOrExpr visit_let(const LetStmtOrLet *op) {
+    template<typename LetStmtOrLet>
+    auto visit_let(const LetStmtOrLet *op) -> decltype(op->body) {
         if (liftable.count(op->value)) {
             // Lift it under its current name to avoid having to
             // rewrite the variables in other lifted exprs.
@@ -1512,11 +1512,11 @@ class LiftVectorizableExprsOutOfSingleAtomicNode : public IRMutator {
     }
 
     Stmt visit(const LetStmt *op) override {
-        return visit_let<Stmt>(op);
+        return visit_let(op);
     }
 
     Expr visit(const Let *op) override {
-        return visit_let<Expr>(op);
+        return visit_let(op);
     }
 
 public:


### PR DESCRIPTION
This is a super minor thing that has been irritating me. visit_let in the codebase uses a wide variety of template names, argument names, and ways of getting the body type. This just picks one and uses it consistently. No functional changes.