### PR TITLE
Fix horrible Shuffle bug in GPU_C_Codegen and add test.

### DIFF
--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -161,9 +161,7 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
 
         std::vector<std::string> vecs;
         for (const Expr &v : op->vectors) {
-            std::string expr = print_expr(v);
-            internal_assert(!expr.empty()) << "Expression did not serialize.";
-            vecs.push_back(std::move(expr));
+            vecs.push_back(print_expr(v));
         }
 
         std::string src = vecs[0];
@@ -190,8 +188,8 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
                     break;
                 }
             }
-            internal_assert(lane_idx != -1) << "Shuffle lane index not found.";
-            internal_assert(vector_idx < op->vectors.size()) << "Shuffle vector index not found.";
+            internal_assert(lane_idx != -1) << "Shuffle lane index not found: i=" << i;
+            internal_assert(vector_idx < op->vectors.size()) << "Shuffle vector index not found: i=" << i << ", lane=" << lane_idx;
             rhs << vecs[vector_idx];
             if (op->vectors[vector_idx].type().lanes() > 1) {
                 switch (vector_declaration_style) {

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -161,7 +161,9 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
 
         std::vector<std::string> vecs;
         for (const Expr &v : op->vectors) {
-            vecs.push_back(print_expr(v));
+            std::string expr = print_expr(v);
+            internal_assert(!expr.empty()) << "Expression did not serialize.";
+            vecs.push_back(std::move(expr));
         }
 
         std::string src = vecs[0];
@@ -189,6 +191,7 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
                 }
             }
             internal_assert(lane_idx != -1) << "Shuffle lane index not found.";
