### PR TITLE
[bug] Fix halide_get_cpu_features() linkage to avoid name mangling issues

### DIFF
--- a/src/runtime/aarch64_cpu_features.cpp
+++ b/src/runtime/aarch64_cpu_features.cpp
@@ -118,7 +118,6 @@ void set_platform_features(CpuFeatures *) {
 }  // namespace Runtime
 }  // namespace Halide
 
-
 extern "C" {
 
 WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features) {
@@ -136,5 +135,5 @@ WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *feature
 
     return halide_error_code_success;
 }
-    
+
 }  // extern "C" linkage

--- a/src/runtime/arm_cpu_features.cpp
+++ b/src/runtime/arm_cpu_features.cpp
@@ -116,5 +116,5 @@ WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *feature
 
     return halide_error_code_success;
 }
-        
-} // extern "C" linkage
+
+}  // extern "C" linkage

--- a/src/runtime/arm_cpu_features.cpp
+++ b/src/runtime/arm_cpu_features.cpp
@@ -18,15 +18,15 @@ extern "C" unsigned long getauxval(unsigned long type);
 
 namespace {
 
-void set_platform_features(CpuFeatures &features) {
+void set_platform_features(CpuFeatures *features) {
     unsigned long hwcaps = getauxval(AT_HWCAP);
 
     if (hwcaps & HWCAP_ASIMDDP) {
-        features.set_available(halide_target_feature_arm_dot_prod);
+        halide_set_available_cpu_feature(features, halide_target_feature_arm_dot_prod);
     }
 
     if (hwcaps & HWCAP_ASIMDHP) {
-        features.set_available(halide_target_feature_arm_fp16);
+        halide_set_available_cpu_feature(features, halide_target_feature_arm_fp16);
     }
 }
 
@@ -68,17 +68,17 @@ bool is_armv7s() {
     return type == CPU_TYPE_ARM && subtype == CPU_SUBTYPE_ARM_V7S;
 }
 
-void set_platform_features(CpuFeatures &features) {
+void set_platform_features(CpuFeatures *features) {
     if (is_armv7s()) {
-        features.set_available(halide_target_feature_armv7s);
+        halide_set_available_cpu_feature(features, halide_target_feature_armv7s);
     }
 
     if (sysctl_is_set("hw.optional.arm.FEAT_DotProd")) {
-        features.set_available(halide_target_feature_arm_dot_prod);
+        halide_set_available_cpu_feature(features, halide_target_feature_arm_dot_prod);
     }
 
     if (sysctl_is_set("hw.optional.arm.FEAT_FP16")) {
-        features.set_available(halide_target_feature_arm_fp16);
+        halide_set_available_cpu_feature(features, halide_target_feature_arm_fp16);
     }
 }
 
@@ -88,30 +88,33 @@ void set_platform_features(CpuFeatures &features) {
 
 namespace {
 
-void set_platform_features(CpuFeatures &) {
+void set_platform_features(CpuFeatures *) {
 }
 
 }  // namespace
 
 #endif
 
-WEAK CpuFeatures halide_get_cpu_features() {
-    CpuFeatures features;
-    features.set_known(halide_target_feature_arm_dot_prod);
-    features.set_known(halide_target_feature_arm_fp16);
-    features.set_known(halide_target_feature_armv7s);
-    features.set_known(halide_target_feature_no_neon);
-    features.set_known(halide_target_feature_sve);
-    features.set_known(halide_target_feature_sve2);
-
-    // All ARM architectures support "No Neon".
-    features.set_available(halide_target_feature_no_neon);
-
-    set_platform_features(features);
-
-    return features;
-}
-
 }  // namespace Internal
 }  // namespace Runtime
 }  // namespace Halide
+
+extern "C" {
+
+WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features) {
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_arm_dot_prod);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_arm_fp16);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_armv7s);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_no_neon);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_sve);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_sve2);
+
+    // All ARM architectures support "No Neon".
+    Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_no_neon);
+
+    Halide::Runtime::Internal::set_platform_features(features);
+
+    return halide_error_code_success;
+}
+        
+} // extern "C" linkage

