### PR TITLE
Math functions renaming table for GPU backends to support vectorized evaluation of math functions.

### DIFF
--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1902,7 +1902,14 @@ string CodeGen_C::print_extern_call(const Call *op) {
     if (function_takes_user_context(op->name)) {
         args.insert(args.begin(), "_ucon");
     }
-    rhs << op->name << "(" << with_commas(args) << ")";
+    std::string name = op->name;
+    auto it = extern_function_name_map.find(name);
+    if (it != extern_function_name_map.end()) {
+        name = it->second;
+        debug(3) << "Rewriting " << op->name << " as " << name << "\n";
+    }
+    debug(3) << "Writing out call to " << name << "\n";
+    rhs << name << "(" << with_commas(args) << ")";
     return rhs.str();
 }
 

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -134,6 +134,8 @@ protected:
      * use different syntax for other C-like languages. */
     virtual void add_vector_typedefs(const std::set<Type> &vector_types);
 
+    std::unordered_map<std::string, std::string> extern_function_name_map;
+
     /** Bottleneck to allow customization of calls to generic Extern/PureExtern calls.  */
     virtual std::string print_extern_call(const Call *op);
 

--- a/src/CodeGen_C.h
+++ b/src/CodeGen_C.h
@@ -10,6 +10,8 @@
 #include "Scope.h"
 #include "Target.h"
 
