### PR TITLE
Add missing outputs to add_halide_library; fix advice in Lesson 21.

### DIFF
--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -173,18 +173,26 @@ function(_Halide_library_from_generator TARGET)
     )
 
     ## "hash table" of extra outputs to extensions
+    # Keep in sync with Module.cpp
     set(assembly_extension ".s")
     set(bitcode_extension ".bc")
+    # set(c_header_extension ".h")  # handled specially
     set(c_source_extension ".halide_generated.cpp")
     set(compiler_log_extension ".halide_compiler_log")
+    set(conceptual_stmt_extension ".conceptual.stmt")
+    set(conceptual_stmt_html_extension ".conceptual.stmt.html")
+    # set(cpp_stub_extension ".stub.h")  # not implemented
+    set(device_code_extension ".device_code")
     set(featurization_extension ".featurization")
     set(function_info_header_extension ".function_info.h")
     set(hlpipe_extension ".hlpipe")
     set(llvm_assembly_extension ".ll")
+    # set(object_extension (is_windows_coff ? ".obj" : ".o"))  # handled specially
     set(python_extension_extension ".py.cpp")
     set(pytorch_wrapper_extension ".pytorch.h")
     set(registration_extension ".registration.cpp")
     set(schedule_extension ".schedule.h")
+    # set(static_library_extension (is_windows_coff ? ".lib" : ".a"))  # handled specially
     set(stmt_extension ".stmt")
     set(stmt_html_extension ".stmt.html")
 
@@ -440,15 +448,17 @@ function(add_halide_library TARGET)
 
     # See Module.cpp for list of extra outputs. The following outputs intentionally do not appear:
     # - `c_header` is always generated
-    # - `c_source` is selected by C_BACKEND
+    # - `cpp_stub` is not available
     # - `object` is selected for CMake-target-compile
     # - `static_library` is selected for cross-compile
-    # - `cpp_stub` is not available
     set(extra_output_names
         ASSEMBLY
         BITCODE
         COMPILER_LOG
+        CONCEPTUAL_STMT
+        CONCEPTUAL_STMT_HTML
         C_SOURCE
+        DEVICE_CODE
         FEATURIZATION
         FUNCTION_INFO_HEADER
         HLPIPE
@@ -458,7 +468,8 @@ function(add_halide_library TARGET)
         REGISTRATION
         SCHEDULE
         STMT
-        STMT_HTML)
+        STMT_HTML
+    )
 
     ##
     # Parse the arguments and set defaults for missing values.

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -31,6 +31,7 @@ std::map<OutputFileType, const OutputInfo> get_output_info(const Target &target)
     constexpr bool IsMulti = true;
     constexpr bool IsSingle = false;
     const bool is_windows_coff = target.os == Target::Windows;
+    // Keep in sync with cmake/HalideGeneratorHelpers.cmake
     std::map<OutputFileType, const OutputInfo> ext = {
         {OutputFileType::assembly, {"assembly", ".s", IsMulti}},
         {OutputFileType::bitcode, {"bitcode", ".bc", IsMulti}},

--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -126,8 +126,9 @@ public:
 
             // If HL_DEBUG_CODEGEN is set to 3 or greater, the schedule will be dumped
             // to stdout (along with much other information); a more useful way is
-            // to add "schedule" to the -e flag to the Generator. (In CMake and Bazel,
-            // this is done using the "extra_outputs" flag.)
+            // to add "schedule" to the -e flag to the Generator. In CMake, this is
+            // done by passing the argument SCHEDULE <outvar> to add_halide_library().
+            // See doc/HalideCMakePackage.md for more detail.
 
             // The generated schedule that is dumped to file is an actual
             // Halide C++ source, which is readily copy-pasteable back into


### PR DESCRIPTION
The extra outputs `conceptual_stmt`, `conceptual_stmt_html`, and `device_code` were missing. Cross-references between `cmake/HalideGeneratorHelpers.cmake` and `src/Module.cpp` were added in comments to serve as reminders to implement missing outputs.