### PR TITLE
Add target-nvptx to target-all in vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -115,6 +115,7 @@
             "target-aarch64",
             "target-arm",
             "target-hexagon",
+            "target-nvptx",
             "target-powerpc",
             "target-riscv"
           ]


### PR DESCRIPTION
Not used by buildbots. Just need rubber-stamp.