### PR TITLE
Fix top LLVM: renamed NVPTX barrier intrinsics.

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -267,13 +267,13 @@ void CodeGen_PTX_Dev::visit(const Call *op) {
             internal_assert(barrier0) << "Could not find PTX barrier intrinsic (llvm.nvvm.barrier0)\n";
 
             builder->CreateCall(barrier0);
-            value = ConstantInt::get(i32_t, 0);
         } else {
             // Changed in LLVM 20.
             barrier0 = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all");
             internal_assert(barrier0) << "Could not find PTX barrier intrinsic (llvm.nvvm.barrier.cta.sync.aligned.all)\n";
             builder->CreateCall(barrier0, builder->getInt32(0));
         }
+        value = ConstantInt::get(i32_t, 0);
         return;
     }
 

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -262,15 +262,13 @@ void CodeGen_PTX_Dev::visit(const Call *op) {
         auto fence_type_ptr = as_const_int(op->args[0]);
         internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
 
-        llvm::Function *barrier0 = module->getFunction("llvm.nvvm.barrier0");
-        if (barrier0) {
-            internal_assert(barrier0) << "Could not find PTX barrier intrinsic (llvm.nvvm.barrier0)\n";
-
+        llvm::Function *barrier = module->getFunction("llvm.nvvm.barrier0");
+        if (barrier) {
             builder->CreateCall(barrier0);
         } else {
-            // Changed in LLVM 20.
-            barrier0 = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all");
-            internal_assert(barrier0) << "Could not find PTX barrier intrinsic (llvm.nvvm.barrier.cta.sync.aligned.all)\n";
+            // Changed in LLVM 20: https://github.com/llvm/llvm-project/pull/140615
+            barrier = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all");
+            internal_assert(barrier) << "Could not find PTX barrier intrinsic llvm.nvvm.barrier0 nor llvm.nvvm.barrier.cta.sync.aligned.all\n";
             builder->CreateCall(barrier0, builder->getInt32(0));
         }
         value = ConstantInt::get(i32_t, 0);

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -263,11 +263,11 @@ void CodeGen_PTX_Dev::visit(const Call *op) {
         internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
 
         llvm::Function *barrier;
-        if ((barrier = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all"))) {
-            // LLVM 20 and above: https://github.com/llvm/llvm-project/pull/140615
+        if ((barrier = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all")) && barrier->getIntrinsicID() != 0) {
+            // LLVM 20.1.6 and above: https://github.com/llvm/llvm-project/pull/140615
             builder->CreateCall(barrier, builder->getInt32(0));
-        } else if ((barrier = module->getFunction("llvm.nvvm.barrier0"))) {
-            // LLVM 19: Testing for llvm.nvvm.barrier0 can be removed once we drop support for LLVM 19
+        } else if ((barrier = module->getFunction("llvm.nvvm.barrier0")) && barrier->getIntrinsicID() != 0) {
+            // LLVM 21.1.5 and below: Testing for llvm.nvvm.barrier0 can be removed once we drop support for LLVM 20
             builder->CreateCall(barrier);
         } else {
             internal_error << "Could not find PTX barrier intrinsic llvm.nvvm.barrier0 nor llvm.nvvm.barrier.cta.sync.aligned.all\n";

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -263,10 +263,10 @@ void CodeGen_PTX_Dev::visit(const Call *op) {
         internal_assert(fence_type_ptr) << "gpu_thread_barrier() parameter is not a constant integer.\n";
 
         llvm::Function *barrier;
-        if (barrier = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all")) {
+        if ((barrier = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all"))) {
             // LLVM 20 and above: https://github.com/llvm/llvm-project/pull/140615
             builder->CreateCall(barrier, builder->getInt32(0));
-        } else if (barrier = module->getFunction("llvm.nvvm.barrier0")) {
+        } else if ((barrier = module->getFunction("llvm.nvvm.barrier0"))) {
             // LLVM 19: Testing for llvm.nvvm.barrier0 can be removed once we drop support for LLVM 19
             builder->CreateCall(barrier);
         } else {

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -265,10 +265,10 @@ void CodeGen_PTX_Dev::visit(const Call *op) {
         llvm::Function *barrier;
         if (barrier = module->getFunction("llvm.nvvm.barrier.cta.sync.aligned.all")) {
             // LLVM 20 and above: https://github.com/llvm/llvm-project/pull/140615
-            builder->CreateCall(barrier0, builder->getInt32(0));
+            builder->CreateCall(barrier, builder->getInt32(0));
         } else if (barrier = module->getFunction("llvm.nvvm.barrier0")) {
             // LLVM 19: Testing for llvm.nvvm.barrier0 can be removed once we drop support for LLVM 19
-            builder->CreateCall(barrier0);
+            builder->CreateCall(barrier);
         } else {
             internal_error << "Could not find PTX barrier intrinsic llvm.nvvm.barrier0 nor llvm.nvvm.barrier.cta.sync.aligned.all\n";
         }

--- a/src/runtime/ptx_dev.ll
+++ b/src/runtime/ptx_dev.ll
@@ -1,4 +1,5 @@
 declare void @llvm.nvvm.barrier0()
+declare void @llvm.nvvm.barrier.cta.sync.aligned.all(i32)
 declare  i32 @llvm.nvvm.read.ptx.sreg.tid.x()
 declare  i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
 declare  i32 @llvm.nvvm.read.ptx.sreg.ntid.x()

--- a/src/runtime/ptx_dev.ll
+++ b/src/runtime/ptx_dev.ll
@@ -1,5 +1,11 @@
-declare void @llvm.nvvm.barrier0()
-declare void @llvm.nvvm.barrier.cta.sync.aligned.all(i32)
+; The two forward declared intrinsics below refer to the same thing.
+; LLVM 20.1.6 introduced a new naming scheme for these intrinsics
+; We have to declare both, such that we can access them from the Module's
+; getFunction(), but one of those will map to an intrinsic, which we
+; will use to determine which intrinsic is supported by LLVM.
+declare void @llvm.nvvm.barrier0() ; LLVM <=20.1.5
+declare void @llvm.nvvm.barrier.cta.sync.aligned.all(i32) ; LLVM >=20.1.6
+
 declare  i32 @llvm.nvvm.read.ptx.sreg.tid.x()
 declare  i32 @llvm.nvvm.read.ptx.sreg.ctaid.x()
 declare  i32 @llvm.nvvm.read.ptx.sreg.ntid.x()


### PR DESCRIPTION
**Problem**: LLVM changed the name of their NPTX barrier intrinsics: https://github.com/llvm/llvm-project/pull/141143/.

**Solution**: Rely on the accompanying auto-upgrade mechanism of LLVM for these intrinsics. As such, I added an `alwaysinline` wrapper that calls the original intrinsic name, which LLVM will upgrade to the new one, if it wants to. This way, it's compatible with all versions of LLVM without relying on any runtime or compiletime checks in the Halide code.
