### PR TITLE
Remove obsolete WasmExecutor specific debug macro.

### DIFF
--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -55,7 +55,7 @@ LLD_HAS_DRIVER(wasm)
 // prevents deleting them and writes a debug message giving the path name.
 #define SAVE_TEMP_OBJECT_FILES 0
 
-// Do an expensive areana validation with significant frequency when allocator is used.
+// Do an expensive arena validation with significant frequency when allocator is used.
 #define FULL_MALLOC_VALIDATION 0
 
 // Print input/output buffers at execution entry/exit.

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -50,7 +50,7 @@
 LLD_HAS_DRIVER(wasm)
 #endif
 
-// Some extra debiugging flags that can be turned on at compile time.
+// Some extra debugging flags that can be turned on at compile time.
 // Code generation and linking has to work through temporary files. This flag
 // prevents deleting them and writes a debug message giving the path name.
 #define SAVE_TEMP_OBJECT_FILES 0

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -51,7 +51,7 @@ LLD_HAS_DRIVER(wasm)
 #endif
 
 // Some extra debiugging flags that can be turned on at compile time.
-// Gode generation and linking has to work through temporary files. This flag
+// Code generation and linking has to work through temporary files. This flag
 // prevents deleting them and writes a debug message giving the path name.
 #define SAVE_TEMP_OBJECT_FILES 0
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -585,7 +585,7 @@ JITUserContext *get_jit_user_context(WabtContext &wabt_context, const wabt::inte
 }
 
 void dump_hostbuf(WabtContext &wabt_context, const halide_buffer_t *buf, const std::string &label) {
-#if DUMP_HOSTBUFS
+#if DUMP_HOST_BUFFERS
     const halide_dimension_t *dim = buf->dim;
     const uint8_t *host = buf->host;
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -2311,11 +2311,13 @@ WasmModuleContents::WasmModuleContents(
         << wabt::FormatErrorsToString(errors, wabt::Location::Type::Binary) << "\n"
         << "  log: " << to_string(log_stream) << "\n";
 
-    debug(2) << "Disassembly:\n" << [&] {
-        wabt::MemoryStream dis_stream;
-        module_desc.istream.Disassemble(&dis_stream);
-        return to_string(dis_stream);
-    }() << "\n";
+    debug(2) << "Disassembly:\n"
+             << [&] {
+                    wabt::MemoryStream dis_stream;
+                    module_desc.istream.Disassemble(&dis_stream);
+                    return to_string(dis_stream);
+                }()
+             << "\n";
 
     module = wabt::interp::Module::New(store, module_desc);
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -206,7 +206,7 @@ public:
         auto next = std::next(it);
         if (next != regions.end() && !next->second.used) {
             debug(4) << "combine next: " << next->first << " w/ " << it->first << " "
-                       << "\n";
+                     << "\n";
             it->second.size += next->second.size;
             regions.erase(next);
         }

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -779,7 +779,7 @@ void copy_hostbuf_to_existing_wasmbuf(WabtContext &wabt_context, const halide_bu
 
     wasm_halide_buffer_t *dst = (wasm_halide_buffer_t *)(base + dst_ptr);
     internal_assert(src->device == 0);
-    internal_assert(src->device_interface == 0);
+    internal_assert(src->device_interface == nullptr);
     internal_assert(src->dimensions == dst->dimensions);
     internal_assert(src->type == dst->type);
 
@@ -1171,7 +1171,7 @@ wabt::Result extern_callback_wrapper(const std::vector<ExternArgType> &arg_types
                                      wabt::interp::Trap::Ptr *trap) {
     WabtContext &wabt_context = get_wabt_context(thread);
 
-    internal_assert(arg_types.size() >= 1);
+    internal_assert(!arg_types.empty());
     const size_t arg_types_len = arg_types.size() - 1;
     const ExternArgType &ret_type = arg_types[0];
 

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -2311,12 +2311,11 @@ WasmModuleContents::WasmModuleContents(
         << wabt::FormatErrorsToString(errors, wabt::Location::Type::Binary) << "\n"
         << "  log: " << to_string(log_stream) << "\n";
 
-    if (debug_is_active(2)) {
+    debug(2) << "Disassembly:\n" << [&] {
         wabt::MemoryStream dis_stream;
         module_desc.istream.Disassemble(&dis_stream);
-        debug(2) << "Disassembly:\n"
-                 << to_string(dis_stream) << "\n";
-    }
+        return to_string(dis_stream);
+    }() << "\n";
 
     module = wabt::interp::Module::New(store, module_desc);
 
@@ -2551,11 +2550,11 @@ int WasmModuleContents::run(const void *const *args) {
     wabt::interp::Thread thread(store);
 
     auto r = func->Call(thread, wabt_args, wabt_results, &trap);
-    if (debug_is_active(2)) {
+    debug(2) << [&] {
         wabt::MemoryStream call_stream;
         WriteCall(&call_stream, func_name, *func_type, wabt_args, wabt_results, trap);
-        debug(2) << to_string(call_stream) << "\n";
-    }
+        return to_string(call_stream);
+    }() << "\n";
     internal_assert(Succeeded(r)) << "Func::Call failed: " << trap->message() << "\n";
     internal_assert(wabt_results.size() == 1);
     int32_t result = wabt_results[0].Get<int32_t>();


### PR DESCRIPTION
WasmExecutor had its own debug macros which were only enabled by changing a `#define` in the .cpp file. Turning this on fails to compile after the addition of rule based debug filtering. The rule based filtering should provide the ability to filter output when debugging wasm test failures and Halide jit wasm execution is not widely used outside of tests. Hence the decision to remove the file specific debug support.

Moved expensive validations and such under new #ifdefs at the top of the file.

Changes some debug levels per making this part of the standard debug set.