### PR TITLE
Bind in-place update operators (e.g. +=) in Python

### DIFF
--- a/python_bindings/src/halide/halide_/PyBinaryOperators.h
+++ b/python_bindings/src/halide/halide_/PyBinaryOperators.h
@@ -78,10 +78,19 @@ HANDLE_SCALAR_TYPE(double)
                   << (result) << ":" << type_desc(result) << "\n"; \
     } while (0)
 
+#define LOG_PY_BINARY_OP_UNEVAL(self, op, other, result)          \
+    do {                                                          \
+        std::cout << "undef funcref "(op) " " << (other) << "\n"; \
+    } while (0)
+
 #else  // DEBUG_BINARY_OPS
 
 #define LOG_PY_BINARY_OP(self, op, other, result) \
     do {                                          \
+    } while (0)
+
+#define LOG_PY_BINARY_OP_UNEVAL(self, op, other, result) \
+    do {                                                 \
     } while (0)
 
 #endif  // DEBUG_BINARY_OPS
@@ -147,7 +156,7 @@ void add_binary_operators_with(PythonClass &class_instance) {
                     return result;                                                                               \
                 } else {                                                                                         \
                     auto result = UnevaluatedFuncRefExpr{self, Promote(other), UnevaluatedFuncRefExpr::Op::val}; \
-                    std::cout << "quote-" #method ": undef funcref " #op " " << other << "\n";                   \
+                    LOG_PY_BINARY_OP_UNEVAL(self, #method, other, result);                                       \
                     return result;                                                                               \
                 }                                                                                                \
             },                                                                                                   \