--- a/src/runtime/can_use_target.cpp
+++ b/src/runtime/can_use_target.cpp
@@ -40,21 +40,26 @@ WEAK int halide_default_can_use_target_features(int count, const uint64_t *featu
 
         static_assert(sizeof(halide_cpu_features_storage) == sizeof(CpuFeatures), "CpuFeatures Mismatch");
         if (!halide_cpu_features_initialized) {
-            CpuFeatures tmp = halide_get_cpu_features();
+            CpuFeatures tmp;
+            int error = halide_get_cpu_features(&tmp);
+            if(error != halide_error_code_success) {
+                halide_error(nullptr, "Internal error: halide_get_cpu_features failed!\n");
+                return 0;
+            }
             memcpy(&halide_cpu_features_storage, &tmp, sizeof(tmp));
             halide_cpu_features_initialized = true;
         }
     }
 
-    if (count != CpuFeatures::kWordCount) {
+    if (count != Halide::Runtime::Internal::cpu_feature_mask_size) {
         // This should not happen unless our runtime is out of sync with the rest of libHalide.
 #ifdef DEBUG_RUNTIME
-        debug(nullptr) << "count " << count << " CpuFeatures::kWordCount " << CpuFeatures::kWordCount << "\n";
+        debug(nullptr) << "count " << count << " Halide::Runtime::Internal::cpu_feature_mask_size " << Halide::Runtime::Internal::cpu_feature_mask_size << "\n";
 #endif
         halide_error(nullptr, "Internal error: wrong structure size passed to halide_can_use_target_features()\n");
     }
     const CpuFeatures *cpu_features = reinterpret_cast<const CpuFeatures *>(&halide_cpu_features_storage[0]);
-    for (int i = 0; i < CpuFeatures::kWordCount; ++i) {
+    for (int i = 0; i < Halide::Runtime::Internal::cpu_feature_mask_size; ++i) {
         uint64_t m;
         if ((m = (features[i] & cpu_features->known[i])) != 0) {
             if ((m & cpu_features->available[i]) != m) {

--- a/src/runtime/can_use_target.cpp
+++ b/src/runtime/can_use_target.cpp
@@ -42,7 +42,7 @@ WEAK int halide_default_can_use_target_features(int count, const uint64_t *featu
         if (!halide_cpu_features_initialized) {
             CpuFeatures tmp;
             int error = halide_get_cpu_features(&tmp);
-            if(error != halide_error_code_success) {
+            if (error != halide_error_code_success) {
                 halide_error(nullptr, "Internal error: halide_get_cpu_features failed!\n");
                 return 0;
             }

--- a/src/runtime/cpu_features.h
+++ b/src/runtime/cpu_features.h
@@ -8,45 +8,40 @@ namespace Halide {
 namespace Runtime {
 namespace Internal {
 
-// Return two masks:
+// Size of CPU feature mask large enough to cover all Halide target features
+static constexpr int cpu_feature_mask_size = (halide_target_feature_end + 63) / (sizeof(uint64_t) * 8);
+
+// Contains two masks:
 // One with all the CPU-specific features that might possible be available on this architecture ('known'),
 // and one with the subset that are actually present ('available').
 struct CpuFeatures {
-    static const int kWordCount = (halide_target_feature_end + 63) / (sizeof(uint64_t) * 8);
-
-    ALWAYS_INLINE void set_known(int i) {
-        known[i >> 6] |= ((uint64_t)1) << (i & 63);
-    }
-
-    ALWAYS_INLINE void set_available(int i) {
-        available[i >> 6] |= ((uint64_t)1) << (i & 63);
-    }
-
-    ALWAYS_INLINE bool test_known(int i) const {
-        return (known[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
-    }
-
-    ALWAYS_INLINE bool test_available(int i) const {
-        return (available[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
-    }
-
-    ALWAYS_INLINE
-    CpuFeatures() {
-        for (int i = 0; i < kWordCount; ++i) {
-            known[i] = 0;
-            available[i] = 0;
-        }
-    }
-
-    uint64_t known[kWordCount];      // mask of the CPU features we know how to detect
-    uint64_t available[kWordCount];  // mask of the CPU features that are available
-                                     // (always a subset of 'known')
+    uint64_t known[cpu_feature_mask_size] = {0};      // mask of the CPU features we know how to detect
+    uint64_t available[cpu_feature_mask_size] = {0};  // mask of the CPU features that are available
+                                                      // (always a subset of 'known')
 };
 
-extern WEAK CpuFeatures halide_get_cpu_features();
+ALWAYS_INLINE void halide_set_known_cpu_feature(CpuFeatures* features, int i) {
+    features->known[i >> 6] |= ((uint64_t)1) << (i & 63);
+}
+
+ALWAYS_INLINE void halide_set_available_cpu_feature(CpuFeatures* features, int i) {
+    features->available[i >> 6] |= ((uint64_t)1) << (i & 63);
+}
+
+ALWAYS_INLINE bool halide_test_known_cpu_feature(CpuFeatures* features, int i) {
+    return (features->known[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
+}
+
+ALWAYS_INLINE bool halide_test_available_cpu_feature(CpuFeatures* features, int i) {
+    return (features->available[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
+}
 
 }  // namespace Internal
 }  // namespace Runtime
 }  // namespace Halide
+
+// NOTE: This method is not part of the public API, but we push it into extern "C" to 
+//       avoid name mangling mismatches between platforms. See: https://github.com/halide/Halide/issues/8565
+extern "C" WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features);
 
 #endif  // HALIDE_CPU_FEATURES_H

--- a/src/runtime/cpu_features.h
+++ b/src/runtime/cpu_features.h
@@ -20,19 +20,19 @@ struct CpuFeatures {
                                                       // (always a subset of 'known')
 };
 
-ALWAYS_INLINE void halide_set_known_cpu_feature(CpuFeatures* features, int i) {
+ALWAYS_INLINE void halide_set_known_cpu_feature(CpuFeatures *features, int i) {
     features->known[i >> 6] |= ((uint64_t)1) << (i & 63);
 }
 
-ALWAYS_INLINE void halide_set_available_cpu_feature(CpuFeatures* features, int i) {
+ALWAYS_INLINE void halide_set_available_cpu_feature(CpuFeatures *features, int i) {
     features->available[i >> 6] |= ((uint64_t)1) << (i & 63);
 }
 
-ALWAYS_INLINE bool halide_test_known_cpu_feature(CpuFeatures* features, int i) {
+ALWAYS_INLINE bool halide_test_known_cpu_feature(CpuFeatures *features, int i) {
     return (features->known[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
 }
 
-ALWAYS_INLINE bool halide_test_available_cpu_feature(CpuFeatures* features, int i) {
+ALWAYS_INLINE bool halide_test_available_cpu_feature(CpuFeatures *features, int i) {
     return (features->available[i >> 6] & ((uint64_t)1) << (i & 63)) != 0;
 }
 
@@ -40,7 +40,7 @@ ALWAYS_INLINE bool halide_test_available_cpu_feature(CpuFeatures* features, int 
 }  // namespace Runtime
 }  // namespace Halide
 
-// NOTE: This method is not part of the public API, but we push it into extern "C" to 
+// NOTE: This method is not part of the public API, but we push it into extern "C" to
 //       avoid name mangling mismatches between platforms. See: https://github.com/halide/Halide/issues/8565
 extern "C" WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features);
 

--- a/src/runtime/hexagon_cpu_features.cpp
+++ b/src/runtime/hexagon_cpu_features.cpp
@@ -1,15 +1,11 @@
 #include "HalideRuntime.h"
 #include "cpu_features.h"
 
-namespace Halide {
-namespace Runtime {
-namespace Internal {
+extern "C" {
 
-WEAK CpuFeatures halide_get_cpu_features() {
+WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features) {
     // Hexagon has no CPU-specific Features.
-    return CpuFeatures();
+    return halide_error_code_success;
 }
 
-}  // namespace Internal
-}  // namespace Runtime
-}  // namespace Halide
+}  // extern "C" linkage

--- a/src/runtime/powerpc_cpu_features.cpp
+++ b/src/runtime/powerpc_cpu_features.cpp
@@ -28,4 +28,4 @@ WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *feature
     return halide_error_code_success;
 }
 
-} // extern "C" linkage
+}  // extern "C" linkage

--- a/src/runtime/powerpc_cpu_features.cpp
+++ b/src/runtime/powerpc_cpu_features.cpp
@@ -8,29 +8,24 @@
 
 #define PPC_FEATURE2_ARCH_2_07 0x80000000
 
-extern "C" unsigned long int getauxval(unsigned long int);
+extern "C" {
 
-namespace Halide {
-namespace Runtime {
-namespace Internal {
+unsigned long int getauxval(unsigned long int);
 
-WEAK CpuFeatures halide_get_cpu_features() {
-    CpuFeatures features;
-    features.set_known(halide_target_feature_vsx);
-    features.set_known(halide_target_feature_power_arch_2_07);
+WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features) {
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_vsx);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_power_arch_2_07);
 
     const unsigned long hwcap = getauxval(AT_HWCAP);
     const unsigned long hwcap2 = getauxval(AT_HWCAP2);
 
     if (hwcap & PPC_FEATURE_HAS_VSX) {
-        features.set_available(halide_target_feature_vsx);
+        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_vsx);
     }
     if (hwcap2 & PPC_FEATURE2_ARCH_2_07) {
-        features.set_available(halide_target_feature_power_arch_2_07);
+        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_power_arch_2_07);
     }
-    return features;
+    return halide_error_code_success;
 }
 
-}  // namespace Internal
-}  // namespace Runtime
-}  // namespace Halide
+} // extern "C" linkage

--- a/src/runtime/riscv_cpu_features.cpp
+++ b/src/runtime/riscv_cpu_features.cpp
@@ -1,15 +1,11 @@
 #include "HalideRuntime.h"
 #include "cpu_features.h"
 
-namespace Halide {
-namespace Runtime {
-namespace Internal {
+extern "C" {
 
-WEAK CpuFeatures halide_get_cpu_features() {
+WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features) {
     // For now, no version specific features, though RISCV promises to have many.
-    return CpuFeatures();
+    return halide_error_code_success;
 }
 
-}  // namespace Internal
-}  // namespace Runtime
-}  // namespace Halide
+}  // extern "C" linkage

--- a/src/runtime/wasm_cpu_features.cpp
+++ b/src/runtime/wasm_cpu_features.cpp
@@ -1,23 +1,16 @@
 #include "HalideRuntime.h"
 #include "cpu_features.h"
 
-namespace Halide {
-namespace Runtime {
-namespace Internal {
+extern "C" {
 
-WEAK CpuFeatures halide_get_cpu_features() {
-    CpuFeatures features;
-
+WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features) {
     // There isn't a way to determine what features are available --
     // if a feature we need isn't available, we couldn't
     // even load. So just declare that all wasm-related features are
     // known and available.
-    features.set_known(halide_target_feature_wasm_simd128);
-    features.set_available(halide_target_feature_wasm_simd128);
-
-    return features;
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_wasm_simd128);
+    Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_wasm_simd128);
+    return halide_error_code_success;
 }
 
-}  // namespace Internal
-}  // namespace Runtime
-}  // namespace Halide
+}  // extern "C" linkage

--- a/src/runtime/x86_cpu_features.cpp
+++ b/src/runtime/x86_cpu_features.cpp
@@ -24,24 +24,29 @@ ALWAYS_INLINE void cpuid(int32_t *info, int32_t fn_id, int32_t extra = 0) {
 
 }  // namespace
 
-WEAK CpuFeatures halide_get_cpu_features() {
-    CpuFeatures features;
-    features.set_known(halide_target_feature_sse41);
-    features.set_known(halide_target_feature_avx);
-    features.set_known(halide_target_feature_f16c);
-    features.set_known(halide_target_feature_fma);
-    features.set_known(halide_target_feature_avx2);
-    features.set_known(halide_target_feature_avx512);
-    features.set_known(halide_target_feature_avx512_knl);
-    features.set_known(halide_target_feature_avx512_skylake);
-    features.set_known(halide_target_feature_avx512_cannonlake);
-    features.set_known(halide_target_feature_avx512_sapphirerapids);
+}  // namespace Internal
+}  // namespace Runtime
+}  // namespace Halide
+
+extern "C" {
+
+WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *features) {
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_sse41);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_avx);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_f16c);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_fma);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_avx2);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_avx512);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_avx512_knl);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_avx512_skylake);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_avx512_cannonlake);
+    Halide::Runtime::Internal::halide_set_known_cpu_feature(features, halide_target_feature_avx512_sapphirerapids);
 
     // Detect CPU features by specific microarchitecture.
     int32_t vendor[4];
