### PR TITLE
Mullapudi2016-GPU: Reorder to avoid for-loops to be sandwiched between `gpu_blocks`.

### DIFF
--- a/test/autoschedulers/mullapudi2016/reorder.cpp
+++ b/test/autoschedulers/mullapudi2016/reorder.cpp
@@ -210,10 +210,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (get_jit_target_from_environment().has_gpu_feature()) {
-        std::cout << "Mullapudi for GPU test for Test Case 3 skipped because of reordering bug.\n";
-    } else {
-
+    {
         double manual_time = run_test_3(false);
         double auto_time = run_test_3(true);
 


### PR DESCRIPTION
After committing `gpu_tiles`, reorder all axes such that the for-loops are inside all `gpu_blocks`.

Also limit the `gpu_blocks` count to no more than 3.

Refer to: #8640 for the list of pending actions to robustify the Mullapudi2016's experimental GPU schedules.