+#include <unordered_map>
+
 namespace Halide {
 
 struct Argument;

--- a/src/CodeGen_D3D12Compute_Dev.cpp
+++ b/src/CodeGen_D3D12Compute_Dev.cpp
@@ -68,10 +68,10 @@ protected:
             : CodeGen_GPU_C(s, t) {
             integer_suffix_style = IntegerSuffixStyle::HLSL;
 
-#define alias(x, y) \
-            extern_function_name_map[x "_f16"] = y; \
-            extern_function_name_map[x "_f32"] = y; \
-            extern_function_name_map[x "_f64"] = y
+#define alias(x, y)                         \
+    extern_function_name_map[x "_f16"] = y; \
+    extern_function_name_map[x "_f32"] = y; \
+    extern_function_name_map[x "_f64"] = y
             alias("sqrt", "sqrt");
             alias("sin", "sin");
             alias("cos", "cos");

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -228,14 +228,21 @@ void CodeGen_GPU_C::visit(const Call *op) {
             Expr equiv = Call::make(op->type, fn.str(), op->args, Call::PureExtern);
             equiv.accept(this);
         } else {
-            // The integer-abs doesn't have suffixes in Halide.
-            // Also, compared to most backends, it has a different signature:
-            // Halide does `unsigned T abs(signed T)`, whereas C and most other
-            // APIs do `T abs(T)`. So we have to wrap it in an additional cast.
-            Type arg_type = op->args[0].type();
-            Expr abs = Call::make(arg_type, "abs", op->args, Call::PureExtern);
-            Expr equiv = cast(op->type, abs);
-            equiv.accept(this);
+            // Note: The integer-abs doesn't have suffixes in Halide.
+            if (abs_returns_unsigned_type) {
+                // Halide also returns unsigned, so we're good. Just replace it
+                // with a PureExtern function call.
+                Expr abs = Call::make(op->type, "abs", op->args, Call::PureExtern);
+                Expr equiv = cast(op->type, abs);
+                equiv.accept(this);
+            } else {
+                // Halide does `unsigned T abs(signed T)`, whereas C and most other
+                // APIs do `T abs(T)`. So we have to wrap it in an additional cast.
+                Type arg_type = op->args[0].type();
+                Expr abs = Call::make(arg_type, "abs", op->args, Call::PureExtern);
+                Expr equiv = cast(op->type, abs);
+                equiv.accept(this);
+            }
         }
     } else {
         CodeGen_C::visit(op);

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -222,14 +222,21 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
 void CodeGen_GPU_C::visit(const Call *op) {
     if (op->is_intrinsic(Call::abs)) {
         internal_assert(op->args.size() == 1);
-        std::stringstream fn;
         if (op->type.is_float()) {
+            std::stringstream fn;
             fn << "abs_f" << op->type.bits();
+            Expr equiv = Call::make(op->type, fn.str(), op->args, Call::PureExtern);
+            equiv.accept(this);
         } else {
-            fn << "abs";
+            // The integer-abs doesn't have suffixes in Halide.
+            // Also, compared to most backends, it has a different signature:
+            // Halide does `unsigned T abs(signed T)`, whereas C and most other
+            // APIs do `T abs(T)`. So we have to wrap it in an additional cast.
+            Type arg_type = op->args[0].type();
+            Expr abs = Call::make(arg_type, "abs", op->args, Call::PureExtern);
+            Expr equiv = cast(op->type, abs);
+            equiv.accept(this);
         }
-        Expr equiv = Call::make(op->type, fn.str(), op->args, Call::PureExtern);
-        equiv.accept(this);
     } else {
         CodeGen_C::visit(op);
     }

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -219,10 +219,16 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
 }
 
 void CodeGen_GPU_C::visit(const Call *op) {
-    // In metal and opencl, "rint" is a polymorphic function that matches our
-    // rounding semantics. GLSL handles it separately using "roundEven".
-    if (op->is_intrinsic(Call::round)) {
-        print_assignment(op->type, "rint(" + print_expr(op->args[0]) + ")");
+    if (op->is_intrinsic(Call::abs)) {
+        internal_assert(op->args.size() == 1);
+        std::stringstream fn;
+        if (op->type.is_float()) {
+            fn << "abs_f" << op->type.bits();
+        } else {
+            fn << "abs";
+        }
+        Expr equiv = Call::make(op->type, fn.str(), op->args, Call::PureExtern);
+        equiv.accept(this);
     } else {
         CodeGen_C::visit(op);
     }

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -1,6 +1,6 @@
 #include "CodeGen_GPU_Dev.h"
-#include "CodeGen_Internal.h"
 #include "CanonicalizeGPUVars.h"
+#include "CodeGen_Internal.h"
 #include "Deinterleave.h"
 #include "ExprUsesVar.h"
 #include "IRMutator.h"
@@ -234,7 +234,6 @@ void CodeGen_GPU_C::visit(const Call *op) {
         CodeGen_C::visit(op);
     }
 }
-
 
 std::string CodeGen_GPU_C::print_extern_call(const Call *op) {
     internal_assert(!function_takes_user_context(op->name)) << op->name;

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -1,4 +1,5 @@
 #include "CodeGen_GPU_Dev.h"
+#include "CodeGen_Internal.h"
 #include "CanonicalizeGPUVars.h"
 #include "Deinterleave.h"
 #include "ExprUsesVar.h"
@@ -232,6 +233,32 @@ void CodeGen_GPU_C::visit(const Call *op) {
     } else {
         CodeGen_C::visit(op);
     }
+}
+
+
+std::string CodeGen_GPU_C::print_extern_call(const Call *op) {
+    internal_assert(!function_takes_user_context(op->name)) << op->name;
+
+    // Here we do not scalarize function calls with vector arguments.
+    // Backends should provide those functions, and if not available,
+    // we could compose them by writing out a call element by element,
+    // but that's never happened until 2025, so I guess we can leave
+    // this to be an error for now, just like it was.
+
+    std::ostringstream rhs;
+    std::vector<std::string> args(op->args.size());
+    for (size_t i = 0; i < op->args.size(); i++) {
+        args[i] = print_expr(op->args[i]);
+    }
+    std::string name = op->name;
+    auto it = extern_function_name_map.find(name);
+    if (it != extern_function_name_map.end()) {
+        name = it->second;
+        debug(3) << "Rewriting " << op->name << " as " << name << "\n";
+    }
+    debug(3) << "Writing out call to " << name << "\n";
+    rhs << name << "(" << with_commas(args) << ")";
+    return rhs.str();
 }
 
 }  // namespace Internal

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -103,6 +103,7 @@ protected:
     std::string print_extern_call(const Call *op) override;
 
     VectorDeclarationStyle vector_declaration_style = VectorDeclarationStyle::CLikeSyntax;
+    bool abs_returns_unsigned_type{false};
 };
 
 }  // namespace Internal

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -100,6 +100,8 @@ protected:
     void visit(const Shuffle *op) override;
     void visit(const Call *op) override;
 
