### PR TITLE
Opt out of JIT exceptions

### DIFF
--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -245,6 +245,11 @@ public:
         code_pages.emplace_back(result, size);
         return result;
     }
+
+    // We don't support throwing C++ exceptions through JIT-compiled code. Avoid
+    // any issues with it by just opting out.
+    void registerEHFrames(uint8_t *, uint64_t, size_t) override {};
+    void deregisterEHFrames() override {};
 };
 
 }  // namespace

--- a/test/performance/parallel_scenarios.cpp
+++ b/test/performance/parallel_scenarios.cpp
@@ -1,6 +1,8 @@
 #include "Halide.h"
 #include "halide_thread_pool.h"
 
+#include <chrono>
+
 using namespace Halide;
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This is an attempt to avoid the recent build failures we've seen related to exception-handling logic inside LLVM when jit-compiling.