### PR TITLE
Upgrade pybind11 to 2.11.1

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -10,7 +10,7 @@ FetchContent_Declare(
 FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG 5b0a6fc2017fcc176545afe3e09c9f9885283242 # v2.10.4
+    GIT_TAG 8a099e44b3d5f85b20f05828d919d2332a8de841 # v2.11.1
     GIT_SHALLOW TRUE
 )
 

--- a/doc/BuildingHalideWithCMake.md
+++ b/doc/BuildingHalideWithCMake.md
@@ -148,7 +148,7 @@ building the core pieces of Halide.
 | [wabt]        | `==1.0.36`         | `Halide_WASM_BACKEND=wabt` | Does not have a stable API; exact version required. |
 | [V8]          | trunk              | `Halide_WASM_BACKEND=V8`   | Difficult to build. See [WebAssembly.md]            |
 | [Python]      | `>=3.8`            | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
-| [pybind11]    | `~=2.10.4`         | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
+| [pybind11]    | `~=2.11.1`         | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
 
 Halide maintains the following compatibility policy with LLVM: Halide version
 `N` supports LLVM versions `N`, `N-1`, and `N-2`. Our binary distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core==0.10.5",
-    "pybind11==2.10.4",
+    "pybind11==2.11.1",
 ]
 build-backend = "scikit_build_core.build"
 

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -47,7 +47,7 @@ cmake_dependent_option(
 find_package(Python 3.8 REQUIRED Interpreter Development.Module)
 
 if (WITH_PYTHON_BINDINGS)
-    find_package(pybind11 2.10.4 REQUIRED)
+    find_package(pybind11 2.11.1 REQUIRED)
 endif ()
 
 # Note: this must happen, especially when WITH_PYTHON_BINDINGS is OFF.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ imageio
 ninja
 numpy
 pillow
-pybind11==2.10.4
+pybind11==2.11.1
 scikit-build-core==0.10.5
 scipy
 setuptools>=43


### PR DESCRIPTION
Pybind11 2.10.4's source builds "require" CMake version compatibility with 3.5, but this has been removed from the most recent versions of CMake. We take this opportunity to upgrade to the version of pybind11 that is included with Ubuntu 24.04 LTS and which fortunately does not suffer from this issue.