+            internal_assert(vector_idx < op->vectors.size()) << "Shuffle vector index not found.";
             rhs << vecs[vector_idx];
             if (op->vectors[vector_idx].type().lanes() > 1) {
                 switch (vector_declaration_style) {

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -276,6 +276,7 @@ tests(GROUPS correctness
       shared_self_references.cpp
       shift_by_unsigned_negated.cpp
       shifted_image.cpp
+      shuffle.cpp
       side_effects.cpp
       simd_op_check_arm.cpp
       simd_op_check_hvx.cpp

--- a/test/correctness/shuffle.cpp
+++ b/test/correctness/shuffle.cpp
@@ -50,10 +50,9 @@ int main(int argc, char **argv) {
     im.copy_to_host();
     for (int x = 0; x < 32; x++) {
         int exp = 0;
-        int halfway = int(indices0.size() / 2);
         for (size_t i = 0; i < indices0.size(); ++i) {
-            int v0 = x * (indices0[i] + (indices0[i] >= halfway ? 3 : 1));
-            int v1 = x * (indices1[i] + (indices1[i] >= halfway ? 3 : 1));
+            int v0 = x * (indices0[i] + (indices0[i] >= 4 ? 3 : 1));
+            int v1 = x * (indices1[i] + (indices1[i] >= 4 ? 3 : 1));
             exp += v0 * v1;
         }
         if (im(x) != exp) {

--- a/test/correctness/shuffle.cpp
+++ b/test/correctness/shuffle.cpp
@@ -1,0 +1,62 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (target.has_feature(Target::Feature::Vulkan)) {
+        std::printf("[SKIP] Vulkan seems to be not working.\n");
+        return 0;
+    }
+
+    Var x{"x"}, y{"y"};
+
+    Func f0{"f0"}, f1{"f1"}, g{"g"};
+    f0(x, y) = x * (y + 1);
+    f1(x, y) = x * (y + 3);
+    Expr vec1 = Internal::Shuffle::make_concat({f0(x, 0), f0(x, 1), f0(x, 2), f0(x, 3)});
+    Expr vec2 = Internal::Shuffle::make_concat({f1(x, 4), f1(x, 5), f1(x, 6), f1(x, 7)});
+    std::vector<int> indices0 = {3, 1, 6, 7, 2, 4, 0, 5};
+    std::vector<int> indices1 = {1, 0, 3, 4, 7, 0, 5, 2};
+    Expr shuffle1 = Internal::Shuffle::make({vec1, vec2}, indices0);
+    Expr shuffle2 = Internal::Shuffle::make({vec1, vec2}, indices1);
+    Expr result = shuffle1 * shuffle2;
+
+    // Manual logarithmic reduce.
+    Expr a_half1 = Halide::Internal::Shuffle::make_slice(result, 0, 1, 4);
+    Expr a_half2 = Halide::Internal::Shuffle::make_slice(result, 4, 1, 4);
+    Expr a_sumhalves = a_half1 + a_half2;
+    Expr b_half1 = Halide::Internal::Shuffle::make_slice(a_sumhalves, 0, 1, 2);
+    Expr b_half2 = Halide::Internal::Shuffle::make_slice(a_sumhalves, 2, 1, 2);
+    Expr b_sumhalves = b_half1 + b_half2;
+    g(x) = Internal::Shuffle::make_extract_element(b_sumhalves, 0) +
+           Internal::Shuffle::make_extract_element(b_sumhalves, 1);
+
+    f0.compute_root();
+    f1.compute_root();
+    if (target.has_gpu_feature()) {
+        Var xo, xi;
+        g.gpu_tile(x, xo, xi, 8).never_partition_all();
+    }
+
+    Buffer<int> im = g.realize({32}, target);
+    im.copy_to_host();
+    for (int x = 0; x < 32; x++) {
+        int fv0[8], fv1[8];
+        for (int i = 0; i < 8; ++i) {
+            fv0[i] = x * (indices0[i] + (indices0[i] >= 4 ? 3 : 1));
+            fv1[i] = x * (indices1[i] + (indices1[i] >= 4 ? 3 : 1));
+        }
+        int exp = 0;
+        for (int i = 0; i < 8; ++i) {
+            exp += fv0[i] * fv1[i];
+        }
+        if (im(x) != exp) {
+            printf("im[%d] = %d (expected %d)\n", x, im(x), exp);
+            return 1;
+        }
+    }
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Shuffle emitting in OpenCL was broken when the input to the `Shuffle` node were actual vectors instead of scalar. For some reason, in most of the scenarios the codegen makes it's way to the Shuffle nodes, the Shuffles are containing all vectors with 1 lane, causing no real issue without this PR. Today I ran into codegen having to shuffle multiple actual vectors in the OpenCL codegen.

@derek-gerstmann I had to disable Vulkan testing, because there is an issue on my machine with that. Could you check that out? Last excerpt from DEBUG_CODEGEN=1 output:

```
Skipping Hexagon offload...
Offloading GPU loops...
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32x8 vectors=2 is_interleave=false is_extract_element=false
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32x4 vectors=4 is_interleave=false is_extract_element=false
    vector shuffle x4 : 0 1 2 3 
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32x4 vectors=4 is_interleave=false is_extract_element=false
    vector shuffle x4 : 0 1 2 3 
    vector shuffle x2 : 3 1 6 7 2 4 0 5 
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32x4 vectors=1 is_interleave=false is_extract_element=false
    vector shuffle x1 : 0 1 2 3 
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32x4 vectors=1 is_interleave=false is_extract_element=false
    vector shuffle x1 : 4 5 6 7 
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32x2 vectors=1 is_interleave=false is_extract_element=false
    vector shuffle x1 : 0 1 
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32x2 vectors=1 is_interleave=false is_extract_element=false
    vector shuffle x1 : 2 3 
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32 vectors=1 is_interleave=false is_extract_element=true
 CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): type=int32 vectors=1 is_interleave=false is_extract_element=true
Vulkan: Using static workgroup local size [8, 1, 1]...
  kernel_count = 1
  spirv_module_size[0] = 2432 bytes
Lowering Parallel Tasks...
Embedding image vulkan_buf
Embedding image vulkan_gpu_source_kernels
Target triple of initial module: x86_64--linux-gnu
Generating llvm bitcode...
Generating llvm bitcode prolog for function g...
Generating llvm bitcode for function g...
JIT compiling g for x86-64-linux-tune_znver1-avx-avx2-f16c-fma-jit-sse41-user_context-vk_v13-vulkan
[New Thread 0x7fffed4006c0 (LWP 434073)]
[New Thread 0x7fffeca006c0 (LWP 434074)]
[New Thread 0x7fffe5c006c0 (LWP 434075)]
[New Thread 0x7fffe40006c0 (LWP 434077)]
[New Thread 0x7fffe36006c0 (LWP 434079)]
NVVM compilation failed: 1
Vulkan [WARNING]: (user_context=0x7fffffffc510, id=2, name:NVIDIA) CreatePipeline: failed to compile internal representation
Vulkan [WARNING]: (user_context=0x7fffffffc510, id=2, name:NVIDIA) CreatePipeline: unexpected compilation failure
Vulkan [WARNING]: (user_context=0x7fffffffc510, id=2, name:NVIDIA) CreateComputePipeline: unexpected failure compiling SPIR-V shader: 0x9c4841a2cbb3db9d
User error triggered at /home/martijn/zec/3rd/halide/src/JITModule.cpp:1232
Error: Vulkan: Failed to create compute pipeline! vkCreateComputePipelines returned <Unknown Vulkan Result Code>
Vulkan: Failed to create compute pipeline!
Vulkan: Failed to setup compute pipeline!
```