### PR TITLE
Check if expression is defined before trying to compute its constant_integer_bounds

### DIFF
--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -747,7 +747,7 @@ protected:
                     auto b_bounds = constant_integer_bounds(b);
                     const int max_shift = op->type.bits() - 1;
 
-                    if (a.defined() & b_bounds >= -max_shift && b_bounds <= max_shift) {
+                    if (a.defined() && b_bounds >= -max_shift && b_bounds <= max_shift) {
                         if (!is_saturated ||
                             (shift->is_intrinsic(Call::rounding_shift_right) && can_prove(b >= 0)) ||
                             (shift->is_intrinsic(Call::rounding_shift_left) && can_prove(b <= 0))) {

--- a/src/FindIntrinsics.cpp
+++ b/src/FindIntrinsics.cpp
@@ -741,16 +741,18 @@ protected:
                 bool is_saturated = op->value.as<Max>() || op->value.as<Min>();
                 Expr a = lossless_cast(op->type, shift->args[0]);
                 Expr b = lossless_cast(op->type.with_code(shift->args[1].type().code()), shift->args[1]);
-                // Doing the shift in the narrower type might introduce UB where
-                // there was no UB before, so we need to make sure b is bounded.
-                auto b_bounds = constant_integer_bounds(b);
-                const int max_shift = op->type.bits() - 1;
+                if (b.defined()) {
+                    // Doing the shift in the narrower type might introduce UB where
+                    // there was no UB before, so we need to make sure b is bounded.
+                    auto b_bounds = constant_integer_bounds(b);
+                    const int max_shift = op->type.bits() - 1;
 
-                if (a.defined() && b.defined() && b_bounds >= -max_shift && b_bounds <= max_shift) {
-                    if (!is_saturated ||
-                        (shift->is_intrinsic(Call::rounding_shift_right) && can_prove(b >= 0)) ||
-                        (shift->is_intrinsic(Call::rounding_shift_left) && can_prove(b <= 0))) {
-                        return mutate(Call::make(op->type, shift->name, {a, b}, Call::PureIntrinsic));
+                    if (a.defined() & b_bounds >= -max_shift && b_bounds <= max_shift) {
+                        if (!is_saturated ||
+                            (shift->is_intrinsic(Call::rounding_shift_right) && can_prove(b >= 0)) ||
+                            (shift->is_intrinsic(Call::rounding_shift_left) && can_prove(b <= 0))) {
+                            return mutate(Call::make(op->type, shift->name, {a, b}, Call::PureIntrinsic));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This was causing internal_assert in one of the Google internal generators, so changed it to check if b is defined before calling constant_integer_bounds.