### PR TITLE
Fix build on GCC 15 (Comes with Fedora 42).

### DIFF
--- a/src/LLVM_Runtime_Linker.h
+++ b/src/LLVM_Runtime_Linker.h
@@ -5,6 +5,7 @@
  * Support for linking LLVM modules that comprise the runtime.
  */
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/StmtToHTML.cpp
+++ b/src/StmtToHTML.cpp
@@ -28,12 +28,12 @@
 #include <filesystem>
 #endif
 
-namespace Halide {
-namespace Internal {
-
 extern "C" unsigned char halide_html_template_StmtToHTML_dependencies_html[];
 extern "C" unsigned char halide_html_template_StmtToHTML_css[];
 extern "C" unsigned char halide_html_template_StmtToHTML_js[];
+
+namespace Halide {
+namespace Internal {
 
 // Classes defined within this file
 class CostModel;


### PR DESCRIPTION
I don't know if the namespace issue is a GCC bug, or actually correct language behavior, but the declarations that look like this:

```cpp
namespace Halide {

namespace { // < anonymous!!
extern "C" int something;
}

namespace Internal { // < named
extern "C" int other;
}

}
```
Yield these symbols:
```
0000000000000000         *UND*	0000000000000000        Halide::(anonymous namespace)::something
0000000001025ae0 g     O .data	0000000000000ca5        other
```
So this behavior is different for GCC when dealing with anonymous namespaces and when dealing with named namespaces. The named namespaces lift `extern "C"` declarations out to global scope, whereas the anonymous have them still in the namespace.

To be honest, I'm clueless if this `extern "C"` _inside_ a namespace makes any sense at all. Doesn't sound very C.