### PR TITLE
In graph_equal(), call the correct implementation for comparing equalities between statements and expressions

### DIFF
--- a/src/IREquality.h
+++ b/src/IREquality.h
@@ -66,7 +66,7 @@ bool graph_equal(const IRNode &a, const IRNode &b) {
     } else if (a.node_type != b.node_type) {
         return false;
     } else {
-        return equal_impl(a, b);
+        return graph_equal_impl(a, b);
     }
 }
 
@@ -79,7 +79,7 @@ bool graph_equal(const IRHandle &a, const IRHandle &b) {
     } else if (!b.defined()) {
         return false;
     } else {
-        return equal(*(a.get()), *(b.get()));
+        return graph_equal(*(a.get()), *(b.get()));
     }
 }
 


### PR DESCRIPTION
This should fix https://github.com/halide/Halide/issues/8610
Please let me know if you want me to create a test -- it seems that the equalities are already tested inside IREquality.cpp, it is just that the wrapper functions were not tested.