### PR TITLE
Use ruff to format and lint Python code

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -17,21 +17,25 @@ permissions:
 
 jobs:
   check_clang_format:
-    name: Check clang-format
+    name: Check clang-format and ruff
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Install clang-format
         run: brew install llvm@19
+
       - name: Check clang-format
         run: ./run-clang-format.sh -c
         env:
           CLANG_FORMAT_LLVM_INSTALL_DIR: /opt/homebrew/opt/llvm@19
+
+      - uses: astral-sh/ruff-action@v3
   check_clang_tidy:
     name: Check clang-tidy
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install clang-tidy
         run: brew install llvm@19 ninja lld@19
       - name: Run clang-tidy
@@ -42,7 +46,7 @@ jobs:
     name: Check CMake file lists
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run test sources check
         run: |
           shopt -s nullglob

--- a/apps/HelloPyTorch/modules.py
+++ b/apps/HelloPyTorch/modules.py
@@ -7,6 +7,7 @@ import halide_ops as ops
 # TODO(mgharbi): maybe find a way to wrap function and module directly in C++
 # instead of generating the C++ wrapper on the fly?
 
+
 def _dispatch(opname, optype=th.float32, cuda=False):
     """
     Helper function that matches an opname and type to the Halide backend.
@@ -40,6 +41,7 @@ def _dispatch(opname, optype=th.float32, cuda=False):
         raise ValueError(f"Module has no operator {opname}")
     return op
 
+
 def _forward_common(ctx, input_a, input_b):
     tp = input_a.dtype
     cuda = input_a.is_cuda
@@ -56,6 +58,7 @@ def _forward_common(ctx, input_a, input_b):
 
     fn_(input_a, input_b, out)
     return out
+
 
 def _backward_common(ctx, d_out, backward_op):
     tp = d_out.dtype
@@ -75,48 +78,54 @@ def _backward_common(ctx, d_out, backward_op):
     fn_(input_a, input_b, d_out.contiguous(), d_input_a, d_input_b)
     return d_input_a, d_input_b
 
+
 # TODO(srj): surely there's a better way to do this,
 # but PyTorch seems to make it tricky to pass in
 # extra info to the backward() method.
 class AddFunction_Grad(th.autograd.Function):
-  """Version using the manually-written backprop"""
-  def __init__(self):
-      super().__init__()
+    """Version using the manually-written backprop"""
 
-  @staticmethod
-  def forward(ctx, input_a, input_b):
-      return _forward_common(ctx, input_a, input_b)
+    def __init__(self):
+        super().__init__()
 
-  @staticmethod
-  def backward(ctx, d_out):
-      return _backward_common(ctx, d_out, "add_grad")
+    @staticmethod
+    def forward(ctx, input_a, input_b):
+        return _forward_common(ctx, input_a, input_b)
+
+    @staticmethod
+    def backward(ctx, d_out):
+        return _backward_common(ctx, d_out, "add_grad")
+
 
 class AddFunction_HalideGrad(th.autograd.Function):
-  """Version using the Halide-generated backprop"""
-  def __init__(self):
-      super().__init__()
+    """Version using the Halide-generated backprop"""
 
-  @staticmethod
-  def forward(ctx, input_a, input_b):
-      return _forward_common(ctx, input_a, input_b)
+    def __init__(self):
+        super().__init__()
 
-  @staticmethod
-  def backward(ctx, d_out):
-      return _backward_common(ctx, d_out, "add_halidegrad")
+    @staticmethod
+    def forward(ctx, input_a, input_b):
+        return _forward_common(ctx, input_a, input_b)
+
+    @staticmethod
+    def backward(ctx, d_out):
+        return _backward_common(ctx, d_out, "add_halidegrad")
+
 
 class Add(th.nn.Module):
     """Defines a module that uses our autograd function.
 
     This is so we can use it as an operator.
     """
+
     def __init__(self, backward_op):
         super().__init__()
         if backward_op == "add_grad":
-          self._adder = AddFunction_Grad
+            self._adder = AddFunction_Grad
         elif backward_op == "add_halidegrad":
-          self._adder = AddFunction_HalideGrad
+            self._adder = AddFunction_HalideGrad
         else:
-          assert False
+            assert False
 
     def forward(self, a, b):
         return self._adder.apply(a, b)

--- a/apps/HelloPyTorch/modules.py
+++ b/apps/HelloPyTorch/modules.py
@@ -34,10 +34,10 @@ def _dispatch(opname, optype=th.float32, cuda=False):
     elif optype == th.float64:
         opname += "_float64"
     else:
-        raise ValueError("Optype %s not recognized %s" % optype)
+        raise ValueError("Optype {} not recognized {}".format(*optype))
     op = getattr(ops, opname)
     if not hasattr(ops, opname):
-        raise ValueError("Module has no operator %s" % opname)
+        raise ValueError(f"Module has no operator {opname}")
     return op
 
 def _forward_common(ctx, input_a, input_b):
@@ -81,7 +81,7 @@ def _backward_common(ctx, d_out, backward_op):
 class AddFunction_Grad(th.autograd.Function):
   """Version using the manually-written backprop"""
   def __init__(self):
-      super(AddFunction_Grad, self).__init__()
+      super().__init__()
 
   @staticmethod
   def forward(ctx, input_a, input_b):
@@ -94,7 +94,7 @@ class AddFunction_Grad(th.autograd.Function):
 class AddFunction_HalideGrad(th.autograd.Function):
   """Version using the Halide-generated backprop"""
   def __init__(self):
-      super(AddFunction_HalideGrad, self).__init__()
+      super().__init__()
 
   @staticmethod
   def forward(ctx, input_a, input_b):
@@ -110,7 +110,7 @@ class Add(th.nn.Module):
     This is so we can use it as an operator.
     """
     def __init__(self, backward_op):
-        super(Add, self).__init__()
+        super().__init__()
         if backward_op == "add_grad":
           self._adder = AddFunction_Grad
         elif backward_op == "add_halidegrad":

--- a/apps/HelloPyTorch/modules.py
+++ b/apps/HelloPyTorch/modules.py
@@ -23,7 +23,7 @@ def _dispatch(opname, optype=th.float32, cuda=False):
       op: a python function wrapping the requested Halide operator.
     """
 
-    assert type(opname) == str, "opname should be a string"
+    assert type(opname) is str, "opname should be a string"
     assert type(optype) == th.dtype, "optype should be a tensor datatype (torch.dtype)"
 
     if cuda:

--- a/apps/HelloPyTorch/setup.py
+++ b/apps/HelloPyTorch/setup.py
@@ -2,10 +2,9 @@
 import os
 import platform
 import re
-from setuptools import setup, find_packages
+from setuptools import setup
 
 from torch.utils.cpp_extension import BuildExtension
-import torch as th
 
 
 def generate_pybind_wrapper(path, headers, has_cuda):

--- a/apps/HelloPyTorch/setup.py
+++ b/apps/HelloPyTorch/setup.py
@@ -19,8 +19,7 @@ def generate_pybind_wrapper(path, headers, has_cuda):
     s += "\nPYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {\n"
     for h in headers:
         name = os.path.splitext(h)[0]
-        s += "  m.def(\"{}\", &{}_th_, \"PyTorch wrapper of the Halide pipeline {}\");\n".format(
-          name, name, name)
+        s += f"  m.def(\"{name}\", &{name}_th_, \"PyTorch wrapper of the Halide pipeline {name}\");\n"
     s += "}\n"
     with open(path, 'w') as fid:
         fid.write(s)
@@ -30,12 +29,12 @@ if __name__ == "__main__":
     # wrapper in this directory
     build_dir = os.getenv("BIN")
     if build_dir is None or not os.path.exists(build_dir):
-        raise ValueError("Bin directory {} is invalid".format(build_dir))
+        raise ValueError(f"Bin directory {build_dir} is invalid")
 
     # Path to a distribution of Halide
     halide_dir = os.getenv("HALIDE_DISTRIB_PATH")
     if halide_dir is None or not os.path.exists(halide_dir):
-        raise ValueError("Halide directory {} is invalid".format(halide_dir))
+        raise ValueError(f"Halide directory {halide_dir} is invalid")
 
     has_cuda = os.getenv("HAS_CUDA")
     if has_cuda is None or has_cuda == "0":

--- a/apps/HelloPyTorch/test.py
+++ b/apps/HelloPyTorch/test.py
@@ -68,7 +68,7 @@ class TestAdd(unittest.TestCase):
                 "ignore", module=r".*gradcheck*")
 
             # Test the gradient is correct
-            res = th.autograd.gradcheck(add, [self.a, self.b], eps=1e-2)
+            th.autograd.gradcheck(add, [self.a, self.b], eps=1e-2)
 
             print("     Test ran successfully: difference is", diff)
 

--- a/apps/HelloPyTorch/test.py
+++ b/apps/HelloPyTorch/test.py
@@ -54,7 +54,7 @@ class TestAdd(unittest.TestCase):
                 print("  .Single-precision mode, backward_op:", backward_op)
 
             diff = (output-self.gt).sum().item()
-            assert diff == 0.0, "Test failed: sum should be 4, got %f" % diff
+            assert diff == 0.0, f"Test failed: sum should be 4, got {diff:f}"
 
             self.a.requires_grad = True
             self.b.requires_grad = True

--- a/apps/HelloPyTorch/test.py
+++ b/apps/HelloPyTorch/test.py
@@ -1,7 +1,6 @@
 """Verifies the Halide operator functions properly."""
 
 
-import os
 import unittest
 import warnings
 

--- a/apps/HelloPyTorch/test.py
+++ b/apps/HelloPyTorch/test.py
@@ -1,6 +1,5 @@
 """Verifies the Halide operator functions properly."""
 
-
 import unittest
 import warnings
 
@@ -11,8 +10,8 @@ import modules
 class TestAdd(unittest.TestCase):
     def setUp(self):
         self.a = th.ones(1, 2, 8, 8)
-        self.b = th.ones(1, 2, 8, 8)*3
-        self.gt = th.ones(1, 2, 8, 8)*4
+        self.b = th.ones(1, 2, 8, 8) * 3
+        self.gt = th.ones(1, 2, 8, 8) * 4
 
     def test_cpu_single(self):
         self._test_add(is_double=False)
@@ -52,7 +51,7 @@ class TestAdd(unittest.TestCase):
             else:
                 print("  .Single-precision mode, backward_op:", backward_op)
 
-            diff = (output-self.gt).sum().item()
+            diff = (output - self.gt).sum().item()
             assert diff == 0.0, f"Test failed: sum should be 4, got {diff:f}"
 
             self.a.requires_grad = True
@@ -61,11 +60,10 @@ class TestAdd(unittest.TestCase):
             for i in range(100):
                 output = add(self.a, self.b).sum()
                 output.backward()
-            
+
             # Inputs are float, the gradient checker wants double inputs and
             # will issue a warning.
-            warnings.filterwarnings(
-                "ignore", module=r".*gradcheck*")
+            warnings.filterwarnings("ignore", module=r".*gradcheck*")
 
             # Test the gradient is correct
             th.autograd.gradcheck(add, [self.a, self.b], eps=1e-2)

--- a/apps/depthwise_separable_conv/tf_separable_conv.py
+++ b/apps/depthwise_separable_conv/tf_separable_conv.py
@@ -1,12 +1,11 @@
 import tensorflow as tf
 import time
 
-with tf.device('/GPU:0'):
-
+with tf.device("/GPU:0"):
     img = tf.random.uniform([4, 112, 112, 32])
     depthwise_filter = tf.random.uniform([3, 3, 32, 1])
     pointwise_filter = tf.random.uniform([1, 1, 32 * 1, 16])
-    
+
     best = None
     num_trials = 10
     num_iter = 10
@@ -14,10 +13,14 @@ with tf.device('/GPU:0'):
         start = time.time()
         for i in range(num_iter):
             out = tf.nn.separable_conv2d(
-                img, depthwise_filter, pointwise_filter,
-                strides = (1, 1, 1, 1), padding = 'VALID')
+                img,
+                depthwise_filter,
+                pointwise_filter,
+                strides=(1, 1, 1, 1),
+                padding="VALID",
+            )
         end = time.time()
         t = (end - start) / num_iter
         if not best or t < best:
             best = t
-    print(f'time: {1000 * best} ms')
+    print(f"time: {1000 * best} ms")

--- a/apps/depthwise_separable_conv/tf_separable_conv.py
+++ b/apps/depthwise_separable_conv/tf_separable_conv.py
@@ -18,5 +18,6 @@ with tf.device('/GPU:0'):
                 strides = (1, 1, 1, 1), padding = 'VALID')
         end = time.time()
         t = (end - start) / num_iter
-        if not best or t < best: best = t
+        if not best or t < best:
+            best = t
     print(f'time: {1000 * best} ms')

--- a/apps/depthwise_separable_conv/tf_separable_conv.py
+++ b/apps/depthwise_separable_conv/tf_separable_conv.py
@@ -19,4 +19,4 @@ with tf.device('/GPU:0'):
         end = time.time()
         t = (end - start) / num_iter
         if not best or t < best: best = t
-    print('time: {} ms'.format(1000 * best))
+    print(f'time: {1000 * best} ms')

--- a/apps/onnx/halide_as_onnx_backend.py
+++ b/apps/onnx/halide_as_onnx_backend.py
@@ -1,6 +1,5 @@
 """Backend for running ONNX using Halide"""
 
-
 from onnx.backend.base import Backend as BackendBase
 import onnx
 import model as halide_model
@@ -8,11 +7,12 @@ import model as halide_model
 
 class HalideBackend(BackendBase):
     @classmethod
-    def is_compatible(cls,
-                      model,  # type: ModelProto
-                      device='CPU',  # type: Text
-                      **kwargs  # type: Any
-                      ):  # type: (...) -> bool
+    def is_compatible(
+        cls,
+        model,  # type: ModelProto
+        device="CPU",  # type: Text
+        **kwargs,  # type: Any
+    ):  # type: (...) -> bool
         """Returns whether the model is compatible with the backend.
         For the moment, we always return True and will throw an exception
         later when preparing or running the model.
@@ -20,11 +20,12 @@ class HalideBackend(BackendBase):
         return True
 
     @classmethod
-    def prepare(cls,
-                model,  # type: ModelProto
-                device='CPU',  # type: Text
-                **kwargs  # type: Any
-                ):
+    def prepare(
+        cls,
+        model,  # type: ModelProto
+        device="CPU",  # type: Text
+        **kwargs,  # type: Any
+    ):
         """Prepare an ONNX model to run using the Halide backend.
 
         Builds and returns an internal representation of the model (which
@@ -46,12 +47,13 @@ class HalideBackend(BackendBase):
         return prepared
 
     @classmethod
-    def run_model(cls,
-                  model,  # type: ModelProto
-                  inputs,  # type: Any
-                  device='CPU',  # type: Text
-                  **kwargs  # type: Any
-                  ):  # type: (...) -> Tuple[Any, ...]
+    def run_model(
+        cls,
+        model,  # type: ModelProto
+        inputs,  # type: Any
+        device="CPU",  # type: Text
+        **kwargs,  # type: Any
+    ):  # type: (...) -> Tuple[Any, ...]
         """Evaluate a ONNX model using the Halide backend.
 
         :param model: The ONNX model to be converted.
@@ -63,13 +65,14 @@ class HalideBackend(BackendBase):
         return prepared.run(inputs, device)
 
     @classmethod
-    def run_node(cls,
-                 node,  # type: NodeProto
-                 inputs,  # type: Any
-                 device='CPU',  # type: Text
-                 outputs_info=None,   # type: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]]
-                 **kwargs  # type: Dict[Text, Any]
-                 ):  # type: (...) -> Optional[Tuple[Any, ...]]
+    def run_node(
+        cls,
+        node,  # type: NodeProto
+        inputs,  # type: Any
+        device="CPU",  # type: Text
+        outputs_info=None,  # type: Optional[Sequence[Tuple[numpy.dtype, Tuple[int, ...]]]]
+        **kwargs,  # type: Dict[Text, Any]
+    ):  # type: (...) -> Optional[Tuple[Any, ...]]
         """Evaluate a single ONNX node using the Halide backend.
         Not supported yet.
         """
@@ -82,7 +85,7 @@ class HalideBackend(BackendBase):
         Checks whether the backend is compiled with support for the requested
         device and that device is available on the machine.
         """
-        if device == 'CPU':
+        if device == "CPU":
             return True
         else:
             # We don't support anything else at this time
@@ -94,4 +97,3 @@ run_node = HalideBackend.run_node
 run_model = HalideBackend.run_model
 supports_device = HalideBackend.supports_device
 is_compatible = HalideBackend.is_compatible
-

--- a/apps/onnx/halide_as_onnx_backend.py
+++ b/apps/onnx/halide_as_onnx_backend.py
@@ -1,7 +1,8 @@
 """Backend for running ONNX using Halide"""
 
-from onnx.backend.base import Backend as BackendBase
 import onnx
+from onnx.backend.base import Backend as BackendBase
+
 import model as halide_model
 
 
@@ -85,10 +86,9 @@ class HalideBackend(BackendBase):
         Checks whether the backend is compiled with support for the requested
         device and that device is available on the machine.
         """
-        if device == "CPU":
+        if device == "CPU":  # noqa: SIM103 - We don't support anything else at this time
             return True
         else:
-            # We don't support anything else at this time
             return False
 
 

--- a/apps/onnx/halide_as_onnx_backend.py
+++ b/apps/onnx/halide_as_onnx_backend.py
@@ -4,10 +4,6 @@
 from onnx.backend.base import Backend as BackendBase
 import onnx
 import model as halide_model
-import signal
-import base64
-import hashlib
-import datetime
 
 
 class HalideBackend(BackendBase):

--- a/apps/onnx/halide_as_onnx_backend_test.py
+++ b/apps/onnx/halide_as_onnx_backend_test.py
@@ -1,72 +1,69 @@
-
 import unittest
 import onnx.backend.test
 import halide_as_onnx_backend as halide_backend
 
 # This is a pytest magic variable to load extra plugins
