### PR TITLE
Fix finding LLD on Homebrew when multiple versions are installed.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install clang-tidy
-        run: brew install llvm@19 ninja lld
+        run: brew install llvm@19 ninja lld@19
       - name: Run clang-tidy
         run: ./run-clang-tidy.sh
         env:

--- a/cmake/FindHalide_LLVM.cmake
+++ b/cmake/FindHalide_LLVM.cmake
@@ -28,13 +28,38 @@ endif ()
 option(Halide_LLVM_SHARED_LIBS "Enable to link to shared libLLVM" "${Halide_LLVM_SHARED_LIBS}")
 
 if (LLVM_FOUND)
-    find_package(Clang HINTS "${LLVM_INSTALL_PREFIX}" "${LLVM_DIR}/../clang" "${LLVM_DIR}/../lib/cmake/clang")
+    # LLVM sadly doesn't provide *ConfigVersion.cmake files for its
+    # sub-components, including Clang and LLD. Consequently, attempting to
+    # constrain the version to LLVM_PACKAGE_VERSION prevents these find_package
+    # calls from succeeding at all. Worse, package maintainers have some
+    # "interesting" ideas as to how they should lay out the -dev packages,
+    # especially when they want to support multiple parallel versions. These
+    # hints take effect at a lower precedence than Halide_LLVM_ROOT
+    # or CMAKE_PREFIX_PATH (which are the standard ways of setting up the
+    # dependency search), but at a higher precedence than the system-wide
+    # fallback locations.
+    find_package(
+        Clang
+        HINTS
+        "${LLVM_INSTALL_PREFIX}" # Same root as the LLVM we found
+        "${LLVM_DIR}/../clang" # LLVM found in $ROOT/lib/cmake/llvm
+        "${LLVM_DIR}/../lib/cmake/clang" # LLVM found in $ROOT/cmake
+    )
 
     foreach (comp IN LISTS LLVM_TARGETS_TO_BUILD)
         if (comp STREQUAL "WebAssembly")
             set(Halide_LLVM_${comp}_FOUND 0)
 
-            find_package(LLD HINTS "${LLVM_INSTALL_PREFIX}" "${LLVM_DIR}/../lld" "${LLVM_DIR}/../lib/cmake/lld")
+            find_package(
+                LLD HINTS
+                "${LLVM_INSTALL_PREFIX}"
+                # Homebrew split the LLVM and LLD packages as of version 19, so
+                # having multiple LLVM versions installed leads to the newest
+                # LLD being found without this hint.
+                "${LLVM_INSTALL_PREFIX}/../lld@${LLVM_VERSION_MAJOR}"
+                "${LLVM_DIR}/../lld"
+                "${LLVM_DIR}/../lib/cmake/lld"
+            )
             if (NOT LLD_FOUND)
                 string(APPEND REASON_FAILURE_MESSAGE
                        "WebAssembly was not found because liblld is missing. "


### PR DESCRIPTION
LLVM sadly doesn't provide *ConfigVersion.cmake files for its sub-components, including Clang and LLD. Consequently, attempting to constrain the version to `LLVM_PACKAGE_VERSION` prevents these find_package calls from succeeding at all. Worse, package maintainers have some "interesting" ideas as to how they should lay out the `-dev` packages, especially when they want to support multiple parallel versions. These hints take effect at a lower precedence than `Halide_LLVM_ROOT` or `CMAKE_PREFIX_PATH` (which are the standard ways of setting up the dependency search), but at a higher precedence than the system-wide fallback locations.

In particular, Homebrew split the LLVM and LLD packages as of version 19, so having multiple LLVM versions installed leads to the newest LLD being found without the hint in this commit.