### PR TITLE
PoC feature: drop functions from the runtime

### DIFF
--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -698,6 +698,9 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
 
     // Implement a quick-and-dirty trick to drop runtime functions for the runtime
     // in case you want to replace them with your own version.
+    // WARNING: Do expect this environment variable to disappear in the future.
+    // Consider this an undocumented and unstable feature. @zvookin has better
+    // ideas for a more sustainable solution involving renaming those functions.
     if (const char *drop_str = getenv("HL_RUNTIME_DROP_FUNCS")) {
         int start = 0;
         int len = strlen(drop_str);
@@ -708,6 +711,7 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
             }
             std::string_view func_name(drop_str + start, stop - start);
             llvm::Function *func = modules[0]->getFunction(func_name);
+            user_assert(func) << "[HL_RUNTIME_DROP_FUNCS] No runtime function found by the name: " << func_name;
             func->deleteBody();
             func->setLinkage(llvm::GlobalValue::ExternalLinkage);
 


### PR DESCRIPTION
**Proof of Concept**: I know that the long-term solution is more elaborate (i.e. runtime function renaming), but this 50 cent hack does the trick for me without any manual steps in my build process.

The `HL_RUNTIME_DROP_FUNCS` environment variable is checked for a comma-separated list of function names to remove from the runtime. Instead of actually deleting them, their body is removed, and their linkage is changed to extern.

@zvookin @abadams Do we want this feature? If so, do we need any changes?

This fixed my issue against which I was battling for 2 days with the Windows linker. Tested this on both Linux and Windows with success.