### PR TITLE
Non-Silent Exit if Wrong Subroutine is Given

### DIFF
--- a/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
+++ b/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
@@ -14,7 +14,6 @@
 #include "clock.h"
 #include "halide_blas.h"
 #include "macros.h"
-#include <iomanip>
 #include <iostream>
 #include <random>
 #include <string>
@@ -82,6 +81,9 @@ struct BenchmarksBase {
             bench_gemm_transB(size);
         } else if (benchmark == "gemm_transAB") {
             bench_gemm_transAB(size);
+        } else {
+            std::cout << "subroutine: <" << benchmark << "> not know\n";
+            return;
         }
     }
 

--- a/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
+++ b/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
@@ -82,7 +82,7 @@ struct BenchmarksBase {
         } else if (benchmark == "gemm_transAB") {
             bench_gemm_transAB(size);
         } else {
-            std::cout << "subroutine: <" << benchmark << "> not know\n";
+            std::cout << "subroutine: <" << benchmark << "> not known\n";
             return;
         }
     }

--- a/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
+++ b/apps/linear_algebra/benchmarks/halide_benchmarks.cpp
@@ -14,6 +14,7 @@
 #include "clock.h"
 #include "halide_blas.h"
 #include "macros.h"
+#include <cstdlib>
 #include <iostream>
 #include <random>
 #include <string>
@@ -82,8 +83,8 @@ struct BenchmarksBase {
         } else if (benchmark == "gemm_transAB") {
             bench_gemm_transAB(size);
         } else {
-            std::cout << "subroutine: <" << benchmark << "> not known\n";
-            return;
+            std::cerr << "subroutine: <" << benchmark << "> not known\n";
+            std::exit(1);
         }
     }
 
@@ -161,8 +162,8 @@ struct BenchmarksDouble : public BenchmarksBase<double> {
 
 int main(int argc, char *argv[]) {
     if (argc != 3) {
-        std::cout << "USAGE: halide_benchmarks <subroutine> <size>\n";
-        return 0;
+        std::cerr << "USAGE: halide_benchmarks <subroutine> <size>\n";
+        return 1;
     }
 
     std::string subroutine = argv[1];
@@ -174,6 +175,9 @@ int main(int argc, char *argv[]) {
         BenchmarksFloat("Halide").run(subroutine, size);
     } else if (type == 'd') {
         BenchmarksDouble("Halide").run(subroutine, size);
+    } else {
+        std::cerr << "type: '" << type << "' not known. Expected 's' or 'd'.\n";
+        return 1;
     }
 
     return 0;


### PR DESCRIPTION
The change notify users that a wrong subroutine argument is given. Currently class such as `halide_benchmarks sgemm  1024` return immediately without a message. 