### PR TITLE
Fix segfault in RDom's operator<<

### DIFF
--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -260,16 +260,19 @@ std::ostream &operator<<(std::ostream &stream, const RVar &v) {
 
 /** Emit an RDom in a human-readable form. */
 std::ostream &operator<<(std::ostream &stream, const RDom &dom) {
+    if (!dom.defined()) {
+        return stream << "RDom()";
+    }
+
     stream << "RDom(\n";
     for (int i = 0; i < dom.dimensions(); i++) {
         stream << "  " << dom[i] << "\n";
     }
     stream << ")";
-    Expr pred = simplify(dom.domain().predicate());
+    const Expr pred = dom.domain().predicate();
     if (!is_const_one(pred)) {
-        stream << " where (\n  " << pred << ")";
+        stream << " where (" << pred << ")";
     }
-    stream << "\n";
     return stream;
 }
 

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -192,6 +192,7 @@ tests(GROUPS correctness
       intrinsics.cpp
       invalid_gpu_loop_nests.cpp
       inverse.cpp
+      irprinter.cpp
       isnan.cpp
       issue_3926.cpp
       iterate_over_circle.cpp

--- a/test/correctness/irprinter.cpp
+++ b/test/correctness/irprinter.cpp
@@ -1,0 +1,26 @@
+#include "Halide.h"
+#include <iostream>
+#include <sstream>
+#include <string_view>
+
+using namespace Halide;
+
+void assert_strings_equal(const std::string_view expected, const std::string_view actual) {
+    if (expected != actual) {
+        std::cerr << "Expected: " << expected << ", actual: " << actual << "\n";
+        std::exit(1);
+    }
+}
+
+void test_empty_rdom() {
+    std::ostringstream os;
+    os << RDom();
+    assert_strings_equal("RDom()", os.str());
+}
+
+int main(int argc, char **argv) {
+    test_empty_rdom();
+
+    std::cout << "Success!\n";
+    return 0;
+}


### PR DESCRIPTION
We were missing a check for `RDom::defined()` here. Slight tweaking of the format to make more sense in the Python repl (which is where this was discovered).

Fixes #8663