+    std::string print_extern_call(const Call *op) override;
+
     VectorDeclarationStyle vector_declaration_style = VectorDeclarationStyle::CLikeSyntax;
 };
 

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -59,15 +59,15 @@ protected:
         CodeGen_Metal_C(std::ostream &s, const Target &t)
             : CodeGen_GPU_C(s, t) {
 
-#define alias(x, y) \
-            extern_function_name_map[x "_f16"] = y; \
-            extern_function_name_map[x "_f32"] = y
+#define alias(x, y)                         \
+    extern_function_name_map[x "_f16"] = y; \
+    extern_function_name_map[x "_f32"] = y
             alias("sqrt", "sqrt");
             alias("sin", "sin");
             alias("cos", "cos");
             alias("exp", "exp");
             alias("log", "log");
-            alias("abs", "fabs"); // f-prefix!
+            alias("abs", "fabs");  // f-prefix!
             alias("floor", "floor");
             alias("ceil", "ceil");
             alias("trunc", "trunc");
@@ -91,8 +91,6 @@ protected:
             alias("fast_inverse", "native_recip");
             alias("fast_inverse_sqrt", "native_rsqrt");
 #undef alias
-
-
         }
         void add_kernel(const Stmt &stmt,
                         const std::string &name,

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -111,7 +111,6 @@ protected:
         std::string print_storage_type(Type type);
         std::string print_type_maybe_storage(Type type, bool storage, AppendSpaceIfNeeded space);
         std::string print_reinterpret(Type type, const Expr &e) override;
-        std::string print_extern_call(const Call *op) override;
 
         std::string get_memory_space(const std::string &);
 
@@ -241,11 +240,6 @@ string simt_intrinsic(const string &name) {
     return "";
 }
 }  // namespace
