### PR TITLE
Another fix for llvm trunk

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -672,9 +672,9 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
 
     auto *tm = llvm_target->createTargetMachine(
 #if LLVM_VERSION >= 210
-        module.getTargetTriple().str(),
+        triple,
 #else
-        module.getTargetTriple(),
+        triple.str(),
 #endif
         mcpu_target,
         mattrs,

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -615,11 +615,16 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     options.GuaranteedTailCallOpt = false;
 
     std::unique_ptr<TargetMachine>
-        target_machine(llvm_target->createTargetMachine(triple.str(),
-                                                        mcpu_target(), mattrs(), options,
-                                                        llvm::Reloc::PIC_,
-                                                        llvm::CodeModel::Small,
-                                                        CodeGenOptLevel::Aggressive));
+        target_machine(llvm_target->createTargetMachine(
+#if LLVM_VERSION >= 210
+            triple,
+#else
+            triple.str(),
+#endif
+            mcpu_target(), mattrs(), options,
+            llvm::Reloc::PIC_,
+            llvm::CodeModel::Small,
+            CodeGenOptLevel::Aggressive));
 
     internal_assert(target_machine.get()) << "Could not allocate target machine!";
 


### PR DESCRIPTION
I believe the last fix actually got things the wrong way around in CodeGen_Internal.cpp, but worked anyway because llvm temporarily reverted the change causing the issue.