-#pytest_plugins = 'onnx.backend.test.report',
+# pytest_plugins = 'onnx.backend.test.report',
 
 backend_test = onnx.backend.test.BackendTest(halide_backend, __name__)
 
 exclude_test_patterns = (
-    r'(test_hardsigmoid'  # Does not support Hardsigmoid.
-     '|test_hardmax'  # Does not support Hardmax.
-     '|test_depthtospace.*'  # Does not support DepthToSpace.
-     '|test_.*pool_with_argmax.*'  # argmax not yet supported
-     '|test_.*pool.*same.*'  # same padding not yet supported
-     '|test_.*unpool.*'  # unpool not yet supported
-     '|test_.*convtranspose.*'   # Not supported yet
-     '|test_.*ConvTranspose.*'   # Not supported yet
-     '|test_.*Conv.*_dilated.*'  # Not supported yet
-     '|test_maxpool.*dilation.*'  # MaxPool doesn't support dilation yet
-     '|test_.*mvn.*'  # MeanVarianceNormalization is not supported.
-     '|test_.*pool.*ceil.*'  # ceil mode is not supported yet
-     '|test_.*like.*'  # Needs implementation
-     '|test_.*instancenorm.*'  # not supported yet
-     '|test_reshape.*'
-     '|test_shrink.*'
-     '|test_tile.*'
-     '|test_dynamic_slice.*'  # not supported yet
-     '|test_arg.*'  # not supported yet
-     '|test_top.*'  # not supported yet
-     '|test_resize.*'  # opset 10 is not supported yet
-     '|test_compress_.*'  # not supported yet
-     '|test_nonzero.*'  # not supported yet
-     '|test_tfidfvectorizer.*'  # not supported yet
-     '|test_cast_FLOAT_to_STRING.*'  # not supported yet
-     '|test_cast_STRING_to_FLOAT.*'  # not supported yet
-     '|test_.*scatter.*'  # not supported yet
-     '|test_.*upsample.*'  # not supported yet
-     '|test_.*qlinear.*'  # skip quantized op test
-     '|test_.*quantize.*'  # skip quantized op test
-     '|test_.*matmulinteger.*'  # skip quantized op test
-     '|test_.*convinteger.*'  # skip quantized op test
-     '|test_mod_.*'  # not supported yet
-     '|test_cumsum_.*'  # not supported yet
-     '|test_bitshift_.*'  # not supported yet
-     '|test_nonmaxsuppression.*'  # not supported yet
-     '|test_reversesequence.*'  # not supported yet
-     '|test_roialign.*'  # not supported yet
-     '|test_round.*'  # not supported yet
-     '|test_scan.*'  # Scan not supported yet
-     '|test_strnorm.*'  # not supported yet
-     '|test_.*index.*'  # Indexing not supported
-     '|test_.*chunk.*'  # chunk not supported
-     '|test_operator_symbolic_override.*'  # InstanceNormalization not supported yet
-     '|test_.*FLOAT16*'  # FLOAT16 not supported yet
-     '|test_densenet.*'   # Times out
-     '|test_inception_v2.*'  # Padding type not supported for pooling
-     ')'
+    r"(test_hardsigmoid"  # Does not support Hardsigmoid.
+    "|test_hardmax"  # Does not support Hardmax.
+    "|test_depthtospace.*"  # Does not support DepthToSpace.
+    "|test_.*pool_with_argmax.*"  # argmax not yet supported
+    "|test_.*pool.*same.*"  # same padding not yet supported
+    "|test_.*unpool.*"  # unpool not yet supported
+    "|test_.*convtranspose.*"  # Not supported yet
+    "|test_.*ConvTranspose.*"  # Not supported yet
+    "|test_.*Conv.*_dilated.*"  # Not supported yet
+    "|test_maxpool.*dilation.*"  # MaxPool doesn't support dilation yet
+    "|test_.*mvn.*"  # MeanVarianceNormalization is not supported.
+    "|test_.*pool.*ceil.*"  # ceil mode is not supported yet
+    "|test_.*like.*"  # Needs implementation
+    "|test_.*instancenorm.*"  # not supported yet
+    "|test_reshape.*"
+    "|test_shrink.*"
+    "|test_tile.*"
+    "|test_dynamic_slice.*"  # not supported yet
+    "|test_arg.*"  # not supported yet
+    "|test_top.*"  # not supported yet
+    "|test_resize.*"  # opset 10 is not supported yet
+    "|test_compress_.*"  # not supported yet
+    "|test_nonzero.*"  # not supported yet
+    "|test_tfidfvectorizer.*"  # not supported yet
+    "|test_cast_FLOAT_to_STRING.*"  # not supported yet
+    "|test_cast_STRING_to_FLOAT.*"  # not supported yet
+    "|test_.*scatter.*"  # not supported yet
+    "|test_.*upsample.*"  # not supported yet
+    "|test_.*qlinear.*"  # skip quantized op test
+    "|test_.*quantize.*"  # skip quantized op test
+    "|test_.*matmulinteger.*"  # skip quantized op test
+    "|test_.*convinteger.*"  # skip quantized op test
+    "|test_mod_.*"  # not supported yet
+    "|test_cumsum_.*"  # not supported yet
+    "|test_bitshift_.*"  # not supported yet
+    "|test_nonmaxsuppression.*"  # not supported yet
+    "|test_reversesequence.*"  # not supported yet
+    "|test_roialign.*"  # not supported yet
+    "|test_round.*"  # not supported yet
+    "|test_scan.*"  # Scan not supported yet
+    "|test_strnorm.*"  # not supported yet
+    "|test_.*index.*"  # Indexing not supported
+    "|test_.*chunk.*"  # chunk not supported
+    "|test_operator_symbolic_override.*"  # InstanceNormalization not supported yet
+    "|test_.*FLOAT16*"  # FLOAT16 not supported yet
+    "|test_densenet.*"  # Times out
+    "|test_inception_v2.*"  # Padding type not supported for pooling
+    ")"
 )
 
 
 backend_test.exclude(exclude_test_patterns)
 
 # import all test cases at global scope to make them visible to python.unittest
-globals().update(backend_test
-                 .enable_report()
-                 .test_cases)
+globals().update(backend_test.enable_report().test_cases)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/apps/onnx/model.py
+++ b/apps/onnx/model.py
@@ -5,36 +5,40 @@ class Model:
     def __init__(self):
         self.pipeline = None
 
-    def BuildFromOnnxModel(self, onnx_model, expected_dim_sizes=None,
-                           layout=model_cpp.Layout.NumPy):
+    def BuildFromOnnxModel(
+        self, onnx_model, expected_dim_sizes=None, layout=model_cpp.Layout.NumPy
+    ):
         assert onnx_model
         if not expected_dim_sizes:
             expected_dim_sizes = {}
 
         if type(onnx_model) is str:
             onnx_model = onnx_model.encode()
-            self.pipeline = model_cpp.ConvertOnnxModel(onnx_model,
-                expected_dim_sizes, layout)
+            self.pipeline = model_cpp.ConvertOnnxModel(
+                onnx_model, expected_dim_sizes, layout
+            )
         elif type(onnx_model) is bytes:
-            self.pipeline = model_cpp.ConvertOnnxModel(onnx_model,
-                expected_dim_sizes, layout)
+            self.pipeline = model_cpp.ConvertOnnxModel(
+                onnx_model, expected_dim_sizes, layout
+            )
         else:
             # protobuf don't support swig, so we have to convert them to string.
             model_str = onnx_model.SerializeToString()
-            self.pipeline = model_cpp.ConvertOnnxModel(model_str,
-                expected_dim_sizes, layout)
+            self.pipeline = model_cpp.ConvertOnnxModel(
+                model_str, expected_dim_sizes, layout
+            )
 
     def OptimizeSchedule(self):
         if not self.pipeline:
             raise Exception("model not initialized, call BuildFromOnnxModel first")
         return model_cpp.AutoSchedule(self.pipeline)
 
-    def run(self, inputs, device=''):
+    def run(self, inputs, device=""):
         if not self.pipeline:
             raise Exception("model not initialized, call BuildFromOnnxModel first")
         return model_cpp.Run(self.pipeline, inputs, device)
 
-    def Benchmark(self, num_iters=5, device=''):
+    def Benchmark(self, num_iters=5, device=""):
         if not self.pipeline:
             raise Exception("model not initialized, call BuildFromOnnxModel first")
         return model_cpp.Benchmark(self.pipeline, num_iters, device)

--- a/apps/onnx/model.py
+++ b/apps/onnx/model.py
@@ -1,7 +1,7 @@
 import model_cpp
 
 
-class Model():
+class Model:
     def __init__(self):
         self.pipeline = None
 

--- a/apps/onnx/model_test.py
+++ b/apps/onnx/model_test.py
@@ -20,25 +20,24 @@ class ModelTest(unittest.TestCase):
 
     def test_small_model(self):
         # Create one input
-        X = helper.make_tensor_value_info('IN', TensorProto.FLOAT, [2, 3])
+        X = helper.make_tensor_value_info("IN", TensorProto.FLOAT, [2, 3])
         # Create one output
-        Y = helper.make_tensor_value_info('OUT', TensorProto.FLOAT, [2, 3])
+        Y = helper.make_tensor_value_info("OUT", TensorProto.FLOAT, [2, 3])
         # Create a node
-        node_def = helper.make_node('Abs', ['IN'], ['OUT'])
+        node_def = helper.make_node("Abs", ["IN"], ["OUT"])
 
         # Create the model
         graph_def = helper.make_graph([node_def], "test-model", [X], [Y])
-        onnx_model = helper.make_model(graph_def,
-                                       producer_name='onnx-example')
+        onnx_model = helper.make_model(graph_def, producer_name="onnx-example")
 
         model = Model()
         model.BuildFromOnnxModel(onnx_model)
         schedule = model.OptimizeSchedule()
-        schedule = schedule.replace('\n', ' ')
-        expected_schedule = r'.*Func OUT = pipeline.get_func\(1\);.+'
+        schedule = schedule.replace("\n", " ")
+        expected_schedule = r".*Func OUT = pipeline.get_func\(1\);.+"
         self.assertRegex(schedule, expected_schedule)
 
-        input = (np.random.rand(2, 3) - 0.5).astype('float32')
+        input = (np.random.rand(2, 3) - 0.5).astype("float32")
         outputs = model.run([input])
         self.assertEqual(1, len(outputs))
         output = outputs[0]
@@ -47,27 +46,26 @@ class ModelTest(unittest.TestCase):
 
     def test_scalars(self):
         # Create 2 inputs
-        X = helper.make_tensor_value_info('A', TensorProto.INT32, [])
-        Y = helper.make_tensor_value_info('B', TensorProto.INT32, [])
+        X = helper.make_tensor_value_info("A", TensorProto.INT32, [])
+        Y = helper.make_tensor_value_info("B", TensorProto.INT32, [])
         # Create one output
-        Z = helper.make_tensor_value_info('C', TensorProto.INT32, [])
+        Z = helper.make_tensor_value_info("C", TensorProto.INT32, [])
         # Create a node
-        node_def = helper.make_node('Add', ['A', 'B'], ['C'])
+        node_def = helper.make_node("Add", ["A", "B"], ["C"])
 
         # Create the model
         graph_def = helper.make_graph([node_def], "scalar-model", [X, Y], [Z])
-        onnx_model = helper.make_model(graph_def,
-                                       producer_name='onnx-example')
+        onnx_model = helper.make_model(graph_def, producer_name="onnx-example")
 
         model = Model()
         model.BuildFromOnnxModel(onnx_model)
         schedule = model.OptimizeSchedule()
-        schedule = schedule.replace('\n', ' ')        
-        expected_schedule = r'.*Func C = pipeline.get_func\(2\);.+'
+        schedule = schedule.replace("\n", " ")
+        expected_schedule = r".*Func C = pipeline.get_func\(2\);.+"
         self.assertRegex(schedule, expected_schedule)
 
-        input1 = np.random.randint(-10, 10, size=()).astype('int32')
-        input2 = np.random.randint(-10, 10, size=()).astype('int32')
+        input1 = np.random.randint(-10, 10, size=()).astype("int32")
+        input2 = np.random.randint(-10, 10, size=()).astype("int32")
         outputs = model.run([input1, input2])
         self.assertEqual(1, len(outputs))
         output = outputs[0]
@@ -75,20 +73,20 @@ class ModelTest(unittest.TestCase):
         np.testing.assert_allclose(expected, output)
 
     def test_model_with_initializer(self):
-        X = helper.make_tensor_value_info('X', TensorProto.FLOAT, [3, 1])
-        Z2 = helper.make_tensor_value_info('Z2', TensorProto.FLOAT, [2, 3, 6])
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [3, 1])
+        Z2 = helper.make_tensor_value_info("Z2", TensorProto.FLOAT, [2, 3, 6])
 
-        expand_node_def = helper.make_node('Expand', ['X', 'Y'], ['Z1'])
-        cast_node_def = helper.make_node('Scale', ['Z1'], ['Z2'])
+        expand_node_def = helper.make_node("Expand", ["X", "Y"], ["Z1"])
+        cast_node_def = helper.make_node("Scale", ["Z1"], ["Z2"])
 
-        graph_def = helper.make_graph([expand_node_def, cast_node_def],
+        graph_def = helper.make_graph(
+            [expand_node_def, cast_node_def],
             "test-node",
             [X],
             [Z2],
-            initializer=[
-                helper.make_tensor('Y', TensorProto.INT64, (3,), (2, 1, 6))])
-        onnx_model = helper.make_model(graph_def,
-                                       producer_name='onnx-example')
+            initializer=[helper.make_tensor("Y", TensorProto.INT64, (3,), (2, 1, 6))],
+        )
+        onnx_model = helper.make_model(graph_def, producer_name="onnx-example")
         model = Model()
         model.BuildFromOnnxModel(onnx_model)
         input_data = np.random.rand(3, 1).astype(np.float32)
@@ -97,20 +95,20 @@ class ModelTest(unittest.TestCase):
         np.testing.assert_allclose(expected, outputs[0])
 
     def test_tensors_rank_zero(self):
-        X = helper.make_tensor_value_info('X', TensorProto.FLOAT, [3, 2])
-        S1 = helper.make_tensor_value_info('S1', TensorProto.INT64, [])
-        S2 = helper.make_tensor_value_info('S2', TensorProto.FLOAT, [])
+        X = helper.make_tensor_value_info("X", TensorProto.FLOAT, [3, 2])
+        S1 = helper.make_tensor_value_info("S1", TensorProto.INT64, [])
+        S2 = helper.make_tensor_value_info("S2", TensorProto.FLOAT, [])
 
-        size_node = helper.make_node('Size', ['X'], ['S1'])
+        size_node = helper.make_node("Size", ["X"], ["S1"])
 
-        graph_def = helper.make_graph([size_node],
+        graph_def = helper.make_graph(
+            [size_node],
             "rank_zero_test",
             [X],
             [S1, S2],
-            initializer=[
-                helper.make_tensor('S2', TensorProto.FLOAT, (), (3.14,))])
-        onnx_model = helper.make_model(graph_def,
-                                       producer_name='onnx-example')
+            initializer=[helper.make_tensor("S2", TensorProto.FLOAT, (), (3.14,))],
+        )
+        onnx_model = helper.make_model(graph_def, producer_name="onnx-example")
         model = Model()
         model.BuildFromOnnxModel(onnx_model)
         input_data = np.random.rand(3, 2).astype(np.float32)

--- a/apps/resnet_50/load_weights.py
+++ b/apps/resnet_50/load_weights.py
@@ -4,6 +4,7 @@ import struct
 import os
 import sys
 
+
 def load_weights(dir):
     if not os.path.isdir(dir):
         print(f"Path {dir} is not a dir")
@@ -28,13 +29,14 @@ def load_weights(dir):
         print(f"{k},{weight.shape},{len(weight.shape)}")
 
         data = weight.tobytes()
-        path = os.path.join(dir, k.replace('.','_'))
+        path = os.path.join(dir, k.replace(".", "_"))
         with open(path + ".data", "wb") as f:
             f.write(data)
-        with open(path + '_shape.data', 'wb') as f:
-            f.write(struct.pack('i', len(weight.shape)))
+        with open(path + "_shape.data", "wb") as f:
+            f.write(struct.pack("i", len(weight.shape)))
             for i in list(reversed(range(len(weight.shape)))):
-                f.write(struct.pack('i', weight.shape[i]))
+                f.write(struct.pack("i", weight.shape[i]))
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:

--- a/apps/resnet_50/load_weights.py
+++ b/apps/resnet_50/load_weights.py
@@ -1,5 +1,3 @@
-import argparse
-import numpy as np
 import numpy as np
 import torchvision.models.resnet as resnet
 import struct

--- a/apps/resnet_50/load_weights.py
+++ b/apps/resnet_50/load_weights.py
@@ -16,7 +16,7 @@ def load_weights(dir):
     dic = resnet50.state_dict()
     # numpy stores weights in output channel, input channel, h, w order
     # we want to transpose to output channel, h, w, input channel order
-    for k in dic.keys():
+    for k in dic:
         weight = dic[k].cpu().detach().numpy()
         weight = weight.astype(np.float32)
         print("weight shape before transpose")

--- a/apps/resnet_50/load_weights.py
+++ b/apps/resnet_50/load_weights.py
@@ -21,13 +21,13 @@ def load_weights(dir):
         weight = dic[k].cpu().detach().numpy()
         weight = weight.astype(np.float32)
         print("weight shape before transpose")
-        print("%s,%s,%d" % (k, str(weight.shape), len(weight.shape)))
+        print(f"{k},{weight.shape},{len(weight.shape)}")
         if len(weight.shape) == 4:
             weight = np.transpose(weight, (1, 2, 3, 0))
         if len(weight.shape) == 2:
             weight = np.transpose(weight, (1, 0))
         print("weight shape after transpose")
-        print("%s,%s,%d" % (k, str(weight.shape), len(weight.shape)))
+        print(f"{k},{weight.shape},{len(weight.shape)}")
 
         data = weight.tobytes()
         path = os.path.join(dir, k.replace('.','_'))

--- a/apps/resnet_50/load_weights.py
+++ b/apps/resnet_50/load_weights.py
@@ -8,7 +8,7 @@ import sys
 
 def load_weights(dir):
     if not os.path.isdir(dir):
-        print("Path %s is not a dir" % dir)
+        print(f"Path {dir} is not a dir")
         sys.exit(1)
 
     print("-----------loading weights------------")

--- a/apps/resnet_50/load_weights.py
+++ b/apps/resnet_50/load_weights.py
@@ -34,8 +34,10 @@ def load_weights(dir):
             f.write(data)
         with open(path + "_shape.data", "wb") as f:
             f.write(struct.pack("i", len(weight.shape)))
-            for i in list(reversed(range(len(weight.shape)))):
-                f.write(struct.pack("i", weight.shape[i]))
+            f.writelines(
+                struct.pack("i", weight.shape[i])
+                for i in reversed(range(len(weight.shape)))
+            )
 
 
 if __name__ == "__main__":

--- a/apps/resnet_50/validate_resnet50_output.py
+++ b/apps/resnet_50/validate_resnet50_output.py
@@ -1,6 +1,5 @@
 import torch
 import torchvision.models.resnet as resnet
-import torchvision.transforms as transforms
 import torch.nn as nn
 import numpy as np
 import sys

--- a/apps/resnet_50/validate_resnet50_output.py
+++ b/apps/resnet_50/validate_resnet50_output.py
@@ -5,16 +5,16 @@ import numpy as np
 import sys
 
 if __name__ == "__main__":
-    assert(len(sys.argv) == 3)
+    assert len(sys.argv) == 3
     halide_output_file = sys.argv[1]
 
     seed = int(sys.argv[2])
     np.random.seed(seed)
     input_data = np.random.rand(1, 224, 224, 3).astype(np.float32)
-    input_data = input_data.transpose(0,3,1,2)
+    input_data = input_data.transpose(0, 3, 1, 2)
     image = torch.from_numpy(input_data)
 
-    net = resnet.resnet50(pretrained=True) 
+    net = resnet.resnet50(pretrained=True)
     net.eval()
     result = net(image)
     # PyTorch resnet50 model doesn't compute softmax of the output.
@@ -22,9 +22,9 @@ if __name__ == "__main__":
     ref_output = softmax(result)
 
     halide_output = np.fromfile(halide_output_file, dtype=np.float32)
-    
+
     ref_output = ref_output.cpu().detach().numpy().reshape(halide_output.shape)
 
     np.testing.assert_almost_equal(np.argmax(halide_output), np.argmax(ref_output))
     np.testing.assert_almost_equal(halide_output, ref_output, decimal=2)
