### PR TITLE
scalarize select condition for LLVM where possible

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1873,7 +1873,11 @@ void CodeGen_LLVM::visit(const Not *op) {
 }
 
 void CodeGen_LLVM::visit(const Select *op) {
-    Value *cmp = codegen(op->condition);
+    Expr cond = op->condition;
+    if (const Broadcast *bc = cond.as<Broadcast>()) {
+        cond = bc->value;
+    }
+    Value *cmp = codegen(cond);
     Value *a = codegen(op->true_value);
     Value *b = codegen(op->false_value);
     if (a->getType()->isVectorTy()) {


### PR DESCRIPTION
I found a case where LLVM was generating worse code for a select on a broadcast of a scalar condition than a select on a scalar condition directly. This change just strips any broadcast around a select condition to help LLVM out.