### PR TITLE
Highlight Metal GPU code in stmt_html

### DIFF
--- a/src/irvisualizer/html_template_StmtToHTML_dependencies.html
+++ b/src/irvisualizer/html_template_StmtToHTML_dependencies.html
@@ -63,23 +63,23 @@
   loadLanguage("asm", asmRules)
   highlightElement(document.getElementById("assemblyContent"), "asm", undefined, {hideLineNumbers: true});
 
-function highlightMetalDeviceCode() {
+  function highlightMetalDeviceCode() {
     const first_five_lines =
-        document.querySelectorAll("#device-code-pane span:nth-child(-n + 5)");
+      document.querySelectorAll("#device-code-pane span:nth-child(-n + 5)");
     const has_metal_code =
-        Array.from(first_five_lines).some((item) => {
-            return item.textContent.search(/using namespace metal/) !== -1;
-        });
+      Array.from(first_five_lines).some((item) => {
+        return item.textContent.search(/using namespace metal/) !== -1;
+      });
 
     const has_opencl_code =
-        Array.from(first_five_lines).some((item) => {
-            return item.textContent.search(/#pragma OPENCL/) !== -1;
-        });
+      Array.from(first_five_lines).some((item) => {
+        return item.textContent.search(/#pragma OPENCL/) !== -1;
+      });
 
     if (has_metal_code || has_opencl_code) {
-        highlightElement(document.getElementById("device-code-pane"),
-                         "c", undefined, {hideLineNumbers : true});
+      highlightElement(document.getElementById("device-code-pane"),
+                       "c", undefined, {hideLineNumbers : true});
     }
-}
-highlightMetalDeviceCode();
+  }
+  highlightMetalDeviceCode();
 </script>

--- a/src/irvisualizer/html_template_StmtToHTML_dependencies.html
+++ b/src/irvisualizer/html_template_StmtToHTML_dependencies.html
@@ -67,12 +67,18 @@ function highlightMetalDeviceCode() {
     const first_five_lines =
         document.querySelectorAll("#device-code-pane span:nth-child(-n + 5)");
     const has_metal_code =
-        Array.from(first_five_lines).some(
-            (item) => {
-                return item.textContent.search(/using namespace metal/) !== -1;
-            });
-    if (has_metal_code) {
-        highlightElement(document.getElementById("device-code-pane"), "c", undefined, {hideLineNumbers: true});
+        Array.from(first_five_lines).some((item) => {
+            return item.textContent.search(/using namespace metal/) !== -1;
+        });
+
+    const has_opencl_code =
+        Array.from(first_five_lines).some((item) => {
+            return item.textContent.search(/#pragma OPENCL/) !== -1;
+        });
+
+    if (has_metal_code || has_opencl_code) {
+        highlightElement(document.getElementById("device-code-pane"),
+                         "c", undefined, {hideLineNumbers : true});
     }
 }
 highlightMetalDeviceCode();

--- a/src/irvisualizer/html_template_StmtToHTML_dependencies.html
+++ b/src/irvisualizer/html_template_StmtToHTML_dependencies.html
@@ -2,7 +2,7 @@
 
 <!-- Assembly Code links (Speed Highlight) -->
 <script type="module" name="hl">
-  const shj = await import('https://cdn.jsdelivr.net/gh/speed-highlight/core/dist/index.js');
+  import {loadLanguage, highlightElement} from 'https://cdn.jsdelivr.net/gh/speed-highlight/core/dist/index.js';
   var asmRules = {}
   asmRules["default"] = [
     {
@@ -60,6 +60,20 @@
       type: 'label'
     }
   ];
-  shj.loadLanguage("asm", asmRules)
-  shj.highlightElement(document.getElementById("assemblyContent"), "asm", undefined, {hideLineNumbers: true});
+  loadLanguage("asm", asmRules)
+  highlightElement(document.getElementById("assemblyContent"), "asm", undefined, {hideLineNumbers: true});
+
+function highlightMetalDeviceCode() {
+    const first_five_lines =
+        document.querySelectorAll("#device-code-pane span:nth-child(-n + 5)");
+    const has_metal_code =
+        Array.from(first_five_lines).some(
+            (item) => {
+                return item.textContent.search(/using namespace metal/) !== -1;
+            });
+    if (has_metal_code) {
+        highlightElement(document.getElementById("device-code-pane"), "c", undefined, {hideLineNumbers: true});
+    }
+}
+highlightMetalDeviceCode();
 </script>


### PR DESCRIPTION
Search the first 5 lines of the device code for the keyword `using namespace metal`. If it exists, invoke the syntax highlighting for Metal/C language.

(Used to debug the `threads_budget` for Metal GPUs. https://github.com/halide/Halide/pull/8650#issuecomment-2972840243)

Screenshot:
![image](https://github.com/user-attachments/assets/234a935d-5503-4095-9808-b6f032edbb57)

cc'ed @mcourteaux .