### PR TITLE
Remove debugging print left in

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -496,7 +496,6 @@ Expr lossless_cast(Type t,
                 Expr a = lossless_cast(t, op->a, scope, cache);
                 Expr b = lossless_cast(t, op->b, scope, cache);
                 if (a.defined() && b.defined()) {
-                    debug(0) << a << " " << b << "\n";
                     return Min::make(a, b);
                 }
             } else if (const Max *op = e.as<Max>()) {


### PR DESCRIPTION
I've also tagged this to be backported, because it's trivial to do so, and the logging of this Expr is confusing in production builds.