--- a/python_bindings/src/halide/halide_/PyBinaryOperators.h
+++ b/python_bindings/src/halide/halide_/PyBinaryOperators.h
@@ -101,35 +101,32 @@ void add_binary_operators_with(PythonClass &class_instance) {
     // If 'other_t' is double, we want to wrap it as an Expr() prior to calling the binary op
     // (so that double literals that lose precision when converted to float issue warnings).
     // For any other type, we just want to leave it as-is.
-    using Promote = typename std::conditional<
-        std::is_same<other_t, double>::value,
-        DoubleToExprCheck,
-        other_t>::type;
+    using Promote = std::conditional_t<
+        std::is_same_v<other_t, double>, DoubleToExprCheck, other_t>;
 
-#define BINARY_OP(op, method)                                                                  \
-    do {                                                                                       \
-        class_instance.def(                                                                    \
-            "__" #method "__",                                                                 \
-            [](const self_t &self, const other_t &other) -> decltype(self op Promote(other)) { \
-                auto result = self op Promote(other);                                          \
-                LOG_PY_BINARY_OP(self, #method, other, result);                                \
-                return result;                                                                 \
-            },                                                                                 \
-            py::is_operator());                                                                \
-        class_instance.def(                                                                    \
-            "__r" #method "__",                                                                \
-            [](const self_t &self, const other_t &other) -> decltype(Promote(other) op self) { \
-                auto result = Promote(other) op self;                                          \
-                LOG_PY_BINARY_OP(self, "r" #method, other, result);                            \
-                return result;                                                                 \
-            },                                                                                 \
-            py::is_operator());                                                                \
+#define BINARY_OP(op, method)                                       \
+    do {                                                            \
+        class_instance.def(                                         \
+            "__" #method "__",                                      \
+            [](const self_t &self, const other_t &other) {          \
+                auto result = self op Promote(other);               \
+                LOG_PY_BINARY_OP(self, #method, other, result);     \
+                return result;                                      \
+            },                                                      \
+            py::is_operator());                                     \
+        class_instance.def(                                         \
+            "__r" #method "__",                                     \
+            [](const self_t &self, const other_t &other) {          \
+                auto result = Promote(other) op self;               \
+                LOG_PY_BINARY_OP(self, "r" #method, other, result); \
+                return result;                                      \
+            },                                                      \
+            py::is_operator());                                     \
     } while (0)
 
     BINARY_OP(+, add);
     BINARY_OP(-, sub);
     BINARY_OP(*, mul);
-    BINARY_OP(/, div);  // TODO: verify only needed for python 2.x (harmless for Python 3.x)
     BINARY_OP(/, truediv);
     BINARY_OP(%, mod);
     BINARY_OP(<<, lshift);
@@ -146,18 +143,16 @@ void add_binary_operators_with(PythonClass &class_instance) {
 
 #undef BINARY_OP
 
-    const auto floordiv_wrap = [](const self_t &self, const other_t &other) -> decltype(self / Promote(other)) {
-        static_assert(std::is_same<decltype(self / Promote(other)), Expr>::value, "We expect all operator// overloads to produce Expr");
-        Expr e = self / Promote(other);
-        if (e.type().is_float()) {
-            e = Halide::floor(e);
-        }
-        return e;
+    const auto floordiv = [](const auto &a, const auto &b) {
+        static_assert(std::is_same_v<decltype(a / b), Expr>,
+                      "We expect all operator// overloads to produce Expr");
+        Expr e = a / b;
+        return e.type().is_float() ? Halide::floor(e) : e;
     };
 
     class_instance
-        .def("__floordiv__", floordiv_wrap, py::is_operator())
-        .def("__rfloordiv__", floordiv_wrap, py::is_operator());
+        .def("__floordiv__", [&](const self_t &self, const other_t &other) { return floordiv(self, Promote(other)); }, py::is_operator())
+        .def("__rfloordiv__", [&](const self_t &self, const other_t &other) { return floordiv(Promote(other), self); }, py::is_operator());
 }  // namespace PythonBindings
 
 template<typename PythonClass>

--- a/python_bindings/src/halide/halide_/PyExpr.cpp
+++ b/python_bindings/src/halide/halide_/PyExpr.cpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 
 #include "PyBinaryOperators.h"
+#include "PyFuncRef.h"
 #include "PyType.h"
 
 namespace Halide {
@@ -44,6 +45,7 @@ void define_expr(py::module &m) {
             .def(py::init([](const RDom &r) -> Expr { return r; }))
             .def(py::init([](const RVar &r) -> Expr { return r; }))
             .def(py::init([](const Var &v) -> Expr { return v; }))
+            .def(py::init([](const UnevaluatedFuncRefExpr &v) -> Expr { return v; }))
 
             .def("__bool__", to_bool)
             .def("__nonzero__", to_bool)
@@ -77,6 +79,7 @@ void define_expr(py::module &m) {
     py::implicitly_convertible<RDom, Expr>();
     py::implicitly_convertible<RVar, Expr>();
     py::implicitly_convertible<Var, Expr>();
+    py::implicitly_convertible<UnevaluatedFuncRefExpr, Expr>();
 
     auto range_class =
         py::class_<Range>(m, "Range")

--- a/python_bindings/src/halide/halide_/PyExpr.cpp
+++ b/python_bindings/src/halide/halide_/PyExpr.cpp
@@ -45,7 +45,6 @@ void define_expr(py::module &m) {
             .def(py::init([](const RDom &r) -> Expr { return r; }))
             .def(py::init([](const RVar &r) -> Expr { return r; }))
             .def(py::init([](const Var &v) -> Expr { return v; }))
-            .def(py::init([](const UnevaluatedFuncRefExpr &v) -> Expr { return v; }))
 
             .def("__bool__", to_bool)
             .def("__nonzero__", to_bool)
@@ -79,7 +78,6 @@ void define_expr(py::module &m) {
     py::implicitly_convertible<RDom, Expr>();
     py::implicitly_convertible<RVar, Expr>();
     py::implicitly_convertible<Var, Expr>();
-    py::implicitly_convertible<UnevaluatedFuncRefExpr, Expr>();
 
     auto range_class =
         py::class_<Range>(m, "Range")

--- a/python_bindings/src/halide/halide_/PyExpr.cpp
+++ b/python_bindings/src/halide/halide_/PyExpr.cpp
@@ -3,7 +3,6 @@
 #include <iomanip>
 
 #include "PyBinaryOperators.h"
-#include "PyFuncRef.h"
 #include "PyType.h"
 
 namespace Halide {

--- a/python_bindings/src/halide/halide_/PyFunc.cpp
+++ b/python_bindings/src/halide/halide_/PyFunc.cpp
@@ -29,7 +29,7 @@ void define_get(py::class_<Func> &func_class) {
 template<typename LHS, typename RHS>
 void setitem_impl(Func &func, const LHS &lhs, const RHS &rhs) {
     if constexpr (std::is_same_v<RHS, UnevaluatedFuncRefExpr>) {
-        static_cast<UnevaluatedFuncRefExpr>(rhs).define_update(func);
+        static_cast<UnevaluatedFuncRefExpr>(rhs).define_update(func, lhs);
     } else {
         func(lhs) = rhs;
     }

--- a/python_bindings/src/halide/halide_/PyFunc.cpp
+++ b/python_bindings/src/halide/halide_/PyFunc.cpp
@@ -29,11 +29,10 @@ void define_get(py::class_<Func> &func_class) {
 template<typename LHS, typename RHS>
 void setitem_impl(Func &func, const LHS &lhs, const RHS &rhs) {
     if constexpr (std::is_same_v<RHS, UnevaluatedFuncRefExpr>) {
-        if (static_cast<UnevaluatedFuncRefExpr>(rhs).define_update(func)) {
-            return;
-        }
+        static_cast<UnevaluatedFuncRefExpr>(rhs).define_update(func);
+    } else {
+        func(lhs) = rhs;
     }
-    func(lhs) = rhs;
 }
 
 template<typename LHS, typename RHS>

--- a/python_bindings/src/halide/halide_/PyFunc.cpp
+++ b/python_bindings/src/halide/halide_/PyFunc.cpp
@@ -474,6 +474,16 @@ void define_func(py::module &m) {
     define_set<Expr, Expr>(func_class);
     define_set<Expr, Tuple>(func_class);
 
+    // When creating a new stage via +=, -=, *=, or /= a new stage
+    // is created as a side effect. This overload prevents creating
+    // an extra update stage (if we returned the FuncRef, we would
+    // add the equivalent of f(...) = f(...) as a separate update).
+    func_class.def(
+        "__setitem__",
+        [](Func &, const py::object &, StageFromInPlaceUpdate &stage) -> Stage {
+            return stage.new_stage;
+        });
+
     add_schedule_methods(func_class);
 
     define_stage(m);

--- a/python_bindings/src/halide/halide_/PyFunc.cpp
+++ b/python_bindings/src/halide/halide_/PyFunc.cpp
@@ -29,7 +29,7 @@ void define_get(py::class_<Func> &func_class) {
 template<typename LHS, typename RHS>
 void setitem_impl(Func &func, const LHS &lhs, const RHS &rhs) {
     if constexpr (std::is_same_v<RHS, UnevaluatedFuncRefExpr>) {
-        static_cast<UnevaluatedFuncRefExpr>(rhs).define_update(func, lhs);
+        static_cast<UnevaluatedFuncRefExpr>(rhs).define_update(func(lhs));
     } else {
         func(lhs) = rhs;
     }

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -5,6 +5,16 @@
 namespace Halide {
 namespace PythonBindings {
 
+template<typename T, typename = std::enable_if_t<!std::is_same_v<T, UnevaluatedFuncRefExpr>>>
+Expr operator-(const UnevaluatedFuncRefExpr &lhs, const T &rhs) {
+    return Expr(lhs) - rhs;
+}
+
+template<typename T>
+Expr operator-(const T &lhs, const UnevaluatedFuncRefExpr &rhs) {
+    return lhs - Expr(rhs);
+}
+
 Expr operator-(const UnevaluatedFuncRefExpr &expr) {
     return -Expr(expr);
 }

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -6,55 +6,18 @@
 namespace Halide {
 namespace PythonBindings {
 
-/*
- * The __iadd__ implementations here are meant to implement the special handling
- * of update definitions like the following:
- *
- *     Func f; RDom r(...);
- *     f(r) += ...;
- *
- * In this case, the type of the zero for f's pure definition is inferred from the
- * RHS. FuncRef's overloads of operator+= return a Stage. However, in Python, if
- * the __iadd__ (+=) method returns a new object, then __setitem__ will be called
- * to update the underlying object. In this case, it would try to call
- *
- *     f.__setitem__(r, <Stage>)
- *
- * where <Stage> is the result of FuncRef::operator+=. This doesn't make sense.
- * Instead, we return a special type (StageFromInPlaceUpdate) that signals to
- * our __setitem__ implementation that this is the case.
- */
+Expr operator-(const UnevaluatedFuncRefExpr &expr) {
+    return -Expr(expr);
+}
 
-namespace {
-
-#define X_FuncRef(op, rhs) (StageFromInPlaceUpdate{self.operator op(rhs), self})
-#define X_StageFromInPlaceUpdate(op, rhs) (self.func_ref.operator op(rhs), self)
-
-// NOLINTBEGIN(bugprone-macro-parentheses)
-#define DEF_IOP(T, pyop, op)                           \
-    .def(pyop, [](T &self, const Expr &other) {        \
-        return X##_##T(op, other);                     \
-    }).def(pyop, [](T &self, const py::tuple &other) { \
-          return X##_##T(op, to_halide_tuple(other));  \
-      }).def(pyop, [](T &self, const FuncRef &other) { \
-        return X##_##T(op, other);                     \
-    })
-// NOLINTEND(bugprone-macro-parentheses)
-
-#define DEF_IOPS(cls, T)                    \
-    do {                                    \
-        cls DEF_IOP(T, "__iadd__", +=);     \
-        cls DEF_IOP(T, "__isub__", -=);     \
-        cls DEF_IOP(T, "__imul__", *=);     \
-        cls DEF_IOP(T, "__itruediv__", /=); \
-    } while (0)
-
-}  // namespace
+Expr operator~(const UnevaluatedFuncRefExpr &expr) {
+    return ~Expr(expr);
+}
 
 void define_func_ref(py::module &m) {
-    auto stage_from_in_place_update_class =
-        py::class_<StageFromInPlaceUpdate>(m, "_StageFromInPlaceUpdate");
-    DEF_IOPS(stage_from_in_place_update_class, StageFromInPlaceUpdate);
+    auto undefined_lhs_funcref_expr_class =
+        py::class_<UnevaluatedFuncRefExpr>(m, "_UndefinedLHSFuncRefExpr");
+    add_binary_operators(undefined_lhs_funcref_expr_class);
 
     auto func_tuple_element_ref_class =
         py::class_<FuncTupleElementRef>(m, "FuncTupleElementRef")
@@ -65,8 +28,19 @@ void define_func_ref(py::module &m) {
         py::class_<FuncRef>(m, "FuncRef")
             .def("__getitem__", &FuncRef::operator[])
             .def("size", &FuncRef::size)
-            .def("__len__", &FuncRef::size);
-    DEF_IOPS(func_ref_class, FuncRef);
+            .def("__len__", &FuncRef::size)
+            .def("__add__", [](const FuncRef &self, const Expr &other) {
+                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Add};
+            })
+            .def("__sub__", [](const FuncRef &self, const Expr &other) {
+                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Sub};
+            })
+            .def("__mul__", [](const FuncRef &self, const Expr &other) {
+                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Mul};
+            })
+            .def("__truediv__", [](const FuncRef &self, const Expr &other) {
+                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Div};
+            });
     add_binary_operators(func_ref_class);
 }
 

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -1,7 +1,6 @@
 #include "PyFuncRef.h"
 
 #include "PyBinaryOperators.h"
-#include "PyTuple.h"
 
 namespace Halide {
 namespace PythonBindings {

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -7,6 +7,9 @@ namespace Halide {
 namespace PythonBindings {
 
 void define_func_ref(py::module &m) {
+    auto stage_from_in_place_update_class =
+        py::class_<StageFromInPlaceUpdate>(m, "_StageFromInPlaceUpdate");
+
     auto func_tuple_element_ref_class =
         py::class_<FuncTupleElementRef>(m, "FuncTupleElementRef")
             .def("index", &FuncTupleElementRef::index);
@@ -33,60 +36,48 @@ void define_func_ref(py::module &m) {
              *     f.__setitem__(r, <Stage>)
              *
              * where <Stage> is the result of FuncRef::operator+=. This doesn't make sense.
-             * Instead, we return the same FuncRef. The same logic applies to the other
-             * in-place overloads.
+             * Instead, we return a special type (StageFromInPlaceUpdate) that signals to
+             * our __setitem__ implementation that this is the case.
              */
             // __iadd__
             .def("__iadd__", [](FuncRef &self, const Expr &other) {
-                self += other;
-                return self;
+                return StageFromInPlaceUpdate{self += other};
             })
             .def("__iadd__", [](FuncRef &self, const py::tuple &other) {
-                self += to_halide_tuple(other);
-                return self;
+                return StageFromInPlaceUpdate{self += to_halide_tuple(other)};
             })
             .def("__iadd__", [](FuncRef &self, const FuncRef &other) {
-                self += other;
-                return self;
+                return StageFromInPlaceUpdate{self += other};
             })
             // __isub__
             .def("__isub__", [](FuncRef &self, const Expr &other) {
-                self -= other;
-                return self;
+                return StageFromInPlaceUpdate{self -= other};
             })
             .def("__isub__", [](FuncRef &self, const py::tuple &other) {
-                self -= to_halide_tuple(other);
-                return self;
+                return StageFromInPlaceUpdate{self -= to_halide_tuple(other)};
             })
             .def("__isub__", [](FuncRef &self, const FuncRef &other) {
-                self -= other;
-                return self;
+                return StageFromInPlaceUpdate{self -= other};
             })
             // __imul__
             .def("__imul__", [](FuncRef &self, const Expr &other) {
-                self *= other;
-                return self;
+                return StageFromInPlaceUpdate{self *= other};
             })
             .def("__imul__", [](FuncRef &self, const py::tuple &other) {
-                self *= to_halide_tuple(other);
-                return self;
+                return StageFromInPlaceUpdate{self *= to_halide_tuple(other)};
             })
             .def("__imul__", [](FuncRef &self, const FuncRef &other) {
-                self *= other;
-                return self;
+                return StageFromInPlaceUpdate{self *= other};
             })
             // __idiv__
             .def("__itruediv__", [](FuncRef &self, const Expr &other) {
-                self /= other;
-                return self;
+                return StageFromInPlaceUpdate{self /= other};
             })
             .def("__itruediv__", [](FuncRef &self, const py::tuple &other) {
-                self /= to_halide_tuple(other);
-                return self;
+                return StageFromInPlaceUpdate{self /= to_halide_tuple(other)};
             })
             .def("__itruediv__", [](FuncRef &self, const FuncRef &other) {
-                self /= other;
-                return self;
+                return StageFromInPlaceUpdate{self /= other};
             });
 
     add_binary_operators(func_ref_class);

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -1,6 +1,7 @@
 #include "PyFuncRef.h"
 
 #include "PyBinaryOperators.h"
+#include "PyTuple.h"
 
 namespace Halide {
 namespace PythonBindings {
@@ -16,7 +17,77 @@ void define_func_ref(py::module &m) {
         py::class_<FuncRef>(m, "FuncRef")
             .def("__getitem__", &FuncRef::operator[])
             .def("size", &FuncRef::size)
-            .def("__len__", &FuncRef::size);
+            .def("__len__", &FuncRef::size)
+            /*
+             * The __iadd__ implementations here are meant to implement the special handling
+             * of update definitions like the following:
+             *
+             *     Func f; RDom r(...);
+             *     f(r) += ...;
+             *
+             * In this case, the type of the zero for f's pure definition is inferred from the
+             * RHS. FuncRef's overloads of operator+= return a Stage. However, in Python, if
+             * the __iadd__ (+=) method returns a new object, then __setitem__ will be called
+             * to update the underlying object. In this case, it would try to call
+             *
+             *     f.__setitem__(r, <Stage>)
+             *
+             * where <Stage> is the result of FuncRef::operator+=. This doesn't make sense.
+             * Instead, we return the same FuncRef. The same logic applies to the other
+             * in-place overloads.
+             */
+            // __iadd__
+            .def("__iadd__", [](FuncRef &self, const Expr &other) {
+                self += other;
+                return self;
+            })
+            .def("__iadd__", [](FuncRef &self, const py::tuple &other) {
+                self += to_halide_tuple(other);
+                return self;
+            })
+            .def("__iadd__", [](FuncRef &self, const FuncRef &other) {
+                self += other;
+                return self;
+            })
+            // __isub__
+            .def("__isub__", [](FuncRef &self, const Expr &other) {
+                self -= other;
+                return self;
+            })
+            .def("__isub__", [](FuncRef &self, const py::tuple &other) {
+                self -= to_halide_tuple(other);
+                return self;
+            })
+            .def("__isub__", [](FuncRef &self, const FuncRef &other) {
+                self -= other;
+                return self;
+            })
+            // __imul__
+            .def("__imul__", [](FuncRef &self, const Expr &other) {
+                self *= other;
+                return self;
+            })
+            .def("__imul__", [](FuncRef &self, const py::tuple &other) {
+                self *= to_halide_tuple(other);
+                return self;
+            })
+            .def("__imul__", [](FuncRef &self, const FuncRef &other) {
+                self *= other;
+                return self;
+            })
+            // __idiv__
+            .def("__itruediv__", [](FuncRef &self, const Expr &other) {
+                self /= other;
+                return self;
+            })
+            .def("__itruediv__", [](FuncRef &self, const py::tuple &other) {
+                self /= to_halide_tuple(other);
+                return self;
+            })
+            .def("__itruediv__", [](FuncRef &self, const FuncRef &other) {
+                self /= other;
+                return self;
+            });
 
     add_binary_operators(func_ref_class);
 }

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -30,6 +30,7 @@ namespace {
 #define X_FuncRef(op, rhs) (StageFromInPlaceUpdate{self.operator op(rhs), self})
 #define X_StageFromInPlaceUpdate(op, rhs) (self.func_ref.operator op(rhs), self)
 
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define DEF_IOP(T, pyop, op)                           \
     .def(pyop, [](T &self, const Expr &other) {        \
         return X##_##T(op, other);                     \
@@ -38,6 +39,7 @@ namespace {
       }).def(pyop, [](T &self, const FuncRef &other) { \
         return X##_##T(op, other);                     \
     })
+// NOLINTEND(bugprone-macro-parentheses)
 
 #define DEF_IOPS(cls, T)                    \
     do {                                    \

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -25,94 +25,45 @@ namespace PythonBindings {
  * our __setitem__ implementation that this is the case.
  */
 
+namespace {
+
+#define X_FuncRef(op, rhs) (StageFromInPlaceUpdate{self.operator op(rhs), self})
+#define X_StageFromInPlaceUpdate(op, rhs) (self.func_ref.operator op(rhs), self)
+
+#define DEF_IOP(T, pyop, op)                           \
+    .def(pyop, [](T &self, const Expr &other) {        \
+        return X##_##T(op, other);                     \
+    }).def(pyop, [](T &self, const py::tuple &other) { \
+          return X##_##T(op, to_halide_tuple(other));  \
+      }).def(pyop, [](T &self, const FuncRef &other) { \
+        return X##_##T(op, other);                     \
+    })
+
+#define DEF_IOPS(cls, T)                    \
+    do {                                    \
+        cls DEF_IOP(T, "__iadd__", +=);     \
+        cls DEF_IOP(T, "__isub__", -=);     \
+        cls DEF_IOP(T, "__imul__", *=);     \
+        cls DEF_IOP(T, "__itruediv__", /=); \
+    } while (0)
+
+}  // namespace
+
 void define_func_ref(py::module &m) {
     auto stage_from_in_place_update_class =
-        py::class_<StageFromInPlaceUpdate>(m, "_StageFromInPlaceUpdate")
-            .def("__iadd__", [](StageFromInPlaceUpdate &self, const Expr &other) {
-                return self.func_ref += other, self;
-            })
-            .def("__iadd__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
-                return self.func_ref += to_halide_tuple(other), self;
-            })
-            .def("__iadd__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
-                return self.func_ref += other, self;
-            })
-            .def("__isub__", [](StageFromInPlaceUpdate &self, const Expr &other) {
-                return self.func_ref -= other, self;
-            })
-            .def("__isub__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
-                return self.func_ref -= to_halide_tuple(other), self;
-            })
-            .def("__isub__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
-                return self.func_ref -= other, self;
-            })
-            .def("__imul__", [](StageFromInPlaceUpdate &self, const Expr &other) {
-                return self.func_ref *= other, self;
-            })
-            .def("__imul__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
-                return self.func_ref *= to_halide_tuple(other), self;
-            })
-            .def("__imul__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
-                return self.func_ref *= other, self;
-            })
-            .def("__itruediv__", [](StageFromInPlaceUpdate &self, const Expr &other) {
-                return self.func_ref /= other, self;
-            })
-            .def("__itruediv__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
-                return self.func_ref /= to_halide_tuple(other), self;
-            })
-            .def("__itruediv__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
-                return self.func_ref /= other, self;
-            });
+        py::class_<StageFromInPlaceUpdate>(m, "_StageFromInPlaceUpdate");
+    DEF_IOPS(stage_from_in_place_update_class, StageFromInPlaceUpdate);
 
     auto func_tuple_element_ref_class =
         py::class_<FuncTupleElementRef>(m, "FuncTupleElementRef")
             .def("index", &FuncTupleElementRef::index);
-
     add_binary_operators(func_tuple_element_ref_class);
 
-    auto func_ref_class =
-        py::class_<FuncRef>(m, "FuncRef")
-            .def("__getitem__", &FuncRef::operator[])
-            .def("size", &FuncRef::size)
-            .def("__len__", &FuncRef::size)
-            .def("__iadd__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self += other, self};
-            })
-            .def("__iadd__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self += to_halide_tuple(other), self};
-            })
-            .def("__iadd__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self += other, self};
-            })
-            .def("__isub__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self -= other, self};
-            })
-            .def("__isub__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self -= to_halide_tuple(other), self};
-            })
-            .def("__isub__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self -= other, self};
-            })
-            .def("__imul__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self *= other, self};
-            })
-            .def("__imul__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self *= to_halide_tuple(other), self};
-            })
-            .def("__imul__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self *= other, self};
-            })
-            .def("__itruediv__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self /= other, self};
-            })
-            .def("__itruediv__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self /= to_halide_tuple(other), self};
-            })
-            .def("__itruediv__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self /= other, self};
-            });
-
+    auto func_ref_class = py::class_<FuncRef>(m, "FuncRef")
+                              .def("__getitem__", &FuncRef::operator[])
+                              .def("size", &FuncRef::size)
+                              .def("__len__", &FuncRef::size);
+    DEF_IOPS(func_ref_class, FuncRef);
     add_binary_operators(func_ref_class);
 }
 

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -59,10 +59,11 @@ void define_func_ref(py::module &m) {
             .def("index", &FuncTupleElementRef::index);
     add_binary_operators(func_tuple_element_ref_class);
 
-    auto func_ref_class = py::class_<FuncRef>(m, "FuncRef")
-                              .def("__getitem__", &FuncRef::operator[])
-                              .def("size", &FuncRef::size)
-                              .def("__len__", &FuncRef::size);
+    auto func_ref_class =
+        py::class_<FuncRef>(m, "FuncRef")
+            .def("__getitem__", &FuncRef::operator[])
+            .def("size", &FuncRef::size)
+            .def("__len__", &FuncRef::size);
     DEF_IOPS(func_ref_class, FuncRef);
     add_binary_operators(func_ref_class);
 }

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -37,19 +37,7 @@ void define_func_ref(py::module &m) {
         py::class_<FuncRef>(m, "FuncRef")
             .def("__getitem__", &FuncRef::operator[])
             .def("size", &FuncRef::size)
-            .def("__len__", &FuncRef::size)
-            .def("__add__", [](const FuncRef &self, const Expr &other) {
-                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Add};
-            })
-            .def("__sub__", [](const FuncRef &self, const Expr &other) {
-                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Sub};
-            })
-            .def("__mul__", [](const FuncRef &self, const Expr &other) {
-                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Mul};
-            })
-            .def("__truediv__", [](const FuncRef &self, const Expr &other) {
-                return UnevaluatedFuncRefExpr{self, other, UnevaluatedFuncRefExpr::Op::Div};
-            });
+            .def("__len__", &FuncRef::size);
     add_binary_operators(func_ref_class);
 }
 

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -5,28 +5,9 @@
 namespace Halide {
 namespace PythonBindings {
 
-template<typename T, typename = std::enable_if_t<!std::is_same_v<T, UnevaluatedFuncRefExpr>>>
-Expr operator-(const UnevaluatedFuncRefExpr &lhs, const T &rhs) {
-    return Expr(lhs) - rhs;
-}
-
-template<typename T>
-Expr operator-(const T &lhs, const UnevaluatedFuncRefExpr &rhs) {
-    return lhs - Expr(rhs);
-}
-
-Expr operator-(const UnevaluatedFuncRefExpr &expr) {
-    return -Expr(expr);
-}
-
-Expr operator~(const UnevaluatedFuncRefExpr &expr) {
-    return ~Expr(expr);
-}
-
 void define_func_ref(py::module &m) {
     auto undefined_lhs_funcref_expr_class =
-        py::class_<UnevaluatedFuncRefExpr>(m, "_UndefinedLHSFuncRefExpr");
-    add_binary_operators(undefined_lhs_funcref_expr_class);
+        py::class_<UnevaluatedFuncRefExpr>(m, "_UnevaluatedFuncRefExpr");
 
     auto func_tuple_element_ref_class =
         py::class_<FuncTupleElementRef>(m, "FuncTupleElementRef")

--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -6,9 +6,64 @@
 namespace Halide {
 namespace PythonBindings {
 
+/*
+ * The __iadd__ implementations here are meant to implement the special handling
+ * of update definitions like the following:
+ *
+ *     Func f; RDom r(...);
+ *     f(r) += ...;
+ *
+ * In this case, the type of the zero for f's pure definition is inferred from the
+ * RHS. FuncRef's overloads of operator+= return a Stage. However, in Python, if
+ * the __iadd__ (+=) method returns a new object, then __setitem__ will be called
+ * to update the underlying object. In this case, it would try to call
+ *
+ *     f.__setitem__(r, <Stage>)
+ *
+ * where <Stage> is the result of FuncRef::operator+=. This doesn't make sense.
+ * Instead, we return a special type (StageFromInPlaceUpdate) that signals to
+ * our __setitem__ implementation that this is the case.
+ */
+
 void define_func_ref(py::module &m) {
     auto stage_from_in_place_update_class =
-        py::class_<StageFromInPlaceUpdate>(m, "_StageFromInPlaceUpdate");
+        py::class_<StageFromInPlaceUpdate>(m, "_StageFromInPlaceUpdate")
+            .def("__iadd__", [](StageFromInPlaceUpdate &self, const Expr &other) {
+                return self.func_ref += other, self;
+            })
+            .def("__iadd__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
+                return self.func_ref += to_halide_tuple(other), self;
+            })
+            .def("__iadd__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
+                return self.func_ref += other, self;
+            })
+            .def("__isub__", [](StageFromInPlaceUpdate &self, const Expr &other) {
+                return self.func_ref -= other, self;
+            })
+            .def("__isub__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
+                return self.func_ref -= to_halide_tuple(other), self;
+            })
+            .def("__isub__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
+                return self.func_ref -= other, self;
+            })
+            .def("__imul__", [](StageFromInPlaceUpdate &self, const Expr &other) {
+                return self.func_ref *= other, self;
+            })
+            .def("__imul__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
+                return self.func_ref *= to_halide_tuple(other), self;
+            })
+            .def("__imul__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
+                return self.func_ref *= other, self;
+            })
+            .def("__itruediv__", [](StageFromInPlaceUpdate &self, const Expr &other) {
+                return self.func_ref /= other, self;
+            })
+            .def("__itruediv__", [](StageFromInPlaceUpdate &self, const py::tuple &other) {
+                return self.func_ref /= to_halide_tuple(other), self;
+            })
+            .def("__itruediv__", [](StageFromInPlaceUpdate &self, const FuncRef &other) {
+                return self.func_ref /= other, self;
+            });
 
     auto func_tuple_element_ref_class =
         py::class_<FuncTupleElementRef>(m, "FuncTupleElementRef")
@@ -21,63 +76,41 @@ void define_func_ref(py::module &m) {
             .def("__getitem__", &FuncRef::operator[])
             .def("size", &FuncRef::size)
             .def("__len__", &FuncRef::size)
-            /*
-             * The __iadd__ implementations here are meant to implement the special handling
-             * of update definitions like the following:
-             *
-             *     Func f; RDom r(...);
-             *     f(r) += ...;
-             *
-             * In this case, the type of the zero for f's pure definition is inferred from the
-             * RHS. FuncRef's overloads of operator+= return a Stage. However, in Python, if
-             * the __iadd__ (+=) method returns a new object, then __setitem__ will be called
-             * to update the underlying object. In this case, it would try to call
-             *
-             *     f.__setitem__(r, <Stage>)
-             *
-             * where <Stage> is the result of FuncRef::operator+=. This doesn't make sense.
-             * Instead, we return a special type (StageFromInPlaceUpdate) that signals to
-             * our __setitem__ implementation that this is the case.
-             */
-            // __iadd__
             .def("__iadd__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self += other};
+                return StageFromInPlaceUpdate{self += other, self};
             })
             .def("__iadd__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self += to_halide_tuple(other)};
+                return StageFromInPlaceUpdate{self += to_halide_tuple(other), self};
             })
             .def("__iadd__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self += other};
+                return StageFromInPlaceUpdate{self += other, self};
             })
-            // __isub__
             .def("__isub__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self -= other};
+                return StageFromInPlaceUpdate{self -= other, self};
             })
             .def("__isub__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self -= to_halide_tuple(other)};
+                return StageFromInPlaceUpdate{self -= to_halide_tuple(other), self};
             })
             .def("__isub__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self -= other};
+                return StageFromInPlaceUpdate{self -= other, self};
             })
-            // __imul__
             .def("__imul__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self *= other};
+                return StageFromInPlaceUpdate{self *= other, self};
             })
             .def("__imul__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self *= to_halide_tuple(other)};
+                return StageFromInPlaceUpdate{self *= to_halide_tuple(other), self};
             })
             .def("__imul__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self *= other};
+                return StageFromInPlaceUpdate{self *= other, self};
             })
-            // __idiv__
             .def("__itruediv__", [](FuncRef &self, const Expr &other) {
-                return StageFromInPlaceUpdate{self /= other};
+                return StageFromInPlaceUpdate{self /= other, self};
             })
             .def("__itruediv__", [](FuncRef &self, const py::tuple &other) {
-                return StageFromInPlaceUpdate{self /= to_halide_tuple(other)};
+                return StageFromInPlaceUpdate{self /= to_halide_tuple(other), self};
             })
             .def("__itruediv__", [](FuncRef &self, const FuncRef &other) {
-                return StageFromInPlaceUpdate{self /= other};
+                return StageFromInPlaceUpdate{self /= other, self};
             });
 
     add_binary_operators(func_ref_class);

--- a/python_bindings/src/halide/halide_/PyFuncRef.h
+++ b/python_bindings/src/halide/halide_/PyFuncRef.h
@@ -6,6 +6,9 @@
 namespace Halide {
 namespace PythonBindings {
 
+struct StageFromInPlaceUpdate {
+    Stage new_stage;
+};
 void define_func_ref(py::module &m);
 
 }  // namespace PythonBindings

--- a/python_bindings/src/halide/halide_/PyFuncRef.h
+++ b/python_bindings/src/halide/halide_/PyFuncRef.h
@@ -6,9 +6,47 @@
 namespace Halide {
 namespace PythonBindings {
 
-struct StageFromInPlaceUpdate {
-    Stage new_stage;
-    FuncRef func_ref;
+struct UnevaluatedFuncRefExpr {
+    FuncRef lhs;
+    Expr rhs;
+    enum class Op {
+        Add,
+        Sub,
+        Mul,
+        Div,
+    } op;
+
+    operator Expr() const {
+        switch (op) {
+        case Op::Add:
+            return lhs + rhs;
+        case Op::Sub:
+            return lhs - rhs;
+        case Op::Mul:
+            return lhs * rhs;
+        case Op::Div:
+            return lhs / rhs;
+        }
+        throw std::runtime_error("Invalid operator");
+    }
+
+    bool define_update(const Func &func) {
+        const Internal::Function &f = func.function();
+        if (f.same_as(lhs.function()) && !(f.has_pure_definition() || f.has_extern_definition())) {
+            switch (op) {
+            case Op::Add:
+                return lhs += rhs, true;
+            case Op::Sub:
+                return lhs -= rhs, true;
+            case Op::Mul:
+                return lhs *= rhs, true;
+            case Op::Div:
+                return lhs /= rhs, true;
+            }
+            throw std::runtime_error("Invalid operator");
+        }
+        return false;
+    }
 };
 void define_func_ref(py::module &m);
 

--- a/python_bindings/src/halide/halide_/PyFuncRef.h
+++ b/python_bindings/src/halide/halide_/PyFuncRef.h
@@ -16,12 +16,19 @@ struct UnevaluatedFuncRefExpr {
         Div,
     } op;
 
-    void define_update(const Func &func) {
+    template<typename T>
+    void define_update(const Func &func, const T &args) {
         const Internal::Function &f = func.function();
         if (!f.same_as(lhs.function())) {
             std::stringstream ss;
             ss << "Cannot use an unevaluated reference to '" << lhs.function().name()
                << "' to define an update in a different func '" << func.name() << "'.";
+            throw CompileError(ss.str());
+        }
+        if (!validate_args(lhs.get_args(), args)) {
+            std::stringstream ss;
+            ss << "Cannot use an unevaluated reference to '" << lhs.function().name()
+               << "' to define an update with different arguments.";
             throw CompileError(ss.str());
         }
         if (f.has_pure_definition() || f.has_extern_definition()) {
@@ -41,6 +48,31 @@ struct UnevaluatedFuncRefExpr {
             return (void)(lhs /= rhs);
         }
         throw InternalError("Invalid Op value.");
+    }
+
+private:
+    template<typename T>
+    static bool validate_args_impl(const std::vector<Expr> &expected, const std::vector<T> &actual) {
+        if (expected.size() != actual.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < expected.size(); i++) {
+            if (!Internal::equal(expected[i], actual[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template<typename T,
+             typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, std::vector<std::decay_t<T>>>>>
+    bool validate_args(const std::vector<Expr> &expected, T &&actual) {
+        return validate_args_impl(expected, std::vector<std::decay_t<T>>{std::forward<T>(actual)});
+    }
+
+    template<typename T>
+    bool validate_args(const std::vector<Expr> &expected, const std::vector<T> &actual) {
+        return validate_args_impl(expected, actual);
     }
 };
 void define_func_ref(py::module &m);

--- a/python_bindings/src/halide/halide_/PyFuncRef.h
+++ b/python_bindings/src/halide/halide_/PyFuncRef.h
@@ -8,6 +8,7 @@ namespace PythonBindings {
 
 struct StageFromInPlaceUpdate {
     Stage new_stage;
+    FuncRef func_ref;
 };
 void define_func_ref(py::module &m);
 

--- a/python_bindings/src/halide/halide_/PyFuncRef.h
+++ b/python_bindings/src/halide/halide_/PyFuncRef.h
@@ -16,36 +16,31 @@ struct UnevaluatedFuncRefExpr {
         Div,
     } op;
 
-    operator Expr() const {
+    void define_update(const Func &func) {
+        const Internal::Function &f = func.function();
+        if (!f.same_as(lhs.function())) {
+            std::stringstream ss;
+            ss << "Cannot use an unevaluated reference to '" << lhs.function().name()
+               << "' to define an update in a different func '" << func.name() << "'.";
+            throw CompileError(ss.str());
+        }
+        if (f.has_pure_definition() || f.has_extern_definition()) {
+            std::stringstream ss;
+            ss << "Cannot use an unevaluated reference to '" << lhs.function().name()
+               << "' to define an update when a pure definition already exists.";
+            throw CompileError(ss.str());
+        }
         switch (op) {
         case Op::Add:
-            return lhs + rhs;
+            return (void)(lhs += rhs);
         case Op::Sub:
-            return lhs - rhs;
+            return (void)(lhs -= rhs);
         case Op::Mul:
-            return lhs * rhs;
+            return (void)(lhs *= rhs);
         case Op::Div:
-            return lhs / rhs;
+            return (void)(lhs /= rhs);
         }
-        throw std::runtime_error("Invalid operator");
-    }
-
-    bool define_update(const Func &func) {
-        const Internal::Function &f = func.function();
-        if (f.same_as(lhs.function()) && !(f.has_pure_definition() || f.has_extern_definition())) {
-            switch (op) {
-            case Op::Add:
-                return lhs += rhs, true;
-            case Op::Sub:
-                return lhs -= rhs, true;
-            case Op::Mul:
-                return lhs *= rhs, true;
-            case Op::Div:
-                return lhs /= rhs, true;
-            }
-            throw std::runtime_error("Invalid operator");
-        }
-        return false;
+        throw InternalError("Invalid Op value.");
     }
 };
 void define_func_ref(py::module &m);

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -564,6 +564,14 @@ def test_unevaluated_funcref():
     else:
         assert False, "Did not see expected exception!"
 
+    # A test to make sure that indexing at a FuncRef is OK
+    g = hl.Func("g")
+    g[x] = 2
+
+    f = hl.Func("f")
+    f[g[0]] += 1
+    assert list(f.realize([3])) == [0, 0, 1]
+
 
 def test_implicit_update_by_int():
     x = hl.Var("x")

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -547,6 +547,24 @@ def test_unevaluated_funcref():
     else:
         assert False, "Did not see expected exception!"
 
+    try:
+        # This is OK
+        g = hl.Func("g")
+        g[0] += 1
+        assert list(g.realize([2])) == [1, 0]
+
+        # This is invalid because the list of arguments changed
+        f = hl.Func("f")
+        ref = f[x] + 1
+        f[0] = ref
+    except hl.HalideError as e:
+        assert re.match(
+            r"Cannot use an unevaluated reference to 'f(\$\d+)?' to define an update with different arguments\.",
+            str(e),
+        )
+    else:
+        assert False, "Did not see expected exception!"
+
 
 def test_implicit_update_by_int():
     x = hl.Var("x")

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -555,8 +555,7 @@ def test_unevaluated_funcref():
 
         # This is invalid because the list of arguments changed
         f = hl.Func("f")
-        ref = f[x] + 1
-        f[0] = ref
+        f[0] = f[x] + 1
     except hl.HalideError as e:
         assert re.match(
             r"Cannot use an unevaluated reference to 'f(\$\d+)?' to define an update with different arguments\.",

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -399,12 +399,12 @@ def test_requirements():
     delta.set(1)
     p.realize([10])
 
-    with assert_throws(hl.HalideError, "Requirement Failed: \(false\)"):
+    with assert_throws(hl.HalideError, r"Requirement Failed: \(false\)"):
         delta.set(0)
         p.realize([10])
 
     with assert_throws(
-        hl.HalideError, "Requirement Failed: \(false\) negative values are bad -1"
+        hl.HalideError, r"Requirement Failed: \(false\) negative values are bad -1"
     ):
         delta.set(-1)
         p.realize([10])
@@ -462,7 +462,7 @@ def test_unevaluated_funcref():
 
     with assert_throws(
         hl.HalideError,
-        r"Cannot use an unevaluated reference to 'f\$\d+' to define an update in a different func 'f\$\d+'.",
+        r"Cannot use an unevaluated reference to 'f\$\d+' to define an update at a different location.",
     ):
         # We also can't use the unevaluated ref to define an update in a
         # different func (even if they look like they have the same name)
@@ -500,7 +500,7 @@ def test_unevaluated_funcref():
 
     with assert_throws(
         hl.HalideError,
-        r"Cannot use an unevaluated reference to 'f(\$\d+)?' to define an update with different arguments\.",
+        r"Cannot use an unevaluated reference to 'f(\$\d+)?' to define an update at a different location\.",
     ):
         # This is OK
         g = hl.Func("g")
@@ -518,6 +518,15 @@ def test_unevaluated_funcref():
     f = hl.Func("f")
     f[g[0]] += 1
     assert list(f.realize([3])) == [0, 0, 1]
+
+    # A test to make sure that placeholder args work
+    g = hl.Func("g")
+    g[x] = 2
+
+    print("------------------------")
+    f = hl.Func("f")
+    f[hl._] += g[hl._]
+    assert list(f.realize([1])) == [2]
 
 
 def test_implicit_update_by_int():

--- a/python_bindings/test/correctness/rdom.py
+++ b/python_bindings/test/correctness/rdom.py
@@ -1,4 +1,5 @@
 import halide as hl
+import numpy as np
 
 
 def test_rdom():
@@ -45,5 +46,24 @@ def test_rdom():
     return 0
 
 
+def test_implicit_pure_definition():
+    a = np.random.ranf((2, 3)).astype(np.float32)
+    expected = a.sum(axis=1)
+
+    ha = hl.Buffer(a, name="ha")
+    da_cols = ha.dim(0).extent()
+
+    x = hl.Var("x")
+    k = hl.RDom([(0, da_cols)], name="k")
+
+    hc = hl.Func("hc")
+    # hc[x] = 0.0 # this is implicit
+    hc[x] += ha[k, x]
+
+    result = np.array(hc.realize([2]))
+    assert np.allclose(result, expected)
+
+
 if __name__ == "__main__":
     test_rdom()
+    test_implicit_pure_definition()

--- a/src/Error.h
+++ b/src/Error.h
@@ -168,7 +168,7 @@ struct ErrorReport : ReportBase<ErrorReport<Exception>> {
 #pragma warning(disable : 4722)
 #endif
     /** When you're done using << on the object, and let it fall out of
-     * scope, this throws an exception or abort if they are disabled.
+     * scope, this throws an exception (or aborts if exceptions are disabled).
      * This is a little dangerous because the destructor will also be
      * called if there's an exception in flight due to an error in one
      * of the arguments passed to operator<<. We handle this by rethrowing

--- a/src/Error.h
+++ b/src/Error.h
@@ -163,19 +163,23 @@ struct ErrorReport : ReportBase<ErrorReport<Exception>> {
         this->msg << "Error: ";
     }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4722)
+#endif
     /** When you're done using << on the object, and let it fall out of
-     * scope, this errors out, or throws an exception if they are
-     * enabled. This is a little dangerous because the destructor will
-     * also be called if there's an exception in flight due to an
-     * error in one of the arguments passed to operator<<. We handle
-     * this by rethrowing the current exception, if it exists.
+     * scope, this throws an exception or abort if they are disabled.
+     * This is a little dangerous because the destructor will also be
+     * called if there's an exception in flight due to an error in one
+     * of the arguments passed to operator<<. We handle this by rethrowing
+     * the current exception, if it exists.
      */
     [[noreturn]] ~ErrorReport() noexcept(false) {
         throw_error(Exception(this->finalize_message()));
-#ifdef _MSC_VER
-#pragma warning(suppress : 4722)
-#endif
     }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 };
 
 struct WarningReport : ReportBase<WarningReport> {

--- a/src/Error.h
+++ b/src/Error.h
@@ -168,11 +168,13 @@ struct ErrorReport : ReportBase<ErrorReport<Exception>> {
      * enabled. This is a little dangerous because the destructor will
      * also be called if there's an exception in flight due to an
      * error in one of the arguments passed to operator<<. We handle
-     * this by only actually throwing if there isn't an exception in
-     * flight already.
+     * this by rethrowing the current exception, if it exists.
      */
     [[noreturn]] ~ErrorReport() noexcept(false) {
         throw_error(Exception(this->finalize_message()));
+#ifdef _MSC_VER
+#pragma warning(suppress : 4722)
+#endif
     }
 };
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3328,6 +3328,21 @@ size_t FuncRef::size() const {
     return func.outputs();
 }
 
+bool FuncRef::equivalent_to(const FuncRef &other) const {
+    if (!func.same_as(other.func) ||
+        implicit_placeholder_pos != other.implicit_placeholder_pos ||
+        implicit_count != other.implicit_count ||
+        args.size() != other.args.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < args.size(); i++) {
+        if (!equal(args[i], other.args[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 FuncTupleElementRef::FuncTupleElementRef(
     const FuncRef &ref, const std::vector<Expr> &args, int idx)
     : func_ref(ref), args(args), idx(idx) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -591,6 +591,11 @@ public:
     Internal::Function function() const {
         return func;
     }
+
+    /** What are the arguments to the function? */
+    const std::vector<Expr> &get_args() const {
+        return args;
+    }
 };
 
 /** Explicit overloads of min and max for FuncRef. These exist to

--- a/src/Func.h
+++ b/src/Func.h
@@ -587,14 +587,12 @@ public:
     /** How many outputs does the function this refers to produce. */
     size_t size() const;
 
+    /** Is this FuncRef syntactically equivalent to another one? */
+    bool equivalent_to(const FuncRef &other) const;
+
     /** What function is this calling? */
     Internal::Function function() const {
         return func;
-    }
-
-    /** What are the arguments to the function? */
-    const std::vector<Expr> &get_args() const {
-        return args;
     }
 };
 

--- a/src/Var.h
+++ b/src/Var.h
@@ -20,7 +20,7 @@ class Var {
     /* The expression representing the Var. Guaranteed to be an
      * Internal::Variable of type Int(32). Created once on
      * construction of the Var to avoid making a fresh Expr every time
-     * the Var is used in a context in which is will be converted to
+     * the Var is used in a context in which it will be converted to
      * one. */
     Expr e;
 


### PR DESCRIPTION
This enables inference of units (and types) for pure definitions in reduction-y update stages.

Fixes #8661