### PR TITLE
Move to opaque llvm pointers

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1500,7 +1500,7 @@ void CodeGen_ARM::visit(const Store *op) {
                   << (t.is_float() ? 'f' : 'i')
                   << t.bits();
             arg_types = vector<llvm::Type *>(num_vecs + 2, intrin_llvm_type);
-            arg_types.front() = PointerType::get(i8_t, 0);
+            arg_types.front() = ptr_t;
             arg_types.back() = i32_t;
         } else {
             if (is_sve) {
@@ -1512,7 +1512,7 @@ void CodeGen_ARM::visit(const Store *op) {
                       << t.bits();
                 arg_types = vector<llvm::Type *>(num_vecs, intrin_llvm_type);
                 arg_types.emplace_back(get_vector_type(i1_t, intrin_type.lanes() / target_vscale(), VectorTypeConstraint::VScale));  // predicate
-                arg_types.emplace_back(PointerType::get(llvm_type_of(intrin_type.element_of()), 0));
+                arg_types.emplace_back(ptr_t);
             } else {
                 instr << "llvm.aarch64.neon.st"
                       << num_vecs
@@ -1522,7 +1522,7 @@ void CodeGen_ARM::visit(const Store *op) {
                       << t.bits()
                       << ".p0";
                 arg_types = vector<llvm::Type *>(num_vecs + 1, intrin_llvm_type);
-                arg_types.back() = PointerType::get(llvm_type_of(intrin_type.element_of()), 0);
+                arg_types.back() = ptr_t;
             }
         }
         llvm::FunctionType *fn_type = FunctionType::get(llvm::Type::getVoidTy(*context), arg_types, false);
@@ -1545,8 +1545,6 @@ void CodeGen_ARM::visit(const Store *op) {
             }
 
             if (target.bits == 32) {
-                // The arm32 versions take an i8*, regardless of the type stored.
-                ptr = builder->CreatePointerCast(ptr, PointerType::get(i8_t, 0));
                 // Set the pointer argument
                 slice_args.insert(slice_args.begin(), ptr);
                 // Set the alignment argument
@@ -1823,7 +1821,7 @@ void CodeGen_ARM::visit(const Load *op) {
                 llvm::Type *elt = llvm_type_of(op->type.element_of());
                 llvm::Type *slice_type = get_vector_type(elt, slice_lanes);
                 StructType *sret_type = StructType::get(module->getContext(), std::vector(stride->value, slice_type));
-                std::vector<llvm::Type *> arg_types{get_vector_type(i1_t, slice_lanes), PointerType::get(elt, 0)};
+                std::vector<llvm::Type *> arg_types{get_vector_type(i1_t, slice_lanes), ptr_t};
                 llvm::FunctionType *fn_type = FunctionType::get(sret_type, arg_types, false);
                 FunctionCallee fn = module->getOrInsertFunction(instr.str(), fn_type);
 

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2228,10 +2228,6 @@ void CodeGen_Hexagon::visit(const Allocate *alloc) {
         Value *args[2] = {get_user_context(), llvm_size};
 
         Value *call = builder->CreateCall(alloc_fn, args);
-
-        // Fix the type to avoid pointless bitcasts later
-        call = builder->CreatePointerCast(
-            call, PointerType::get(llvm_type_of(alloc->type), 0));
         allocation.ptr = call;
 
         // Assert that the allocation worked.

--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -723,10 +723,10 @@ void set_function_attributes_from_halide_target_options(llvm::Function &fn) {
 }
 
 void embed_bitcode(llvm::Module *M, const string &halide_command) {
-    // Save llvm.compiler.used and remote it.
+    // Save llvm.compiler.used and remove it.
     SmallVector<Constant *, 2> used_array;
     SmallVector<GlobalValue *, 4> used_globals;
-    llvm::Type *used_element_type = PointerType::get(llvm::Type::getInt8Ty(M->getContext()), 0);
+    llvm::Type *used_element_type = PointerType::get(M->getContext(), 0);
     GlobalVariable *used = collectUsedGlobalVariables(*M, used_globals, true);
     for (auto *GV : used_globals) {
         if (GV->getName() != "llvm.embedded.module" &&

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -291,6 +291,7 @@ void CodeGen_LLVM::init_context() {
     f16_t = llvm::Type::getHalfTy(*context);
     f32_t = llvm::Type::getFloatTy(*context);
     f64_t = llvm::Type::getDoubleTy(*context);
+    ptr_t = llvm::PointerType::get(*context, 0);
 
     // Ensure no Value pointers carry over from previous context.
     struct_type_recovery.clear();
@@ -360,7 +361,7 @@ llvm::FunctionType *CodeGen_LLVM::signature_to_type(const ExternSignature &signa
     std::vector<llvm::Type *> llvm_arg_types;
     for (const Type &t : signature.arg_types()) {
         if (t == type_of<struct halide_buffer_t *>()) {
-            llvm_arg_types.push_back(PointerType::get(halide_buffer_t_type, 0));
+            llvm_arg_types.push_back(ptr_t);
         } else {
             llvm_arg_types.push_back(llvm_type_of(upgrade_type_for_argument_passing(t)));
         }
@@ -476,7 +477,7 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
         vector<llvm::Type *> arg_types(f.args.size());
         for (size_t i = 0; i < f.args.size(); i++) {
             if (f.args[i].is_buffer()) {
-                arg_types[i] = PointerType::get(halide_buffer_t_type, 0);
+                arg_types[i] = ptr_t;
             } else {
                 arg_types[i] = llvm_type_of(upgrade_type_for_argument_passing(f.args[i].type));
             }
@@ -556,8 +557,6 @@ std::unique_ptr<llvm::Module> CodeGen_LLVM::compile(const Module &input) {
                 for (auto &arg : wrapper_func->args()) {
                     wrapper_call_args.push_back(&arg);
                 }
-                wrapper_call_args[wrapper_ucon_index] = builder->CreatePointerCast(wrapper_call_args[wrapper_ucon_index],
-                                                                                   llvm_type_of(type_of<void const *>()));
 
                 llvm::CallInst *wrapper_result = builder->CreateCall(function, wrapper_call_args);
                 // This call should never inline
@@ -729,11 +728,8 @@ BasicBlock *CodeGen_LLVM::get_destructor_block() {
 Value *CodeGen_LLVM::register_destructor(llvm::Function *destructor_fn, Value *obj, DestructorType when) {
 
     // Create a null-initialized stack slot to track this object
-    llvm::Type *void_ptr = PointerType::get(i8_t, 0);
+    llvm::Type *void_ptr = ptr_t;
     llvm::Value *stack_slot = create_alloca_at_entry(void_ptr, 1, true);
-
-    // Cast the object to llvm's representation of void *
-    obj = builder->CreatePointerCast(obj, void_ptr);
 
     // Put it in the stack slot
     builder->CreateStore(obj, stack_slot);
@@ -787,7 +783,6 @@ void CodeGen_LLVM::trigger_destructor(llvm::Function *destructor_fn, Value *stac
     llvm::Function *call_destructor = module->getFunction("call_destructor");
     internal_assert(call_destructor);
     internal_assert(destructor_fn);
-    stack_slot = builder->CreatePointerCast(stack_slot, PointerType::get(PointerType::get(i8_t, 0), 0));
     Value *should_call = ConstantInt::get(i1_t, 1);
     Value *args[] = {get_user_context(), destructor_fn, stack_slot, should_call};
     builder->CreateCall(call_destructor, args);
@@ -813,9 +808,8 @@ void CodeGen_LLVM::compile_buffer(const Buffer<> &buf) {
         size_t shape_size = buf.dimensions() * sizeof(halide_dimension_t);
         vector<char> shape_blob((char *)buf.raw_buffer()->dim, (char *)buf.raw_buffer()->dim + shape_size);
         shape = create_binary_blob(shape_blob, buf.name() + ".shape");
-        shape = ConstantExpr::getPointerCast(shape, PointerType::get(dimension_t_type, 0));
     } else {
-        shape = ConstantPointerNull::get(PointerType::get(dimension_t_type, 0));
+        shape = ConstantPointerNull::get(ptr_t);
     }
 
     // For now, we assume buffers that aren't scalar are constant,
@@ -827,14 +821,14 @@ void CodeGen_LLVM::compile_buffer(const Buffer<> &buf) {
     vector<char> data_blob((const char *)buf.data(), (const char *)buf.data() + buf.size_in_bytes());
 
     Constant *fields[] = {
-        ConstantInt::get(i64_t, 0),                                              // device
-        ConstantPointerNull::get(PointerType::get(device_interface_t_type, 0)),  // device_interface
-        create_binary_blob(data_blob, buf.name() + ".data", constant),           // host
-        ConstantInt::get(i64_t, halide_buffer_flag_host_dirty),                  // flags
-        ConstantStruct::get(type_t_type, type_fields),                           // type
-        ConstantInt::get(i32_t, buf.dimensions()),                               // dimensions
-        shape,                                                                   // dim
-        ConstantPointerNull::get(PointerType::get(i8_t, 0)),                     // padding
+        ConstantInt::get(i64_t, 0),                                     // device
+        ConstantPointerNull::get(ptr_t),                                // device_interface
+        create_binary_blob(data_blob, buf.name() + ".data", constant),  // host
+        ConstantInt::get(i64_t, halide_buffer_flag_host_dirty),         // flags
+        ConstantStruct::get(type_t_type, type_fields),                  // type
+        ConstantInt::get(i32_t, buf.dimensions()),                      // dimensions
+        shape,                                                          // dim
+        ConstantPointerNull::get(ptr_t),                                // padding
     };
     Constant *buffer_struct = ConstantStruct::get(halide_buffer_t_type, fields);
 
@@ -852,7 +846,7 @@ void CodeGen_LLVM::compile_buffer(const Buffer<> &buf) {
 
 Constant *CodeGen_LLVM::embed_constant_scalar_value_t(const Expr &e) {
     if (!e.defined()) {
-        return Constant::getNullValue(PointerType::get(scalar_value_t_type, 0));
+        return Constant::getNullValue(ptr_t);
     }
 
     internal_assert(!e.type().is_handle()) << "Should never see Handle types here.";
@@ -895,16 +889,14 @@ Constant *CodeGen_LLVM::embed_constant_scalar_value_t(const Expr &e) {
     storage->setAlignment(llvm::Align((int)sizeof(halide_scalar_value_t)));
 
     Constant *zero[] = {ConstantInt::get(i32_t, 0)};
-    return ConstantExpr::getBitCast(
-        ConstantExpr::getInBoundsGetElementPtr(array_type, storage, zero),
-        PointerType::get(scalar_value_t_type, 0));
+    return ConstantExpr::getInBoundsGetElementPtr(array_type, storage, zero);
 }
 
 Constant *CodeGen_LLVM::embed_constant_expr(Expr e, llvm::Type *t) {
     internal_assert(t != scalar_value_t_type);
 
     if (!e.defined()) {
-        return Constant::getNullValue(PointerType::get(t, 0));
+        return Constant::getNullValue(ptr_t);
     }
 
     internal_assert(!e.type().is_handle()) << "Should never see Handle types here.";
@@ -925,9 +917,7 @@ Constant *CodeGen_LLVM::embed_constant_expr(Expr e, llvm::Type *t) {
         constant);
 
     Constant *zero[] = {ConstantInt::get(i32_t, 0)};
-    return ConstantExpr::getBitCast(
-        ConstantExpr::getInBoundsGetElementPtr(constant->getType(), storage, zero),
-        PointerType::get(t, 0));
+    return ConstantExpr::getInBoundsGetElementPtr(constant->getType(), storage, zero);
 }
 
 // Make a wrapper to call the function with an array of pointer
@@ -943,7 +933,7 @@ llvm::Function *CodeGen_LLVM::add_argv_wrapper(llvm::Function *fn,
                                                bool result_in_argv,
                                                std::vector<bool> &arg_is_buffer) {
     llvm::Type *wrapper_result_type = result_in_argv ? void_t : i32_t;
-    llvm::Type *wrapper_args_t[] = {PointerType::get(PointerType::get(i8_t, 0), 0)};
+    llvm::Type *wrapper_args_t[] = {ptr_t};
     llvm::FunctionType *wrapper_func_t = llvm::FunctionType::get(wrapper_result_type, wrapper_args_t, false);
     llvm::Function *wrapper_func = llvm::Function::Create(wrapper_func_t, llvm::GlobalValue::ExternalLinkage, name, module.get());
     llvm::BasicBlock *wrapper_block = llvm::BasicBlock::Create(module->getContext(), "entry", wrapper_func);
@@ -953,15 +943,12 @@ llvm::Function *CodeGen_LLVM::add_argv_wrapper(llvm::Function *fn,
     std::vector<llvm::Value *> wrapper_args;
     for (llvm::Function::arg_iterator i = fn->arg_begin(); i != fn->arg_end(); i++) {
         // Get the address of the nth argument
-        llvm::Value *ptr = CreateConstGEP1_32(builder.get(), PointerType::get(i8_t, 0),
+        llvm::Value *ptr = CreateConstGEP1_32(builder.get(), ptr_t,
                                               arg_array, wrapper_args.size());
-        ptr = builder->CreateLoad(PointerType::get(i8_t, 0), ptr);
+        ptr = builder->CreateLoad(ptr_t, ptr);
         if (arg_is_buffer[i->getArgNo()]) {
-            // Cast the argument to a halide_buffer_t *
-            wrapper_args.push_back(builder->CreatePointerCast(ptr, PointerType::get(halide_buffer_t_type, 0)));
+            wrapper_args.push_back(ptr);
         } else {
-            // Cast to the appropriate type and load
-            ptr = builder->CreatePointerCast(ptr, PointerType::get(i->getType(), 0));
             wrapper_args.push_back(builder->CreateLoad(i->getType(), ptr));
         }
     }
@@ -971,12 +958,10 @@ llvm::Function *CodeGen_LLVM::add_argv_wrapper(llvm::Function *fn,
     result->setIsNoInline();
 
     if (result_in_argv) {
-        llvm::Value *result_in_argv_ptr = CreateConstGEP1_32(builder.get(), PointerType::get(i8_t, 0),
+        llvm::Value *result_in_argv_ptr = CreateConstGEP1_32(builder.get(), ptr_t,
                                                              arg_array, wrapper_args.size());
         if (fn->getReturnType() != void_t) {
-            result_in_argv_ptr = builder->CreateLoad(PointerType::get(i8_t, 0), result_in_argv_ptr);
-            // Cast to the appropriate type and store
-            result_in_argv_ptr = builder->CreatePointerCast(result_in_argv_ptr, PointerType::get(fn->getReturnType(), 0));
+            result_in_argv_ptr = builder->CreateLoad(ptr_t, result_in_argv_ptr);
             builder->CreateStore(result, result_in_argv_ptr);
         }
         builder->CreateRetVoid();
@@ -1038,7 +1023,7 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
                 buffer_estimates_array_entries.push_back(embed_constant_expr(extent, i64_t));
             }
 
-            llvm::ArrayType *buffer_estimates_array = ArrayType::get(PointerType::get(i64_t, 0), buffer_estimates_array_entries.size());
+            llvm::ArrayType *buffer_estimates_array = ArrayType::get(ptr_t, buffer_estimates_array_entries.size());
             GlobalVariable *buffer_estimates_array_storage = new GlobalVariable(
                 *module,
                 buffer_estimates_array,
@@ -1049,7 +1034,7 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
             Value *zeros[] = {zero, zero};
             buffer_estimates_array_ptr = ConstantExpr::getInBoundsGetElementPtr(buffer_estimates_array, buffer_estimates_array_storage, zeros);
         } else {
-            buffer_estimates_array_ptr = Constant::getNullValue(PointerType::get(PointerType::get(i64_t, 0), 0));
+            buffer_estimates_array_ptr = Constant::getNullValue(ptr_t);
         }
 
         Constant *argument_fields[] = {
@@ -1090,7 +1075,7 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
         ConstantStruct::get(metadata_t_type, metadata_fields),
         metadata_name + "_storage");
 
-    llvm::FunctionType *func_t = llvm::FunctionType::get(PointerType::get(metadata_t_type, 0), false);
+    llvm::FunctionType *func_t = llvm::FunctionType::get(ptr_t, false);
     llvm::Function *metadata_getter = llvm::Function::Create(func_t, llvm::GlobalValue::ExternalLinkage, metadata_name, module.get());
     llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", metadata_getter);
     builder->SetInsertPoint(block);
@@ -1949,12 +1934,6 @@ Value *CodeGen_LLVM::codegen_buffer_pointer(const string &buffer, Halide::Type t
 Value *CodeGen_LLVM::codegen_buffer_pointer(Value *base_address, Halide::Type type, Value *index) {
     type = upgrade_type_for_storage(type);
     llvm::Type *load_type = llvm_type_of(type);
-    unsigned address_space = base_address->getType()->getPointerAddressSpace();
-    llvm::Type *pointer_load_type = PointerType::get(load_type, address_space);
-
-    // TODO: This can likely be removed once opaque pointers are default
-    // in all supported LLVM versions.
-    base_address = builder->CreatePointerCast(base_address, pointer_load_type);
 
     llvm::Constant *constant_index = dyn_cast<llvm::Constant>(index);
     if (constant_index && constant_index->isZeroValue()) {
@@ -2309,8 +2288,7 @@ void CodeGen_LLVM::codegen_predicated_store(const Store *op) {
             Expr slice_stride = make_one(slice_base.type());
             Expr slice_index = slice_lanes == 1 ? slice_base : Ramp::make(slice_base, slice_stride, slice_lanes);
             Value *slice_val = slice_vector(val, i, slice_lanes);
-            Value *elt_ptr = codegen_buffer_pointer(op->name, value_type.element_of(), slice_base);
-            Value *vec_ptr = builder->CreatePointerCast(elt_ptr, PointerType::get(slice_val->getType(), 0));
+            Value *vec_ptr = codegen_buffer_pointer(op->name, value_type.element_of(), slice_base);
 
             Value *slice_mask = slice_vector(vpred, i, slice_lanes);
             Instruction *store;
@@ -2409,8 +2387,7 @@ llvm::Value *CodeGen_LLVM::codegen_vector_load(const Type &type, const std::stri
         Expr slice_stride = make_one(slice_base.type());
         Expr slice_index = slice_lanes == 1 ? slice_base : Ramp::make(slice_base, slice_stride, slice_lanes);
         llvm::Type *slice_type = get_vector_type(llvm_type_of(type.element_of()), slice_lanes);
-        Value *elt_ptr = codegen_buffer_pointer(name, type.element_of(), slice_base);
-        Value *vec_ptr = builder->CreatePointerCast(elt_ptr, PointerType::get(slice_type, 0));
+        Value *vec_ptr = codegen_buffer_pointer(name, type.element_of(), slice_base);
 
         Value *slice_mask = (vpred != nullptr) ? match_vector_type_scalable(slice_vector(vpred, i, slice_lanes), slice_type) : nullptr;
         MaskVariant vp_slice_mask = slice_mask ? MaskVariant(slice_mask) : AllEnabledMask();
@@ -2607,8 +2584,6 @@ void CodeGen_LLVM::codegen_atomic_rmw(const Store *op) {
             bool need_bit_cast = val_type->isFloatingPointTy();
             if (need_bit_cast) {
                 IntegerType *int_type = builder->getIntNTy(val_type->getPrimitiveSizeInBits());
-                unsigned int addr_space = ptr->getType()->getPointerAddressSpace();
-                ptr = builder->CreateBitCast(ptr, PointerType::get(int_type, addr_space));
                 val = builder->CreateBitCast(val, int_type);
                 cmp_val = builder->CreateBitCast(cmp_val, int_type);
             }
@@ -2655,7 +2630,6 @@ void CodeGen_LLVM::visit(const Call *op) {
         vector<Value *> args = {user_context, char_ptr};
 
         Value *buffer = codegen(op->args[1]);
-        buffer = builder->CreatePointerCast(buffer, debug_to_file->getFunctionType()->getParamType(2));
         args.push_back(buffer);
 
         value = builder->CreateCall(debug_to_file, args);
@@ -2875,7 +2849,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             // Empty structs can be emitted for arrays of size zero
             // (e.g. the shape of a zero-dimensional buffer). We
             // generate a null in this situation. */
-            value = ConstantPointerNull::get(dyn_cast<PointerType>(llvm_type_of(op->type)));
+            value = ConstantPointerNull::get(ptr_t);
         } else {
             // Codegen each element.
             bool all_same_type = true;
@@ -2916,7 +2890,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         internal_assert(op->args.size() == 3);
         llvm::Value *struct_instance = codegen(op->args[0]);
         llvm::Value *struct_prototype = codegen(op->args[1]);
-        llvm::Value *typed_struct_instance = builder->CreatePointerCast(struct_instance, struct_prototype->getType());
+
         auto index = as_const_int(op->args[2]);
 
         // make_struct can use a fixed-size struct, an array type, or a scalar
@@ -2931,7 +2905,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         llvm::Type *array_type = llvm::dyn_cast<llvm::ArrayType>(pointee_type);
         if (struct_type || array_type) {
             internal_assert(index);
-            llvm::Value *gep = CreateInBoundsGEP(builder.get(), pointee_type, typed_struct_instance,
+            llvm::Value *gep = CreateInBoundsGEP(builder.get(), pointee_type, struct_instance,
                                                  {ConstantInt::get(i32_t, 0),
                                                   ConstantInt::get(i32_t, (int)*index)});
             llvm::Type *result_type = struct_type ? struct_type->getElementType(*index) : array_type->getArrayElementType();
@@ -2939,7 +2913,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         } else {
             // The struct is actually just a scalar
             internal_assert(!index || *index == 0);
-            value = builder->CreateLoad(pointee_type, typed_struct_instance);
+            value = builder->CreateLoad(pointee_type, struct_instance);
         }
     } else if (op->is_intrinsic(Call::get_user_context)) {
         internal_assert(op->args.empty());
@@ -3064,13 +3038,11 @@ void CodeGen_LLVM::visit(const Call *op) {
                     dst = builder->CreateCall(append_double, call_args);
                 } else if (t == type_of<halide_buffer_t *>()) {
                     Value *buf = codegen(arg);
-                    buf = builder->CreatePointerCast(buf, append_buffer->getFunctionType()->getParamType(2));
                     call_args.push_back(buf);
                     dst = builder->CreateCall(append_buffer, call_args);
                 } else {
                     internal_assert(t.is_handle());
                     Value *ptr = codegen(arg);
-                    ptr = builder->CreatePointerCast(ptr, PointerType::get(i8_t, 0));
                     call_args.push_back(ptr);
                     dst = builder->CreateCall(append_pointer, call_args);
                 }
@@ -3125,7 +3097,7 @@ void CodeGen_LLVM::visit(const Call *op) {
         internal_assert(fn);
         llvm::Function *f = module->getFunction(fn->value);
         if (!f) {
-            llvm::Type *arg_types[] = {PointerType::get(i8_t, 0), PointerType::get(i8_t, 0)};
+            llvm::Type *arg_types[] = {ptr_t, ptr_t};
             FunctionType *func_t = FunctionType::get(void_t, arg_types, false);
             f = llvm::Function::Create(func_t, llvm::Function::ExternalLinkage, fn->value, module.get());
             f->setCallingConv(CallingConv::C);
@@ -3494,11 +3466,6 @@ void CodeGen_LLVM::visit(const Call *op) {
                         t = get_vector_type(t, halide_arg.type().lanes());
                     }
 
-                    if (t != args[i]->getType()) {
-                        debug(4) << "Pointer casting argument to extern call: "
-                                 << halide_arg << "\n";
-                        args[i] = builder->CreatePointerCast(args[i], t);
-                    }
                 } else if (args[i]->getType()->isVectorTy()) {
                     llvm::Type *t = func_t->getParamType(i);
                     if (t->isVectorTy()) {
@@ -3840,8 +3807,7 @@ void CodeGen_LLVM::visit(const Store *op) {
                 Expr slice_stride = make_one(slice_base.type());
                 Expr slice_index = slice_lanes == 1 ? slice_base : Ramp::make(slice_base, slice_stride, slice_lanes);
                 Value *slice_val = slice_vector(val, i, slice_lanes);
-                Value *elt_ptr = codegen_buffer_pointer(op->name, value_type.element_of(), slice_base);
-                Value *vec_ptr = builder->CreatePointerCast(elt_ptr, PointerType::get(slice_val->getType(), 0));
+                Value *vec_ptr = codegen_buffer_pointer(op->name, value_type.element_of(), slice_base);
                 if (is_dense || slice_lanes == 1) {
                     if (try_vector_predication_intrinsic("llvm.vp.store", void_t, slice_lanes, AllEnabledMask(),
                                                          {VPArg(slice_val, 0), VPArg(vec_ptr, 1, alignment)})) {
@@ -4507,7 +4473,7 @@ Value *CodeGen_LLVM::create_alloca_at_entry(llvm::Type *t, int n, bool zero_init
 Value *CodeGen_LLVM::get_user_context() const {
     Value *ctx = sym_get("__user_context", false);
     if (!ctx) {
-        ctx = ConstantPointerNull::get(PointerType::get(i8_t, 0));  // void*
+        ctx = ConstantPointerNull::get(ptr_t);  // void*
     }
     return ctx;
 }

--- a/src/CodeGen_LLVM.h
+++ b/src/CodeGen_LLVM.h
@@ -18,6 +18,7 @@ template<typename, typename>
 class IRBuilder;
 class LLVMContext;
 class Type;
+class PointerType;
 class StructType;
 class Instruction;
 class CallInst;
@@ -208,6 +209,7 @@ protected:
     /** Some useful llvm types */
     // @{
     llvm::Type *void_t = nullptr, *i1_t = nullptr, *i8_t = nullptr, *i16_t = nullptr, *i32_t = nullptr, *i64_t = nullptr, *f16_t = nullptr, *f32_t = nullptr, *f64_t = nullptr;
+    llvm::PointerType *ptr_t = nullptr;
     llvm::StructType *halide_buffer_t_type = nullptr,
                      *type_t_type,
                      *dimension_t_type,

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -138,7 +138,7 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
     vector<llvm::Type *> arg_types(args.size());
     for (size_t i = 0; i < args.size(); i++) {
         if (args[i].is_buffer) {
-            arg_types[i] = PointerType::get(llvm_type_of(UInt(8)), 0);
+            arg_types[i] = ptr_t;
         } else {
             arg_types[i] = llvm_type_of(args[i].type);
         }
@@ -311,7 +311,7 @@ void CodeGen_PTX_Dev::visit(const Allocate *alloc) {
                                             << "(Memoization is not supported inside GPU kernels at present.)\n";
     if (alloc->memory_type == MemoryType::GPUShared) {
         // PTX uses zero in address space 3 as the base address for shared memory
-        Value *shared_base = Constant::getNullValue(PointerType::get(i8_t, 3));
+        Value *shared_base = Constant::getNullValue(PointerType::get(*context, 3));
         sym_push(alloc->name, shared_base);
     } else {
         debug(2) << "Allocate " << alloc->name << " on device\n";

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -907,7 +907,7 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
 
     ReductionDomain rdom{definition.schedule().rvars(), definition.predicate(), true};
     SubstitutionMap rdom_promises;
-    for (int i = 0; i < rdom.domain().size(); i++) {
+    for (int i = 0; i < (int)rdom.domain().size(); i++) {
         const auto &[var, min, extent] = rdom.domain()[i];
         rdom_promises.emplace(var, promise_clamped(RVar(rdom, i), min, min + extent - 1));
     }


### PR DESCRIPTION
For a long time llvm has been slowly moving to a model where pointers are an opaque type, instead of knowing the pointee type. This has been complete for a while now, so they've started deprecating the APIs for constructing a pointer with a pointee type (these APIs ignore the pointee type anyway), or doing pointer casts, which are no-ops. This PR removes use of those APIs and is a nice simplification of some code.

Hopefully this unbreaks the build for trunk llvm.