### PR TITLE
Constrain Clang and LLD searches to LLVM version

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -157,7 +157,8 @@
         "rhs": "Darwin"
       },
       "cacheVariables": {
-        "CMAKE_PREFIX_PATH": "/opt/homebrew;/opt/homebrew/opt/llvm;/opt/homebrew/opt/jpeg"
+        "Halide_LLVM_ROOT": "/opt/homebrew/opt/llvm",
+        "CMAKE_PREFIX_PATH": "/opt/homebrew;/opt/homebrew/opt/jpeg"
       }
     },
     {
@@ -169,7 +170,7 @@
       "displayName": "macOS (vcpkg)",
       "description": "macOS build with vcpkg dependencies",
       "cacheVariables": {
-        "CMAKE_PREFIX_PATH": "/opt/homebrew/opt/llvm"
+        "CMAKE_PREFIX_PATH": ""
       }
     },
     {

--- a/cmake/FindHalide_LLVM.cmake
+++ b/cmake/FindHalide_LLVM.cmake
@@ -96,7 +96,6 @@ find_package_handle_standard_args(
     REASON_FAILURE_MESSAGE "${REASON_FAILURE_MESSAGE}"
     HANDLE_COMPONENTS
     HANDLE_VERSION_RANGE
-    NAME_MISMATCHED
 )
 
 function(_Halide_LLVM_link target visibility)

--- a/cmake/FindHalide_LLVM.cmake
+++ b/cmake/FindHalide_LLVM.cmake
@@ -9,9 +9,9 @@ set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL MinSizeRel Release RelWithDebInfo "")
 set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO RelWithDebInfo Release MinSizeRel "")
 set(CMAKE_MAP_IMPORTED_CONFIG_RELEASE Release MinSizeRel RelWithDebInfo "")
 
-find_package(LLVM ${PACKAGE_FIND_VERSION} CONFIG)
+find_package(LLVM CONFIG)
 
-set(Halide_LLVM_VERSION "${LLVM_PACKAGE_VERSION}")
+set(Halide_LLVM_VERSION "${LLVM_VERSION}")
 
 if (NOT DEFINED Halide_LLVM_SHARED_LIBS)
     # Normally, we don't like making decisions for our users. However,
@@ -28,18 +28,14 @@ endif ()
 option(Halide_LLVM_SHARED_LIBS "Enable to link to shared libLLVM" "${Halide_LLVM_SHARED_LIBS}")
 
 if (LLVM_FOUND)
-    # LLVM sadly doesn't provide *ConfigVersion.cmake files for its
-    # sub-components, including Clang and LLD. Consequently, attempting to
-    # constrain the version to LLVM_PACKAGE_VERSION prevents these find_package
-    # calls from succeeding at all. Worse, package maintainers have some
-    # "interesting" ideas as to how they should lay out the -dev packages,
-    # especially when they want to support multiple parallel versions. These
-    # hints take effect at a lower precedence than Halide_LLVM_ROOT
-    # or CMAKE_PREFIX_PATH (which are the standard ways of setting up the
-    # dependency search), but at a higher precedence than the system-wide
-    # fallback locations.
+    # Package maintainers have some "interesting" ideas as to how they should
+    # lay out the -dev packages, especially when they want to support multiple
+    # parallel versions. These hints take effect at a lower precedence than
+    # Halide_LLVM_ROOT or CMAKE_PREFIX_PATH (which are the standard ways of
+    # setting up the dependency search), but at a higher precedence than the
+    # system-wide fallback locations.
     find_package(
-        Clang
+        Clang "${Halide_LLVM_VERSION}" EXACT
         HINTS
         "${LLVM_INSTALL_PREFIX}" # Same root as the LLVM we found
         "${LLVM_DIR}/../clang" # LLVM found in $ROOT/lib/cmake/llvm
@@ -51,7 +47,8 @@ if (LLVM_FOUND)
             set(Halide_LLVM_${comp}_FOUND 0)
 
             find_package(
-                LLD HINTS
+                LLD "${Halide_LLVM_VERSION}" EXACT
+                HINTS
                 "${LLVM_INSTALL_PREFIX}"
                 # Homebrew split the LLVM and LLD packages as of version 19, so
                 # having multiple LLVM versions installed leads to the newest

--- a/cmake/FindHalide_LLVM.cmake
+++ b/cmake/FindHalide_LLVM.cmake
@@ -11,7 +11,10 @@ set(CMAKE_MAP_IMPORTED_CONFIG_RELEASE Release MinSizeRel RelWithDebInfo "")
 
 find_package(LLVM CONFIG)
 
-set(Halide_LLVM_VERSION "${LLVM_PACKAGE_VERSION}")
+# Neither LLVM_VERSION nor LLVM_PACKAGE_VERSION work as find_package arguments
+# in git/development builds as they include a "git" suffix. This applies at
+# time of writing to versions 18-21, inclusive.
+set(Halide_LLVM_VERSION "${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}")
 
 if (NOT DEFINED Halide_LLVM_SHARED_LIBS)
     # Normally, we don't like making decisions for our users. However,

--- a/cmake/FindHalide_LLVM.cmake
+++ b/cmake/FindHalide_LLVM.cmake
@@ -11,7 +11,7 @@ set(CMAKE_MAP_IMPORTED_CONFIG_RELEASE Release MinSizeRel RelWithDebInfo "")
 
 find_package(LLVM CONFIG)
 
-set(Halide_LLVM_VERSION "${LLVM_VERSION}")
+set(Halide_LLVM_VERSION "${LLVM_PACKAGE_VERSION}")
 
 if (NOT DEFINED Halide_LLVM_SHARED_LIBS)
     # Normally, we don't like making decisions for our users. However,


### PR DESCRIPTION
As of LLVM 17 or so, the `*ConfigVersion.cmake` files have been correctly shipped with Clang and LLD, not just LLVM. The `FindHalide_LLVM.cmake` module now searches for the exact matching versions of Clang and LLD. Unfortunately, neither the `LLVM_PACKAGE_VERSION` variable (which is documented as being safe to use with CMake version comparisons) nor the `LLVM_VERSION` variable (which is undocumented, but used internally) are suitable for use with CMake version comparisons. LLVM's CMake build continues to be a fractal of insanity. Instead, we reconstruct a valid version string from the major/minor/patch versions. Whee...

Fixes #8633