### PR TITLE
[vulkan] Fix vector shuffle for Vulkan CodeGen

### DIFF
--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -156,8 +156,7 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
         // Construct the mapping for each shuffled element to find
         // the corresponding vector-index to use and which lane-index
         // of the selected vector.
-        std::vector<std::pair<int, int>> vector_lane_indices;
-        vector_lane_indices = op->calculate_vector_and_lane_indices();
+        auto vector_lane_indices = op->vector_and_lane_indices();
 
         // Traverse all the vector args
         std::vector<std::string> vecs;

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -145,12 +145,7 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
         CodeGen_C::visit(op);
     } else {
         // Vector shuffle with arbitrary number of lanes per arg
-
-        // Sanity check the types and number of lanes all match
         internal_assert(!op->vectors.empty());
-        for (size_t i = 1; i < op->vectors.size(); i++) {
-            internal_assert(op->vectors[0].type() == op->vectors[i].type());
-        }
         internal_assert(op->type.lanes() == (int)op->indices.size());
 
         // Construct the mapping for each shuffled element to find

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2014,7 +2014,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
 
     // The Shuffle operator supports any combination of vector width for its
     // arguments, as long as the indices match the number of lanes for the result
-    // type.  This means the arguments can be a mixed combination of vectors with 
+    // type.  This means the arguments can be a mixed combination of vectors with
     // any number of lanes (or a scalar).  We special case interleave and extract,
     // and then use the vector and lane index mapping to determine which values to
     // use from the arguments to do the shufffle.

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2109,8 +2109,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
         // Construct the mapping for each shuffled element to find
         // the corresponding vector-index to use and which lane-index
         // of the selected vector.
-        std::vector<std::pair<int, int>> vector_lane_indices;
-        vector_lane_indices = op->calculate_vector_and_lane_indices();
+        auto vector_lane_indices = op->vector_and_lane_indices();
 
         SpvId type_id = builder.declare_type(op->type);
         SpvId result_id = builder.reserve_id(SpvResultId);

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2130,10 +2130,17 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
     } else {
 
         // Vector shuffle with arbitrary number of lanes per arg
-        //
-        // We need to construct the mapping between shuffled-index,
-        // and source-vector-index and source-element-index-within-the-vector.
-        //
+
+        // Sanity check the types and number of lanes all match
+        internal_assert(!op->vectors.empty());
+        for (size_t i = 1; i < op->vectors.size(); i++) {
+            internal_assert(op->vectors[0].type() == op->vectors[i].type());
+        }
+        internal_assert(op->type.lanes() == (int)op->indices.size());
+
+        // Construct the mapping for each shuffled element to find
+        // the corresponding vector-index to use and which lane-index
+        // of the selected vector.
         std::vector<std::pair<int, int>> vector_lane_indices;
         vector_lane_indices = op->calculate_vector_and_lane_indices();
 

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2003,11 +2003,18 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Evaluate *op) {
 }
 
 void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
-    std::cout << " CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): "
-              << "type=" << op->type << " "
-              << "vectors=" << (uint32_t)op->vectors.size() << " "
-              << "is_interleave=" << (op->is_interleave() ? "true" : "false") << " "
-              << "is_extract_element=" << (op->is_extract_element() ? "true" : "false") << "\n";
+    debug(2) << " CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): "
+             << "type=" << op->type << " "
+             << "vectors=" << (uint32_t)op->vectors.size() << " "
+             << "is_interleave=" << (op->is_interleave() ? "true" : "false") << " "
+             << "is_extract_element=" << (op->is_extract_element() ? "true" : "false") << "\n";
+
+    // Sanity check that the total lane count matches between the op-type and indices
+    internal_assert(!op->vectors.empty());
+    for (size_t i = 1; i < op->vectors.size(); i++) {
+        internal_assert(op->vectors[0].type() == op->vectors[i].type());
+    }
+    internal_assert(op->type.lanes() == (int)op->indices.size());
 
     // Traverse all the arg vectors
     uint32_t arg_idx = 0;
@@ -2018,17 +2025,17 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
         e.accept(this);
         arg_ids.push_back(builder.current_id());
     }
