### PR TITLE
Upgrade halide_type_t to 64-bit to support very large vectors and types

### DIFF
--- a/apps/hannk/interpreter/ops.cpp
+++ b/apps/hannk/interpreter/ops.cpp
@@ -584,22 +584,22 @@ double dequantize_scalar(const Tensor *t) {
     int zero = q.zero.empty() ? 0 : q.zero.front();
 
     const auto &buf = t->buffer();
-    switch (buf.type().element_of().as_u32()) {
-    case halide_type_of<uint8_t>().as_u32():
+    switch (buf.type().element_of().as_u64()) {
+    case halide_type_of<uint8_t>().as_u64():
         return (as_scalar<uint8_t>(buf) - zero) * scale;
-    case halide_type_of<int8_t>().as_u32():
+    case halide_type_of<int8_t>().as_u64():
         return (as_scalar<int8_t>(buf) - zero) * scale;
-    case halide_type_of<uint16_t>().as_u32():
+    case halide_type_of<uint16_t>().as_u64():
         return (as_scalar<uint16_t>(buf) - zero) * scale;
-    case halide_type_of<int16_t>().as_u32():
+    case halide_type_of<int16_t>().as_u64():
         return (as_scalar<int16_t>(buf) - zero) * scale;
-    case halide_type_of<uint32_t>().as_u32():
+    case halide_type_of<uint32_t>().as_u64():
         return (as_scalar<uint32_t>(buf) - zero) * scale;
-    case halide_type_of<int32_t>().as_u32():
+    case halide_type_of<int32_t>().as_u64():
         return (as_scalar<int32_t>(buf) - zero) * scale;
-    case halide_type_of<float>().as_u32():
+    case halide_type_of<float>().as_u64():
         return (as_scalar<float>(buf) - zero) * scale;
-    case halide_type_of<double>().as_u32():
+    case halide_type_of<double>().as_u64():
         return (as_scalar<double>(buf) - zero) * scale;
     default:
         HLOG(FATAL) << "Unsupported type " << buf.type();

--- a/apps/hannk/util/buffer_util.h
+++ b/apps/hannk/util/buffer_util.h
@@ -37,10 +37,10 @@ auto dynamic_type_dispatch(const halide_type_t &type, Args &&...args)
     -> decltype(std::declval<Functor<uint8_t>>()(std::forward<Args>(args)...)) {
 
 #define HANDLE_CASE(CODE, BITS, TYPE)        \
-    case halide_type_t(CODE, BITS).as_u32(): \
+    case halide_type_t(CODE, BITS).as_u64(): \
         return Functor<TYPE>()(std::forward<Args>(args)...);
 
-    switch (type.element_of().as_u32()) {
+    switch (type.element_of().as_u64()) {
         // HANDLE_CASE(halide_type_float, 16, float)  // TODO
         HANDLE_CASE(halide_type_float, 32, float)
         HANDLE_CASE(halide_type_float, 64, double)

--- a/python_bindings/src/halide/halide_/PyCallable.cpp
+++ b/python_bindings/src/halide/halide_/PyCallable.cpp
@@ -112,12 +112,12 @@ public:
                 // clang-format off
 
                 #define HALIDE_HANDLE_TYPE_DISPATCH(CODE, BITS, TYPE, FIELD)                \
-                    case halide_type_t(CODE, BITS).as_u32():                                \
+                    case halide_type_t(CODE, BITS).as_u64():                                \
                         scalar_storage[slot].u.FIELD = cast_to<TYPE>(value);                \
                         cci[slot] = Callable::make_scalar_qcci(halide_type_t(CODE, BITS));   \
                         break;
 
-                switch (((halide_type_t)c_arg.type).element_of().as_u32()) {
+                switch (((halide_type_t)c_arg.type).element_of().as_u64()) {
                     HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 32, float, f32)
                     HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 64, double, f64)
                     HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 8, int8_t, i8)

--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -332,9 +332,9 @@ Stmt add_image_checks_inner(Stmt s,
         // Check the type matches the internally-understood type
         {
             string type_name = name + ".type";
-            Expr type_var = Variable::make(UInt(32), type_name, image, param, rdom);
-            uint32_t correct_type_bits = ((halide_type_t)type).as_u32();
-            Expr correct_type_expr = make_const(UInt(32), correct_type_bits);
+            Expr type_var = Variable::make(UInt(64), type_name, image, param, rdom);
+            uint64_t correct_type_bits = ((halide_type_t)type).as_u64();
+            Expr correct_type_expr = make_const(UInt(64), correct_type_bits);
             Expr error = Call::make(Int(32), "halide_error_bad_type",
                                     {error_name, type_var, correct_type_expr},
                                     Call::Extern);

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1212,9 +1212,9 @@ void CodeGen_C::compile(const Buffer<> &buffer) {
            << "0, "                                              // device
            << "nullptr, "                                        // device_interface
            << "const_cast<uint8_t*>(&" << name << "_data[0]), "  // host
-           << "0, "                                              // flags
            << "halide_type_t((halide_type_code_t)(" << (int)t.code() << "), " << t.bits() << ", " << t.lanes() << "), "
            << buffer.dimensions() << ", "
+           << "0, "  // flags
            << buffer_shape << "};\n";
 
     // Make a global pointer to it.

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -799,9 +799,9 @@ void CodeGen_LLVM::compile_buffer(const Buffer<> &buf) {
         << " because it has a dirty device pointer\n";
 
     Constant *type_fields[] = {
-        ConstantInt::get(i8_t, buf.type().code()),
-        ConstantInt::get(i8_t, buf.type().bits()),
-        ConstantInt::get(i16_t, buf.type().lanes())};
+        ConstantInt::get(i16_t, buf.type().code()),
+        ConstantInt::get(i16_t, buf.type().bits()),
+        ConstantInt::get(i32_t, buf.type().lanes())};
 
     Constant *shape = nullptr;
     if (buf.dimensions()) {
@@ -824,9 +824,9 @@ void CodeGen_LLVM::compile_buffer(const Buffer<> &buf) {
         ConstantInt::get(i64_t, 0),                                     // device
         ConstantPointerNull::get(ptr_t),                                // device_interface
         create_binary_blob(data_blob, buf.name() + ".data", constant),  // host
-        ConstantInt::get(i64_t, halide_buffer_flag_host_dirty),         // flags
         ConstantStruct::get(type_t_type, type_fields),                  // type
         ConstantInt::get(i32_t, buf.dimensions()),                      // dimensions
+        ConstantInt::get(i32_t, halide_buffer_flag_host_dirty),         // flags
         shape,                                                          // dim
         ConstantPointerNull::get(ptr_t),                                // padding
     };
@@ -994,9 +994,9 @@ llvm::Function *CodeGen_LLVM::embed_metadata_getter(const std::string &metadata_
         internal_assert(type_t_type) << "Did not find halide_type_t in module.\n";
 
         Constant *type_fields[] = {
-            ConstantInt::get(i8_t, args[arg].type.code()),
-            ConstantInt::get(i8_t, args[arg].type.bits()),
-            ConstantInt::get(i16_t, 1)};
+            ConstantInt::get(i16_t, args[arg].type.code()),
+            ConstantInt::get(i16_t, args[arg].type.bits()),
+            ConstantInt::get(i32_t, 1)};
         Constant *type = ConstantStruct::get(type_t_type, type_fields);
 
         auto argument_estimates = args[arg].argument_estimates;

--- a/src/IREquality.cpp
+++ b/src/IREquality.cpp
@@ -169,8 +169,8 @@ struct Comparer {
 
     HALIDE_ALWAYS_INLINE
     void cmp(const Type &a, const Type &b) {
-        uint32_t ta = ((halide_type_t)a).as_u32();
-        uint32_t tb = ((halide_type_t)b).as_u32();
+        uint64_t ta = ((halide_type_t)a).as_u64();
+        uint64_t tb = ((halide_type_t)b).as_u64();
         if (ta < tb) {
             result = Order::LessThan;
         } else if (ta > tb) {

--- a/src/OffloadGPULoops.cpp
+++ b/src/OffloadGPULoops.cpp
@@ -194,7 +194,7 @@ class InjectGpuOffload : public IRMutator {
             args.emplace_back(val);
 
             if (runtime_run_takes_types) {
-                arg_types_or_sizes.emplace_back(((halide_type_t)i.type).as_u32());
+                arg_types_or_sizes.emplace_back(((halide_type_t)i.type).as_u64());
             } else {
                 arg_types_or_sizes.emplace_back(cast(target_size_t_type, i.is_buffer ? 8 : i.type.bytes()));
             }

--- a/src/Param.h
+++ b/src/Param.h
@@ -184,14 +184,14 @@ public:
             // it just to reduce code size for the common case of T != void.
 
             #define HALIDE_HANDLE_TYPE_DISPATCH(CODE, BITS, TYPE)                                     \
-                case halide_type_t(CODE, BITS).as_u32():                                              \
+                case halide_type_t(CODE, BITS).as_u64():                                              \
                     user_assert(Internal::IsRoundtrippable<TYPE>::value(val))                         \
                         << "The value " << val << " cannot be losslessly converted to type " << type; \
                     param.set_scalar<TYPE>(Internal::StaticCast<TYPE>::value(val));                   \
                     break;
 
             const Type type = param.type();
-            switch (((halide_type_t)type).element_of().as_u32()) {
+            switch (((halide_type_t)type).element_of().as_u64()) {
                 HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 32, float)
                 HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 64, double)
                 HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 8, int8_t)
@@ -264,14 +264,14 @@ public:
             // it just to reduce code size for the common case of T != void.
 
             #define HALIDE_HANDLE_TYPE_DISPATCH(CODE, BITS, TYPE)                                     \
-                case halide_type_t(CODE, BITS).as_u32():                                              \
+                case halide_type_t(CODE, BITS).as_u64():                                              \
                     user_assert(Internal::IsRoundtrippable<TYPE>::value(val))                         \
                         << "The value " << val << " cannot be losslessly converted to type " << type; \
                     param.set_estimate(Expr(Internal::StaticCast<TYPE>::value(val)));                   \
                     break;
 
             const Type type = param.type();
-            switch (((halide_type_t)type).element_of().as_u32()) {
+            switch (((halide_type_t)type).element_of().as_u64()) {
                 HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 32, float)
                 HALIDE_HANDLE_TYPE_DISPATCH(halide_type_float, 64, double)
                 HALIDE_HANDLE_TYPE_DISPATCH(halide_type_int, 8, int8_t)

--- a/src/Type.h
+++ b/src/Type.h
@@ -310,7 +310,7 @@ public:
      * bits: The bit size of one element.
      * lanes: The number of vector elements in the type. */
     Type(halide_type_code_t code, int bits, int lanes, const halide_handle_cplusplus_type *handle_type = nullptr)
-        : type(code, (uint8_t)bits, (uint16_t)lanes), handle_type(handle_type) {
+        : type(code, (uint16_t)bits, (int32_t)lanes), handle_type(handle_type) {
         user_assert(lanes == type.lanes)
             << "Halide only supports vector types with up to 65535 lanes. " << lanes << " lanes requested.";
         user_assert(bits == type.bits)

--- a/src/UnpackBuffers.cpp
+++ b/src/UnpackBuffers.cpp
@@ -101,7 +101,7 @@ Stmt unpack_buffers(Stmt s) {
         lets.emplace_back(dev_interface_var, dev_interface_val);
 
         string type_code_var = name + ".type";
-        Expr type_code_val = Call::make(UInt(32), Call::buffer_get_type, args, Call::Extern);
+        Expr type_code_val = Call::make(UInt(64), Call::buffer_get_type, args, Call::Extern);
         lets.emplace_back(type_code_var, type_code_val);
 
         string host_dirty_var = name + ".host_dirty";

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -662,7 +662,7 @@ void dump_wasmbuf(WabtContext &wabt_context, wasm32_ptr_t buf_ptr, const std::st
 // memory space and copy all relevant data. The resulting buf is laid out in
 // contiguous memory, and can be free with a single free().
 wasm32_ptr_t hostbuf_to_wasmbuf(WabtContext &wabt_context, const halide_buffer_t *src) {
-    static_assert(sizeof(halide_type_t) == 4, "halide_type_t");
+    static_assert(sizeof(halide_type_t) == 8, "halide_type_t");
     static_assert(sizeof(halide_dimension_t) == 16, "halide_dimension_t");
     static_assert(sizeof(wasm_halide_buffer_t) == 40, "wasm_halide_buffer_t");
 
@@ -1567,7 +1567,7 @@ void dump_wasmbuf(const Local<Context> &context, wasm32_ptr_t buf_ptr, const std
 // memory space and copy all relevant data. The resulting buf is laid out in
 // contiguous memory, and can be free with a single free().
 wasm32_ptr_t hostbuf_to_wasmbuf(const Local<Context> &context, const halide_buffer_t *src) {
-    static_assert(sizeof(halide_type_t) == 4, "halide_type_t");
+    static_assert(sizeof(halide_type_t) == 8, "halide_type_t");
     static_assert(sizeof(halide_dimension_t) == 16, "halide_dimension_t");
     static_assert(sizeof(wasm_halide_buffer_t) == 40, "wasm_halide_buffer_t");
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -406,10 +406,10 @@ template<template<typename> class Functor, typename... Args>
 auto dynamic_type_dispatch(const halide_type_t &type, Args &&... args) -> decltype(std::declval<Functor<uint8_t>>()(std::forward<Args>(args)...)) {
 
 #define HANDLE_CASE(CODE, BITS, TYPE)  \
-    case halide_type_t(CODE, BITS).as_u32(): \
+    case halide_type_t(CODE, BITS).as_u64(): \
         return Functor<TYPE>()(std::forward<Args>(args)...);
 
-    switch (type.element_of().as_u32()) {
+    switch (type.element_of().as_u64()) {
         HANDLE_CASE(halide_type_bfloat, 16, bfloat16_t)
         HANDLE_CASE(halide_type_float, 16, float16_t)
         HANDLE_CASE(halide_type_float, 32, float)

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -522,14 +522,14 @@ struct wasm_halide_buffer_t {
     uint64_t device;
     wasm32_ptr_t device_interface;  // halide_device_interface_t*
     wasm32_ptr_t host;              // uint8_t*
-    uint64_t flags;
     halide_type_t type;
     int32_t dimensions;
+    uint32_t flags;
     wasm32_ptr_t dim;      // halide_dimension_t*
     wasm32_ptr_t padding;  // always zero
 };
 
-static_assert(sizeof(halide_type_t) == 4, "halide_type_t");
+static_assert(sizeof(halide_type_t) == 8, "halide_type_t");
 static_assert(sizeof(halide_dimension_t) == 16, "halide_dimension_t");
 static_assert(sizeof(wasm_halide_buffer_t) == 40, "wasm_halide_buffer_t");
 

--- a/src/runtime/errors.cpp
+++ b/src/runtime/errors.cpp
@@ -28,10 +28,10 @@ WEAK int halide_error_explicit_bounds_too_small(void *user_context, const char *
 }
 
 WEAK int halide_error_bad_type(void *user_context, const char *func_name,
-                               uint32_t type_given_bits, uint32_t correct_type_bits) {
+                               uint64_t type_given_bits, uint64_t correct_type_bits) {
     halide_type_t correct_type, type_given;
-    memcpy(&correct_type, &correct_type_bits, sizeof(uint32_t));
-    memcpy(&type_given, &type_given_bits, sizeof(uint32_t));
+    memcpy(&correct_type, &correct_type_bits, sizeof(uint64_t));
+    memcpy(&type_given, &type_given_bits, sizeof(uint64_t));
     error(user_context)
         << func_name << " has type " << correct_type
         << " but type of the buffer passed in is " << type_given;

--- a/src/runtime/halide_buffer_t.cpp
+++ b/src/runtime/halide_buffer_t.cpp
@@ -87,8 +87,8 @@ bool _halide_buffer_is_bounds_query(const halide_buffer_t *buf) {
 }
 
 HALIDE_BUFFER_HELPER_ATTRS
-uint32_t _halide_buffer_get_type(const halide_buffer_t *buf) {
-    return buf->type.as_u32();
+uint64_t _halide_buffer_get_type(const halide_buffer_t *buf) {
+    return buf->type.as_u64();
 }
 
 HALIDE_BUFFER_HELPER_ATTRS

--- a/src/runtime/metal.cpp
+++ b/src/runtime/metal.cpp
@@ -911,7 +911,7 @@ WEAK int halide_metal_run(void *user_context,
     set_compute_pipeline_state(encoder, pipeline_state);
 
     int num_kernel_args = 0;
-    for (int i = 0; arg_types[i].as_u32() != 0; i++) {
+    for (int i = 0; arg_types[i].as_u64() != 0; i++) {
         ++num_kernel_args;
     }
 

--- a/src/runtime/to_string.cpp
+++ b/src/runtime/to_string.cpp
@@ -289,7 +289,7 @@ WEAK char *halide_type_to_string(char *dst, char *end, const halide_type_t *t) {
     dst = halide_uint64_to_string(dst, end, t->bits, 1);
     if (t->lanes != 1) {
         dst = halide_string_to_string(dst, end, "x");
-        dst = halide_uint64_to_string(dst, end, t->lanes, 1);
+        dst = halide_int64_to_string(dst, end, t->lanes, 1);
     }
     return dst;
 }

--- a/test/correctness/buffer_t.cpp
+++ b/test/correctness/buffer_t.cpp
@@ -18,11 +18,11 @@ int main(int argc, char **argv) {
     CHECK(device, 0, 0);
     CHECK(device_interface, 8, 8);
     CHECK(host, 12, 16);
-    CHECK(flags, 16, 24);
-    CHECK(type, 24, 32);
-    CHECK(dimensions, 28, 36);
+    CHECK(type, 16, 24);
+    CHECK(dimensions, 24, 32);
+    CHECK(flags, 28, 36);
     CHECK(dim, 32, 40);
-    CHECK(padding, 36, 48);
+    CHECK(padding, 40, 48);
 
     static_assert((sizeof(void *) == 8 && sizeof(halide_buffer_t) == 56) ||
                       (sizeof(void *) == 4 && sizeof(halide_buffer_t) == 40),

--- a/test/generator/metadata_tester_aottest.cpp
+++ b/test/generator/metadata_tester_aottest.cpp
@@ -44,30 +44,30 @@ struct typed_scalar {
             std::cerr << "Mismatched types\n";
             exit(1);
         }
-        switch (type.element_of().as_u32()) {
-        case halide_type_t(halide_type_float, 32).as_u32():
+        switch (type.element_of().as_u64()) {
+        case halide_type_t(halide_type_float, 32).as_u64():
             return value.u.f32 == that.value.u.f32;
-        case halide_type_t(halide_type_float, 64).as_u32():
+        case halide_type_t(halide_type_float, 64).as_u64():
             return value.u.f64 == that.value.u.f64;
-        case halide_type_t(halide_type_int, 8).as_u32():
+        case halide_type_t(halide_type_int, 8).as_u64():
             return value.u.i8 == that.value.u.i8;
-        case halide_type_t(halide_type_int, 16).as_u32():
+        case halide_type_t(halide_type_int, 16).as_u64():
             return value.u.i16 == that.value.u.i16;
-        case halide_type_t(halide_type_int, 32).as_u32():
+        case halide_type_t(halide_type_int, 32).as_u64():
             return value.u.i32 == that.value.u.i32;
-        case halide_type_t(halide_type_int, 64).as_u32():
+        case halide_type_t(halide_type_int, 64).as_u64():
             return value.u.i64 == that.value.u.i64;
-        case halide_type_t(halide_type_uint, 1).as_u32():
+        case halide_type_t(halide_type_uint, 1).as_u64():
             return value.u.b == that.value.u.b;
-        case halide_type_t(halide_type_uint, 8).as_u32():
+        case halide_type_t(halide_type_uint, 8).as_u64():
             return value.u.u8 == that.value.u.u8;
-        case halide_type_t(halide_type_uint, 16).as_u32():
+        case halide_type_t(halide_type_uint, 16).as_u64():
             return value.u.u16 == that.value.u.u16;
-        case halide_type_t(halide_type_uint, 32).as_u32():
+        case halide_type_t(halide_type_uint, 32).as_u64():
             return value.u.u32 == that.value.u.u32;
-        case halide_type_t(halide_type_uint, 64).as_u32():
+        case halide_type_t(halide_type_uint, 64).as_u64():
             return value.u.u64 == that.value.u.u64;
-        case halide_type_t(halide_type_handle, 64).as_u32():
+        case halide_type_t(halide_type_handle, 64).as_u64():
             return value.u.handle == that.value.u.handle;
         default:
             std::cerr << "Unsupported type\n";
@@ -81,41 +81,41 @@ struct typed_scalar {
     }
 
     friend std::ostream &operator<<(std::ostream &o, const typed_scalar &s) {
-        switch (s.type.element_of().as_u32()) {
-        case halide_type_t(halide_type_float, 32).as_u32():
+        switch (s.type.element_of().as_u64()) {
+        case halide_type_t(halide_type_float, 32).as_u64():
             o << s.value.u.f32;
             break;
-        case halide_type_t(halide_type_float, 64).as_u32():
+        case halide_type_t(halide_type_float, 64).as_u64():
             o << s.value.u.f64;
             break;
-        case halide_type_t(halide_type_int, 8).as_u32():
+        case halide_type_t(halide_type_int, 8).as_u64():
             o << (int)s.value.u.i8;
             break;
-        case halide_type_t(halide_type_int, 16).as_u32():
+        case halide_type_t(halide_type_int, 16).as_u64():
             o << s.value.u.i16;
             break;
-        case halide_type_t(halide_type_int, 32).as_u32():
+        case halide_type_t(halide_type_int, 32).as_u64():
             o << s.value.u.i32;
             break;
-        case halide_type_t(halide_type_int, 64).as_u32():
+        case halide_type_t(halide_type_int, 64).as_u64():
             o << s.value.u.i64;
             break;
-        case halide_type_t(halide_type_uint, 1).as_u32():
+        case halide_type_t(halide_type_uint, 1).as_u64():
             o << (s.value.u.b ? "true" : "false");
             break;
-        case halide_type_t(halide_type_uint, 8).as_u32():
+        case halide_type_t(halide_type_uint, 8).as_u64():
             o << (int)s.value.u.u8;
             break;
-        case halide_type_t(halide_type_uint, 16).as_u32():
+        case halide_type_t(halide_type_uint, 16).as_u64():
             o << s.value.u.u16;
             break;
-        case halide_type_t(halide_type_uint, 32).as_u32():
+        case halide_type_t(halide_type_uint, 32).as_u64():
             o << s.value.u.u32;
             break;
-        case halide_type_t(halide_type_uint, 64).as_u32():
+        case halide_type_t(halide_type_uint, 64).as_u64():
             o << s.value.u.u64;
             break;
-        case halide_type_t(halide_type_handle, 64).as_u32():
+        case halide_type_t(halide_type_handle, 64).as_u64():
             o << (uint64_t)s.value.u.handle;
             break;
         default:
@@ -1373,10 +1373,10 @@ constexpr char arginfo_to_sigchar(::HalideFunctionInfo::ArgumentInfo arg) {
     } else {
 
         #define HANDLE_CASE(CODE, BITS, CHAR)        \
-            case halide_type_t(CODE, BITS).as_u32(): \
+            case halide_type_t(CODE, BITS).as_u64(): \
                 return (CHAR);
 
-        switch (arg.type.as_u32()) {
+        switch (arg.type.as_u64()) {
             HANDLE_CASE(halide_type_bfloat, 16, '!')
             HANDLE_CASE(halide_type_float, 16, 'e')
             HANDLE_CASE(halide_type_float, 32, 'f')

--- a/tools/RunGen.h
+++ b/tools/RunGen.h
@@ -201,10 +201,10 @@ template<template<typename> class Functor, typename... Args>
 auto dynamic_type_dispatch(const halide_type_t &type, Args &&...args) -> decltype(std::declval<Functor<uint8_t>>()(std::forward<Args>(args)...)) {
 
 #define HANDLE_CASE(CODE, BITS, TYPE)        \
-    case halide_type_t(CODE, BITS).as_u32(): \
+    case halide_type_t(CODE, BITS).as_u64(): \
         return Functor<TYPE>()(std::forward<Args>(args)...);
 
-    switch (type.element_of().as_u32()) {
+    switch (type.element_of().as_u64()) {
         HANDLE_CASE(halide_type_float, 32, float)
         HANDLE_CASE(halide_type_float, 64, double)
         HANDLE_CASE(halide_type_int, 8, int8_t)
@@ -581,28 +581,28 @@ private:
     template<typename T2 = T, typename std::enable_if<!std::is_pointer<T2>::value>::type * = nullptr>
     T as_T(const halide_scalar_value_t &value) {
         constexpr halide_type_t type = halide_type_of<T>();
-        switch (type.element_of().as_u32()) {
-        case halide_type_t(halide_type_int, 8).as_u32():
+        switch (type.element_of().as_u64()) {
+        case halide_type_t(halide_type_int, 8).as_u64():
             return (T)value.u.i8;
-        case halide_type_t(halide_type_int, 16).as_u32():
+        case halide_type_t(halide_type_int, 16).as_u64():
             return (T)value.u.i16;
-        case halide_type_t(halide_type_int, 32).as_u32():
+        case halide_type_t(halide_type_int, 32).as_u64():
             return (T)value.u.i32;
-        case halide_type_t(halide_type_int, 64).as_u32():
+        case halide_type_t(halide_type_int, 64).as_u64():
             return (T)value.u.i64;
-        case halide_type_t(halide_type_uint, 1).as_u32():
+        case halide_type_t(halide_type_uint, 1).as_u64():
             return (T)value.u.b;
-        case halide_type_t(halide_type_uint, 8).as_u32():
+        case halide_type_t(halide_type_uint, 8).as_u64():
             return (T)value.u.u8;
-        case halide_type_t(halide_type_uint, 16).as_u32():
+        case halide_type_t(halide_type_uint, 16).as_u64():
             return (T)value.u.u16;
-        case halide_type_t(halide_type_uint, 32).as_u32():
+        case halide_type_t(halide_type_uint, 32).as_u64():
             return (T)value.u.u32;
-        case halide_type_t(halide_type_uint, 64).as_u32():
+        case halide_type_t(halide_type_uint, 64).as_u64():
             return (T)value.u.u64;
-        case halide_type_t(halide_type_float, 32).as_u32():
+        case halide_type_t(halide_type_float, 32).as_u64():
             return (T)value.u.f32;
-        case halide_type_t(halide_type_float, 64).as_u32():
+        case halide_type_t(halide_type_float, 64).as_u64():
             return (T)value.u.f64;
         default:
             fail() << "Can't convert value with type: " << (int)type.code << "bits: " << type.bits;
@@ -613,8 +613,8 @@ private:
     template<typename T2 = T, typename std::enable_if<std::is_pointer<T2>::value>::type * = nullptr>
     T as_T(const halide_scalar_value_t &value) {
         constexpr halide_type_t type = halide_type_of<T>();
-        switch (type.element_of().as_u32()) {
-        case halide_type_t(halide_type_handle, 64).as_u32():
+        switch (type.element_of().as_u64()) {
+        case halide_type_t(halide_type_handle, 64).as_u64():
             return (T)value.u.handle;
         default:
             fail() << "Can't convert value with type: " << (int)type.code << "bits: " << type.bits;
@@ -653,41 +653,41 @@ inline Halide::Tools::FormatInfo best_save_format(const Buffer<> &b, const std::
 inline std::string scalar_to_string(const halide_type_t &type,
                                     const halide_scalar_value_t &value) {
     std::ostringstream o;
-    switch (type.element_of().as_u32()) {
-    case halide_type_t(halide_type_float, 32).as_u32():
+    switch (type.element_of().as_u64()) {
+    case halide_type_t(halide_type_float, 32).as_u64():
         o << value.u.f32;
         break;
-    case halide_type_t(halide_type_float, 64).as_u32():
+    case halide_type_t(halide_type_float, 64).as_u64():
         o << value.u.f64;
         break;
-    case halide_type_t(halide_type_int, 8).as_u32():
+    case halide_type_t(halide_type_int, 8).as_u64():
         o << (int)value.u.i8;
         break;
-    case halide_type_t(halide_type_int, 16).as_u32():
+    case halide_type_t(halide_type_int, 16).as_u64():
         o << value.u.i16;
         break;
-    case halide_type_t(halide_type_int, 32).as_u32():
+    case halide_type_t(halide_type_int, 32).as_u64():
         o << value.u.i32;
         break;
-    case halide_type_t(halide_type_int, 64).as_u32():
+    case halide_type_t(halide_type_int, 64).as_u64():
         o << value.u.i64;
         break;
-    case halide_type_t(halide_type_uint, 1).as_u32():
+    case halide_type_t(halide_type_uint, 1).as_u64():
         o << (value.u.b ? "true" : "false");
         break;
-    case halide_type_t(halide_type_uint, 8).as_u32():
+    case halide_type_t(halide_type_uint, 8).as_u64():
         o << (int)value.u.u8;
         break;
-    case halide_type_t(halide_type_uint, 16).as_u32():
+    case halide_type_t(halide_type_uint, 16).as_u64():
         o << value.u.u16;
         break;
-    case halide_type_t(halide_type_uint, 32).as_u32():
+    case halide_type_t(halide_type_uint, 32).as_u64():
         o << value.u.u32;
         break;
-    case halide_type_t(halide_type_uint, 64).as_u32():
+    case halide_type_t(halide_type_uint, 64).as_u64():
         o << value.u.u64;
         break;
-    case halide_type_t(halide_type_handle, 64).as_u32():
+    case halide_type_t(halide_type_handle, 64).as_u64():
         o << (uint64_t)value.u.handle;
         break;
     default:

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -2321,7 +2321,7 @@ bool save_tiff(ImageType &im, const std::string &filename) {
 
     // Otherwise, write it out via manual traversal.
 #define HANDLE_CASE(CODE, BITS, TYPE)                             \
-    case halide_type_t(CODE, BITS).as_u32(): {                    \
+    case halide_type_t(CODE, BITS).as_u64(): {                    \
         ElemWriter<TYPE> ew(&f);                                  \
         im.template as<const TYPE, AnyDims>().for_each_value(ew); \
         if (!check(ew.ok, "TIFF write failed")) {                 \
@@ -2330,7 +2330,7 @@ bool save_tiff(ImageType &im, const std::string &filename) {
         break;                                                    \
     }
 
-    switch (im_type.element_of().as_u32()) {
+    switch (im_type.element_of().as_u64()) {
         HANDLE_CASE(halide_type_float, 32, float)
         HANDLE_CASE(halide_type_float, 64, double)
         HANDLE_CASE(halide_type_int, 8, int8_t)
@@ -2495,32 +2495,32 @@ struct ImageTypeConversion {
         constexpr int AnyDims = Internal::AnyDims;
 
         const halide_type_t src_type = src.type();
-        switch (src_type.element_of().as_u32()) {
+        switch (src_type.element_of().as_u64()) {
 #ifdef HALIDE_CPP_COMPILER_HAS_FLOAT16
-        case halide_type_t(halide_type_float, 16).as_u32():
+        case halide_type_t(halide_type_float, 16).as_u64():
             return convert_image<DstElemType>(src.template as<_Float16, AnyDims>());
 #endif
-        case halide_type_t(halide_type_float, 32).as_u32():
+        case halide_type_t(halide_type_float, 32).as_u64():
             return convert_image<DstElemType>(src.template as<float, AnyDims>());
-        case halide_type_t(halide_type_float, 64).as_u32():
+        case halide_type_t(halide_type_float, 64).as_u64():
             return convert_image<DstElemType>(src.template as<double, AnyDims>());
-        case halide_type_t(halide_type_int, 8).as_u32():
+        case halide_type_t(halide_type_int, 8).as_u64():
             return convert_image<DstElemType>(src.template as<int8_t, AnyDims>());
-        case halide_type_t(halide_type_int, 16).as_u32():
+        case halide_type_t(halide_type_int, 16).as_u64():
             return convert_image<DstElemType>(src.template as<int16_t, AnyDims>());
-        case halide_type_t(halide_type_int, 32).as_u32():
+        case halide_type_t(halide_type_int, 32).as_u64():
             return convert_image<DstElemType>(src.template as<int32_t, AnyDims>());
-        case halide_type_t(halide_type_int, 64).as_u32():
+        case halide_type_t(halide_type_int, 64).as_u64():
             return convert_image<DstElemType>(src.template as<int64_t, AnyDims>());
-        case halide_type_t(halide_type_uint, 1).as_u32():
+        case halide_type_t(halide_type_uint, 1).as_u64():
             return convert_image<DstElemType>(src.template as<bool, AnyDims>());
-        case halide_type_t(halide_type_uint, 8).as_u32():
+        case halide_type_t(halide_type_uint, 8).as_u64():
             return convert_image<DstElemType>(src.template as<uint8_t, AnyDims>());
-        case halide_type_t(halide_type_uint, 16).as_u32():
+        case halide_type_t(halide_type_uint, 16).as_u64():
             return convert_image<DstElemType>(src.template as<uint16_t, AnyDims>());
-        case halide_type_t(halide_type_uint, 32).as_u32():
+        case halide_type_t(halide_type_uint, 32).as_u64():
             return convert_image<DstElemType>(src.template as<uint32_t, AnyDims>());
-        case halide_type_t(halide_type_uint, 64).as_u32():
+        case halide_type_t(halide_type_uint, 64).as_u64():
             return convert_image<DstElemType>(src.template as<uint64_t, AnyDims>());
         default:
             assert(false && "Unsupported type");
@@ -2544,32 +2544,32 @@ struct ImageTypeConversion {
 
         // Call the appropriate static-to-static conversion routine
         // based on the desired dst type.
-        switch (dst_type.element_of().as_u32()) {
+        switch (dst_type.element_of().as_u64()) {
 #ifdef HALIDE_CPP_COMPILER_HAS_FLOAT16
-        case halide_type_t(halide_type_float, 16).as_u32():
+        case halide_type_t(halide_type_float, 16).as_u64():
             return convert_image<_Float16>(src);
 #endif
-        case halide_type_t(halide_type_float, 32).as_u32():
+        case halide_type_t(halide_type_float, 32).as_u64():
             return convert_image<float>(src);
-        case halide_type_t(halide_type_float, 64).as_u32():
+        case halide_type_t(halide_type_float, 64).as_u64():
             return convert_image<double>(src);
-        case halide_type_t(halide_type_int, 8).as_u32():
+        case halide_type_t(halide_type_int, 8).as_u64():
             return convert_image<int8_t>(src);
-        case halide_type_t(halide_type_int, 16).as_u32():
+        case halide_type_t(halide_type_int, 16).as_u64():
             return convert_image<int16_t>(src);
-        case halide_type_t(halide_type_int, 32).as_u32():
+        case halide_type_t(halide_type_int, 32).as_u64():
             return convert_image<int32_t>(src);
-        case halide_type_t(halide_type_int, 64).as_u32():
+        case halide_type_t(halide_type_int, 64).as_u64():
             return convert_image<int64_t>(src);
-        case halide_type_t(halide_type_uint, 1).as_u32():
+        case halide_type_t(halide_type_uint, 1).as_u64():
             return convert_image<bool>(src);
-        case halide_type_t(halide_type_uint, 8).as_u32():
+        case halide_type_t(halide_type_uint, 8).as_u64():
             return convert_image<uint8_t>(src);
-        case halide_type_t(halide_type_uint, 16).as_u32():
+        case halide_type_t(halide_type_uint, 16).as_u64():
             return convert_image<uint16_t>(src);
-        case halide_type_t(halide_type_uint, 32).as_u32():
+        case halide_type_t(halide_type_uint, 32).as_u64():
             return convert_image<uint32_t>(src);
-        case halide_type_t(halide_type_uint, 64).as_u32():
+        case halide_type_t(halide_type_uint, 64).as_u64():
             return convert_image<uint64_t>(src);
         default:
             assert(false && "Unsupported type");
@@ -2597,28 +2597,28 @@ struct ImageTypeConversion {
         // this forces instantiation of the complete any-to-any conversion
         // matrix of code.)
         const halide_type_t src_type = src.type();
-        switch (src_type.element_of().as_u32()) {
-        case halide_type_t(halide_type_float, 32).as_u32():
+        switch (src_type.element_of().as_u64()) {
+        case halide_type_t(halide_type_float, 32).as_u64():
             return convert_image(src.template as<float, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_float, 64).as_u32():
+        case halide_type_t(halide_type_float, 64).as_u64():
             return convert_image(src.template as<double, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_int, 8).as_u32():
+        case halide_type_t(halide_type_int, 8).as_u64():
             return convert_image(src.template as<int8_t, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_int, 16).as_u32():
+        case halide_type_t(halide_type_int, 16).as_u64():
             return convert_image(src.template as<int16_t, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_int, 32).as_u32():
+        case halide_type_t(halide_type_int, 32).as_u64():
             return convert_image(src.template as<int32_t, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_int, 64).as_u32():
+        case halide_type_t(halide_type_int, 64).as_u64():
             return convert_image(src.template as<int64_t, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_uint, 1).as_u32():
+        case halide_type_t(halide_type_uint, 1).as_u64():
             return convert_image(src.template as<bool, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_uint, 8).as_u32():
+        case halide_type_t(halide_type_uint, 8).as_u64():
             return convert_image(src.template as<uint8_t, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_uint, 16).as_u32():
+        case halide_type_t(halide_type_uint, 16).as_u64():
             return convert_image(src.template as<uint16_t, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_uint, 32).as_u32():
+        case halide_type_t(halide_type_uint, 32).as_u64():
             return convert_image(src.template as<uint32_t, AnyDims>(), dst_type);
-        case halide_type_t(halide_type_uint, 64).as_u32():
+        case halide_type_t(halide_type_uint, 64).as_u64():
             return convert_image(src.template as<uint64_t, AnyDims>(), dst_type);
         default:
             assert(false && "Unsupported type");

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -107,28 +107,28 @@ struct fail {
 
 template<typename T>
 T value_as(const halide_type_t &type, const halide_scalar_value_t &value) {
-    switch (type.element_of().as_u32()) {
-    case halide_type_t(halide_type_int, 8).as_u32():
+    switch (type.element_of().as_u64()) {
+    case halide_type_t(halide_type_int, 8).as_u64():
         return (T)value.u.i8;
-    case halide_type_t(halide_type_int, 16).as_u32():
+    case halide_type_t(halide_type_int, 16).as_u64():
         return (T)value.u.i16;
-    case halide_type_t(halide_type_int, 32).as_u32():
+    case halide_type_t(halide_type_int, 32).as_u64():
         return (T)value.u.i32;
-    case halide_type_t(halide_type_int, 64).as_u32():
+    case halide_type_t(halide_type_int, 64).as_u64():
         return (T)value.u.i64;
-    case halide_type_t(halide_type_uint, 1).as_u32():
+    case halide_type_t(halide_type_uint, 1).as_u64():
         return (T)value.u.b;
-    case halide_type_t(halide_type_uint, 8).as_u32():
+    case halide_type_t(halide_type_uint, 8).as_u64():
         return (T)value.u.u8;
-    case halide_type_t(halide_type_uint, 16).as_u32():
+    case halide_type_t(halide_type_uint, 16).as_u64():
         return (T)value.u.u16;
-    case halide_type_t(halide_type_uint, 32).as_u32():
+    case halide_type_t(halide_type_uint, 32).as_u64():
         return (T)value.u.u32;
-    case halide_type_t(halide_type_uint, 64).as_u32():
+    case halide_type_t(halide_type_uint, 64).as_u64():
         return (T)value.u.u64;
-    case halide_type_t(halide_type_float, 32).as_u32():
+    case halide_type_t(halide_type_float, 32).as_u64():
         return (T)value.u.f32;
-    case halide_type_t(halide_type_float, 64).as_u32():
+    case halide_type_t(halide_type_float, 64).as_u64():
         return (T)value.u.f64;
     default:
         fail() << "Can't convert packet with type: " << (int)type.code << "bits: " << type.bits;


### PR DESCRIPTION
On current SIMD hardware very large vectors are very rarely used (a 256x256 transpose maybe?), but if we represent operations on matrix multiply accelerators using vector types, they can get large fast. Opening for discussion at the dev meeting.