-    cpuid(vendor, 0);
+    Halide::Runtime::Internal::cpuid(vendor, 0);
     int32_t info[4];
-    cpuid(info, 1);
+    Halide::Runtime::Internal::cpuid(info, 1);
 
     uint32_t family = (info[0] >> 8) & 0xF;  // Bits 8..11
     uint32_t model = (info[0] >> 4) & 0xF;   // Bits 4..7
@@ -58,16 +63,16 @@ WEAK CpuFeatures halide_get_cpu_features() {
         // AMD
         if (family == 0x19 && model == 0x61) {
             // Zen4
-            features.set_available(halide_target_feature_sse41);
-            features.set_available(halide_target_feature_avx);
-            features.set_available(halide_target_feature_f16c);
-            features.set_available(halide_target_feature_fma);
-            features.set_available(halide_target_feature_avx2);
-            features.set_available(halide_target_feature_avx512);
-            features.set_available(halide_target_feature_avx512_skylake);
-            features.set_available(halide_target_feature_avx512_cannonlake);
-            features.set_available(halide_target_feature_avx512_zen4);
-            return features;
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_sse41);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_f16c);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_fma);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx2);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_skylake);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_cannonlake);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_zen4);
+            return halide_error_code_success;
         }
     }
 
@@ -81,21 +86,21 @@ WEAK CpuFeatures halide_get_cpu_features() {
     const bool have_rdrand = (info[2] & (1 << 30)) != 0;
     const bool have_fma = (info[2] & (1 << 12)) != 0;
     if (have_sse41) {
-        features.set_available(halide_target_feature_sse41);
+        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_sse41);
     }
     if (have_avx) {
-        features.set_available(halide_target_feature_avx);
+        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx);
     }
     if (have_f16c) {
-        features.set_available(halide_target_feature_f16c);
+        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_f16c);
     }
     if (have_fma) {
-        features.set_available(halide_target_feature_fma);
+        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_fma);
     }
 
     if (use_64_bits && have_avx && have_f16c && have_rdrand) {
         int info2[4];
-        cpuid(info2, 7);
+        Halide::Runtime::Internal::cpuid(info2, 7);
         constexpr uint32_t avx2 = 1U << 5;
         constexpr uint32_t avx512f = 1U << 16;
         constexpr uint32_t avx512dq = 1U << 17;
@@ -112,31 +117,29 @@ WEAK CpuFeatures halide_get_cpu_features() {
         constexpr uint32_t avx512_skylake = avx512 | avx512vl | avx512bw | avx512dq;
         constexpr uint32_t avx512_cannonlake = avx512_skylake | avx512ifma;  // Assume ifma => vbmi
         if ((info2[1] & avx2) == avx2) {
-            features.set_available(halide_target_feature_avx2);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx2);
         }
         if ((info2[1] & avx512) == avx512) {
-            features.set_available(halide_target_feature_avx512);
+            Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512);
             if ((info2[1] & avx512_knl) == avx512_knl) {
-                features.set_available(halide_target_feature_avx512_knl);
+                Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_knl);
             }
             if ((info2[1] & avx512_skylake) == avx512_skylake) {
-                features.set_available(halide_target_feature_avx512_skylake);
+                Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_skylake);
             }
             if ((info2[1] & avx512_cannonlake) == avx512_cannonlake) {
-                features.set_available(halide_target_feature_avx512_cannonlake);
+                Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_cannonlake);
 
                 int32_t info3[4];