-
+    
     if (op->is_interleave()) {
         int op_lanes = op->type.lanes();
         internal_assert(!arg_ids.empty());
         int arg_lanes = op->vectors[0].type().lanes();
 
-        std::cout << "    vector interleave x" << (uint32_t)op->vectors.size() << " : ";
+        debug(2) << "    vector interleave x" << (uint32_t)op->vectors.size() << " : ";
         for (int idx : op->indices) {
-            std::cout << idx << " ";
+            debug(2) << idx << " ";
         }
-        std::cout << "\n";
+        debug(2) << "\n";
 
         if (arg_ids.size() == 1) {
 
@@ -2110,8 +2117,10 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
                     SpvId type_id = builder.declare_type(op->type);
                     result_id = builder.reserve_id(SpvResultId);
                     builder.append(SpvFactory::composite_extract(type_id, result_id, arg_ids[vec_idx], indices));
+                    builder.update_id(result_id);
                 } else {
-                    result_id = arg_ids[vec_idx];
+                    SpvId result_id = cast_type(op->type, op->vectors[arg_idx].type(), arg_ids[arg_idx]);
+                    builder.update_id(result_id);
                 }
                 break;
             }
@@ -2120,53 +2129,65 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
 
     } else {
 
-        // vector shuffle ... not interleaving
-        int op_lanes = op->type.lanes();
-        int num_vectors = (int)op->vectors.size();
-
-        std::cout << "    vector shuffle x" << num_vectors << " : ";
-        for (int idx : op->indices) {
-            std::cout << idx << " ";
+        // Vector shuffle with arbitrary number of lanes per arg
+        //
+        // We need to construct the mapping between shuffled-index,
+        // and source-vector-index and source-element-index-within-the-vector.
+        //
+        // To start, we'll figure out what the first shuffle-index is per
+        // source-vector. Also let's compute the total number of
+        // source-elements the to be able to assert that all of the
+        // shuffle-indices are within range.
+        //
+        std::vector<int> vector_first_index;
+        int max_index = 0;
+        for (const Expr &v : op->vectors) {
+            vector_first_index.push_back(max_index);
+            max_index += v.type().lanes();
         }
-        std::cout << "\n";
+        for (int i : op->indices) {
+            internal_assert(i >= 0 && i < max_index);
+        }
 
-        if (num_vectors == 1) {
-            // 1 argument, just do a simple assignment via a cast
-            SpvId result_id = cast_type(op->type, op->vectors[0].type(), arg_ids[0]);
-            builder.update_id(result_id);
+        SpvId type_id = builder.declare_type(op->type);
+        SpvId result_id = builder.reserve_id(SpvResultId);
 
-        } else if (num_vectors == 2) {
+        SpvFactory::Components constituents;
+        debug(2) << " CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): Composite(" << op->type << ") => ";
+        for (int i : op->indices) {
+            uint32_t arg_idx = 0;
+            int lane_idx = -1;
 
-            // 2 arguments, use the builtin vector shuffle that takes a pair of vectors
-            SpvFactory::Indices indices;
-            indices.reserve(op->indices.size());
-            indices.insert(indices.end(), op->indices.begin(), op->indices.end());
-            SpvId type_id = builder.declare_type(op->type);
-            SpvId result_id = builder.reserve_id(SpvResultId);
-            builder.append(SpvFactory::vector_shuffle(type_id, result_id, arg_ids[0], arg_ids[1], indices));
-            builder.update_id(result_id);
-        } else {
-            std::vector<SpvFactory::Components> vector_component_ids(num_vectors);
-            for (uint32_t i = 0; i < (uint32_t)arg_ids.size(); ++i) {
-                if (op->vectors[i].type().is_vector()) {
-                    vector_component_ids[i] = split_vector(op->vectors[i].type(), arg_ids[i]);
-                } else {
-                    vector_component_ids[i] = {arg_ids[i]};
+            // Find in which source vector this shuffle-index "i" falls:
+            for (arg_idx = 0; arg_idx < op->vectors.size(); ++arg_idx) {
+                const int first_index = vector_first_index[arg_idx];
+                if (i >= first_index &&
+                    i < first_index + op->vectors[arg_idx].type().lanes()) {
+                    lane_idx = i - first_index;
+                    break;
                 }
             }
+            internal_assert(lane_idx != -1) << "Shuffle lane index not found: i=" << i;
+            internal_assert(arg_idx < op->vectors.size()) << "Shuffle vector index not found: i=" << i << ", lane=" << lane_idx;
 
-            SpvFactory::Components result_component_ids(op_lanes);
-            for (int i = 0; i < op_lanes && i < (int)op->indices.size(); i++) {
-                int idx = op->indices[i];
-                int arg = idx % num_vectors;
-                int arg_idx = idx / num_vectors;
-                internal_assert(arg_idx <= (int)vector_component_ids[arg].size());
-                result_component_ids[i] = vector_component_ids[arg][arg_idx];
+            if (op->vectors[arg_idx].type().lanes() > 1) {
+                SpvFactory::Indices indices = {(uint32_t)lane_idx};
+                SpvId scalar_type_id = builder.declare_type(op->vectors[arg_idx].type().element_of());
+                SpvId scalar_id = builder.reserve_id(SpvResultId);
+                builder.append(SpvFactory::composite_extract(scalar_type_id, scalar_id, arg_ids[arg_idx], indices));
+
+                debug(2) << arg_ids[arg_idx] << "(v" << op->vectors[arg_idx].type().lanes() << "[" << lane_idx << "]) ";
+                constituents.push_back(scalar_id); // insert a component from a vector 
+            } else {
+                debug(2) << arg_ids[arg_idx] << " ";
+                SpvId scalar_id = cast_type(op->type.element_of(), op->vectors[arg_idx].type(), arg_ids[arg_idx]);
+                constituents.push_back(scalar_id); // inserting a scalar
             }
-
-            SpvId result_id = join_vector(op->type, result_component_ids);
-            builder.update_id(result_id);
         }
+
+        debug(2) << "\n";
+        builder.append(SpvFactory::composite_construct(type_id, result_id, constituents));
+        builder.update_id(result_id);
     }
 }
 

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2025,7 +2025,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
         e.accept(this);
         arg_ids.push_back(builder.current_id());
     }
-    
+
     if (op->is_interleave()) {
         int op_lanes = op->type.lanes();
         internal_assert(!arg_ids.empty());
@@ -2177,11 +2177,11 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
                 builder.append(SpvFactory::composite_extract(scalar_type_id, scalar_id, arg_ids[arg_idx], indices));
 
                 debug(2) << arg_ids[arg_idx] << "(v" << op->vectors[arg_idx].type().lanes() << "[" << lane_idx << "]) ";
-                constituents.push_back(scalar_id); // insert a component from a vector 
+                constituents.push_back(scalar_id);  // insert a component from a vector
             } else {
                 debug(2) << arg_ids[arg_idx] << " ";
                 SpvId scalar_id = cast_type(op->type.element_of(), op->vectors[arg_idx].type(), arg_ids[arg_idx]);
-                constituents.push_back(scalar_id); // inserting a scalar
+                constituents.push_back(scalar_id);  // inserting a scalar
             }
         }
 

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2021,7 +2021,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
     SpvFactory::Operands arg_ids;
     arg_ids.reserve(op->vectors.size());
     for (const Expr &e : op->vectors) {
-        debug(2) << " CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): Arg[" << arg_idx++ << "] => " << e << "\n";
+        debug(3) << " CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): Arg[" << arg_idx++ << "] => " << e << "\n";
         e.accept(this);
         arg_ids.push_back(builder.current_id());
     }
@@ -2031,11 +2031,11 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
         internal_assert(!arg_ids.empty());
         int arg_lanes = op->vectors[0].type().lanes();
 
-        debug(2) << "    vector interleave x" << (uint32_t)op->vectors.size() << " : ";
+        debug(3) << "    vector interleave x" << (uint32_t)op->vectors.size() << " : ";
         for (int idx : op->indices) {
-            debug(2) << idx << " ";
+            debug(3) << idx << " ";
         }
-        debug(2) << "\n";
+        debug(3) << "\n";
 
         if (arg_ids.size() == 1) {
 
@@ -2148,7 +2148,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
         SpvId result_id = builder.reserve_id(SpvResultId);
 
         SpvFactory::Components constituents;
-        debug(2) << " CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(Shuffle): Composite(" << op->type << ") => ";
+        debug(3) << " Shuffle Composite(" << op->type << ") => ";
         for (auto element_mapping : vector_lane_indices) {
             int arg_idx = element_mapping.first;
             int lane_idx = element_mapping.second;
@@ -2159,16 +2159,16 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
                 SpvId scalar_id = builder.reserve_id(SpvResultId);
                 builder.append(SpvFactory::composite_extract(scalar_type_id, scalar_id, arg_ids[arg_idx], indices));
 
-                debug(2) << arg_ids[arg_idx] << "(v" << op->vectors[arg_idx].type().lanes() << "[" << lane_idx << "]) ";
+                debug(3) << arg_ids[arg_idx] << "(v" << op->vectors[arg_idx].type().lanes() << "[" << lane_idx << "]) ";
                 constituents.push_back(scalar_id);  // insert a component from a vector
             } else {
-                debug(2) << arg_ids[arg_idx] << " ";
+                debug(3) << arg_ids[arg_idx] << " ";
                 SpvId scalar_id = cast_type(op->type.element_of(), op->vectors[arg_idx].type(), arg_ids[arg_idx]);
                 constituents.push_back(scalar_id);  // inserting a scalar
             }
         }
 
-        debug(2) << "\n";
+        debug(3) << "\n";
         builder.append(SpvFactory::composite_construct(type_id, result_id, constituents));
         builder.update_id(result_id);
     }

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2012,7 +2012,14 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
     internal_assert(!op->vectors.empty());
     internal_assert(op->type.lanes() == (int)op->indices.size());
 
-    // Traverse all the arg vectors
+    // The Shuffle operator supports any combination of vector width for its
+    // arguments, as long as the indices match the number of lanes for the result
+    // type.  This means the arguments can be a mixed combination of vectors with 
+    // any number of lanes (or a scalar).  We special case interleave and extract,
+    // and then use the vector and lane index mapping to determine which values to
+    // use from the arguments to do the shufffle.
+
+    // First, traverse all the arg vectors
     uint32_t arg_idx = 0;
     SpvFactory::Operands arg_ids;
     arg_ids.reserve(op->vectors.size());

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -2009,11 +2009,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const Shuffle *op) {
              << "is_interleave=" << (op->is_interleave() ? "true" : "false") << " "
              << "is_extract_element=" << (op->is_extract_element() ? "true" : "false") << "\n";
 
-    // Sanity check that the total lane count matches between the op-type and indices
     internal_assert(!op->vectors.empty());
-    for (size_t i = 1; i < op->vectors.size(); i++) {
-        internal_assert(op->vectors[0].type() == op->vectors[i].type());
-    }
     internal_assert(op->type.lanes() == (int)op->indices.size());
 
     // Traverse all the arg vectors

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -922,14 +922,14 @@ std::vector<std::pair<int, int>> Shuffle::vector_and_lane_indices() const {
     std::vector<std::pair<int, int>> all_indices;
     all_indices.reserve(indices.size());
     for (int i = 0; i < (int)vectors.size(); i++) {
-      for (int j = 0; j < vectors[i].type().lanes(); j++) {
-        all_indices.emplace_back(i, j);
-      }
+        for (int j = 0; j < vectors[i].type().lanes(); j++) {
+            all_indices.emplace_back(i, j);
+        }
     }
     std::vector<std::pair<int, int>> result;
     result.reserve(indices.size());
     for (int i : indices) {
-      result.push_back(all_indices[i]);
+        result.push_back(all_indices[i]);
     }
     return result;
 }

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -917,15 +917,15 @@ bool Shuffle::is_interleave() const {
 
 std::vector<std::pair<int, int>> Shuffle::calculate_vector_and_lane_indices() const {
 
-    // Construct the mapping between shuffled-index, and source-vector-index 
+    // Construct the mapping between shuffled-index, and source-vector-index
     // and source-element-index-within-the-vector.
     std::vector<std::pair<int, int>> vector_lane_indices;
-    if(vectors.empty() || indices.empty()) {
+    if (vectors.empty() || indices.empty()) {
         return vector_lane_indices;
     }
 
     // To start, we'll figure out what the first shuffle-index is per
-    // source-vector. Also let's compute the total number of source-elements 
+    // source-vector. Also let's compute the total number of source-elements
     // and assert that all of the shuffle-indices are within range.
     int max_index = 0;
     std::vector<int> vector_first_index;
@@ -955,8 +955,8 @@ std::vector<std::pair<int, int>> Shuffle::calculate_vector_and_lane_indices() co
                 break;
             }
             ++vector_idx;
-        }    
-    
+        }
+
         // Sanity check the vector and lane indices are valid
         internal_assert(vector_idx < (int)vectors.size()) << "Shuffle vector index not found: i=" << i << ", lane=" << lane_idx;
         internal_assert(lane_idx != -1) << "Shuffle lane index not found: i=" << i;
@@ -967,7 +967,6 @@ std::vector<std::pair<int, int>> Shuffle::calculate_vector_and_lane_indices() co
 
     return vector_lane_indices;
 }
