### PR TITLE
Add (iOS) simulator target feature.

### DIFF
--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -204,6 +204,7 @@ void define_enums(py::module &m) {
         .value("Semihosting", Target::Feature::Semihosting)
         .value("AVX10_1", Target::Feature::AVX10_1)
         .value("X86APX", Target::Feature::X86APX)
+        .value("Simulator", Target::Feature::Simulator)
         .value("FeatureEnd", Target::Feature::FeatureEnd);
 
     py::enum_<halide_type_code_t>(m, "TypeCode")

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -574,6 +574,11 @@ llvm::Triple get_triple_for_target(const Target &target) {
         // Return default-constructed triple. Must be set later.
     }
 
+    if (target.has_feature(Target::Simulator)) {
+        user_assert(target.os == Target::IOS) << "Simulator only supported for iOS\n";
+        triple.setEnvironment(llvm::Triple::Simulator);
+    }
+
     // Setting a minimum OS version here enables LLVM to include platform
     // metadata in the MachO object file. Without this, Xcode 15's ld
     // issues warnings about missing the "platform load command".

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -715,6 +715,7 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"semihosting", Target::Semihosting},
     {"avx10_1", Target::AVX10_1},
     {"x86apx", Target::X86APX},
+    {"simulator", Target::Simulator},
     // NOTE: When adding features to this map, be sure to update PyEnums.cpp as well.
 };
 
@@ -1512,7 +1513,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // (c) must match across both targets; it is an error if one target has the feature and the other doesn't
 
     // clang-format off
-    const std::array<Feature, 33> union_features = {{
+     constexpr std::array<Feature, 33> union_features = {{
         // These are true union features.
         CUDA,
         D3D12Compute,
@@ -1557,7 +1558,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // clang-format on
 
     // clang-format off
-    const std::array<Feature, 14> intersection_features = {{
+     constexpr std::array<Feature, 14> intersection_features = {{
         ARMv7s,
         AVX,
         AVX2,
@@ -1576,7 +1577,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // clang-format on
 
     // clang-format off
-    const std::array<Feature, 9> matching_features = {{
+     constexpr std::array<Feature, 10> matching_features = {{
         ASAN,
         Debug,
         HexagonDma,
@@ -1586,6 +1587,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
         TSAN,
         WasmThreads,
         SanitizerCoverage,
+        Simulator,
     }};
     // clang-format on
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -179,6 +179,7 @@ struct Target {
         Semihosting = halide_target_feature_semihosting,
         AVX10_1 = halide_target_feature_avx10_1,
         X86APX = halide_target_feature_x86_apx,
+        Simulator = halide_target_feature_simulator,
         FeatureEnd = halide_target_feature_end
     };
     Target() = default;

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1463,6 +1463,7 @@ typedef enum halide_target_feature_t {
     halide_target_feature_semihosting,            ///< Used together with Target::NoOS for the baremetal target built with semihosting library and run with semihosting mode where minimum I/O communication with a host PC is available.
     halide_target_feature_avx10_1,                ///< Intel AVX10 version 1 support. vector_bits is used to indicate width.
     halide_target_feature_x86_apx,                ///< Intel x86 APX support. Covers initial set of features released as APX: egpr,push2pop2,ppx,ndd .
+    halide_target_feature_simulator,              ///< Target is for a simulator environment. Currently only applies to iOS.
     halide_target_feature_end                     ///< A sentinel. Every target is considered to have this feature, and setting this feature does nothing.
 } halide_target_feature_t;
 


### PR DESCRIPTION
First attempt at adding simulator information to the LLVM triple via a target feature.

@vksnk - can you help me test this? AFAICT reading the LLVM sources, just setting the environment on the triple should be enough.