### PR TITLE
Accurately annotate Error system with [[noreturn]]

### DIFF
--- a/python_bindings/src/halide/halide_/PyError.cpp
+++ b/python_bindings/src/halide/halide_/PyError.cpp
@@ -16,13 +16,10 @@ public:
         halide_python_print(nullptr, msg);
     }
 
-    void error(const char *msg) override {
+    [[noreturn]] void error(const char *msg) override {
         // This method is called *only* from the Compiler -- never from jitted
         // code -- so throwing an Error here is the right thing to do.
-
         throw Error(msg);
-
-        // This method must not return!
     }
 };
 

--- a/python_bindings/stub/PyStubImpl.cpp
+++ b/python_bindings/stub/PyStubImpl.cpp
@@ -37,9 +37,8 @@ public:
         py::print(msg, py::arg("end") = "");
     }
 
-    void error(const char *msg) override {
+    [[noreturn]] void error(const char *msg) override {
         throw Halide::Error(msg);
-        // This method must not return!
     }
 };
 

--- a/src/autoschedulers/anderson2021/test/test.h
+++ b/src/autoschedulers/anderson2021/test/test.h
@@ -7,7 +7,8 @@ namespace Halide {
 namespace Internal {
 namespace Autoscheduler {
 
-#define user_assert(c) _halide_internal_assertion(c, Halide::Internal::ErrorReport::User)
+#define user_assert(c) _halide_internal_assertion(c, Halide::CompileError)
+
 #define EXPECT_EQ(expected, actual) expect_eq(__LINE__, expected, actual)
 #define APPROX_EQ(expected, actual, epsilon) approx_eq(__LINE__, expected, actual, epsilon)
 #define EXPECT(expected) expect(__LINE__, expected)

--- a/src/autoschedulers/common/Errors.h
+++ b/src/autoschedulers/common/Errors.h
@@ -3,24 +3,11 @@
 
 #include "Halide.h"
 
-#ifndef user_error
-#define user_error Halide::Internal::ErrorReport(__FILE__, __LINE__, nullptr, Halide::Internal::ErrorReport::User)
-#endif
+#define internal_error Halide::Internal::ErrorReport<Halide::InternalError>(__FILE__, __LINE__, nullptr)
+#define user_error Halide::Internal::ErrorReport<Halide::CompileError>(__FILE__, __LINE__, nullptr)
+#define user_warning Halide::Internal::WarningReport(__FILE__, __LINE__, nullptr)
 
-#ifndef user_warning
-#define user_warning Halide::Internal::ErrorReport(__FILE__, __LINE__, nullptr, Halide::Internal::ErrorReport::User | Halide::Internal::ErrorReport::Warning)
-#endif
-
-#ifndef user_assert
-#define user_assert(c) _halide_internal_assertion(c, Halide::Internal::ErrorReport::User)
-#endif
-
-#ifndef internal_assert
-#define internal_assert(c) _halide_internal_assertion(c, 0)
-#endif
-
-#ifndef internal_error
-#define internal_error Halide::Internal::ErrorReport(__FILE__, __LINE__, nullptr, 0)
-#endif
+#define user_assert(c) _halide_internal_assertion(c, Halide::CompileError)
+#define internal_assert(c) _halide_internal_assertion(c, Halide::InternalError)
 
 #endif

--- a/test/correctness/custom_error_reporter.cpp
+++ b/test/correctness/custom_error_reporter.cpp
@@ -33,7 +33,7 @@ public:
         warnings_occurred++;
     }
 
-    void error(const char *msg) override {
+    [[noreturn]] void error(const char *msg) override {
         // Emitting "error.*:" to stdout or stderr will cause CMake to report the
         // test as a failure on Windows, regardless of error code returned.
         // The error text we get from ErrorReport probably contains some variant
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
     MyCustomErrorReporter reporter;
     set_custom_compile_time_error_reporter(&reporter);
 
-    Halide::Internal::ErrorReport("", 0, nullptr, Halide::Internal::ErrorReport::User | Halide::Internal::ErrorReport::Warning) << "Here is a warning.";
+    Halide::Internal::WarningReport("", 0, nullptr) << "Here is a warning.";
 
     // This call should not return.
     _halide_user_assert(argc == 0) << should_be_evaluated();


### PR DESCRIPTION
This PR splits the ErrorReport type into two types:

1. `WarningReport`, which does not throw/abort on destruction.
2. `ErrorReport`, which always throws/aborts on destruction, and is annotated with `[[noreturn]]`.

This makes `internal_error` a valid statement to use at the end of a function that would otherwise fail to return.

Also applies `HALIDE_ALWAYS_INLINE` to the `operator<<` overload because it was getting specialized for every size of `const char *` literal.