### PR TITLE
Don't include CMAKE_INSTALL_PREFIX when LIBDIR is absolute

### DIFF
--- a/cmake/HalidePackageConfigHelpers.cmake
+++ b/cmake/HalidePackageConfigHelpers.cmake
@@ -78,9 +78,10 @@ function(_Halide_install_pkgdeps)
     )
 
     set(depFile "${CMAKE_CURRENT_BINARY_DIR}/${ARG_FILE_NAME}")
+    set(installPrefix "$<$<PATH:IS_RELATIVE,${ARG_DESTINATION}>:\${CMAKE_INSTALL_PREFIX}/>")
 
     _Halide_install_code(
-        "file(READ \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${ARG_DESTINATION}/${ARG_EXPORT_FILE}\" target_cmake)"
+        "file(READ \"\$ENV{DESTDIR}${installPrefix}${ARG_DESTINATION}/${ARG_EXPORT_FILE}\" target_cmake)"
         "file(WRITE \"${depFile}.in\" \"\")"
     )
 


### PR DESCRIPTION
If the destination for libraries is given as an absolute path (an antipattern, but some build systems do it) then the installation would fail with a file-not-found error pointing at the Halide target cmake files.