### PR TITLE
Fix argument order in __rpow__

### DIFF
--- a/python_bindings/src/halide/halide_/PyBinaryOperators.h
+++ b/python_bindings/src/halide/halide_/PyBinaryOperators.h
@@ -174,12 +174,12 @@ void add_binary_operators(PythonClass &class_instance) {
     add_binary_operators_with<int>(class_instance);
 
     // Halide::pow() has only an Expr, Expr variant
-    const auto pow_wrap = [](const Expr &self, const Expr &other) -> decltype(Halide::pow(self, other)) {
-        return Halide::pow(self, other);
-    };
     class_instance
-        .def("__pow__", pow_wrap, py::is_operator())
-        .def("__rpow__", pow_wrap, py::is_operator());
+        .def("__pow__", Halide::pow, py::is_operator())
+        .def("__rpow__", [](const Expr &self, const Expr &other) {
+            return Halide::pow(other, self);  //
+        },
+             py::is_operator());
 
     const auto logical_not_wrap = [](const self_t &self) -> decltype(!self) {
         return !self;

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -1,5 +1,4 @@
 import halide as hl
-import numpy as np
 
 
 def test_compiletime_error():
@@ -447,7 +446,18 @@ def test_requirements():
 
 def test_implicit_convert_int64():
     assert (hl.i32(0) + 0x7fffffff).type() == hl.Int(32)
-    assert (hl.i32(0) + (0x7fffffff+1)).type() == hl.Int(64)
+    assert (hl.i32(0) + (0x7fffffff + 1)).type() == hl.Int(64)
+
+
+def test_pow_rpow():
+    two = hl.Expr(2.0)
+    x = hl.Var("x")
+    for three in (3, hl.Expr(3)):
+        f = hl.Func("f")
+        f[x] = 0.0
+        f[0] = two ** three
+        f[1] = three ** two
+        assert list(f.realize([2])) == [8.0, 9.0]
 
 
 if __name__ == "__main__":
@@ -469,3 +479,4 @@ if __name__ == "__main__":
     test_bool_conversion()
     test_requirements()
     test_implicit_convert_int64()
+    test_pow_rpow()


### PR DESCRIPTION
The arguments were reversed.

We add a test, too.

Tagging `release_notes` because people should check their code.

Fixes #8676