### PR TITLE
Dequalify names when constructing RVars in rfactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,10 +126,12 @@ function(set_halide_compiler_warnings NAME)
 
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wcast-qual>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wignored-qualifiers>
-        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Woverloaded-virtual>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wimplicit-fallthrough>
 
-        $<$<CXX_COMPILER_ID:GNU>:-Wsuggest-override>
+        # GCC warns when these warnings are given to plain-C sources
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-Woverloaded-virtual>
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wsuggest-override>
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:-Wno-old-style-cast>
 
         $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Winconsistent-missing-destructor-override>
         $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Winconsistent-missing-override>
@@ -139,7 +141,6 @@ function(set_halide_compiler_warnings NAME)
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-float-conversion>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-float-equal>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-missing-field-initializers>
-        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-old-style-cast>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-shadow>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-sign-conversion>
         $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-switch-enum>

--- a/python_bindings/src/halide/halide_/PyError.cpp
+++ b/python_bindings/src/halide/halide_/PyError.cpp
@@ -54,7 +54,12 @@ void define_error(py::module &m) {
                 std::rethrow_exception(p);
             }
         } catch (const Error &e) {
-            halide_error(e.what());
+#if PYBIND11_VERSION_HEX >= 0x020C0000  // 2.12
+            set_error(halide_error, e.what());
+#else
+            // TODO: remove this branch when upgrading pybind11 past 2.12.0
+            PyErr_SetString(halide_error.ptr(), e.what());
+#endif
         }
     });
 }

--- a/src/Reduction.h
+++ b/src/Reduction.h
@@ -14,7 +14,12 @@ class IRMutator;
 
 /** A single named dimension of a reduction domain */
 struct ReductionVariable {
+    /**
+     * A variable name for the reduction variable. This name must be a
+     * valid Var name, i.e. it must not contain a <tt>.</tt> character.
+     */
     std::string var;
+
     Expr min, extent;
 
     /** This lets you use a ReductionVariable as a key in a map of the form


### PR DESCRIPTION
This PR fixes a very frustrating bug that arises from treating a Dim name as a valid RVar name. In this particular case, everything appears to work until we serialize the schedule in an autoscheduler. Managing renaming mars some of the elegance of the new rfactor implementation, which I find sad. I think a "perfect" solution would lift naming restrictions rather than lean into them.

Adding Rename splits is not a solution for the reasons documented in #8557.

Includes two drive-by fixes for compiler warnings I noticed while building.

Fixes #8557 