-                cpuid(info3, 7, 1);
+                Halide::Runtime::Internal::cpuid(info3, 7, 1);
                 if ((info3[0] & avxvnni) == avxvnni &&
                     (info3[0] & avx512bf16) == avx512bf16) {
-                    features.set_available(halide_target_feature_avx512_sapphirerapids);
+                        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_sapphirerapids);
                 }
             }
         }
     }
-    return features;
+    return halide_error_code_success;
 }
 
-}  // namespace Internal
-}  // namespace Runtime
-}  // namespace Halide
+} // extern "C" linkage

--- a/src/runtime/x86_cpu_features.cpp
+++ b/src/runtime/x86_cpu_features.cpp
@@ -134,7 +134,7 @@ WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *feature
                 Halide::Runtime::Internal::cpuid(info3, 7, 1);
                 if ((info3[0] & avxvnni) == avxvnni &&
                     (info3[0] & avx512bf16) == avx512bf16) {
-                        Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_sapphirerapids);
+                    Halide::Runtime::Internal::halide_set_available_cpu_feature(features, halide_target_feature_avx512_sapphirerapids);
                 }
             }
         }
@@ -142,4 +142,4 @@ WEAK int halide_get_cpu_features(Halide::Runtime::Internal::CpuFeatures *feature
     return halide_error_code_success;
 }
 
-} // extern "C" linkage
+}  // extern "C" linkage


### PR DESCRIPTION
This PR changes the linkage of `halide_get_cpu_features(...)` into `extern "C"` to avoid issues with name mangling between different platform ABIs.  It also changes `CpuFeatures` into a POD struct, which is passed by pointer to allow C linkage.

Fixes: https://github.com/halide/Halide/issues/8565