-
-string CodeGen_Metal_Dev::CodeGen_Metal_C::print_extern_call(const Call *op) {
-    internal_assert(!function_takes_user_context(op->name)) << op->name;
-    return CodeGen_GPU_C::print_extern_call(op);
-}
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Max *op) {
     print_expr(Call::make(op->type, "max", {op->a, op->b}, Call::Extern));

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -88,7 +88,7 @@ protected:
             alias("is_inf", "isinf");
             alias("is_finite", "isfinite");
 
-            alias("fast_inverse_sqrt", "native_rsqrt");
+            alias("fast_inverse_sqrt", "fast::rsqrt");
 #undef alias
         }
         void add_kernel(const Stmt &stmt,

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -58,6 +58,7 @@ protected:
     public:
         CodeGen_Metal_C(std::ostream &s, const Target &t)
             : CodeGen_GPU_C(s, t) {
+            abs_returns_unsigned_type = false;
 
 #define alias(x, y)                         \
     extern_function_name_map[x "_f16"] = y; \

--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -88,7 +88,6 @@ protected:
             alias("is_inf", "isinf");
             alias("is_finite", "isfinite");
 
-            alias("fast_inverse", "native_recip");
             alias("fast_inverse_sqrt", "native_rsqrt");
 #undef alias
         }
@@ -841,6 +840,7 @@ void CodeGen_Metal_Dev::init_module() {
                << "constexpr half nan_f16() { return half_from_bits(32767); }\n"
                << "constexpr half neg_inf_f16() { return half_from_bits(64512); }\n"
                << "constexpr half inf_f16() { return half_from_bits(31744); }\n"
+               << "half fast_inverse_f16(half x) { return 1.0h / x; }\n"
                // This is quite annoying: even though the MSL docs claim
                // all versions of Metal support the same memory fence
                // names, the truth is that 1.0 does not.

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -63,16 +63,16 @@ protected:
             integer_suffix_style = IntegerSuffixStyle::OpenCL;
             vector_declaration_style = VectorDeclarationStyle::OpenCLSyntax;
 
-#define alias(x, y) \
-            extern_function_name_map[x "_f16"] = y; \
-            extern_function_name_map[x "_f32"] = y; \
-            extern_function_name_map[x "_f64"] = y
+#define alias(x, y)                         \
+    extern_function_name_map[x "_f16"] = y; \
+    extern_function_name_map[x "_f32"] = y; \
+    extern_function_name_map[x "_f64"] = y
             alias("sqrt", "sqrt");
             alias("sin", "sin");
             alias("cos", "cos");
             alias("exp", "exp");
             alias("log", "log");
-            alias("abs", "fabs"); // f-prefix! (although it's handled as an intrinsic).
+            alias("abs", "fabs");  // f-prefix! (although it's handled as an intrinsic).
             alias("floor", "floor");
             alias("ceil", "ceil");
             alias("trunc", "trunc");

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -62,6 +62,7 @@ protected:
             : CodeGen_GPU_C(s, t) {
             integer_suffix_style = IntegerSuffixStyle::OpenCL;
             vector_declaration_style = VectorDeclarationStyle::OpenCLSyntax;
+            abs_returns_unsigned_type = true;
 
 #define alias(x, y)                         \
     extern_function_name_map[x "_f16"] = y; \

--- a/src/CodeGen_OpenCL_Dev.cpp
+++ b/src/CodeGen_OpenCL_Dev.cpp
@@ -105,7 +105,6 @@ protected:
         using CodeGen_GPU_C::visit;
         std::string print_type(Type type, AppendSpaceIfNeeded append_space = DoNotAppendSpace) override;
         std::string print_reinterpret(Type type, const Expr &e) override;
-        std::string print_extern_call(const Call *op) override;
         std::string print_array_access(const std::string &name,
                                        const Type &type,
                                        const std::string &id_index);
@@ -486,11 +485,6 @@ void CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::visit(const Call *op) {
     } else {
         CodeGen_GPU_C::visit(op);
     }
-}
-
-string CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::print_extern_call(const Call *op) {
-    internal_assert(!function_takes_user_context(op->name)) << op->name;
-    return CodeGen_GPU_C::print_extern_call(op);
 }
 
 string CodeGen_OpenCL_Dev::CodeGen_OpenCL_C::print_array_access(const string &name,

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -148,7 +148,7 @@ protected:
 
         SpvFactory::Components split_vector(Type type, SpvId value_id);
         SpvId join_vector(Type type, const SpvFactory::Components &value_components);
-        SpvId fill_vector(Type type, SpvId value_id);        
+        SpvId fill_vector(Type type, SpvId value_id);
         SpvId cast_type(Type target_type, Type value_type, SpvId value_id);
         SpvId convert_to_bool(Type target_type, Type value_type, SpvId value_id);
 
@@ -1299,7 +1299,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Call *op) {
     } else if (op->name == "nan_f32") {
         float value = NAN;
         SpvId result_id = builder.declare_constant(Float(32), &value);
-        if(op->type.is_vector()) {
+        if (op->type.is_vector()) {
             SpvId value_id = result_id;
             result_id = fill_vector(op->type, value_id);
         }
@@ -1307,7 +1307,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Call *op) {
     } else if (op->name == "inf_f32") {
         float value = INFINITY;
         SpvId result_id = builder.declare_constant(Float(32), &value);
-        if(op->type.is_vector()) {
+        if (op->type.is_vector()) {
             SpvId value_id = result_id;
             result_id = fill_vector(op->type, value_id);
         }
@@ -1315,7 +1315,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Call *op) {
     } else if (op->name == "neg_inf_f32") {
         float value = -INFINITY;
         SpvId result_id = builder.declare_constant(Float(32), &value);
-        if(op->type.is_vector()) {
+        if (op->type.is_vector()) {
             SpvId value_id = result_id;
             result_id = fill_vector(op->type, value_id);
         }

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -102,7 +102,6 @@ protected:
                                AppendSpaceIfNeeded append_space =
                                    DoNotAppendSpace) override;
         std::string print_reinterpret(Type type, const Expr &e) override;
-        std::string print_extern_call(const Call *op) override;
         std::string print_assignment(Type t, const std::string &rhs) override;
         std::string print_const(Type t, const std::string &rhs);
         std::string print_assignment_or_const(Type t, const std::string &rhs,
@@ -297,11 +296,6 @@ string CodeGen_WebGPU_Dev::CodeGen_WGSL::print_reinterpret(Type type,
     ostringstream oss;
     oss << "bitcast<" << print_type(type) << ">(" << print_expr(e) << ")";
     return oss.str();
-}
-
-string CodeGen_WebGPU_Dev::CodeGen_WGSL::print_extern_call(const Call *op) {
-    internal_assert(!function_takes_user_context(op->name)) << op->name;
-    return CodeGen_GPU_C::print_extern_call(op);
 }
 
 void CodeGen_WebGPU_Dev::CodeGen_WGSL::add_kernel(

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -530,12 +530,12 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::visit(const Call *op) {
         equiv = select(ox > 0.0f,
                        equiv,
                        select(oy == 0.0f,
-                              1.0f,
+                              make_const(oy.type(), 1.0f),
                               select(oy == trunc(oy),
                                      select(cast(int_type, oy) % 2 == 0,
                                             equiv,
                                             -equiv),
-                                     float(std::nanf("")))));
+                                     make_const(oy.type(), std::nanf("")))));
         equiv.accept(this);
 
     } else {

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -67,7 +67,7 @@ protected:
             alias("cos", "cos");
             alias("exp", "exp");
             alias("log", "log");
-            alias("abs", "fabs");  // f-prefix! (although it's handled as an intrinsic).
+            alias("abs", "abs");
             alias("floor", "floor");
             alias("ceil", "ceil");
             alias("trunc", "trunc");

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -57,6 +57,7 @@ protected:
         CodeGen_WGSL(std::ostream &s, Target t)
             : CodeGen_GPU_C(s, t) {
             vector_declaration_style = VectorDeclarationStyle::WGSLSyntax;
+            abs_returns_unsigned_type = false;
 
 #define alias(x, y)                         \
     extern_function_name_map[x "_f16"] = y; \

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -526,12 +526,13 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::visit(const Call *op) {
         Expr ox = op->args[0];
         Expr oy = op->args[1];
         Expr equiv = Call::make(op->type, "pow", {abs(ox), oy}, Call::PureExtern);
+        Type int_type = Type(Type::Int, 32, oy.type().lanes());
         equiv = select(ox > 0.0f,
                        equiv,
                        select(oy == 0.0f,
                               1.0f,
                               select(oy == trunc(oy),
-                                     select(cast<int>(oy) % 2 == 0,
+                                     select(cast(int_type, oy) % 2 == 0,
                                             equiv,
                                             -equiv),
                                      float(std::nanf("")))));

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -57,6 +57,38 @@ protected:
         CodeGen_WGSL(std::ostream &s, Target t)
             : CodeGen_GPU_C(s, t) {
             vector_declaration_style = VectorDeclarationStyle::WGSLSyntax;
+
+
+#define alias(x, y) \
+            extern_function_name_map[x "_f16"] = y; \
+            extern_function_name_map[x "_f32"] = y
+
+            alias("sqrt", "sqrt");
+            alias("sin", "sin");
+            alias("cos", "cos");
+            alias("exp", "exp");
+            alias("log", "log");
+            alias("abs", "fabs"); // f-prefix! (although it's handled as an intrinsic).
+            alias("floor", "floor");
+            alias("ceil", "ceil");
+            alias("trunc", "trunc");
+            alias("asin", "asin");
+            alias("acos", "acos");
+            alias("tan", "tan");
+            alias("atan", "atan");
+            alias("atan2", "atan2");
+            alias("sinh", "sinh");
+            alias("asinh", "asinh");
+            alias("cosh", "cosh");
+            alias("acosh", "acosh");
+            alias("tanh", "tanh");
+            alias("atanh", "atanh");
+
+            alias("round", "round");
+
+            alias("fast_inverse_sqrt", "inverseSqrt");
+#undef alias
+
         }
         void add_kernel(const Stmt &stmt,
                         const string &name,
@@ -140,21 +172,7 @@ void CodeGen_WebGPU_Dev::init_module() {
         << "fn nan_f32() -> f32 {return float_from_bits(0x7fc00000);}\n"
         << "fn neg_inf_f32() -> f32 {return float_from_bits(0xff800000);}\n"
         << "fn inf_f32() -> f32 {return float_from_bits(0x7f800000);}\n"
-        << "fn acos_f32(x : f32) -> f32 {return acos(x);}\n"
-        << "fn acosh_f32(x : f32) -> f32 {return acosh(x);}\n"
-        << "fn asin_f32(x : f32) -> f32 {return asin(x);}\n"
-        << "fn asinh_f32(x : f32) -> f32 {return asinh(x);}\n"
-        << "fn atan_f32(x : f32) -> f32 {return atan(x);}\n"
-        << "fn atan2_f32(y : f32, x : f32) -> f32 {return atan2(y, x);}\n"
-        << "fn atanh_f32(x : f32) -> f32 {return atanh(x);}\n"
-        << "fn ceil_f32(x : f32) -> f32 {return ceil(x);}\n"
-        << "fn cos_f32(x : f32) -> f32 {return cos(x);}\n"
-        << "fn cosh_f32(x : f32) -> f32 {return cosh(x);}\n"
-        << "fn exp_f32(x : f32) -> f32 {return exp(x);}\n"
-        << "fn floor_f32(x : f32) -> f32 {return floor(x);}\n"
         << "fn fast_inverse_f32(x : f32) -> f32 {return 1.0 / x;}\n"
-        << "fn fast_inverse_sqrt_f32(x : f32) -> f32 {return inverseSqrt(x);}\n"
-        << "fn log_f32(x : f32) -> f32 {return log(x);}\n"
         // pow() in WGSL has the same semantics as C if x > 0.
         // Otherwise, we need to emulate the behavior.
         << "fn pow_f32(x : f32, y : f32) -> f32 { \n"
@@ -172,14 +190,6 @@ void CodeGen_WebGPU_Dev::init_module() {
         << "    return nan_f32();             \n"
         << "  }                               \n"
         << "}                                 \n"
-        << "fn rint(x : f32) -> f32 {return round(x);}\n"
-        << "fn round_f32(x : f32) -> f32 {return round(x);}\n"
-        << "fn sin_f32(x : f32) -> f32 {return sin(x);}\n"
-        << "fn sinh_f32(x : f32) -> f32 {return sinh(x);}\n"
-        << "fn sqrt_f32(x : f32) -> f32 {return sqrt(x);}\n"
-        << "fn tan_f32(x : f32) -> f32 {return tan(x);}\n"
-        << "fn tanh_f32(x : f32) -> f32 {return tanh(x);}\n"
-        << "fn trunc_f32(x : f32) -> f32 {return trunc(x);}\n"
         // WGSL doesn't provide these by default, but we can exploit the nature
         // of comparison ops to construct them... although they are of dubious value
         // (since the WGSL spec says that "Implementations may assume that NaNs
@@ -291,14 +301,7 @@ string CodeGen_WebGPU_Dev::CodeGen_WGSL::print_reinterpret(Type type,
 
 string CodeGen_WebGPU_Dev::CodeGen_WGSL::print_extern_call(const Call *op) {
     internal_assert(!function_takes_user_context(op->name)) << op->name;
-
-    vector<string> args(op->args.size());
-    for (size_t i = 0; i < op->args.size(); i++) {
-        args[i] = print_expr(op->args[i]);
-    }
-    ostringstream rhs;
-    rhs << op->name << "(" << with_commas(args) << ")";
-    return rhs.str();
+    return CodeGen_GPU_C::print_extern_call(op);
 }
 
 void CodeGen_WebGPU_Dev::CodeGen_WGSL::add_kernel(
@@ -538,6 +541,9 @@ void CodeGen_WebGPU_Dev::CodeGen_WGSL::visit(const Call *op) {
             close_scope("if " + cond_id + " else");
         }
         print_assignment(op->type, result_id);
+    } else if (op->is_intrinsic(Call::round)) {
+        Expr equiv = Call::make(op->type, "round", op->args, Call::PureExtern);
+        equiv.accept(this);
     } else {
         CodeGen_GPU_C::visit(op);
     }

--- a/src/CodeGen_WebGPU_Dev.cpp
+++ b/src/CodeGen_WebGPU_Dev.cpp
@@ -58,17 +58,16 @@ protected:
             : CodeGen_GPU_C(s, t) {
             vector_declaration_style = VectorDeclarationStyle::WGSLSyntax;
 
-
-#define alias(x, y) \
-            extern_function_name_map[x "_f16"] = y; \
-            extern_function_name_map[x "_f32"] = y
+#define alias(x, y)                         \
+    extern_function_name_map[x "_f16"] = y; \
+    extern_function_name_map[x "_f32"] = y
 
             alias("sqrt", "sqrt");
             alias("sin", "sin");
             alias("cos", "cos");
             alias("exp", "exp");
             alias("log", "log");
-            alias("abs", "fabs"); // f-prefix! (although it's handled as an intrinsic).
+            alias("abs", "fabs");  // f-prefix! (although it's handled as an intrinsic).
             alias("floor", "floor");
             alias("ceil", "ceil");
             alias("trunc", "trunc");
@@ -88,7 +87,6 @@ protected:
 
             alias("fast_inverse_sqrt", "inverseSqrt");
 #undef alias
-
         }
         void add_kernel(const Stmt &stmt,
                         const string &name,

--- a/src/runtime/opencl.cpp
+++ b/src/runtime/opencl.cpp
@@ -37,7 +37,7 @@ extern "C" WEAK void *halide_opencl_get_symbol(void *user_context, const char *n
 #ifdef WINDOWS
         "opencl.dll",
 #else
-        "libOpenCL.so",
+        "libOpenCL.so.1",
         "/System/Library/Frameworks/OpenCL.framework/OpenCL",
 #endif
     };

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -24,7 +24,7 @@ void schedule_test(Func f, int vector_width, Partition partition_policy, const T
     }
     f.partition(x, partition_policy);
     f.partition(y, partition_policy);
-    if (t.has_gpu_feature() && vector_width <= 16) {
+    if (t.has_gpu_feature()) {
         f.gpu_tile(x, y, xo, yo, xi, yi, 2, 2);
     } else if (t.has_feature(Target::HVX)) {
         // TODO: Non-native vector widths hang the compiler here.
@@ -387,6 +387,9 @@ int main(int argc, char **argv) {
         target.has_feature(Target::WebGPU)) {
         // https://github.com/halide/Halide/issues/2148
         vector_width_max = 4;
+    }
+    if (target.has_feature(Target::OpenCL)) {
+        vector_width_max = 16;
     }
     if (target.arch == Target::WebAssembly) {
         // The wasm jit is very slow, so shorten this test here.

--- a/test/correctness/math.cpp
+++ b/test/correctness/math.cpp
@@ -137,7 +137,7 @@ struct TestArgs {
         Var x("x"), xi("xi");                                                                              \
         test_##name(x) = name(in(x));                                                                      \
         if (target.has_gpu_feature()) {                                                                    \
-            test_##name.gpu_tile(x, xi, 8);                                                                \
+            test_##name.gpu_tile(x, xi, 16).vectorize(xi, 2);                                              \
         } else if (target.has_feature(Target::HVX)) {                                                      \
             test_##name.hexagon();                                                                         \
         }                                                                                                  \
@@ -168,7 +168,7 @@ struct TestArgs {
         Var x("x"), xi("xi");                                                                              \
         test_##name(x) = name(in(0, x), in(1, x));                                                         \
         if (target.has_gpu_feature()) {                                                                    \
-            test_##name.gpu_tile(x, xi, 8);                                                                \
+            test_##name.gpu_tile(x, xi, 16).vectorize(xi, 2);                                              \
         } else if (target.has_feature(Target::HVX)) {                                                      \
             test_##name.hexagon();                                                                         \
         }                                                                                                  \


### PR DESCRIPTION
Fixes #8594.
This clears up all the preprocessor prologues or wrapper function prologues.

Update: `pow()` for WGSL is removed from the preamble now, and its behavior is emulated during codegen in the WGSL_CodeGen backend. There is a potential for simplyfing that again if there are meaningful bounds on expressions inferred. I'd consider that future work. Removing this from the preamble and using Halide's IR to emulate this, enables support for vectorized calls. There is a caveat with this: WGSL says there are no nans. However, their own builtin pow() function returns nan for negative inputs to x and y. Emulating that was tricky, because I think the WGSL simplifier removes those? Not sure why I couldn't simply do `make_const(x.type(), std::nanf(""))`. I had to resort to `make_const(x.type(), 1.0f) * Call::make(Float(32), "nan_f32", {}, Call::PureExtern)` to get the NaN value in.