-
 
 Stmt Atomic::make(const std::string &producer_name,
                   const std::string &mutex_name,

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -915,57 +915,23 @@ bool Shuffle::is_interleave() const {
     return true;
 }
 
-std::vector<std::pair<int, int>> Shuffle::calculate_vector_and_lane_indices() const {
+std::vector<std::pair<int, int>> Shuffle::vector_and_lane_indices() const {
 
-    // Construct the mapping between shuffled-index, and source-vector-index
-    // and source-element-index-within-the-vector.
-    std::vector<std::pair<int, int>> vector_lane_indices;
-    if (vectors.empty() || indices.empty()) {
-        return vector_lane_indices;
-    }
-
-    // To start, we'll figure out what the first shuffle-index is per
-    // source-vector. Also let's compute the total number of source-elements
-    // and assert that all of the shuffle-indices are within range.
-    int max_index = 0;
-    std::vector<int> vector_first_index;
-    vector_first_index.reserve(vectors.size());
-
-    for (const Expr &v : vectors) {
-        vector_first_index.push_back(max_index);
-        max_index += v.type().lanes();
-    }
-    for (int i : indices) {
-        internal_assert(i >= 0 && i < max_index);
-    }
-
-    // Now construct the mapping for each shuffled element and find the index
+    // Construct the mapping for each shuffled element and find the index
     // of which vector to use and the index for which of its lanes to use
-    vector_lane_indices.reserve(indices.size());
-    for (int i : indices) {
-        int vector_idx = 0;
-        int lane_idx = -1;
-
-        // Find in which source vector this shuffle-index "i" falls:
-        while (vector_idx < (int)vectors.size()) {
-            const int first_index = vector_first_index[vector_idx];
-            if (i >= first_index &&
-                i < first_index + vectors[vector_idx].type().lanes()) {
-                lane_idx = i - first_index;
-                break;
-            }
-            ++vector_idx;
-        }
-
-        // Sanity check the vector and lane indices are valid
-        internal_assert(vector_idx < (int)vectors.size()) << "Shuffle vector index not found: i=" << i << ", lane=" << lane_idx;
-        internal_assert(lane_idx != -1) << "Shuffle lane index not found: i=" << i;
-
-        // Save the vector and lane index to use for this shuffle element
-        vector_lane_indices.emplace_back(vector_idx, lane_idx);
+    std::vector<std::pair<int, int>> all_indices;
+    all_indices.reserve(indices.size());
+    for (int i = 0; i < (int)vectors.size(); i++) {
+      for (int j = 0; j < vectors[i].type().lanes(); j++) {
+        all_indices.emplace_back(i, j);
+      }
     }
-
-    return vector_lane_indices;
+    std::vector<std::pair<int, int>> result;
+    result.reserve(indices.size());
+    for (int i : indices) {
+      result.push_back(all_indices[i]);
+    }
+    return result;
 }
 
 Stmt Atomic::make(const std::string &producer_name,

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -962,7 +962,7 @@ std::vector<std::pair<int, int>> Shuffle::calculate_vector_and_lane_indices() co
         internal_assert(lane_idx != -1) << "Shuffle lane index not found: i=" << i;
 
         // Save the vector and lane index to use for this shuffle element
-        vector_lane_indices.push_back({vector_idx, lane_idx});
+        vector_lane_indices.emplace_back(vector_idx, lane_idx);
     }
 
     return vector_lane_indices;

--- a/src/IR.h
+++ b/src/IR.h
@@ -917,7 +917,7 @@ struct Shuffle : public ExprNode<Shuffle> {
 
     /** Returns the sequence of vector and lane indices that represent each
      * entry to be used for the shuffled vector */
-    std::vector<std::pair<int, int>> calculate_vector_and_lane_indices() const;
+    std::vector<std::pair<int, int>> vector_and_lane_indices() const;
 
     static const IRNodeType _node_type = IRNodeType::Shuffle;
 };

--- a/src/IR.h
+++ b/src/IR.h
@@ -915,6 +915,10 @@ struct Shuffle : public ExprNode<Shuffle> {
      * arguments. */
     bool is_extract_element() const;
 
+    /** Returns the sequence of vector and lane indices that represent each
+     * entry to be used for the shuffled vector */
+    std::vector<std::pair<int, int>> calculate_vector_and_lane_indices() const;
+
     static const IRNodeType _node_type = IRNodeType::Shuffle;
 };
 

--- a/test/correctness/vector_shuffle.cpp
+++ b/test/correctness/vector_shuffle.cpp
@@ -5,13 +5,8 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.has_feature(Target::Feature::Vulkan)) {
-        std::printf("[SKIP] Vulkan seems to be not working.\n");
-        return 0;
-    }
 
     Var x{"x"}, y{"y"};
-
     Func f0{"f0"}, f1{"f1"}, g{"g"};
     f0(x, y) = x * (y + 1);
     f1(x, y) = x * (y + 3);


### PR DESCRIPTION
CodeGen wasn't handling arbitrary mixing of vectors with different lanes to form a shuffle, causing a cast instruction to be generated with mixed types which generated invalid SPIR-V and caused the driver compiler to fail to compile.

Now, we handle the extraction of each selected lane of each vector argument, and construct a new Vector from the combined composite.

Fixes https://github.com/halide/Halide/issues/8580