-    print('Success!')
+    print("Success!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,16 +106,17 @@ inherit.cmake.define = "append"
 cmake.define.Halide_WASM_BACKEND = "OFF"
 
 [tool.ruff.lint]
+# docs: https://docs.astral.sh/ruff/rules/
 select = [
-    "E4", # Default rule set
-    "E7", # Default rule set
-    "E9", # Default rule set
-    "F", # Default rule set
-    "FURB", # Rules for upgrading old Python usage
-    "PERF", # Rules for performance pitfalls
+    "E4", # pycodestyle / import statements
+    "E7", # pycodestyle / superfluous or misused syntax
+    "E9", # pycodestyle / internal error (odd this can be disabled)
+    "F", # pyflakes
+    "FURB", # refurb / rules for upgrading old Python usage
+    "PERF", # perflint / rules for performance pitfalls
     "RUF", # Ruff-specific rules
-    "SIM", # Flake 8 - simplify
-    "UP" # Uses of old Python features
+    "SIM", # flake8 / simplify
+    "UP" # pyupgrade / detect uses of old Python features
 ]
 ignore = [
     "UP045", # Don't replace Optional[T] with T | None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ select = [
     "E7", # Default rule set
     "E9", # Default rule set
     "F", # Default rule set
+    "FURB", # Rules for upgrading old Python usage
     "RUF", # Ruff-specific rules
     "SIM", # Flake 8 - simplify
     "UP" # Uses of old Python features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ cmake.define.Halide_WASM_BACKEND = "OFF"
 select = [
     "UP" # Uses of old Python features
 ]
+ignore = [
+    "UP045" # Don't replace Optional[T] with T | None
+]
 
 [tool.tbump]
 github_url = "https://github.com/halide/Halide/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ select = [
     "E7", # Default rule set
     "E9", # Default rule set
     "F", # Default rule set
+    "RUF", # Ruff-specific rules
     "SIM", # Flake 8 - simplify
     "UP" # Uses of old Python features
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ if.platform-system = "^win32"
 inherit.cmake.define = "append"
 cmake.define.Halide_WASM_BACKEND = "OFF"
 
+[tool.ruff.lint]
+select = [
+    "UP" # Uses of old Python features
+]
+
 [tool.tbump]
 github_url = "https://github.com/halide/Halide/"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ select = [
     "E9", # Default rule set
     "F", # Default rule set
     "FURB", # Rules for upgrading old Python usage
+    "PERF", # Rules for performance pitfalls
     "RUF", # Ruff-specific rules
     "SIM", # Flake 8 - simplify
     "UP" # Uses of old Python features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,10 +111,12 @@ select = [
     "E7", # Default rule set
     "E9", # Default rule set
     "F", # Default rule set
+    "SIM", # Flake 8 - simplify
     "UP" # Uses of old Python features
 ]
 ignore = [
-    "UP045" # Don't replace Optional[T] with T | None
+    "UP045", # Don't replace Optional[T] with T | None
+    "SIM108", # Don't replace an if statement with ternary
 ]
 
 [tool.tbump]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ cmake.define.Halide_WASM_BACKEND = "OFF"
 
 [tool.ruff.lint]
 select = [
+    "E4", # Default rule set
+    "E7", # Default rule set
+    "E9", # Default rule set
+    "F", # Default rule set
     "UP" # Uses of old Python features
 ]
 ignore = [

--- a/python_bindings/apps/bilateral_grid_app.py
+++ b/python_bindings/apps/bilateral_grid_app.py
@@ -4,6 +4,7 @@ Bilateral histogram.
 
 from bilateral_grid import bilateral_grid
 from bilateral_grid_Adams2019 import bilateral_grid_Adams2019
+
 # from bilateral_grid_Li2018 import bilateral_grid_Li2018
 from bilateral_grid_Mullapudi2016 import bilateral_grid_Mullapudi2016
 import halide.imageio

--- a/python_bindings/apps/bilateral_grid_app.py
+++ b/python_bindings/apps/bilateral_grid_app.py
@@ -4,7 +4,7 @@ Bilateral histogram.
 
 from bilateral_grid import bilateral_grid
 from bilateral_grid_Adams2019 import bilateral_grid_Adams2019
-from bilateral_grid_Li2018 import bilateral_grid_Li2018
+# from bilateral_grid_Li2018 import bilateral_grid_Li2018
 from bilateral_grid_Mullapudi2016 import bilateral_grid_Mullapudi2016
 import halide.imageio
 import numpy as np

--- a/python_bindings/apps/bilateral_grid_app.py
+++ b/python_bindings/apps/bilateral_grid_app.py
@@ -14,8 +14,8 @@ import timeit
 
 def main():
     if len(sys.argv) < 4:
-        print("Usage: %s input.png output.png range_sigma" % sys.argv[0])
-        print("e.g. %s input.png output.png 0.1 10" % sys.argv[0])
+        print(f"Usage: {sys.argv[0]} input.png output.png range_sigma")
+        print(f"e.g. {sys.argv[0]} input.png output.png 0.1 10")
         sys.exit(1)
 
     input_path = sys.argv[1]
@@ -23,7 +23,7 @@ def main():
     output_path = sys.argv[3]
     timing_iterations = 10
 
-    print("Reading from %s ..." % input_path)
+    print(f"Reading from {input_path} ...")
     input_buf_u8 = halide.imageio.imread(input_path)
     assert input_buf_u8.dtype == np.uint8
     # Convert to float32
@@ -45,14 +45,14 @@ def main():
     }
 
     for name, fn in tests.items():
-        print("Running %s... " % name, end="")
+        print(f"Running {name}... ", end="")
         t = timeit.Timer(lambda: fn(input_buf, r_sigma, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 
     output_buf *= 255.0
     output_buf_u8 = output_buf.astype(np.uint8)
-    print("Saving to %s ..." % output_path)
+    print(f"Saving to {output_path} ...")
     halide.imageio.imwrite(output_path, output_buf_u8)
 
     print("Success!")

--- a/python_bindings/apps/blur_app.py
+++ b/python_bindings/apps/blur_app.py
@@ -11,15 +11,15 @@ import timeit
 
 def main():
     if len(sys.argv) < 3:
-        print("Usage: %s input.png output.png" % sys.argv[0])
-        print("e.g. %s input.png output.png 10" % sys.argv[0])
+        print(f"Usage: {sys.argv[0]} input.png output.png")
+        print(f"e.g. {sys.argv[0]} input.png output.png 10")
         sys.exit(1)
 
     input_path = sys.argv[1]
     output_path = sys.argv[2]
     timing_iterations = 10
 
-    print("Reading from %s ..." % input_path)
+    print(f"Reading from {input_path} ...")
     input_buf_u8 = halide.imageio.imread(input_path)
     assert input_buf_u8.dtype == np.uint8
     # Convert to uint16... but remember that the blur() generator
@@ -34,13 +34,13 @@ def main():
     }
 
     for name, fn in tests.items():
-        print("Running %s... " % name, end="")
+        print(f"Running {name}... ", end="")
         t = timeit.Timer(lambda: fn(input_buf, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 
     output_buf_u8 = output_buf.astype(np.uint8)
-    print("Saving to %s ..." % output_path)
+    print(f"Saving to {output_path} ...")
     halide.imageio.imwrite(output_path, output_buf_u8)
 
     print("Success!")

--- a/python_bindings/apps/interpolate_app.py
+++ b/python_bindings/apps/interpolate_app.py
@@ -12,15 +12,15 @@ import timeit
 
 def main():
     if len(sys.argv) < 3:
-        print("Usage: %s input.png output.png" % sys.argv[0])
-        print("e.g. %s input.png output.png 10" % sys.argv[0])
+        print(f"Usage: {sys.argv[0]} input.png output.png")
+        print(f"e.g. {sys.argv[0]} input.png output.png 10")
         sys.exit(1)
 
     input_path = sys.argv[1]
     output_path = sys.argv[2]
     timing_iterations = 10
 
-    print("Reading from %s ..." % input_path)
+    print(f"Reading from {input_path} ...")
     input_buf_u8 = halide.imageio.imread(input_path)
     assert input_buf_u8.dtype == np.uint8
     # Convert to float32 in range [0..1]
@@ -35,7 +35,7 @@ def main():
     }
 
     for name, fn in tests.items():
-        print("Running %s... " % name, end="")
+        print(f"Running {name}... ", end="")
         t = timeit.Timer(lambda: fn(input_buf, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
@@ -43,7 +43,7 @@ def main():
     output_buf *= 255.0
     output_buf_u8 = output_buf.astype(np.uint8)
 
-    print("Saving to %s ..." % output_path)
+    print(f"Saving to {output_path} ...")
     halide.imageio.imwrite(output_path, output_buf_u8)
 
     print("Success!")

--- a/python_bindings/apps/interpolate_generator.py
+++ b/python_bindings/apps/interpolate_generator.py
@@ -42,43 +42,43 @@ class interpolate:
             clamped[x, y, 3],
         )
 
-        for l in range(1, g.levels):
-            prev = downsampled[l - 1]
+        for lv in range(1, g.levels):
+            prev = downsampled[lv - 1]
 
-            if l == 4:
+            if lv == 4:
                 # Also add a boundary condition at a middle pyramid level
                 # to prevent the footprint of the downsamplings to extend
                 # too far off the base image. Otherwise we look 512
                 # pixels off each edge.
-                w = g.input_buf.width() / (1 << (l - 1))
-                h = g.input_buf.height() / (1 << (l - 1))
+                w = g.input_buf.width() / (1 << (lv - 1))
+                h = g.input_buf.height() / (1 << (lv - 1))
                 prev = hl.lambda_func(
                     x, y, c, prev[hl.clamp(x, 0, w), hl.clamp(y, 0, h), c]
                 )
 
-            downx[l][x, y, c] = (
+            downx[lv][x, y, c] = (
                 prev[x * 2 - 1, y, c] + 2 * prev[x * 2, y, c] + prev[x * 2 + 1, y, c]
             ) * 0.25
 
-            downsampled[l][x, y, c] = (
-                downx[l][x, y * 2 - 1, c]
-                + 2 * downx[l][x, y * 2, c]
-                + downx[l][x, y * 2 + 1, c]
+            downsampled[lv][x, y, c] = (
+                downx[lv][x, y * 2 - 1, c]
+                + 2 * downx[lv][x, y * 2, c]
+                + downx[lv][x, y * 2 + 1, c]
             ) * 0.25
 
         interpolated[g.levels - 1][x, y, c] = downsampled[g.levels - 1][x, y, c]
 
-        for l in range(g.levels - 2, -1, -1):
-            upsampledx[l][x, y, c] = (
-                interpolated[l + 1][x / 2, y, c]
-                + interpolated[l + 1][(x + 1) / 2, y, c]
+        for lv in range(g.levels - 2, -1, -1):
+            upsampledx[lv][x, y, c] = (
+                interpolated[lv + 1][x / 2, y, c]
+                + interpolated[lv + 1][(x + 1) / 2, y, c]
             ) / 2
-            upsampled[l][x, y, c] = (
-                upsampledx[l][x, y / 2, c] + upsampledx[l][x, (y + 1) / 2, c]
+            upsampled[lv][x, y, c] = (
+                upsampledx[lv][x, y / 2, c] + upsampledx[lv][x, (y + 1) / 2, c]
             ) / 2
-            alpha = 1.0 - downsampled[l][x, y, 3]
-            interpolated[l][x, y, c] = (
-                downsampled[l][x, y, c] + alpha * upsampled[l][x, y, c]
+            alpha = 1.0 - downsampled[lv][x, y, 3]
+            interpolated[lv][x, y, c] = (
+                downsampled[lv][x, y, c] + alpha * upsampled[lv][x, y, c]
             )
 
         g.output_buf[x, y, c] = interpolated[0][x, y, c] / interpolated[0][x, y, 3]
@@ -105,18 +105,18 @@ class interpolate:
                 .unroll(c)
             )
 
-            for l in range(1, g.levels):
+            for lv in range(1, g.levels):
                 (
-                    downsampled[l]
+                    downsampled[lv]
                     .compute_root()
                     .reorder(c, x, y)
                     .unroll(c)
                     .gpu_tile(x, y, xi, yi, 16, 16)
                 )
 
-            for l in range(3, g.levels, 2):
+            for lv in range(3, g.levels, 2):
                 (
-                    interpolated[l]
+                    interpolated[lv]
                     .compute_root()
                     .reorder(c, x, y)
                     .tile(x, y, xi, yi, 32, 32, hl.TailStrategy.RoundUp)
@@ -162,13 +162,13 @@ class interpolate:
             # 4.54ms on an Intel i9-9960X using 16 threads
             xo, xi, yo, yi = hl.vars("xo xi yo yi")
             vec = g.natural_vector_size(hl.Float(32))
-            for l in range(1, g.levels - 1):
+            for lv in range(1, g.levels - 1):
                 # We must refer to the downsampled stages in the
                 # upsampling later, so they must all be
                 # compute_root or redundantly recomputed, as in
                 # the local_laplacian app.
                 (
-                    downsampled[l]
+                    downsampled[lv]
                     .compute_root()
                     .reorder(x, c, y)
                     .split(y, yo, yi, 8)
@@ -203,9 +203,9 @@ class interpolate:
                 .parallel(yo)
             )
 
-            for l in range(1, g.levels):
+            for lv in range(1, g.levels):
                 (
-                    interpolated[l]
+                    interpolated[lv]
                     .store_at(g.output_buf, yo)
                     .compute_at(g.output_buf, yi)
                     .vectorize(x, vec)

--- a/python_bindings/apps/interpolate_generator.py
+++ b/python_bindings/apps/interpolate_generator.py
@@ -7,7 +7,7 @@ import halide as hl
 
 def _func_list(name, size):
     """Return a list containing `size` Funcs, named `name_n` for n in 0..size-1."""
-    return [hl.Func("%s_%d" % (name, i)) for i in range(size)]
+    return [hl.Func(f"{name}_{i}") for i in range(size)]
 
 
 @hl.alias(

--- a/python_bindings/apps/local_laplacian_app.py
+++ b/python_bindings/apps/local_laplacian_app.py
@@ -13,9 +13,9 @@ import timeit
 def main():
     if len(sys.argv) < 6:
         print(
-            "Usage: %s input.png input.png levels alpha beta output.png" % sys.argv[0]
+            f"Usage: {sys.argv[0]} input.png input.png levels alpha beta output.png"
         )
-        print("e.g. %s input.png 8 1 1 output.png 10" % sys.argv[0])
+        print(f"e.g. {sys.argv[0]} input.png 8 1 1 output.png 10")
         sys.exit(1)
 
     input_path = sys.argv[1]
@@ -25,7 +25,7 @@ def main():
     output_path = sys.argv[5]
     timing_iterations = 10
 
-    print("Reading from %s ..." % input_path)
+    print(f"Reading from {input_path} ...")
     input_buf_u8 = halide.imageio.imread(input_path)
     assert input_buf_u8.dtype == np.uint8
     # Convert to uint16 in range [0..1]
@@ -40,14 +40,14 @@ def main():
     }
 
     for name, fn in tests.items():
-        print("Running %s... " % name, end="")
+        print(f"Running {name}... ", end="")
         t = timeit.Timer(lambda: fn(input_buf, levels, alpha / (levels - 1), beta, output_buf))
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 
     output_buf_u8 = (output_buf // 257).astype(np.uint8)
 
-    print("Saving to %s ..." % output_path)
+    print(f"Saving to {output_path} ...")
     halide.imageio.imwrite(output_path, output_buf_u8)
 
     print("Success!")

--- a/python_bindings/apps/local_laplacian_app.py
+++ b/python_bindings/apps/local_laplacian_app.py
@@ -12,9 +12,7 @@ import timeit
 
 def main():
     if len(sys.argv) < 6:
-        print(
-            f"Usage: {sys.argv[0]} input.png input.png levels alpha beta output.png"
-        )
+        print(f"Usage: {sys.argv[0]} input.png input.png levels alpha beta output.png")
         print(f"e.g. {sys.argv[0]} input.png 8 1 1 output.png 10")
         sys.exit(1)
 
@@ -41,7 +39,9 @@ def main():
 
     for name, fn in tests.items():
         print(f"Running {name}... ", end="")
-        t = timeit.Timer(lambda: fn(input_buf, levels, alpha / (levels - 1), beta, output_buf))
+        t = timeit.Timer(
+            lambda: fn(input_buf, levels, alpha / (levels - 1), beta, output_buf)
+        )
         avg_time_sec = t.timeit(number=timing_iterations) / timing_iterations
         print("time: %fms" % (avg_time_sec * 1e3))
 

--- a/python_bindings/apps/local_laplacian_generator.py
+++ b/python_bindings/apps/local_laplacian_generator.py
@@ -10,7 +10,7 @@ x, y, c, k = hl.vars("x y c k")
 
 def _func_list(name, size):
     """Return a list containing `size` Funcs, named `name_n` for n in 0..size-1."""
-    return [hl.Func("%s_%d" % (name, i)) for i in range(size)]
+    return [hl.Func(f"{name}_{i}") for i in range(size)]
 
 
 def _downsample(f):

--- a/python_bindings/cmake/AddPythonTest.cmake
+++ b/python_bindings/cmake/AddPythonTest.cmake
@@ -23,5 +23,6 @@ function(add_python_test)
         LABELS "python"
         ENVIRONMENT "${ARG_ENVIRONMENT}"
         ENVIRONMENT_MODIFICATION "${ARG_PYTHONPATH}"
+        SKIP_REGULAR_EXPRESSION "\\[SKIP\\]"
     )
 endfunction()

--- a/python_bindings/src/halide/__init__.py
+++ b/python_bindings/src/halide/__init__.py
@@ -1,8 +1,10 @@
 def patch_dll_dirs():
     import os
-    if hasattr(os, 'add_dll_directory'):
+
+    if hasattr(os, "add_dll_directory"):
         from pathlib import Path
-        bin_dir = Path(__file__).parent / 'bin'
+
+        bin_dir = Path(__file__).parent / "bin"
         if bin_dir.exists():
             os.add_dll_directory(str(bin_dir))
 
@@ -11,12 +13,14 @@ patch_dll_dirs()
 del patch_dll_dirs
 
 from .halide_ import *  # noqa: E402, F403
+
 # noinspection PyUnresolvedReferences, PyProtectedMember
 from .halide_ import _, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9  # noqa: E402, F401
 
 
 def install_dir():
     import os
+
     return os.path.dirname(__file__)
 
 

--- a/python_bindings/src/halide/__init__.py
+++ b/python_bindings/src/halide/__init__.py
@@ -10,9 +10,9 @@ def patch_dll_dirs():
 patch_dll_dirs()
 del patch_dll_dirs
 
-from .halide_ import *
-# noinspection PyUnresolvedReferences
-from .halide_ import _, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9
+from .halide_ import *  # noqa: E402, F403
+# noinspection PyUnresolvedReferences, PyProtectedMember
+from .halide_ import _, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9  # noqa: E402, F401
 
 
 def install_dir():
@@ -20,7 +20,7 @@ def install_dir():
     return os.path.dirname(__file__)
 
 
-from ._generator_helpers import (
+from ._generator_helpers import (  # noqa: E402, F401
     _create_python_generator,
     _generatorcontext_enter,
     _generatorcontext_exit,

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -3,8 +3,28 @@ from abc import ABC, abstractmethod
 from contextvars import ContextVar
 from enum import Enum
 from functools import total_ordering
-from .halide_ import *
-from .halide_ import _unique_name, _UnspecifiedType
+from .halide_ import (
+    ArgInfo,
+    ArgInfoDirection,
+    ArgInfoKind,
+    Bool,
+    Buffer,
+    Expr,
+    Float,
+    Func,
+    GeneratorContext,
+    HalideError,
+    ImageParam,
+    Int,
+    Param,
+    Pipeline,
+    Type,
+    UInt,
+    Var,
+    _,
+    _UnspecifiedType,
+    _unique_name,
+)
 from inspect import isclass
 from typing import Any, Optional
 import re
@@ -715,7 +735,7 @@ class Generator(ABC):
         self._stage = _Stage.pipeline_built
         return self._pipeline
 
-    def _get_input_parameter(self, name: str) -> InternalParameter:
+    def _get_input_parameter(self, name: str):
         assert self._stage == _Stage.pipeline_built
         _check(name in self._input_parameters, f"Unknown input: {name}")
         return self._input_parameters[name]

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -130,16 +130,16 @@ class Requirement:
 
         _check(
             len(types) == len(self._types),
-            "Type mismatch for %s: expected %d types but saw %d" % (self._name, len(self._types), len(types)),
+            f"Type mismatch for {self._name}: expected {len(self._types)} types but saw {len(types)}",
         )
         for i in range(0, len(types)):
             _check(
                 self._types[i] == types[i],
-                "Type mismatch for %s:%d: expected %s saw %s" % (self._name, i, self._types[i], types[i]),
+                f"Type mismatch for {self._name}:{i}: expected {self._types[i]} saw {types[i]}",
             )
         _check(
             dimensions == self._dimensions,
-            "Dimensions mismatch for %s: expected %d saw %d" % (self._name, self._dimensions, dimensions),
+            f"Dimensions mismatch for {self._name}: expected {self._dimensions} saw {dimensions}",
         )
 
 
@@ -410,8 +410,7 @@ class Generator(ABC):
 
         _check(
             len(args) <= len(generator._arginfos_in),
-            "Generator '%s' allows at most %d positional args, but %d were specified." %
-            (generator._get_name(), len(generator._arginfos_in), len(args)))
+            f"Generator '{generator._get_name()}' allows at most {len(generator._arginfos_in)} positional args, but {len(args)} were specified.")
 
         inputs_set = []
         for i in range(0, len(args)):
@@ -430,8 +429,8 @@ class Generator(ABC):
             generator._bind_input(k, [v])
 
         _check(
-            len(inputs_set) == len(generator._arginfos_in), "Generator '%s' requires %d args, but %d were specified." %
-            (generator._get_name(), len(generator._arginfos_in), len(inputs_set)))
+            len(inputs_set) == len(generator._arginfos_in),
+            f"Generator '{generator._get_name()}' requires {len(generator._arginfos_in)} args, but {len(inputs_set)} were specified.")
 
         generator._build_pipeline()
 

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -7,7 +7,6 @@ from .halide_ import *
 from .halide_ import _unique_name, _UnspecifiedType
 from inspect import isclass
 from typing import Any, Optional
-import builtins
 import re
 import sys
 import warnings
@@ -67,7 +66,7 @@ def _normalize_type_list(types: object) -> list[Type]:
     elif isinstance(types, Type) and types == _UnspecifiedType():
         types = []
     if type(types) is not list:
-        types = [types];
+        types = [types]
     types = [_sanitize_type(t) for t in types]
     return types
 

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -85,9 +85,7 @@ def _sanitize_type(t: object) -> Type:
 
 def _normalize_type_list(types: object) -> list[Type]:
     # Always treat _UnspecifiedType as a non-type
-    if types is None:
-        types = []
-    elif isinstance(types, Type) and types == _UnspecifiedType():
+    if types is None or isinstance(types, Type) and types == _UnspecifiedType():
         types = []
     if type(types) is not list:
         types = [types]
@@ -812,7 +810,7 @@ def _get_python_generator_names() -> list[str]:
 
 
 def _create_python_generator(name: str, context: GeneratorContext):
-    cls = _python_generators.get(name, None)
+    cls = _python_generators.get(name)
     if not isclass(cls):
         return None
     with context:

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -85,7 +85,7 @@ def _sanitize_type(t: object) -> Type:
 
 def _normalize_type_list(types: object) -> list[Type]:
     # Always treat _UnspecifiedType as a non-type
-    if types is None or isinstance(types, Type) and types == _UnspecifiedType():
+    if types is None or (isinstance(types, Type) and types == _UnspecifiedType()):
         types = []
     if type(types) is not list:
         types = [types]
@@ -118,21 +118,14 @@ def _parse_halide_type_list(s: str) -> list[Type]:
 
 
 class Requirement:
-    # Name
-    _name: str = ""
-
-    # List of the required types, if any. An empty list means
-    # no constraints. The list will usually be a single type,
-    # except for Outputs that have Tuple-valued results, which
-    # can have multiple types.
-    _types: list[Type] = []
-
-    # Required dimensions. 0 = scalar. -1 = unconstrained.
-    _dimensions: int = -1
-
     def __init__(self, name: str, types: object, dimensions: int):
         self._name = _check_valid_name(name)
+        # List of the required types, if any. An empty list means
+        # no constraints. The list will usually be a single type,
+        # except for Outputs that have Tuple-valued results, which
+        # can have multiple types.
         self._types = _normalize_type_list(types)
+        # Required dimensions. 0 = scalar. -1 = unconstrained.
         self._dimensions = dimensions
         _check(
             len(self._types) > 0,
@@ -236,7 +229,7 @@ class InputBuffer(ImageParam):
 
         _check(
             isinstance(value, (Buffer, ImageParam)),
-            f"Input {r._name} requires an ImageParam or Buffer argument when using call(), but saw {str(value)}",
+            f"Input {r._name} requires an ImageParam or Buffer argument when using call(), but saw {value}",
         )
         _check(
             value.defined(),
@@ -273,7 +266,7 @@ class InputScalar(Param):
         else:
             _check(
                 isinstance(value, Param),
-                f"Input {r._name} requires a Param (or scalar literal) argument when using call(), but saw {str(value)}.",
+                f"Input {r._name} requires a Param (or scalar literal) argument when using call(), but saw {value}.",
             )
             _check(
                 value.defined(),
@@ -305,7 +298,7 @@ class OutputBuffer(Func):
 
         _check(
             isinstance(value, (Buffer, Func)),
-            f"Output {r._name} requires a Func or Buffer argument when using call(), but saw {str(value)}",
+            f"Output {r._name} requires a Func or Buffer argument when using call(), but saw {value}",
         )
         _check(
             value.defined(),
@@ -340,7 +333,7 @@ class OutputScalar(OutputBuffer):
 
         _check(
             isinstance(value, Expr),
-            f"Output {r._name} requires an Expr argument when using call(), but saw {str(value)}",
+            f"Output {r._name} requires an Expr argument when using call(), but saw {value}",
         )
         _check(
             value.defined(),

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -450,9 +450,7 @@ class Generator(ABC):
 
         generator._build_pipeline()
 
-        outputs = []
-        for o in generator._arginfos_out:
-            outputs.append(generator._get_output_func(o.name))
+        outputs = [generator._get_output_func(o.name) for o in generator._arginfos_out]
 
         return outputs[0] if len(outputs) == 1 else tuple(outputs)
 

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -532,7 +532,6 @@ class Generator(ABC):
         }
         assert new_stage in _stage_advancers
         a = _stage_advancers[new_stage]
-        old_stage = self._stage
         if self._stage < new_stage:
             a()
         assert self._stage >= new_stage

--- a/python_bindings/src/halide/imageio.py
+++ b/python_bindings/src/halide/imageio.py
@@ -1,6 +1,6 @@
 try:
     import imageio.v2 as imageio
-except:
+except ImportError:
     import imageio
 import numpy as np
 

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -214,7 +214,7 @@ def test_float_or_int():
     assert (2 * (x % 2)).type() == i32
     assert ((x // 2) - 1 + 2 * (x % 2)).type() == i32
 
-    assert type(x) == hl.Var
+    assert type(x) is hl.Var
     assert (hl.Expr(x)).type() == i32
     assert (hl.Expr(2.0)).type() == f32
     assert (hl.Expr(2)).type() == i32
@@ -335,7 +335,7 @@ def test_typed_funcs():
     f = hl.Func("f")
     assert not f.defined()
     try:
-        assert f.type() == Int(32)
+        assert f.type() == hl.Int(32)
     except hl.HalideError as e:
         assert "it is undefined" in str(e)
     else:

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -99,13 +99,13 @@ def test_basics():
 
 def test_basics2():
     input = hl.ImageParam(hl.Float(32), 3, "input")
-    r_sigma = hl.Param(hl.Float(32), "r_sigma", 0.1)
+    hl.Param(hl.Float(32), "r_sigma", 0.1)
     s_sigma = 8
 
     x = hl.Var("x")
     y = hl.Var("y")
-    z = hl.Var("z")
-    c = hl.Var("c")
+    hl.Var("z")
+    hl.Var("c")
 
     # Add a boundary condition
     clamped = hl.Func("clamped")
@@ -115,16 +115,16 @@ def test_basics2():
 
     # Construct the bilateral grid
     r = hl.RDom([(0, s_sigma), (0, s_sigma)], "r")
-    val0 = clamped[x * s_sigma, y * s_sigma]
-    val00 = clamped[x * s_sigma * hl.i32(1), y * s_sigma * hl.i32(1)]
-    val22 = clamped[
+    clamped[x * s_sigma, y * s_sigma]
+    clamped[x * s_sigma * hl.i32(1), y * s_sigma * hl.i32(1)]
+    clamped[
         x * s_sigma - hl.i32(s_sigma // 2), y * s_sigma - hl.i32(s_sigma // 2)
     ]
-    val2 = clamped[x * s_sigma - s_sigma // 2, y * s_sigma - s_sigma // 2]
-    val3 = clamped[x * s_sigma + r.x - s_sigma // 2, y * s_sigma + r.y - s_sigma // 2]
+    clamped[x * s_sigma - s_sigma // 2, y * s_sigma - s_sigma // 2]
+    clamped[x * s_sigma + r.x - s_sigma // 2, y * s_sigma + r.y - s_sigma // 2]
 
     try:
-        val1 = clamped[x * s_sigma - s_sigma / 2, y * s_sigma - s_sigma / 2]
+        clamped[x * s_sigma - s_sigma / 2, y * s_sigma - s_sigma / 2]
     except hl.HalideError as e:
         assert "Implicit cast from float32 to int" in str(e)
     else:
@@ -289,7 +289,7 @@ def test_vector_tile():
     xo, yo, zo = [hl.Var(c + "o") for c in "xyz"]
     f = hl.Func("f")
     g = hl.Func("g")
-    h = hl.Func("h")
+    hl.Func("h")
     f[x, y] = y
     f[x, y] += x
     g[x, y, z] = x + y
@@ -324,7 +324,6 @@ def test_bool_conversion():
     x = hl.Var("x")
     f = hl.Func("f")
     f[x] = x
-    s = True
     # Verify that this doesn't fail with 'Argument passed to specialize must be of type bool'
     f.compute_root().specialize(True)
 

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -206,11 +206,11 @@ def test_float_or_int():
     assert (x / 2).type() == i32
     assert ((x // 2) - 1 + 2 * (x % 2)).type() == i32
     assert ((x / 2) - 1 + 2 * (x % 2)).type() == i32
-    assert ((x / 2)).type() == i32
-    assert ((x / 2.0)).type() == f32
-    assert ((x // 2)).type() == i32
+    assert (x / 2).type() == i32
+    assert (x / 2.0).type() == f32
+    assert (x // 2).type() == i32
     assert ((x // 2) - 1).type() == i32
-    assert ((x % 2)).type() == i32
+    assert (x % 2).type() == i32
     assert (2 * (x % 2)).type() == i32
     assert ((x // 2) - 1 + 2 * (x % 2)).type() == i32
 
@@ -232,7 +232,7 @@ def test_float_or_int():
     assert (2 * x).type() == i32
     assert (x * 2).type() == i32
     assert (x * 2).type() == i32
-    assert ((x % 2)).type() == i32
+    assert (x % 2).type() == i32
     assert ((x % 2) * 2).type() == i32
     assert (2 * (x % 2)).type() == i32
     assert ((x + 2) * 2).type() == i32
@@ -324,7 +324,7 @@ def test_bool_conversion():
     x = hl.Var("x")
     f = hl.Func("f")
     f[x] = x
-    s = bool(True)
+    s = True
     # Verify that this doesn't fail with 'Argument passed to specialize must be of type bool'
     f.compute_root().specialize(True)
 

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -117,9 +117,7 @@ def test_basics2():
     r = hl.RDom([(0, s_sigma), (0, s_sigma)], "r")
     clamped[x * s_sigma, y * s_sigma]
     clamped[x * s_sigma * hl.i32(1), y * s_sigma * hl.i32(1)]
-    clamped[
-        x * s_sigma - hl.i32(s_sigma // 2), y * s_sigma - hl.i32(s_sigma // 2)
-    ]
+    clamped[x * s_sigma - hl.i32(s_sigma // 2), y * s_sigma - hl.i32(s_sigma // 2)]
     clamped[x * s_sigma - s_sigma // 2, y * s_sigma - s_sigma // 2]
     clamped[x * s_sigma + r.x - s_sigma // 2, y * s_sigma + r.y - s_sigma // 2]
 
@@ -444,8 +442,8 @@ def test_requirements():
 
 
 def test_implicit_convert_int64():
-    assert (hl.i32(0) + 0x7fffffff).type() == hl.Int(32)
-    assert (hl.i32(0) + (0x7fffffff + 1)).type() == hl.Int(64)
+    assert (hl.i32(0) + 0x7FFFFFFF).type() == hl.Int(32)
+    assert (hl.i32(0) + (0x7FFFFFFF + 1)).type() == hl.Int(64)
 
 
 def test_pow_rpow():
@@ -454,8 +452,8 @@ def test_pow_rpow():
     for three in (3, hl.Expr(3)):
         f = hl.Func("f")
         f[x] = 0.0
-        f[0] = two ** three
-        f[1] = three ** two
+        f[0] = two**three
+        f[1] = three**two
         assert list(f.realize([2])) == [8.0, 9.0]
 
 

--- a/python_bindings/test/correctness/bit_test.py
+++ b/python_bindings/test/correctness/bit_test.py
@@ -19,7 +19,7 @@ def test(fn):
 
     fn(input_bools, True, output_bools)
     for i in range(0, 4):
-        assert output_bools[i] == True
+        assert output_bools[i]
 
     fn(input_bools, False, output_bools)
     for i in range(0, 4):

--- a/python_bindings/test/correctness/boundary_conditions.py
+++ b/python_bindings/test/correctness/boundary_conditions.py
@@ -15,8 +15,8 @@ def schedule_test(f, vector_width, target, partition_policy):
     if vector_width != 1:
         f.vectorize(x, vector_width)
 
-    f.partition(x, partition_policy);
-    f.partition(y, partition_policy);
+    f.partition(x, partition_policy)
+    f.partition(y, partition_policy)
 
     if target.has_gpu_feature() and vector_width <= 16:
         xo, yo, xi, yi = hl.vars("xo yo xi yi")

--- a/python_bindings/test/correctness/boundary_conditions.py
+++ b/python_bindings/test/correctness/boundary_conditions.py
@@ -198,9 +198,11 @@ if __name__ == "__main__":
 
     vector_width_power_max = 6
     # https://github.com/halide/Halide/issues/2148
-    if target.has_feature(hl.TargetFeature.Metal) or \
-        target.has_feature(hl.TargetFeature.Vulkan) or \
-        target.has_feature(hl.TargetFeature.D3D12Compute):
+    if (
+        target.has_feature(hl.TargetFeature.Metal)
+        or target.has_feature(hl.TargetFeature.Vulkan)
+        or target.has_feature(hl.TargetFeature.D3D12Compute)
+    ):
         vector_width_power_max = 2
 
     for i in range(0, vector_width_power_max):

--- a/python_bindings/test/correctness/boundary_conditions.py
+++ b/python_bindings/test/correctness/boundary_conditions.py
@@ -8,7 +8,7 @@ x, y = hl.vars("x y")
 
 
 def expect_eq(actual, expected):
-    assert expected == actual, "Failed: expected %d, actual %d" % (expected, actual)
+    assert expected == actual, f"Failed: expected {expected}, actual {actual}"
 
 
 def schedule_test(f, vector_width, target, partition_policy):

--- a/python_bindings/test/correctness/buffer.py
+++ b/python_bindings/test/correctness/buffer.py
@@ -203,7 +203,7 @@ def test_float16():
 def test_int64():
     array_in = np.zeros((256, 256, 3), dtype=np.int64, order="F")
     hl_img = hl.Buffer(array_in)
-    array_out = np.array(hl_img, copy=False)
+    np.array(hl_img, copy=False)
 
 
 def test_make_interleaved():

--- a/python_bindings/test/correctness/buffer.py
+++ b/python_bindings/test/correctness/buffer.py
@@ -182,7 +182,7 @@ def test_bufferinfo_sharing():
 def test_float16():
     array_in = np.zeros((256, 256, 3), dtype=np.float16, order="F")
     hl_img = hl.Buffer(array_in)
-    array_out = np.array(hl_img, copy=False)
+    np.array(hl_img, copy=False)
 
 
 # TODO: https://github.com/halide/Halide/issues/6849

--- a/python_bindings/test/correctness/callable.py
+++ b/python_bindings/test/correctness/callable.py
@@ -1,8 +1,7 @@
 import halide as hl
-import numpy as np
 
 from simplepy_generator import SimplePy
-import simplecpp_pystub  # Needed for create_callable_from_generator("simplecpp") to work
+import simplecpp_pystub  # noqa: F401 - needed for create_callable_from_generator("simplecpp") to work
 
 
 def test_callable():
@@ -60,7 +59,6 @@ def test_callable():
 
 
 def test_simple(callable_factory):
-    x, y = hl.Var(), hl.Var()
     target = hl.get_jit_target_from_environment()
 
     b_in = hl.Buffer(hl.UInt(8), [2, 2])

--- a/python_bindings/test/correctness/compile_to.py
+++ b/python_bindings/test/correctness/compile_to.py
@@ -1,4 +1,6 @@
-import os, shutil, tempfile
+import os
+import shutil
+import tempfile
 import halide as hl
 
 

--- a/python_bindings/test/correctness/extern.py
+++ b/python_bindings/test/correctness/extern.py
@@ -1,5 +1,5 @@
-import halide as hl
-import numpy as np
+# import halide as hl
+# import numpy as np
 
 
 def test_extern():
@@ -9,9 +9,9 @@ def test_extern():
     """
 
     # Requires Makefile support to build the external function in linkable form
-    print("TODO: test_extern not yet implemented in Python; skipping...")
-    return 0
+    print("[SKIP] TODO: test_extern not yet implemented in Python")
 
+    """
     data = np.random.random(10).astype(np.float64)
     expected_result = np.sort(data)
     output_data = np.empty(10, dtype=np.float64)
@@ -58,8 +58,7 @@ def test_extern():
     sort_func.realize(output_data)
 
     assert np.isclose(expected_result, output_data)
-
-    return
+    """
 
 
 if __name__ == "__main__":

--- a/python_bindings/test/correctness/extern.py
+++ b/python_bindings/test/correctness/extern.py
@@ -12,8 +12,6 @@ def test_extern():
     print("TODO: test_extern not yet implemented in Python; skipping...")
     return 0
 
-    x = hl.Var("x")
-
     data = np.random.random(10).astype(np.float64)
     expected_result = np.sort(data)
     output_data = np.empty(10, dtype=np.float64)
@@ -32,7 +30,7 @@ def test_extern():
 
     try:
         sort_func.compile_jit()
-    except hl.HalideError:
+    except hl.HalideError as e:
         assert "cannot be converted to a bool" in str(e)
     else:
         assert False, "Did not see expected exception!"
@@ -44,14 +42,14 @@ def test_extern():
 
     try:
         sort_func.compile_jit()
-    except hl.HalideError:
+    except hl.HalideError as e:
         assert "cannot be converted to a bool" in str(e)
     else:
         assert False, "Did not see expected exception!"
 
     lib_path = "the_sort_function.so"
     load_error = load_library_into_llvm(lib_path)
-    assert load_error == False
+    assert not load_error
 
     sort_func.compile_jit()
 
@@ -65,5 +63,4 @@ def test_extern():
 
 
 if __name__ == "__main__":
-
     test_extern()

--- a/python_bindings/test/correctness/float_precision_test.py
+++ b/python_bindings/test/correctness/float_precision_test.py
@@ -1,5 +1,4 @@
 import math
-import sys
 import warnings
 
 import halide as hl

--- a/python_bindings/test/correctness/float_precision_test.py
+++ b/python_bindings/test/correctness/float_precision_test.py
@@ -38,7 +38,7 @@ def test():
         for i, hl_value in enumerate(numpy.asarray(f.realize([10]))):
             py_value = i * c * (0.1 + 0.2)
             check = math.isclose(hl_value, py_value)
-            assert check, "{}[{}]: {} != {}".format(i, c, hl_value, py_value)
+            assert check, f"{i}[{c}]: {hl_value} != {py_value}"
 
     test_pattern(0.123456789012345678)
     test_pattern(0.987654321098765432)

--- a/python_bindings/test/correctness/iroperator.py
+++ b/python_bindings/test/correctness/iroperator.py
@@ -26,7 +26,7 @@ def test_print_expr():
         f.realize(buf)
         expected = "0 is what the 1 and 3.141500 saw\n"
         actual = output.getvalue()
-        assert expected == actual, "Expected: %s, Actual: %s" % (expected, actual)
+        assert expected == actual, f"Expected: {expected}, Actual: {actual}"
 
 
 def test_print_when():
@@ -39,7 +39,7 @@ def test_print_when():
         f.realize(buf)
         expected = "9 is result at 3\n"
         actual = output.getvalue()
-        assert expected == actual, "Expected: %s, Actual: %s" % (expected, actual)
+        assert expected == actual, f"Expected: {expected}, Actual: {actual}"
 
 
 def test_select():

--- a/python_bindings/test/correctness/iroperator.py
+++ b/python_bindings/test/correctness/iroperator.py
@@ -3,6 +3,7 @@ import halide as hl
 import sys
 import io
 
+
 # redirect_stdout() requires Python3, alas
 @contextlib.contextmanager
 def _redirect_stdout(out):

--- a/python_bindings/test/correctness/multi_method_module_test.py
+++ b/python_bindings/test/correctness/multi_method_module_test.py
@@ -37,7 +37,7 @@ def test_aot_call_failure_throws_exception():
         simplecpp(buffer_input, float_arg, simple_output)
     except RuntimeError as e:
         assert "Halide Runtime Error: -3" in str(e), str(e)
-    else:
+    except Exception as e:
         assert False, "Did not see expected exception, saw: " + str(e)
 
 

--- a/python_bindings/test/correctness/multi_method_module_test.py
+++ b/python_bindings/test/correctness/multi_method_module_test.py
@@ -39,6 +39,8 @@ def test_aot_call_failure_throws_exception():
         assert "Halide Runtime Error: -3" in str(e), str(e)
     except Exception as e:
         assert False, "Did not see expected exception, saw: " + str(e)
+    else:
+        assert False, "Did not see ANY exception, but one was expected!"
 
 
 if __name__ == "__main__":

--- a/python_bindings/test/correctness/multipass_constraints.py
+++ b/python_bindings/test/correctness/multipass_constraints.py
@@ -42,7 +42,6 @@ def test_multipass_constraints():
         or query_buf.dim(1).min() != 2
         or query_buf.dim(1).extent() != 8
     ):
-
         print(
             "Constraints not correctly satisfied:\n",
             "in:",

--- a/python_bindings/test/correctness/pystub.py
+++ b/python_bindings/test/correctness/pystub.py
@@ -207,7 +207,7 @@ def test_complex(cls, extra_input_name=""):
             for c in range(3):
                 expected = constant_image[x, y, c]
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
+                assert expected == actual, f"Expected {expected} Actual {actual}"
 
     b = tuple_output.realize([32, 32, 3], target)
     assert b[0].type() == hl.Float(32)
@@ -219,14 +219,8 @@ def test_complex(cls, extra_input_name=""):
                 expected1 = constant_image[x, y, c] * float_arg
                 expected2 = expected1 + int_arg
                 actual1, actual2 = b[0][x, y, c], b[1][x, y, c]
-                assert expected1 == actual1, "Expected1 %s Actual1 %s" % (
-                    expected1,
-                    actual1,
-                )
-                assert expected2 == actual2, "Expected2 %s Actual1 %s" % (
-                    expected2,
-                    actual2,
-                )
+                assert expected1 == actual1, f"Expected1 {expected1} Actual1 {actual1}"
+                assert expected2 == actual2, f"Expected2 {expected2} Actual1 {actual2}"
 
     # TODO: Output<Buffer<>> has additional behaviors useful when a Stub
     # is used within another Generator; this isn't yet implemented since there
@@ -239,7 +233,7 @@ def test_complex(cls, extra_input_name=""):
             for c in range(3):
                 expected = constant_image[x, y, c]
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
+                assert expected == actual, f"Expected {expected} Actual {actual}"
 
     b = untyped_buffer_output.realize([32, 32, 3], target)
     assert b.type() == hl.UInt(8)
@@ -248,7 +242,7 @@ def test_complex(cls, extra_input_name=""):
             for c in range(3):
                 expected = constant_image[x, y, c]
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
+                assert expected == actual, f"Expected {expected} Actual {actual}"
 
     b = static_compiled_buffer_output.realize([4, 4, 1], target)
     assert b.type() == hl.UInt(8)
@@ -257,7 +251,7 @@ def test_complex(cls, extra_input_name=""):
             for c in range(1):
                 expected = constant_image[x, y, c] + 42
                 actual = b[x, y, c]
-                assert expected == actual, "Expected %s Actual %s" % (expected, actual)
+                assert expected == actual, f"Expected {expected} Actual {actual}"
 
     b = scalar_output.realize([], target)
     assert b.type() == hl.Float(32)
@@ -272,7 +266,7 @@ def test_complex(cls, extra_input_name=""):
             else:
                 expected = 0
             actual = b[x, y]
-            assert expected == actual, "Expected %s Actual %s" % (expected, actual)
+            assert expected == actual, f"Expected {expected} Actual {actual}"
 
 
 if __name__ == "__main__":

--- a/python_bindings/test/correctness/pystub.py
+++ b/python_bindings/test/correctness/pystub.py
@@ -18,8 +18,6 @@ def _realize_and_check(f, offset=0):
 
 
 def test_simple(cls):
-    x, y = hl.Var(), hl.Var()
-
     b_in = hl.Buffer(hl.UInt(8), [2, 2])
     b_in.fill(123)
     for xx in range(2):

--- a/python_bindings/test/correctness/realize_warnings.py
+++ b/python_bindings/test/correctness/realize_warnings.py
@@ -29,7 +29,7 @@ def test_warnings():
 
 def test_unscheduled(suppress):
     x = hl.Var()
-    f = hl.Func("f_%s" % str(suppress))
+    f = hl.Func(f"f_{str(suppress)}")
     f[x] = 0
     f[x] += 5
     f.vectorize(x, 8)
@@ -48,7 +48,7 @@ def test_unscheduled(suppress):
         expected_warning = "Warning: Update definition 0 of function f_False has not been scheduled"
         assert len(stdout_lines) > 0
         for line in stdout_lines:
-            assert line.startswith(expected_warning), "\n%s\n%s" % (line, expected_warning)
+            assert line.startswith(expected_warning), f"\n{line}\n{expected_warning}"
 
 if __name__ == "__main__":
     test_warnings()

--- a/python_bindings/test/correctness/realize_warnings.py
+++ b/python_bindings/test/correctness/realize_warnings.py
@@ -30,7 +30,7 @@ def test_warnings():
 
 def test_unscheduled(suppress):
     x = hl.Var()
-    f = hl.Func(f"f_{str(suppress)}")
+    f = hl.Func(f"f_{suppress}")
     f[x] = 0
     f[x] += 5
     f.vectorize(x, 8)

--- a/python_bindings/test/correctness/realize_warnings.py
+++ b/python_bindings/test/correctness/realize_warnings.py
@@ -27,6 +27,7 @@ def test_warnings():
     for line in stdout_lines:
         assert line == expected_warning
 
+
 def test_unscheduled(suppress):
     x = hl.Var()
     f = hl.Func(f"f_{str(suppress)}")
@@ -45,10 +46,13 @@ def test_unscheduled(suppress):
     if suppress:
         assert len(stdout_lines) == 0
     else:
-        expected_warning = "Warning: Update definition 0 of function f_False has not been scheduled"
+        expected_warning = (
+            "Warning: Update definition 0 of function f_False has not been scheduled"
+        )
         assert len(stdout_lines) > 0
         for line in stdout_lines:
             assert line.startswith(expected_warning), f"\n{line}\n{expected_warning}"
+
 
 if __name__ == "__main__":
     test_warnings()

--- a/python_bindings/test/correctness/tuple_select.py
+++ b/python_bindings/test/correctness/tuple_select.py
@@ -82,7 +82,9 @@ def test_tuple_select():
         f = hl.Func("f")
         f[x, y] = hl.select((x < 30, y < 30), (x, y, 0), (1, 2, 3, 4))
     except hl.HalideError as e:
-        assert "select() on Tuples requires all Tuples to have identical sizes." in str(e)
+        assert "select() on Tuples requires all Tuples to have identical sizes." in str(
+            e
+        )
     else:
         assert False, "Did not see expected exception!"
 

--- a/python_bindings/test/correctness/tuple_select.py
+++ b/python_bindings/test/correctness/tuple_select.py
@@ -1,5 +1,4 @@
 import halide as hl
-import numpy as np
 
 
 def test_tuple_select():

--- a/python_bindings/test/correctness/user_context_test.py
+++ b/python_bindings/test/correctness/user_context_test.py
@@ -1,4 +1,3 @@
-import array
 from user_context import user_context
 
 

--- a/python_bindings/test/correctness/var.py
+++ b/python_bindings/test/correctness/var.py
@@ -48,10 +48,10 @@ def test_var():
     assert repr(x) == "<halide.Var 'x'>"
 
     # This verifies that halide.Var is implicitly convertible to halide.Expr
-    hl.random_int(x)
+    assert type(hl.random_int(x)) is hl.Expr
 
     # This verifies that halide.Var is explicitly convertible to halide.Expr
-    hl.random_int(hl.Expr(x))
+    assert type(hl.random_int(hl.Expr(x))) is hl.Expr
 
 
 if __name__ == "__main__":

--- a/python_bindings/test/correctness/var.py
+++ b/python_bindings/test/correctness/var.py
@@ -48,10 +48,10 @@ def test_var():
     assert repr(x) == "<halide.Var 'x'>"
 
     # This verifies that halide.Var is implicitly convertible to halide.Expr
-    r = hl.random_int(x)
+    hl.random_int(x)
 
     # This verifies that halide.Var is explicitly convertible to halide.Expr
-    r = hl.random_int(hl.Expr(x))
+    hl.random_int(hl.Expr(x))
 
 
 if __name__ == "__main__":

--- a/python_bindings/tutorial/lesson_01_basics.py
+++ b/python_bindings/tutorial/lesson_01_basics.py
@@ -83,8 +83,7 @@ def main():
             # syntax to defining and using functions.
             assert output[i, j] == i + j, \
                 "Something went wrong!\n" + \
-                "Pixel %d, %d was supposed to be %d, but instead it's %d\n" % (
-                    i, j, i + j, output[i, j])
+                f"Pixel {i}, {j} was supposed to be {i + j}, but instead it's {output[i, j]}\n"
 
     # Everything worked! We defined a hl.Func, then called 'realize' on
     # it to generate and run machine code that produced a hl.Buffer.

--- a/python_bindings/tutorial/lesson_01_basics.py
+++ b/python_bindings/tutorial/lesson_01_basics.py
@@ -12,7 +12,6 @@ import halide as hl
 
 
 def main():
-
     # This program defines a single-stage imaging pipeline that
     # outputs a grayscale diagonal gradient.
 
@@ -81,15 +80,17 @@ def main():
         for i in range(output.width()):
             # We can access a pixel of an hl.Buffer object using similar
             # syntax to defining and using functions.
-            assert output[i, j] == i + j, \
-                "Something went wrong!\n" + \
+            assert output[i, j] == i + j, (
+                "Something went wrong!\n"
                 f"Pixel {i}, {j} was supposed to be {i + j}, but instead it's {output[i, j]}\n"
+            )
 
     # Everything worked! We defined a hl.Func, then called 'realize' on
     # it to generate and run machine code that produced a hl.Buffer.
     print("Success!")
 
     return 0
+
 
 if __name__ == "__main__":
     main()

--- a/python_bindings/tutorial/lesson_01_basics.py
+++ b/python_bindings/tutorial/lesson_01_basics.py
@@ -36,7 +36,7 @@ def main():
     # appropriate operator overloading so that expressions like
     # 'x + y' become 'hl.Expr' objects.
     e = x + y
-    assert type(e) == hl.Expr
+    assert isinstance(e, hl.Expr)
 
     # Now we'll add a definition for the hl.Func object. At pixel x, y,
     # the image will have the value of the hl.Expr e. On the left hand

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -39,7 +39,7 @@ def main():
 
     # For each pixel of the input image.
     value = input[x, y, c]
-    assert type(value) == hl.Expr
+    assert isinstance(value, hl.Expr)
 
     # Cast it to a floating point value.
     value = hl.cast(hl.Float(32), value)

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -13,12 +13,13 @@ import os.path
 
 
 def main():
-
     # This program defines a single-stage imaging pipeline that
     # brightens an image.
 
     # First we'll load the input image we wish to brighten.
-    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(
+        os.path.dirname(__file__), "../../tutorial/images/rgb.png"
+    )
 
     # We create a hl.Buffer object to wrap the numpy array
     input = hl.Buffer(halide.imageio.imread(image_path))

--- a/python_bindings/tutorial/lesson_02_input_image.py
+++ b/python_bindings/tutorial/lesson_02_input_image.py
@@ -40,7 +40,7 @@ def main():
 
     # For each pixel of the input image.
     value = input[x, y, c]
-    assert isinstance(value, hl.Expr)
+    assert type(value) is hl.Expr
 
     # Cast it to a floating point value.
     value = hl.cast(hl.Float(32), value)

--- a/python_bindings/tutorial/lesson_03_debugging_1.py
+++ b/python_bindings/tutorial/lesson_03_debugging_1.py
@@ -28,7 +28,7 @@ def main():
 
     # Realize the function to produce an output image. We'll keep it
     # very small for this lesson.
-    output = gradient.realize([8, 8])
+    gradient.realize([8, 8])
 
     # That line compiled and ran the pipeline. Try running this
     # lesson with the environment variable HL_DEBUG_CODEGEN set to

--- a/python_bindings/tutorial/lesson_03_debugging_1.py
+++ b/python_bindings/tutorial/lesson_03_debugging_1.py
@@ -13,7 +13,6 @@ import halide as hl
 
 
 def main():
-
     # We'll start by defining the simple single-stage imaging
     # pipeline from lesson 1.
 

--- a/python_bindings/tutorial/lesson_04_debugging_2.py
+++ b/python_bindings/tutorial/lesson_04_debugging_2.py
@@ -25,7 +25,7 @@ def main():
 
     # Realize the function over an 8x8 region.
     print("Evaluating gradient")
-    output = gradient.realize([8, 8])
+    gradient.realize([8, 8])
 
     # This will print out all the times gradient(x, y) gets
     # evaluated.

--- a/python_bindings/tutorial/lesson_04_debugging_2.py
+++ b/python_bindings/tutorial/lesson_04_debugging_2.py
@@ -12,7 +12,6 @@ import halide as hl
 
 
 def main():
-
     gradient = hl.Func("gradient")
     x, y = hl.Var("x"), hl.Var("y")
 

--- a/python_bindings/tutorial/lesson_05_scheduling_1.py
+++ b/python_bindings/tutorial/lesson_05_scheduling_1.py
@@ -31,7 +31,7 @@ def main():
         # slowly. x is the column and y is the row, so this is a
         # row-major traversal.
         print("Evaluating gradient row-major")
-        output = gradient.realize([4, 4])
+        gradient.realize([4, 4])
 
         # The equivalent C is:
         print("Equivalent C:")
@@ -72,7 +72,7 @@ def main():
         # traversal.
 
         print("Evaluating gradient column-major")
-        output = gradient.realize([4, 4])
+        gradient.realize([4, 4])
 
         print("Equivalent C:")
         for xx in range(4):
@@ -109,7 +109,7 @@ def main():
         # also added within the loops.
 
         print("Evaluating gradient with x split into x_outer and x_inner ")
-        output = gradient.realize([4, 4])
+        gradient.realize([4, 4])
 
         print("Equivalent C:")
         for yy in range(4):
@@ -144,7 +144,7 @@ def main():
         gradient.fuse(x, y, fused)
 
         print("Evaluating gradient with x and y fused")
-        output = gradient.realize([4, 4])
+        gradient.realize([4, 4])
 
         print("Equivalent C:")
         for fused in range(4 * 4):
@@ -183,7 +183,7 @@ def main():
         # gradient.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)
 
         print("Evaluating gradient in 2x2 tiles")
-        output = gradient.realize([4, 4])
+        gradient.realize([4, 4])
 
         print("Equivalent C:")
         for y_outer in range(2):
@@ -235,7 +235,7 @@ def main():
         # This time we'll evaluate over an 8x4 box, so that we have
         # more than one vector of work per scanline.
         print("Evaluating gradient with x_inner vectorized ")
-        output = gradient.realize([8, 4])
+        gradient.realize([8, 4])
 
         print("Equivalent C:")
         for yy in range(4):
@@ -323,7 +323,7 @@ def main():
         gradient.split(x, x_outer, x_inner, 2)
 
         print("Evaluating gradient over a 5x4 box with x split by two ")
-        output = gradient.realize([5, 4])
+        gradient.realize([5, 4])
 
         print("Equivalent C:")
         for yy in range(4):

--- a/python_bindings/tutorial/lesson_05_scheduling_1.py
+++ b/python_bindings/tutorial/lesson_05_scheduling_1.py
@@ -37,7 +37,7 @@ def main():
         print("Equivalent C:")
         for yy in range(4):
             for xx in range(4):
-                print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print("\n")
 
@@ -77,7 +77,7 @@ def main():
         print("Equivalent C:")
         for xx in range(4):
             for yy in range(4):
-                print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print()
 
@@ -116,7 +116,7 @@ def main():
             for x_outer in range(2):
                 for x_inner in range(2):
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print()
 
@@ -150,7 +150,7 @@ def main():
         for fused in range(4 * 4):
             yy = fused / 4
             xx = fused % 4
-            print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+            print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print()
 
@@ -192,7 +192,7 @@ def main():
                     for x_inner in range(2):
                         xx = x_outer * 2 + x_inner
                         yy = y_outer * 2 + y_inner
-                        print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                        print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print()
 
@@ -252,8 +252,10 @@ def main():
                        x_vec[1] + yy,
                        x_vec[2] + yy,
                        x_vec[3] + yy]
-                print("Evaluating at <%d, %d, %d, %d>, <%d, %d, %d, %d>: <%d, %d, %d, %d>" % (
-                    x_vec[0], x_vec[1], x_vec[2], x_vec[3], yy, yy, yy, yy, val[0], val[1], val[2], val[3]))
+                print(
+                    f"Evaluating at <{x_vec[0]}, {x_vec[1]}, {x_vec[2]}, {x_vec[3]}>, <{yy}, {yy}, {yy}, {yy}>: "
+                    f"<{val[0]}, {val[1]}, {val[2]}, {val[3]}>"
+                )
 
         print()
 
@@ -291,12 +293,12 @@ def main():
                 if True:
                     x_inner = 0
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
                 if True:
                     x_inner = 1
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print()
 
@@ -335,7 +337,7 @@ def main():
                     if xx > 3:
                         xx = 3
                     xx += x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print()
 
@@ -418,7 +420,7 @@ def main():
                 for x_inner in range(2):
                     yy = y_outer * 2 + y_inner
                     xx = x_outer * 2 + x_inner
-                    print("Evaluating at x = %d, y = %d: %d" % (xx, yy, xx + yy))
+                    print(f"Evaluating at x = {xx}, y = {yy}: {xx + yy}")
 
         print()
 
@@ -495,7 +497,7 @@ def main():
                         # Check the result.
                         for i in range(4):
                             assert result[x_vec[i], y_vec[i]] == val[i], \
-                                "There was an error at %d %d!" % (x_vec[i], y_vec[i])
+                                f"There was an error at {x_vec[i]} {y_vec[i]}!"
 
                     if True:
                         # y_pairs = 1
@@ -509,7 +511,7 @@ def main():
                         # Check the result.
                         for i in range(4):
                             assert result[x_vec[i], y_vec[i]] == val[i], \
-                                "There was an error at %d %d!" % (x_vec[i], y_vec[i])
+                                f"There was an error at {x_vec[i]} {y_vec[i]}!"
 
         print()
 

--- a/python_bindings/tutorial/lesson_05_scheduling_1.py
+++ b/python_bindings/tutorial/lesson_05_scheduling_1.py
@@ -405,7 +405,7 @@ def main():
         #     .parallel(tile_index)
 
         print("Evaluating gradient tiles in parallel")
-        output = gradient.realize([4, 4])
+        gradient.realize([4, 4])
 
         # The tiles should occur in arbitrary order, but within each
         # tile the pixels will be traversed in row-major order.

--- a/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
+++ b/python_bindings/tutorial/lesson_06_realizing_over_shifted_domains.py
@@ -13,7 +13,6 @@ import halide as hl
 
 
 def main():
-
     # The last lesson was quite involved, and scheduling complex
     # multi-stage pipelines is ahead of us. As an interlude, let's
     # consider something easy: evaluating funcs over rectangular

--- a/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
+++ b/python_bindings/tutorial/lesson_07_multi_stage_pipelines.py
@@ -19,7 +19,9 @@ def main():
     # First we'll declare some Vars to use below.
     x, y, c = hl.Var("x"), hl.Var("y"), hl.Var("c")
 
-    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/rgb.png")
+    image_path = os.path.join(
+        os.path.dirname(__file__), "../../tutorial/images/rgb.png"
+    )
 
     # Now we'll express a multi-stage pipeline that blurs an image
     # first horizontally, and then vertically.
@@ -34,13 +36,15 @@ def main():
 
         # Blur it horizontally:
         blur_x = hl.Func("blur_x")
-        blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 *
-                           input_16[x, y, c] + input_16[x + 1, y, c]) / 4
+        blur_x[x, y, c] = (
+            input_16[x - 1, y, c] + 2 * input_16[x, y, c] + input_16[x + 1, y, c]
+        ) / 4
 
         # Blur it vertically:
         blur_y = hl.Func("blur_y")
-        blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 *
-                           blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
+        blur_y[x, y, c] = (
+            blur_x[x, y - 1, c] + 2 * blur_x[x, y, c] + blur_x[x, y + 1, c]
+        ) / 4
 
         # Convert back to 8-bit.
         output = hl.Func("output")
@@ -134,13 +138,15 @@ def main():
 
         # Blur it horizontally:
         blur_x = hl.Func("blur_x")
-        blur_x[x, y, c] = (input_16[x - 1, y, c] + 2 *
-                           input_16[x, y, c] + input_16[x + 1, y, c]) / 4
+        blur_x[x, y, c] = (
+            input_16[x - 1, y, c] + 2 * input_16[x, y, c] + input_16[x + 1, y, c]
+        ) / 4
 
         # Blur it vertically:
         blur_y = hl.Func("blur_y")
-        blur_y[x, y, c] = (blur_x[x, y - 1, c] + 2 *
-                           blur_x[x, y, c] + blur_x[x, y + 1, c]) / 4
+        blur_y[x, y, c] = (
+            blur_x[x, y - 1, c] + 2 * blur_x[x, y, c] + blur_x[x, y + 1, c]
+        ) / 4
 
         # Convert back to 8-bit.
         output = hl.Func("output")

--- a/python_bindings/tutorial/lesson_08_scheduling_2.py
+++ b/python_bindings/tutorial/lesson_08_scheduling_2.py
@@ -21,8 +21,7 @@ def main():
     # pipeline. We'll start with the default schedule:
     if True:
         print("=" * 50)
-        producer, consumer = hl.Func(
-            "producer_default"), hl.Func("consumer_default")
+        producer, consumer = hl.Func("producer_default"), hl.Func("consumer_default")
 
         # The first stage will be some simple pointwise math similar
         # to our familiar gradient function. The value at position x,
@@ -31,10 +30,12 @@ def main():
 
         # Now we'll add a second stage which adds together multiple
         # points in the first stage.
-        consumer[x, y] = (producer[x, y] +
-                          producer[x, y + 1] +
-                          producer[x + 1, y] +
-                          producer[x + 1, y + 1])
+        consumer[x, y] = (
+            producer[x, y]
+            + producer[x, y + 1]
+            + producer[x + 1, y]
+            + producer[x + 1, y + 1]
+        )
 
         # We'll turn on tracing for both functions.
         consumer.trace_stores()
@@ -62,10 +63,12 @@ def main():
         result = np.empty((4, 4), dtype=np.float32)
         for yy in range(4):
             for xx in range(4):
-                result[yy][xx] = (math.sqrt(xx * yy) +
-                                  math.sqrt(xx * (yy + 1)) +
-                                  math.sqrt((xx + 1) * yy) +
-                                  math.sqrt((xx + 1) * (yy + 1)))
+                result[yy][xx] = (
+                    math.sqrt(xx * yy)
+                    + math.sqrt(xx * (yy + 1))
+                    + math.sqrt((xx + 1) * yy)
+                    + math.sqrt((xx + 1) * (yy + 1))
+                )
 
         print()
 
@@ -83,10 +86,12 @@ def main():
         # Start with the same function definitions:
         producer, consumer = hl.Func("producer_root"), hl.Func("consumer_root")
         producer[x, y] = hl.sqrt(x * y)
-        consumer[x, y] = (producer[x, y] +
-                          producer[x, y + 1] +
-                          producer[x + 1, y] +
-                          producer[x + 1, y + 1])
+        consumer[x, y] = (
+            producer[x, y]
+            + producer[x, y + 1]
+            + producer[x + 1, y]
+            + producer[x + 1, y + 1]
+        )
 
         # Tell Halide to evaluate all of producer before any of consumer.
         producer.compute_root()
@@ -117,10 +122,12 @@ def main():
         # Compute the consumer. Skip the prints this time.
         for yy in range(4):
             for xx in range(4):
-                result[yy][xx] = (producer_storage[yy][xx] +
-                                  producer_storage[yy + 1][xx] +
-                                  producer_storage[yy][xx + 1] +
-                                  producer_storage[yy + 1][xx + 1])
+                result[yy][xx] = (
+                    producer_storage[yy][xx]
+                    + producer_storage[yy + 1][xx]
+                    + producer_storage[yy][xx + 1]
+                    + producer_storage[yy + 1][xx + 1]
+                )
 
         # Note that consumer was evaluated over a 4x4 box, so Halide
         # automatically inferred that producer was needed over a 5x5
@@ -175,10 +182,12 @@ def main():
         # Start with the same function definitions:
         producer, consumer = hl.Func("producer_y"), hl.Func("consumer_y")
         producer[x, y] = hl.sqrt(x * y)
-        consumer[x, y] = (producer[x, y] +
-                          producer[x, y + 1] +
-                          producer[x + 1, y] +
-                          producer[x + 1, y + 1])
+        consumer[x, y] = (
+            producer[x, y]
+            + producer[x, y + 1]
+            + producer[x + 1, y]
+            + producer[x + 1, y + 1]
+        )
 
         # Tell Halide to evaluate producer as needed per y coordinate
         # of the consumer:
@@ -203,7 +212,6 @@ def main():
 
         # There's an outer loop over scanlines of consumer:
         for yy in range(4):
-
             # Allocate space and compute enough of the producer to
             # satisfy this single scanline of the consumer. This
             # means a 5x2 box of the producer.
@@ -214,10 +222,12 @@ def main():
 
             # Compute a scanline of the consumer.
             for xx in range(4):
-                result[yy][xx] = (producer_storage[0][xx] +
-                                  producer_storage[1][xx] +
-                                  producer_storage[0][xx + 1] +
-                                  producer_storage[1][xx + 1])
+                result[yy][xx] = (
+                    producer_storage[0][xx]
+                    + producer_storage[1][xx]
+                    + producer_storage[0][xx + 1]
+                    + producer_storage[1][xx + 1]
+                )
 
         # Again, if we print the loop nest, we'll see something very
         # similar to the C above.
@@ -248,10 +258,12 @@ def main():
         producer = hl.Func("producer_store_root_compute_y")
         consumer = hl.Func("consumer_store_root_compute_y")
         producer[x, y] = hl.sqrt(x * y)
-        consumer[x, y] = (producer[x, y] +
-                          producer[x, y + 1] +
-                          producer[x + 1, y] +
-                          producer[x + 1, y + 1])
+        consumer[x, y] = (
+            producer[x, y]
+            + producer[x, y + 1]
+            + producer[x + 1, y]
+            + producer[x + 1, y + 1]
+        )
 
         # Tell Halide to make a buffer to store all of producer at
         # the outermost level:
@@ -284,11 +296,9 @@ def main():
 
         # There's an outer loop over scanlines of consumer:
         for yy in range(4):
-
             # Compute enough of the producer to satisfy this scanline
             # of the consumer.
             for py in range(yy, yy + 2):
-
                 # Skip over rows of producer that we've already
                 # computed in a previous iteration.
                 if yy > 0 and py == yy:
@@ -299,10 +309,12 @@ def main():
 
             # Compute a scanline of the consumer.
             for xx in range(4):
-                result[yy][xx] = (producer_storage[yy][xx] +
-                                  producer_storage[yy + 1][xx] +
-                                  producer_storage[yy][xx + 1] +
-                                  producer_storage[yy + 1][xx + 1])
+                result[yy][xx] = (
+                    producer_storage[yy][xx]
+                    + producer_storage[yy + 1][xx]
+                    + producer_storage[yy][xx + 1]
+                    + producer_storage[yy + 1][xx + 1]
+                )
 
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
@@ -332,7 +344,6 @@ def main():
 
             for yy in range(4):
                 for py in range(yy, yy + 2):
-
                     if yy > 0 and py == yy:
                         continue
 
@@ -345,10 +356,12 @@ def main():
                 for xx in range(4):
                     # Loads from producer_storage have their y coordinate
                     # bit-masked.
-                    result[yy][xx] = (producer_storage[yy & 1][xx] +
-                                      producer_storage[(yy + 1) & 1][xx] +
-                                      producer_storage[yy & 1][xx + 1] +
-                                      producer_storage[(yy + 1) & 1][xx + 1])
+                    result[yy][xx] = (
+                        producer_storage[yy & 1][xx]
+                        + producer_storage[(yy + 1) & 1][xx]
+                        + producer_storage[yy & 1][xx + 1]
+                        + producer_storage[(yy + 1) & 1][xx + 1]
+                    )
 
     # We can do even better, by leaving the storage outermost, but
     # moving the computation into the innermost loop:
@@ -357,10 +370,12 @@ def main():
         producer = hl.Func("producer_store_root_compute_x")
         consumer = hl.Func("consumer_store_root_compute_x")
         producer[x, y] = hl.sqrt(x * y)
-        consumer[x, y] = (producer[x, y] +
-                          producer[x, y + 1] +
-                          producer[x + 1, y] +
-                          producer[x + 1, y + 1])
+        consumer[x, y] = (
+            producer[x, y]
+            + producer[x, y + 1]
+            + producer[x + 1, y]
+            + producer[x + 1, y + 1]
+        )
 
         # Store outermost, compute innermost.
         producer.store_root().compute_at(consumer, x)
@@ -384,7 +399,6 @@ def main():
         # For every pixel of the consumer:
         for yy in range(4):
             for xx in range(4):
-
                 # Compute enough of the producer to satisfyy this
                 # pixxel of the consumer, but skip values that we've
                 # alreadyy computed:
@@ -397,10 +411,12 @@ def main():
 
                 producer_storage[(yy + 1) & 1][xx + 1] = math.sqrt((xx + 1) * (yy + 1))
 
-                result[yy][xx] = (producer_storage[yy & 1][xx] +
-                                  producer_storage[(yy + 1) & 1][xx] +
-                                  producer_storage[yy & 1][xx + 1] +
-                                  producer_storage[(yy + 1) & 1][xx + 1])
+                result[yy][xx] = (
+                    producer_storage[yy & 1][xx]
+                    + producer_storage[(yy + 1) & 1][xx]
+                    + producer_storage[yy & 1][xx + 1]
+                    + producer_storage[(yy + 1) & 1][xx + 1]
+                )
 
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
@@ -440,10 +456,12 @@ def main():
         print("=" * 50)
         producer, consumer = hl.Func("producer_tile"), hl.Func("consumer_tile")
         producer[x, y] = hl.sqrt(x * y)
-        consumer[x, y] = (producer[x, y] +
-                          producer[x, y + 1] +
-                          producer[x + 1, y] +
-                          producer[x + 1, y + 1])
+        consumer[x, y] = (
+            producer[x, y]
+            + producer[x, y + 1]
+            + producer[x + 1, y]
+            + producer[x + 1, y + 1]
+        )
 
         # Tile the consumer using 2x2 tiles.
         x_outer, y_outer = hl.Var("x_outer"), hl.Var("y_outer")
@@ -463,9 +481,11 @@ def main():
         producer.trace_stores()
         consumer.trace_stores()
 
-        print("\nEvaluating:"
-              "consumer.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)"
-              "producer.compute_at(consumer, x_outer)")
+        print(
+            "\nEvaluating:"
+            "consumer.tile(x, y, x_outer, y_outer, x_inner, y_inner, 2, 2)"
+            "producer.compute_at(consumer, x_outer)"
+        )
         consumer.realize([4, 4])
 
         # Reading the log, you should see that producer and consumer
@@ -493,10 +513,12 @@ def main():
                     for x_inner in range(2):
                         xx = x_base + x_inner
                         yy = y_base + y_inner
-                        result[yy][xx] = (producer_storage[yy - y_base][xx - x_base] +
-                                          producer_storage[yy - y_base + 1][xx - x_base] +
-                                          producer_storage[yy - y_base][xx - x_base + 1] +
-                                          producer_storage[yy - y_base + 1][xx - x_base + 1])
+                        result[yy][xx] = (
+                            producer_storage[yy - y_base][xx - x_base]
+                            + producer_storage[yy - y_base + 1][xx - x_base]
+                            + producer_storage[yy - y_base][xx - x_base + 1]
+                            + producer_storage[yy - y_base + 1][xx - x_base + 1]
+                        )
 
         print("Pseudo-code for the schedule:")
         consumer.print_loop_nest()
@@ -517,10 +539,12 @@ def main():
         print("=" * 50)
         producer, consumer = hl.Func("producer_mixed"), hl.Func("consumer_mixed")
         producer[x, y] = hl.sqrt(x * y)
-        consumer[x, y] = (producer[x, y] +
-                          producer[x, y + 1] +
-                          producer[x + 1, y] +
-                          producer[x + 1, y + 1])
+        consumer[x, y] = (
+            producer[x, y]
+            + producer[x, y + 1]
+            + producer[x + 1, y]
+            + producer[x + 1, y + 1]
+        )
 
         # Split the y coordinate of the consumer into strips of 16 scanlines:
         yo, yi = hl.Var("yo"), hl.Var("yi")
@@ -583,10 +607,12 @@ def main():
                         # If you're on x86, Halide generates SSE code for this
                         # part:
                         xx = [x_base + 0, x_base + 1, x_base + 2, x_base + 3]
-                        vec = [math.sqrt(xx[0] * py),
-                               math.sqrt(xx[1] * py),
-                               math.sqrt(xx[2] * py),
-                               math.sqrt(xx[3] * py)]
+                        vec = [
+                            math.sqrt(xx[0] * py),
+                            math.sqrt(xx[1] * py),
+                            math.sqrt(xx[2] * py),
+                            math.sqrt(xx[3] * py),
+                        ]
                         producer_storage[py & 1][xx[0]] = vec[0]
                         producer_storage[py & 1][xx[1]] = vec[1]
                         producer_storage[py & 1][xx[2]] = vec[2]
@@ -598,22 +624,30 @@ def main():
                     # Again, Halide's equivalent here uses SSE.
                     xx = [x_base, x_base + 1, x_base + 2, x_base + 3]
                     vec = [
-                        (producer_storage[yy & 1][xx[0]] +
-                         producer_storage[(yy + 1) & 1][xx[0]] +
-                         producer_storage[yy & 1][xx[0] + 1] +
-                         producer_storage[(yy + 1) & 1][xx[0] + 1]),
-                        (producer_storage[yy & 1][xx[1]] +
-                         producer_storage[(yy + 1) & 1][xx[1]] +
-                         producer_storage[yy & 1][xx[1] + 1] +
-                         producer_storage[(yy + 1) & 1][xx[1] + 1]),
-                        (producer_storage[yy & 1][xx[2]] +
-                         producer_storage[(yy + 1) & 1][xx[2]] +
-                         producer_storage[yy & 1][xx[2] + 1] +
-                         producer_storage[(yy + 1) & 1][xx[2] + 1]),
-                        (producer_storage[yy & 1][xx[3]] +
-                         producer_storage[(yy + 1) & 1][xx[3]] +
-                         producer_storage[yy & 1][xx[3] + 1] +
-                         producer_storage[(yy + 1) & 1][xx[3] + 1])
+                        (
+                            producer_storage[yy & 1][xx[0]]
+                            + producer_storage[(yy + 1) & 1][xx[0]]
+                            + producer_storage[yy & 1][xx[0] + 1]
+                            + producer_storage[(yy + 1) & 1][xx[0] + 1]
+                        ),
+                        (
+                            producer_storage[yy & 1][xx[1]]
+                            + producer_storage[(yy + 1) & 1][xx[1]]
+                            + producer_storage[yy & 1][xx[1] + 1]
+                            + producer_storage[(yy + 1) & 1][xx[1] + 1]
+                        ),
+                        (
+                            producer_storage[yy & 1][xx[2]]
+                            + producer_storage[(yy + 1) & 1][xx[2]]
+                            + producer_storage[yy & 1][xx[2] + 1]
+                            + producer_storage[(yy + 1) & 1][xx[2] + 1]
+                        ),
+                        (
+                            producer_storage[yy & 1][xx[3]]
+                            + producer_storage[(yy + 1) & 1][xx[3]]
+                            + producer_storage[yy & 1][xx[3] + 1]
+                            + producer_storage[(yy + 1) & 1][xx[3] + 1]
+                        ),
                     ]
 
                     c_result[yy][xx[0]] = vec[0]
@@ -634,8 +668,9 @@ def main():
             for xx in range(800):
                 error = halide_result[xx, yy] - c_result[yy][xx]
                 # It's floating-point math, so we'll allow some slop:
-                assert abs(error) <= 0.001, \
+                assert abs(error) <= 0.001, (
                     f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {c_result[yy][xx]}"
+                )
 
     # This stuff is hard. We ended up in a three-way trade-off
     # between memory bandwidth, redundant work, and

--- a/python_bindings/tutorial/lesson_08_scheduling_2.py
+++ b/python_bindings/tutorial/lesson_08_scheduling_2.py
@@ -635,8 +635,7 @@ def main():
                 error = halide_result[xx, yy] - c_result[yy][xx]
                 # It's floating-point math, so we'll allow some slop:
                 assert abs(error) <= 0.001, \
-                    "halide_result(%d, %d) = %f instead of %f" % (
-                        xx, yy, halide_result[xx, yy], c_result[yy][xx])
+                    f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {c_result[yy][xx]}"
 
     # This stuff is hard. We ended up in a three-way trade-off
     # between memory bandwidth, redundant work, and

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -8,8 +8,6 @@
 # This lesson can be built by invoking the command:
 #    make test_tutorial_lesson_09_update_definitions
 # in a shell with the current directory at python_bindings/
-from datetime import datetime
-
 import halide as hl
 
 import halide.imageio

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -20,10 +20,12 @@ def main():
     x, y = hl.Var("x"), hl.Var("y")
 
     # Load a grayscale image to use as an input.
-    image_path = os.path.join(os.path.dirname(__file__), "../../tutorial/images/gray.png")
+    image_path = os.path.join(
+        os.path.dirname(__file__), "../../tutorial/images/gray.png"
+    )
     input_data = halide.imageio.imread(image_path)
     if True:
-         # making the image smaller to go faster
+        # making the image smaller to go faster
         input_data = input_data[:150, :160]
     assert input_data.dtype == np.uint8
     input = hl.Buffer(input_data)
@@ -89,8 +91,8 @@ def main():
         # before the next one begins. Let's trace the loads and
         # stores for a simpler example:
         g = hl.Func("g")
-        g[x, y] = x + y   # Pure definition
-        g[2, 1] = 42      # First update definition
+        g[x, y] = x + y  # Pure definition
+        g[2, 1] = 42  # First update definition
         g[x, 0] = g[x, 1]  # Second update definition
 
         g.trace_loads()
@@ -156,13 +158,13 @@ def main():
         # Check the results match:
         for yy in range(100):
             for xx in range(100):
-                assert halide_result[xx, yy] == py_result[yy][xx], \
+                assert halide_result[xx, yy] == py_result[yy][xx], (
                     f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[yy][xx]}"
+                )
 
     # Now we'll examine a real-world use for an update definition:
     # computing a histogram.
     if True:
-
         # Some operations on images can't be cleanly expressed as a pure
         # function from the output coordinates to the value stored
         # there. The classic example is computing a histogram. The
@@ -194,8 +196,9 @@ def main():
 
         # Check the answers agree:
         for xx in range(256):
-            assert py_result[xx] == halide_result[xx], \
+            assert py_result[xx] == halide_result[xx], (
                 f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
+            )
 
     # Scheduling update steps
     if True:
@@ -263,8 +266,9 @@ def main():
         # Check the C and Halide results match:
         for yy in range(16):
             for xx in range(16):
-                assert halide_result[xx, yy] == py_result[yy][xx], \
+                assert halide_result[xx, yy] == py_result[yy][xx], (
                     f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[yy][xx]}"
+                )
 
     # That covers how to schedule the variables within a hl.Func that
     # uses update steps, but what about producer-consumer
@@ -295,8 +299,9 @@ def main():
 
         # Check the results match
         for xx in range(10):
-            assert halide_result[xx] == py_result[xx], \
+            assert halide_result[xx] == py_result[xx], (
                 f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
+            )
 
         # For all other compute_at/store_at options, the reduction
         # gets placed where you would expect, somewhere in the loop
@@ -353,8 +358,9 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], \
+                assert halide_result[xx] == py_result[xx], (
                     f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
+                )
 
         if True:
             # Case 2: The consumer references the producer in the update step
@@ -395,8 +401,9 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], \
+                assert halide_result[xx] == py_result[xx], (
                     f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
+                )
 
         if True:
             # Case 3: The consumer references the producer in
@@ -433,8 +440,9 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], \
+                assert halide_result[xx] == py_result[xx], (
                     f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
+                )
 
         if True:
             # Case 4: The consumer references the producer in
@@ -459,7 +467,11 @@ def main():
             # those instead:
 
             # Attempt 2:
-            producer_wrapper_1, producer_wrapper_2, consumer_2 = hl.Func(), hl.Func(), hl.Func()
+            producer_wrapper_1, producer_wrapper_2, consumer_2 = (
+                hl.Func(),
+                hl.Func(),
+                hl.Func(),
+            )
             producer_wrapper_1[x, y] = producer[x, y]
             producer_wrapper_2[x, y] = producer[x, y]
 
@@ -497,8 +509,9 @@ def main():
             # Check the results match
             for yy in range(10):
                 for xx in range(10):
-                    assert halide_result[xx, yy] == py_result[yy][xx], \
+                    assert halide_result[xx, yy] == py_result[yy][xx], (
                         f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[yy][xx]}"
+                    )
 
         if True:
             # Case 5: Scheduling a producer under a reduction domain
@@ -542,8 +555,9 @@ def main():
 
             # Check the results match
             for xx in range(10):
-                assert halide_result[xx] == py_result[xx], \
+                assert halide_result[xx] == py_result[xx], (
                     f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
+                )
 
     # A real-world example of a reduction inside a producer-consumer chain.
     if True:
@@ -576,7 +590,7 @@ def main():
         # because the default schedule for reductions is
         # compute-innermost. Here's the equivalent Python:
 
-        #cast_to_uint8 = lambda x_: np.array([x_], dtype=np.uint8)[0]
+        # cast_to_uint8 = lambda x_: np.array([x_], dtype=np.uint8)[0]
         local_sum = np.empty((1), dtype=np.int32)
 
         py_result = hl.Buffer(hl.UInt(8), [input.width(), input.height()])
@@ -595,15 +609,16 @@ def main():
 
                 # Pure step of blurry
                 # py_result(x, y) = (uint8_t)(local_sum[0] / 25)
-                #py_result[xx, yy] = cast_to_uint8(local_sum[0] / 25)
+                # py_result[xx, yy] = cast_to_uint8(local_sum[0] / 25)
                 # hl.cast done internally
                 py_result[xx, yy] = int(local_sum[0] / 25)
 
         # Check the results match
         for yy in range(input.height()):
             for xx in range(input.width()):
-                assert halide_result[xx, yy] == py_result[xx, yy], \
+                assert halide_result[xx, yy] == py_result[xx, yy], (
                     f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[xx, yy]}"
+                )
 
     # Reduction helpers.
     if True:
@@ -640,10 +655,12 @@ def main():
 
         # Check they all match.
         for xx in range(10):
-            assert halide_result_1[xx] == py_result[xx], \
+            assert halide_result_1[xx] == py_result[xx], (
                 f"halide_result_1({xx}) = {halide_result_1[xx]} instead of {py_result[xx]}"
-            assert halide_result_2[xx] == py_result[xx], \
+            )
+            assert halide_result_2[xx] == py_result[xx], (
                 f"halide_result_2({xx}) = {halide_result_2[xx]} instead of {py_result[xx]}"
+            )
 
     print("Success!")
     return 0

--- a/python_bindings/tutorial/lesson_09_update_definitions.py
+++ b/python_bindings/tutorial/lesson_09_update_definitions.py
@@ -159,8 +159,7 @@ def main():
         for yy in range(100):
             for xx in range(100):
                 assert halide_result[xx, yy] == py_result[yy][xx], \
-                    "halide_result(%d, %d) = %d instead of %d" % (
-                        xx, yy, halide_result[xx, yy], py_result[yy][xx])
+                    f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[yy][xx]}"
 
     # Now we'll examine a real-world use for an update definition:
     # computing a histogram.
@@ -198,7 +197,7 @@ def main():
         # Check the answers agree:
         for xx in range(256):
             assert py_result[xx] == halide_result[xx], \
-                "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
+                f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
 
     # Scheduling update steps
     if True:
@@ -267,8 +266,7 @@ def main():
         for yy in range(16):
             for xx in range(16):
                 assert halide_result[xx, yy] == py_result[yy][xx], \
-                    "halide_result(%d, %d) = %d instead of %d" % (
-                        xx, yy, halide_result[xx, yy], py_result[yy][xx])
+                    f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[yy][xx]}"
 
     # That covers how to schedule the variables within a hl.Func that
     # uses update steps, but what about producer-consumer
@@ -300,7 +298,7 @@ def main():
         # Check the results match
         for xx in range(10):
             assert halide_result[xx] == py_result[xx], \
-                "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
+                f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
 
         # For all other compute_at/store_at options, the reduction
         # gets placed where you would expect, somewhere in the loop
@@ -358,7 +356,7 @@ def main():
             # Check the results match
             for xx in range(10):
                 assert halide_result[xx] == py_result[xx], \
-                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
+                    f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
 
         if True:
             # Case 2: The consumer references the producer in the update step
@@ -400,7 +398,7 @@ def main():
             # Check the results match
             for xx in range(10):
                 assert halide_result[xx] == py_result[xx], \
-                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
+                    f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
 
         if True:
             # Case 3: The consumer references the producer in
@@ -438,7 +436,7 @@ def main():
             # Check the results match
             for xx in range(10):
                 assert halide_result[xx] == py_result[xx], \
-                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
+                    f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
 
         if True:
             # Case 4: The consumer references the producer in
@@ -502,8 +500,7 @@ def main():
             for yy in range(10):
                 for xx in range(10):
                     assert halide_result[xx, yy] == py_result[yy][xx], \
-                        "halide_result(%d, %d) = %d instead of %d" % (
-                            xx, yy, halide_result[xx, yy], py_result[yy][xx])
+                        f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[yy][xx]}"
 
         if True:
             # Case 5: Scheduling a producer under a reduction domain
@@ -548,7 +545,7 @@ def main():
             # Check the results match
             for xx in range(10):
                 assert halide_result[xx] == py_result[xx], \
-                    "halide_result(%d) = %d instead of %d" % (xx, halide_result[xx], py_result[xx])
+                    f"halide_result({xx}) = {halide_result[xx]} instead of {py_result[xx]}"
 
     # A real-world example of a reduction inside a producer-consumer chain.
     if True:
@@ -608,8 +605,7 @@ def main():
         for yy in range(input.height()):
             for xx in range(input.width()):
                 assert halide_result[xx, yy] == py_result[xx, yy], \
-                    "halide_result(%d, %d) = %d instead of %d" % (
-                        xx, yy, halide_result[xx, yy], py_result[xx, yy])
+                    f"halide_result({xx}, {yy}) = {halide_result[xx, yy]} instead of {py_result[xx, yy]}"
 
     # Reduction helpers.
     if True:
@@ -647,9 +643,9 @@ def main():
         # Check they all match.
         for xx in range(10):
             assert halide_result_1[xx] == py_result[xx], \
-                "halide_result_1(%d) = %d instead of %d" % (xx, halide_result_1[xx], py_result[xx])
+                f"halide_result_1({xx}) = {halide_result_1[xx]} instead of {py_result[xx]}"
             assert halide_result_2[xx] == py_result[xx], \
-                "halide_result_2(%d) = %d instead of %d" % (xx, halide_result_2[xx], py_result[xx])
+                f"halide_result_2({xx}) = {halide_result_2[xx]} instead of {py_result[xx]}"
 
     print("Success!")
     return 0

--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -64,9 +64,9 @@ def main():
     # arguments to the routine. This routine takes two. Arguments are
     # usually Params or ImageParams.
     fname = "lesson_10_halide"
-    brighter.compile_to({hl.OutputFileType.object: "lesson_10_halide.o",
-                         hl.OutputFileType.python_extension: "lesson_10_halide.py.cpp"},
-                        [input, offset], "lesson_10_halide")
+    brighter.compile_to({hl.OutputFileType.object: f"{fname}.o",
+                         hl.OutputFileType.python_extension: f"{fname}.py.cpp"},
+                        [input, offset], fname)
 
     print("Halide pipeline compiled, but not yet run.")
 

--- a/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_generate.py
@@ -28,7 +28,6 @@ import halide as hl
 
 
 def main():
-
     # We'll define a simple one-stage pipeline:
     brighter = hl.Func("brighter")
     x, y = hl.Var("x"), hl.Var("y")
@@ -64,9 +63,14 @@ def main():
     # arguments to the routine. This routine takes two. Arguments are
     # usually Params or ImageParams.
     fname = "lesson_10_halide"
-    brighter.compile_to({hl.OutputFileType.object: f"{fname}.o",
-                         hl.OutputFileType.python_extension: f"{fname}.py.cpp"},
-                        [input, offset], fname)
+    brighter.compile_to(
+        {
+            hl.OutputFileType.object: f"{fname}.o",
+            hl.OutputFileType.python_extension: f"{fname}.py.cpp",
+        },
+        [input, offset],
+        fname,
+    )
 
     print("Halide pipeline compiled, but not yet run.")
 

--- a/python_bindings/tutorial/lesson_10_aot_compilation_run.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_run.py
@@ -51,7 +51,7 @@ def main():
             # we add over a uint8 value (will properly model overflow)
             correct_val[0] += offset_value
             assert output_val == correct_val[0], \
-                "output(%d, %d) was %d instead of %d" % (x, y, output_val, correct_val)
+                f"output({x}, {y}) was {output_val} instead of {correct_val}"
 
     # Everything worked!
     print("Success!")

--- a/python_bindings/tutorial/lesson_10_aot_compilation_run.py
+++ b/python_bindings/tutorial/lesson_10_aot_compilation_run.py
@@ -28,13 +28,13 @@ def main():
     # code.
 
     # Let's make some input data to test with:
-    input = np.empty((640, 480), dtype=np.uint8, order='F')
+    input = np.empty((640, 480), dtype=np.uint8, order="F")
     for y in range(480):
         for x in range(640):
             input[x, y] = (x ^ (y + 1)) & 0xFF
 
     # And the memory where we want to write our output:
-    output = np.empty((640, 480), dtype=np.uint8, order='F')
+    output = np.empty((640, 480), dtype=np.uint8, order="F")
 
     offset_value = 5
 
@@ -50,8 +50,9 @@ def main():
             correct_val[0] = input_val
             # we add over a uint8 value (will properly model overflow)
             correct_val[0] += offset_value
-            assert output_val == correct_val[0], \
+            assert output_val == correct_val[0], (
                 f"output({x}, {y}) was {output_val} instead of {correct_val}"
+            )
 
     # Everything worked!
     print("Success!")

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -111,12 +111,8 @@ def main():
         # uint8_t  []
         win_64_magic = [0x64, 0x86]
 
-        f = open("lesson_11_x86_64_windows.obj", "rb")
-        try:
+        with open("lesson_11_x86_64_windows.obj", "rb") as f:
             header_bytes = f.read(2)
-        except:
-            assert False, "Windows object file not generated"
-        f.close()
 
         header = list(unpack("B" * 2, header_bytes))
         assert header == win_64_magic, "Unexpected header bytes in 64-bit windows object file."
@@ -130,12 +126,8 @@ def main():
             12,  # CPU type is ARM
             11,  # CPU subtype is ARMv7s
             1]  # It's a relocatable object file.
-        f = open("lesson_11_arm_32_ios.o", "rb")
-        try:
+        with open("lesson_11_arm_32_ios.o", "rb") as f:
             header_bytes = f.read(4 * 4)
-        except:
-            assert False, "ios object file not generated"
-        f.close()
 
         header = list(unpack("I" * 4, header_bytes))
         assert header == arm_32_ios_magic, "Unexpected header bytes in 32-bit arm ios object file."

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -93,12 +93,8 @@ def main():
                                 1]       # Current version of elf
 
         length = len(arm_32_android_magic)
-        f = open("lesson_11_arm_32_android.o", "rb")
-        try:
+        with open("lesson_11_arm_32_android.o", "rb") as f:
             header_bytes = f.read(length)
-        except:
-            assert False, "Android object file not generated"
-        f.close()
 
         header = list(unpack("B" * length, header_bytes))
         assert header == arm_32_android_magic, \

--- a/python_bindings/tutorial/lesson_11_cross_compilation.py
+++ b/python_bindings/tutorial/lesson_11_cross_compilation.py
@@ -13,7 +13,6 @@ from struct import unpack
 
 
 def main():
-
     # We'll define the simple one-stage pipeline that we used in lesson 10.
     brighter = hl.Func("brighter")
     x, y = hl.Var("x"), hl.Var("y")
@@ -49,12 +48,13 @@ def main():
         target = hl.Target()
         target.os = hl.TargetOS.Android  # The operating system
         target.arch = hl.TargetArch.ARM  # The CPU architecture
-        target.bits = 32              # The bit-width of the architecture
-        arm_features = []             # A list of features to set
+        target.bits = 32  # The bit-width of the architecture
+        arm_features = []  # A list of features to set
         target.set_features(arm_features)
         # Pass the target as the last argument.
-        brighter.compile_to_file("lesson_11_arm_32_android", args,
-                                 "lesson_11_arm_32_android", target)
+        brighter.compile_to_file(
+            "lesson_11_arm_32_android", args, "lesson_11_arm_32_android", target
+        )
 
     if create_windows:
         # And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
@@ -63,8 +63,9 @@ def main():
         target.arch = hl.TargetArch.X86
         target.bits = 64
         target.set_features([hl.TargetFeature.AVX, hl.TargetFeature.SSE41])
-        brighter.compile_to_file("lesson_11_x86_64_windows", args,
-                                 "lesson_11_x86_64_windows", target)
+        brighter.compile_to_file(
+            "lesson_11_x86_64_windows", args, "lesson_11_x86_64_windows", target
+        )
 
     if create_ios:
         # And finally an iOS mach-o object file for one of Apple's 32-bit
@@ -78,8 +79,9 @@ def main():
         target.arch = hl.TargetArch.ARM
         target.bits = 32
         target.set_features([hl.TargetFeature.ARMv7s])
-        brighter.compile_to_file("lesson_11_arm_32_ios", args,
-                                 "lesson_11_arm_32_ios", target)
+        brighter.compile_to_file(
+            "lesson_11_arm_32_ios", args, "lesson_11_arm_32_ios", target
+        )
 
     # Now let's check these files are what they claim, by examining
     # their first few bytes.
@@ -87,19 +89,25 @@ def main():
     if create_android:
         # 32-arm android object files start with the magic bytes:
         # uint8_t []
-        arm_32_android_magic = [0x7f, ord('E'), ord('L'), ord('F'),  # ELF format
-                                1,       # 32-bit
-                                1,       # 2's complement little-endian
-                                1]       # Current version of elf
+        arm_32_android_magic = [
+            0x7F,
+            ord("E"),
+            ord("L"),
+            ord("F"),  # ELF format
+            1,  # 32-bit
+            1,  # 2's complement little-endian
+            1,
+        ]  # Current version of elf
 
         length = len(arm_32_android_magic)
         with open("lesson_11_arm_32_android.o", "rb") as f:
             header_bytes = f.read(length)
 
         header = list(unpack("B" * length, header_bytes))
-        assert header == arm_32_android_magic, \
-            "Unexpected header bytes in 32-bit arm object file: " + \
-            str([x == y for x, y in zip(header, arm_32_android_magic)])
+        assert header == arm_32_android_magic, (
+            "Unexpected header bytes in 32-bit arm object file: "
+            + str([x == y for x, y in zip(header, arm_32_android_magic)])
+        )
 
     if create_windows:
         # 64-bit windows object files start with the magic 16-bit value 0x8664
@@ -111,22 +119,27 @@ def main():
             header_bytes = f.read(2)
 
         header = list(unpack("B" * 2, header_bytes))
-        assert header == win_64_magic, "Unexpected header bytes in 64-bit windows object file."
+        assert header == win_64_magic, (
+            "Unexpected header bytes in 64-bit windows object file."
+        )
 
     if create_ios:
         # 32-bit arm iOS mach-o files start with the following magic bytes:
         #  uint32_t []
         arm_32_ios_magic = [
-            0xfeedface,  # Mach-o magic bytes
+            0xFEEDFACE,  # Mach-o magic bytes
             # 0xfe, 0xed, 0xfa, 0xce, # Mach-o magic bytes
             12,  # CPU type is ARM
             11,  # CPU subtype is ARMv7s
-            1]  # It's a relocatable object file.
+            1,
+        ]  # It's a relocatable object file.
         with open("lesson_11_arm_32_ios.o", "rb") as f:
             header_bytes = f.read(4 * 4)
 
         header = list(unpack("I" * 4, header_bytes))
-        assert header == arm_32_ios_magic, "Unexpected header bytes in 32-bit arm ios object file."
+        assert header == arm_32_ios_magic, (
+            "Unexpected header bytes in 32-bit arm ios object file."
+        )
 
     # It looks like the object files we produced are plausible for
     # those targets. We'll count that as a success for the purposes

--- a/python_bindings/tutorial/lesson_12_using_the_gpu.py
+++ b/python_bindings/tutorial/lesson_12_using_the_gpu.py
@@ -231,8 +231,8 @@ class MyPipeline:
             for yy in range(self.input.height()):
                 for xx in range(self.input.width()):
                     assert output[xx, yy, cc] == reference_output[xx, yy, cc], \
-                        "Mismatch between output (%d) and reference output (%d) at %d, %d, %d" % (
-                            output[xx, yy, cc], reference_output[xx, yy, cc], xx, yy, cc)
+                        f"Mismatch between output ({output[xx, yy, cc]}) and reference output " \
+                        f"({reference_output[xx, yy, cc]}) at {xx}, {yy}, {cc}"
 
         print("CPU and GPU outputs are consistent.")
 

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -295,7 +295,7 @@ def main():
                     print(f"{code[index]}", end="")
                 else:
                     pass  # is lesson 13 cpp version buggy ?
-            print("")
+            print()
 
     print("Success!")
 

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -288,7 +288,7 @@ def main():
             for xx in range(result.width()):
                 index = result[xx, yy]
                 if index < len(code):
-                    print(f"{code[index]:c}", end="")
+                    print(f"{code[index]}", end="")
                 else:
                     pass  # is lesson 13 cpp version buggy ?
             print("")

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -288,7 +288,7 @@ def main():
             for xx in range(result.width()):
                 index = result[xx, yy]
                 if index < len(code):
-                    print("%c" % code[index], end="")
+                    print(f"{code[index]:c}", end="")
                 else:
                     pass  # is lesson 13 cpp version buggy ?
             print("")

--- a/python_bindings/tutorial/lesson_13_tuples.py
+++ b/python_bindings/tutorial/lesson_13_tuples.py
@@ -9,14 +9,13 @@
 #    make test_tutorial_lesson_13_tuples
 # in a shell with the current directory at python_bindings/
 
-import halide as hl
-
-import numpy as np
 import math
+
+import halide as hl
+import numpy as np
 
 
 def main():
-
     # So far Funcs (such as the one below) have evaluated to a single
     # scalar value for each point in their domain.
     single_valued = hl.Func()
@@ -30,9 +29,13 @@ def main():
     # for every x, y coordinate indexed by c.
     color_image = hl.Func()
     c = hl.Var("c")
-    color_image[x, y, c] = hl.select(c == 0, 245,  # Red value
-                                     c == 1, 42,  # Green value
-                                     132)        # Blue value
+    color_image[x, y, c] = hl.select(
+        c == 0,
+        245,  # Red value
+        c == 1,
+        42,  # Green value
+        132,  # Blue value
+    )
 
     # Since this pattern appears quite often, Halide provides a
     # syntatic sugar to write the code above as the following,
@@ -206,7 +209,6 @@ def main():
         # can be converted to and from a Tuple is one way to extend
         # Halide's type system with user-defined types.
         class Complex:
-
             def __init__(self, r, i=None):
                 if type(r) is float and type(i) is float:
                     self.real = hl.Expr(r)
@@ -228,8 +230,10 @@ def main():
 
             def __mul__(self, other):
                 "Complex multiplication"
-                return Complex(self.real * other.real - self.imag * other.imag,
-                               self.real * other.imag + self.imag * other.real)
+                return Complex(
+                    self.real * other.real - self.imag * other.imag,
+                    self.real * other.imag + self.imag * other.real,
+                )
 
             def __getitem__(self, idx):
                 return (self.real, self.imag)[idx]
@@ -261,7 +265,7 @@ def main():
 
         # The following line uses the complex multiplication and
         # addition we defined above.
-        mandelbrot[x, y, r] = (Complex(current * current) + initial)
+        mandelbrot[x, y, r] = Complex(current * current) + initial
 
         # We'll use another tuple reduction to compute the iteration
         # number where the value first escapes a circle of radius 4.

--- a/python_bindings/tutorial/lesson_14_types.py
+++ b/python_bindings/tutorial/lesson_14_types.py
@@ -13,7 +13,6 @@ import halide as hl
 
 
 def main():
-
     # All Exprs have a scalar type, and all Funcs evaluate to one or
     # more scalar types. The scalar types in Halide are unsigned
     # integers of various bit widths, signed integers of the same set
@@ -22,9 +21,18 @@ def main():
     # following array contains all the legal types.
 
     valid_halide_types = [
-        hl.UInt(8), hl.UInt(16), hl.UInt(32), hl.UInt(64),
-        hl.Int(8), hl.Int(16), hl.Int(32), hl.Int(64),
-        hl.Float(32), hl.Float(64), hl.Handle()]
+        hl.UInt(8),
+        hl.UInt(16),
+        hl.UInt(32),
+        hl.UInt(64),
+        hl.Int(8),
+        hl.Int(16),
+        hl.Int(32),
+        hl.Int(64),
+        hl.Float(32),
+        hl.Float(64),
+        hl.Handle(),
+    ]
 
     # Constructing and inspecting types.
     if True:
@@ -185,7 +193,9 @@ def main():
         x = hl.Var("x")
         assert average(hl.cast(hl.Float(32), x), 3.0).type() == hl.Float(32)
         assert average(x, 3).type() == hl.Int(32)
-        assert average(hl.cast(hl.UInt(8), x), hl.cast(hl.UInt(8), 3)).type() == hl.UInt(8)
+        assert average(
+            hl.cast(hl.UInt(8), x), hl.cast(hl.UInt(8), 3)
+        ).type() == hl.UInt(8)
 
     print("Success!")
 
@@ -193,7 +203,6 @@ def main():
 
 
 def average(a, b):
-
     if type(a) is not hl.Expr:
         a = hl.Expr(a)
 
@@ -205,7 +214,7 @@ def average(a, b):
     assert a.type() == b.type()
 
     # For floating point types:
-    if (a.type().is_float()):
+    if a.type().is_float():
         # The '2' will be promoted to the floating point type due to
         # rule 3 above.
         return (a + b) / 2

--- a/python_bindings/tutorial/lesson_14_types.py
+++ b/python_bindings/tutorial/lesson_14_types.py
@@ -119,7 +119,7 @@ def main():
 
         # 5) If one of the expressions is an integer constant, then it is
         # coerced to the type of the other expression.
-        assert (u32 + 3).type() == hl.UInt(32)
+        assert (u64 + 3).type() == hl.UInt(64)
         assert (3 + s16).type() == hl.Int(16)
 
         # If this rule would cause the integer to overflow, then Halide
@@ -143,25 +143,24 @@ def main():
         # case where the bit widths are the same.
         assert (u32 + s32).type() == hl.Int(32)
 
-        if False:  # evaluate<X> not yet exposed to python
-            # When an unsigned hl.Expr is converted to a wider signed type in
-            # this way, it is first widened to a wider unsigned type
-            # (zero-extended), and then reinterpreted as a signed
-            # integer. I.e. casting the hl.UInt(8) value 255 to an hl.Int(32)
-            # produces 255, not -1.
-            # int32_t result32 =
-            # evaluate<int>(hl.cast<int32_t>(hl.cast<uint8_t>(255)))
-            assert result32 == 255
+    ## TODO: evaluate<X> not yet exposed to python
 
-            # When a signed type is explicitly converted to a wider unsigned
-            # type with the hl.cast operator (the type promotion rules will
-            # never do this automatically), it is first converted to the
-            # wider signed type (sign-extended), and then reinterpreted as
-            # an unsigned integer. I.e. casting the hl.Int(8) value -1 to a
-            # hl.UInt(16) produces 65535, not 255.
-            # uint16_t result16 =
-            # evaluate<uint16_t>(hl.cast<uint16_t>(hl.cast<int8_t>(-1)))
-            assert result16 == 65535
+    # When an unsigned hl.Expr is converted to a wider signed type in
+    # this way, it is first widened to a wider unsigned type
+    # (zero-extended), and then reinterpreted as a signed
+    # integer. I.e. casting the hl.UInt(8) value 255 to an hl.Int(32)
+    # produces 255, not -1.
+    # int32_t result32 = evaluate<int>(hl.cast<int32_t>(hl.cast<uint8_t>(255)))
+    # assert result32 == 255
+
+    # When a signed type is explicitly converted to a wider unsigned
+    # type with the hl.cast operator (the type promotion rules will
+    # never do this automatically), it is first converted to the
+    # wider signed type (sign-extended), and then reinterpreted as
+    # an unsigned integer. I.e. casting the hl.Int(8) value -1 to a
+    # hl.UInt(16) produces 65535, not 255.
+    # uint16_t result16 = evaluate<uint16_t>(hl.cast<uint16_t>(hl.cast<int8_t>(-1)))
+    # assert result16 == 65535
 
     # The type hl.Handle().
     if True:

--- a/src/irvisualizer/generate_palettes.py
+++ b/src/irvisualizer/generate_palettes.py
@@ -1,5 +1,5 @@
 def make_oklch(l, c, h):
-    return (f"oklch({l * 100:.1f}% {c:.2f} {h:.0f})")
+    return f"oklch({l * 100:.1f}% {c:.2f} {h:.0f})"
 
 
 STEPS = 20
@@ -10,14 +10,14 @@ for color_theme, fL in [("light", 1.0), ("dark", 0.7)]:
     for i in range(STEPS):
         f = i / (STEPS - 1)
         col = make_oklch((0.9 - f * 0.5) * fL, 0.05 + 0.1 * f, 140)
-        print("    .block-CostColor%d:first-child { border-left: 8px solid %s; }" % (i, col))
+        print(f"    .block-CostColor{i}:first-child {{ border-left: 8px solid {col}; }}")
     print("    .block-CostColorNone:first-child { border-left: transparent; }")
     print()
 
     for i in range(STEPS):
         f = i / (STEPS - 1)
         col = make_oklch((0.9 - f * 0.5) * fL, 0.05 + 0.1 * f, 140)
-        print("    .line-CostColor%d:first-child { border-right: 8px solid %s; }" % (i, col))
+        print(f"    .line-CostColor{i}:first-child {{ border-right: 8px solid {col}; }}")
     print("    .line-CostColorNone:first-child { border-right: transparent; }")
     print()
 
@@ -25,14 +25,14 @@ for color_theme, fL in [("light", 1.0), ("dark", 0.7)]:
     for i in range(STEPS):
         f = i / (STEPS - 1)
         col = make_oklch((0.9 - f * 0.5) * fL, 0.05 + 0.1 * f, 300)
-        print("    .block-CostColor%d:last-child { border-left: 8px solid %s; }" % (i, col))
+        print(f"    .block-CostColor{i}:last-child {{ border-left: 8px solid {col}; }}")
     print("    .block-CostColorNone:last-child { border-left: transparent; }")
     print()
 
     for i in range(STEPS):
         f = i / (STEPS - 1)
         col = make_oklch((0.9 - f * 0.5) * fL, 0.05 + 0.1 * f, 300)
-        print("    .line-CostColor%d:last-child { border-right: 8px solid %s; }" % (i, col))
+        print(f"    .line-CostColor{i}:last-child {{ border-right: 8px solid {col}; }}")
     print("    .line-CostColorNone:last-child { border-right: transparent; }")
 
     print("} /* End of", color_theme, "theme. */")
@@ -42,20 +42,20 @@ print("Theme agnostic")
 print()
 
 def make_oklch(l, c, h):
-    return (f"oklch(calc({l * 100:.1f}% * var(--cost-Lf)) {c:.2f} {h:.0f})")
+    return f"oklch(calc({l * 100:.1f}% * var(--cost-Lf)) {c:.2f} {h:.0f})"
 
 
 for i in range(STEPS):
     f = i / (STEPS - 1)
     col = make_oklch(0.9 - f * 0.5, 0.05 + 0.1 * f, 140)
-    print(".block-CostColor%d:first-child { border-left: 8px solid %s; }" % (i, col))
+    print(f".block-CostColor{i}:first-child {{ border-left: 8px solid {col}; }}")
 print(".block-CostColorNone:first-child { border-left: transparent; }")
 print()
 
 for i in range(STEPS):
     f = i / (STEPS - 1)
     col = make_oklch(0.9 - f * 0.5, 0.05 + 0.1 * f, 140)
-    print(".line-CostColor%d:first-child { border-right: 8px solid %s; }" % (i, col))
+    print(f".line-CostColor{i}:first-child {{ border-right: 8px solid {col}; }}")
 print(".line-CostColorNone:first-child { border-right: transparent; }")
 print()
 
@@ -63,12 +63,12 @@ print()
 for i in range(STEPS):
     f = i / (STEPS - 1)
     col = make_oklch(0.9 - f * 0.5, 0.05 + 0.1 * f, 300)
-    print(".block-CostColor%d:last-child { border-left: 8px solid %s; }" % (i, col))
+    print(f".block-CostColor{i}:last-child {{ border-left: 8px solid {col}; }}")
 print(".block-CostColorNone:last-child { border-left: transparent; }")
 print()
 
 for i in range(STEPS):
     f = i / (STEPS - 1)
     col = make_oklch(0.9 - f * 0.5, 0.05 + 0.1 * f, 300)
-    print(".line-CostColor%d:last-child { border-right: 8px solid %s; }" % (i, col))
+    print(f".line-CostColor{i}:last-child {{ border-right: 8px solid {col}; }}")
 print(".line-CostColorNone:last-child { border-right: transparent; }")

--- a/src/irvisualizer/generate_palettes.py
+++ b/src/irvisualizer/generate_palettes.py
@@ -1,5 +1,5 @@
-def make_oklch(l, c, h):
-    return f"oklch({l * 100:.1f}% {c:.2f} {h:.0f})"
+def make_oklch(L, c, h):
+    return f"oklch({L * 100:.1f}% {c:.2f} {h:.0f})"
 
 
 STEPS = 20
@@ -41,8 +41,8 @@ print()
 print("Theme agnostic")
 print()
 
-def make_oklch(l, c, h):
-    return f"oklch(calc({l * 100:.1f}% * var(--cost-Lf)) {c:.2f} {h:.0f})"
+def make_oklch(L, c, h):
+    return f"oklch(calc({L * 100:.1f}% * var(--cost-Lf)) {c:.2f} {h:.0f})"
 
 
 for i in range(STEPS):

--- a/src/irvisualizer/generate_palettes.py
+++ b/src/irvisualizer/generate_palettes.py
@@ -1,5 +1,5 @@
 def make_oklch(l, c, h):
-    return ("oklch(%.1f%% %.2f %.0f)" % (l * 100, c, h))
+    return (f"oklch({l * 100:.1f}% {c:.2f} {h:.0f})")
 
 
 STEPS = 20
@@ -42,7 +42,7 @@ print("Theme agnostic")
 print()
 
 def make_oklch(l, c, h):
-    return ("oklch(calc(%.1f%% * var(--cost-Lf)) %.2f %.0f)" % (l * 100, c, h))
+    return (f"oklch(calc({l * 100:.1f}% * var(--cost-Lf)) {c:.2f} {h:.0f})")
 
 
 for i in range(STEPS):

--- a/src/irvisualizer/generate_palettes.py
+++ b/src/irvisualizer/generate_palettes.py
@@ -5,22 +5,25 @@ def make_oklch(L, c, h):
 STEPS = 20
 for color_theme, fL in [("light", 1.0), ("dark", 0.7)]:
     print()
-    print("[data-theme=\"" + color_theme + "\"] {")
+    print(f'[data-theme="{color_theme}"] {{')
 
     for i in range(STEPS):
         f = i / (STEPS - 1)
         col = make_oklch((0.9 - f * 0.5) * fL, 0.05 + 0.1 * f, 140)
-        print(f"    .block-CostColor{i}:first-child {{ border-left: 8px solid {col}; }}")
+        print(
+            f"    .block-CostColor{i}:first-child {{ border-left: 8px solid {col}; }}"
+        )
     print("    .block-CostColorNone:first-child { border-left: transparent; }")
     print()
 
     for i in range(STEPS):
         f = i / (STEPS - 1)
         col = make_oklch((0.9 - f * 0.5) * fL, 0.05 + 0.1 * f, 140)
-        print(f"    .line-CostColor{i}:first-child {{ border-right: 8px solid {col}; }}")
+        print(
+            f"    .line-CostColor{i}:first-child {{ border-right: 8px solid {col}; }}"
+        )
     print("    .line-CostColorNone:first-child { border-right: transparent; }")
     print()
-
 
     for i in range(STEPS):
         f = i / (STEPS - 1)
@@ -40,6 +43,7 @@ for color_theme, fL in [("light", 1.0), ("dark", 0.7)]:
 print()
 print("Theme agnostic")
 print()
+
 
 def make_oklch(L, c, h):
     return f"oklch(calc({L * 100:.1f}% * var(--cost-Lf)) {c:.2f} {h:.0f})"

--- a/test/autoschedulers/li2018/test.py
+++ b/test/autoschedulers/li2018/test.py
@@ -22,7 +22,7 @@ def main():
     print(result.schedule_source)
 
     p.compile_jit() # compile
-    buf = p.realize([1000]) # compute and get the buffer
+    p.realize([1000]) # compute and get the buffer
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:

--- a/test/autoschedulers/li2018/test.py
+++ b/test/autoschedulers/li2018/test.py
@@ -1,32 +1,34 @@
 import halide as hl
 import sys
 
+
 def main():
-    x = hl.Var('x')
-    f_in = hl.Func('in')
-    f_in[x] = hl.f32(x) # Cast to float 32
-    f_0 = hl.Func('f_0')
+    x = hl.Var("x")
+    f_in = hl.Func("in")
+    f_in[x] = hl.f32(x)  # Cast to float 32
+    f_0 = hl.Func("f_0")
     f_0[x] = 2 * f_in[x]
-    f_1 = hl.Func('f_1')
+    f_1 = hl.Func("f_1")
     f_1[x] = hl.sin(f_0[x])
-    f_2 = hl.Func('f_2')
+    f_2 = hl.Func("f_2")
     f_2[x] = f_1[x] * f_1[x]
 
     # Setup
     f_2.set_estimate(x, 0, 1000)
     p = hl.Pipeline(f_2)
     target = hl.Target()
-    asp = hl.AutoschedulerParams('Li2018', {'parallelism': 32})
+    asp = hl.AutoschedulerParams("Li2018", {"parallelism": 32})
     result = p.apply_autoscheduler(target, asp)
-    print('Schedule:')
+    print("Schedule:")
     print(result.schedule_source)
 
-    p.compile_jit() # compile
-    p.realize([1000]) # compute and get the buffer
+    p.compile_jit()  # compile
+    p.realize([1000])  # compute and get the buffer
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: test path/to/Li2018-autoscheduler-plugin",sys.argv)
+        print("Usage: test path/to/Li2018-autoscheduler-plugin", sys.argv)
         sys.exit(1)
 
     hl.load_plugin(sys.argv[1])

--- a/tools/lldbhalide.py
+++ b/tools/lldbhalide.py
@@ -6,7 +6,7 @@ import lldb
 
 
 def normalize(raw):
-    return raw.lstrip('"').rstrip('"').replace(r'\n', ' ').replace('  ', ' ')
+    return raw.lstrip('"').rstrip('"').replace(r"\n", " ").replace("  ", " ")
 
 
 def summary_string(summary_fn):
@@ -30,7 +30,9 @@ def call_name(value):
 
 @summary_string
 def call_lldb_string(value):
-    return value.EvaluateExpression("Halide::Internal::lldb_string(*this)", lldb.SBExpressionOptions())
+    return value.EvaluateExpression(
+        "Halide::Internal::lldb_string(*this)", lldb.SBExpressionOptions()
+    )
 
 
 class ProxyChildrenProvider:
@@ -63,27 +65,55 @@ class BoxChildrenProvider(IRChildrenProvider):
 
 class FunctionChildrenProvider(ProxyChildrenProvider):
     def __init__(self, valobj, _):
-        contents = valobj.EvaluateExpression("*this->contents.get()", lldb.SBExpressionOptions())
+        contents = valobj.EvaluateExpression(
+            "*this->contents.get()", lldb.SBExpressionOptions()
+        )
         print(contents)
         super().__init__(contents, None)
 
 
 def __lldb_init_module(debugger, _):
-    base_exprs = ["Add", "And", "Broadcast", "Call", "Cast", "Div", "EQ", "GE", "GT", "LE", "LT", "Let", "Load", "Max",
-                  "Min", "Mod", "Mul", "NE", "Not", "Or", "Ramp", "Reinterpret", "Select", "Shuffle", "Sub", "Variable",
-                  "VectorReduce"]
+    base_exprs = [
+        "Add",
+        "And",
+        "Broadcast",
+        "Call",
+        "Cast",
+        "Div",
+        "EQ",
+        "GE",
+        "GT",
+        "LE",
+        "LT",
+        "Let",
+        "Load",
+        "Max",
+        "Min",
+        "Mod",
+        "Mul",
+        "NE",
+        "Not",
+        "Or",
+        "Ramp",
+        "Reinterpret",
+        "Select",
+        "Shuffle",
+        "Sub",
+        "Variable",
+        "VectorReduce",
+    ]
 
     for ty in base_exprs:
         debugger.HandleCommand(
             f"type summary add Halide::Internal::{ty} --python-function lldbhalide.call_lldb_string"
         )
 
-    for ty in ('Expr', 'Internal::Stmt'):
+    for ty in ("Expr", "Internal::Stmt"):
         debugger.HandleCommand(
             f"type summary add Halide::{ty} --python-function lldbhalide.call_lldb_string"
         )
         debugger.HandleCommand(
-            f'type synthetic add Halide::{ty} -l lldbhalide.IRChildrenProvider'
+            f"type synthetic add Halide::{ty} -l lldbhalide.IRChildrenProvider"
         )
 
     for ty in ("Definition", "FuncSchedule", "ReductionDomain", "StageSchedule"):
@@ -92,12 +122,20 @@ def __lldb_init_module(debugger, _):
         )
 
     debugger.HandleCommand(
-        'type synthetic add Halide::Internal::Function -l lldbhalide.FunctionChildrenProvider'
+        "type synthetic add Halide::Internal::Function -l lldbhalide.FunctionChildrenProvider"
     )
 
     debugger.HandleCommand("type summary add Halide::Internal::Dim -s '${var.var%S}'")
-    debugger.HandleCommand("type summary add Halide::RVar --python-function lldbhalide.call_name")
-    debugger.HandleCommand("type summary add Halide::Var --python-function lldbhalide.call_name")
+    debugger.HandleCommand(
+        "type summary add Halide::RVar --python-function lldbhalide.call_name"
+    )
+    debugger.HandleCommand(
+        "type summary add Halide::Var --python-function lldbhalide.call_name"
+    )
 
-    debugger.HandleCommand("type summary add halide_type_t -s '${var.code%S} bits=${var.bits%u} lanes=${var.lanes%u}'")
-    debugger.HandleCommand("type summary add Halide::Internal::RefCount -s ${var.count.Value%S}")
+    debugger.HandleCommand(
+        "type summary add halide_type_t -s '${var.code%S} bits=${var.bits%u} lanes=${var.lanes%u}'"
+    )
+    debugger.HandleCommand(
+        "type summary add Halide::Internal::RefCount -s ${var.count.Value%S}"
+    )

--- a/tools/lldbhalide.py
+++ b/tools/lldbhalide.py
@@ -30,7 +30,7 @@ def call_name(value):
 
 @summary_string
 def call_lldb_string(value):
-    return value.EvaluateExpression(f"Halide::Internal::lldb_string(*this)", lldb.SBExpressionOptions())
+    return value.EvaluateExpression("Halide::Internal::lldb_string(*this)", lldb.SBExpressionOptions())
 
 
 class ProxyChildrenProvider:
@@ -92,7 +92,7 @@ def __lldb_init_module(debugger, _):
         )
 
     debugger.HandleCommand(
-        f'type synthetic add Halide::Internal::Function -l lldbhalide.FunctionChildrenProvider'
+        'type synthetic add Halide::Internal::Function -l lldbhalide.FunctionChildrenProvider'
     )
 
     debugger.HandleCommand("type summary add Halide::Internal::Dim -s '${var.var%S}'")


### PR DESCRIPTION
Ruff is a formatter and linter for Python. This PR shows what would happen to our codebase if we were to adopt it. I believe this is a useful tool, and it does not mangle our formatting too much. There are a few stylistic pain points:

1. Method chaining isn't really a "thing" in Python. We need to manually parenthesize and use breaking comments.
2. The `select` expression looks awkward when all its arguments get their own lines. We could adjust the API to allow taking `(cond, val)` tuples, which would at least pair these up.
3. Ruff (like Black and most other Python formatters these days) strongly prefers double quotes to single, unless using single would save space (e.g. because of escaping).

Using the linter produced a few classes of changes:

1. String formatting has been normalized to use f-strings.
2. Unused imports revealed places that code has been haphazardly disabled. I adjusted the build to correctly mark `python_correctness_extern` as skipped until we implement it.
3. Many values are evaluated for their side effects, apparently just to see if they crash. The linter insisted upon removing the unused variable names to which they were bound. We might want to do something different here. 

GitHub Actions has been set to enforce these rules.

---

To run locally in a standard venv, you can install ruff via `pip`:

```
$ python -m pip install ruff
$ ruff check
$ ruff format
```

If you have `uv` installed, prefer to use `uvx ruff check` and `uvx ruff format` (no need to pip install).