### PR TITLE
[PTX] RewriteLoadsAs32Bit should use the mutated index

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -433,7 +433,7 @@ class RewriteLoadsAs32Bit : public IRMutator {
         } else if (index.same_as(op->index)) {
             return op;
         } else {
-            return Load::make(op->type, op->name, op->index, op->image, op->param, op->predicate, op->alignment);
+            return Load::make(op->type, op->name, std::move(index), op->image, op->param, op->predicate, op->alignment);
         }
     }
 };


### PR DESCRIPTION
This would only matter when the index itself uses a load, e.g. in a LUT.