### PR TITLE
Disable SVE patterns changed with LLVM trunk

### DIFF
--- a/test/correctness/simd_op_check_sve2.cpp
+++ b/test/correctness/simd_op_check_sve2.cpp
@@ -699,10 +699,14 @@ private:
                 Expr load_store_1 = in_im(x) * 3;
 
                 if (has_sve()) {
-                    // in native width, ld1b/st1b is used regardless of data type
-                    const bool allow_byte_ls = (width == target.vector_bits);
-                    add({get_sve_ls_instr("ld1", bits, bits, "", allow_byte_ls ? "b" : "")}, total_lanes, load_store_1);
-                    add({get_sve_ls_instr("st1", bits, bits, "", allow_byte_ls ? "b" : "")}, total_lanes, load_store_1);
+                    // This pattern has changed with LLVM 21, see https://github.com/halide/Halide/issues/8584 for more
+                    // details.
+                    if (Halide::Internal::get_llvm_version() <= 200) {
+                        // in native width, ld1b/st1b is used regardless of data type
+                        const bool allow_byte_ls = (width == target.vector_bits);
+                        add({get_sve_ls_instr("ld1", bits, bits, "", allow_byte_ls ? "b" : "")}, total_lanes, load_store_1);
+                        add({get_sve_ls_instr("st1", bits, bits, "", allow_byte_ls ? "b" : "")}, total_lanes, load_store_1);
+                    }
                 } else {
                     // vector register is not used for simple load/store
                     string reg_prefix = (width <= 64) ? "d" : "q";


### PR DESCRIPTION
This is a workaround for #8584.