### PR TITLE
Unstrictify expr in the bounds inference in a single pass

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1843,7 +1843,8 @@ Interval bounds_of_expr_in_scope_with_indent(const Expr &expr, const Scope<Inter
 #if DO_TRACK_BOUNDS_INTERVALS
     b.log_indent = indent + 1;
 #endif
-    expr.accept(&b);
+    Expr unstricted = unstrictify(expr);
+    unstricted.accept(&b);
 #if DO_TRACK_BOUNDS_INTERVALS
     debug(0) << spaces << " mn=" << simplify(b.interval.min) << "\n"
              << spaces << " mx=" << simplify(b.interval.max) << "\n"

--- a/src/Bounds.h
+++ b/src/Bounds.h
@@ -33,7 +33,8 @@ const FuncValueBounds &empty_func_value_bounds();
 Interval bounds_of_expr_in_scope(const Expr &expr,
                                  const Scope<Interval> &scope,
                                  const FuncValueBounds &func_bounds = empty_func_value_bounds(),
-                                 bool const_bound = false);
+                                 bool const_bound = false,
+                                 bool any_strict_float = true);
 
 /** Given a varying expression, try to find a constant that is either:
  * An upper bound (always greater than or equal to the expression), or
@@ -171,7 +172,8 @@ Box box_touched(Stmt s, const std::string &fn,
 /** Compute the maximum and minimum possible value for each function
  * in an environment. */
 FuncValueBounds compute_function_value_bounds(const std::vector<std::string> &order,
-                                              const std::map<std::string, Function> &env);
+                                              const std::map<std::string, Function> &env,
+                                              bool any_strict_float);
 
 /* Find an upper bound of bounds.max - bounds.min. */
 Expr span_of_bounds(const Interval &bounds);

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -241,7 +241,7 @@ map<string, Box> inference_bounds(const vector<Func> &funcs,
     }
     // Sort functions
     vector<string> order = realization_order(functions, env).first;
-    FuncValueBounds func_value_bounds = compute_function_value_bounds(order, env);
+    FuncValueBounds func_value_bounds = compute_function_value_bounds(order, env, false);
 
     map<string, Box> bounds;
     // Set up bounds for outputs

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -196,7 +196,7 @@ void lower_impl(const vector<Function> &output_funcs,
     // Compute the maximum and minimum possible value of each
     // function. Used in later bounds inference passes.
     debug(1) << "Computing bounds of each function's value\n";
-    FuncValueBounds func_bounds = compute_function_value_bounds(order, env);
+    FuncValueBounds func_bounds = compute_function_value_bounds(order, env, any_strict_float);
 
     // Clamp unsafe instances where a Func f accesses a Func g using
     // an index which depends on a third Func h.

--- a/src/PrintLoopNest.cpp
+++ b/src/PrintLoopNest.cpp
@@ -205,7 +205,7 @@ string print_loop_nest(const vector<Function> &output_funcs) {
 
     // Compute the maximum and minimum possible value of each
     // function. Used in later bounds inference passes.
-    FuncValueBounds func_bounds = compute_function_value_bounds(order, env);
+    FuncValueBounds func_bounds = compute_function_value_bounds(order, env, false);
 
     // This pass injects nested definitions of variable names, so we
     // can't simplify statements from here until we fix them up. (We

--- a/src/StrictifyFloat.cpp
+++ b/src/StrictifyFloat.cpp
@@ -165,20 +165,20 @@ Expr unstrictify_float(const Call *op) {
 }
 
 namespace {
-    class Unstrictify : public IRMutator {
-        using IRMutator::visit;
-        Expr visit(const Call* op) override {
-            if (op->is_strict_float_intrinsic()) {
-                Expr unstricted = unstrictify_float(op);
-                return mutate(unstricted);
-            } else {
-                return IRMutator::visit(op);
-            }
+class Unstrictify : public IRMutator {
+    using IRMutator::visit;
+    Expr visit(const Call *op) override {
+        if (op->is_strict_float_intrinsic()) {
+            Expr unstricted = unstrictify_float(op);
+            return mutate(unstricted);
+        } else {
+            return IRMutator::visit(op);
         }
-    };
-}
+    }
+};
+}  // namespace
 
-Expr unstrictify_all(const Expr& e) {
+Expr unstrictify_all(const Expr &e) {
     Unstrictify mutator;
     return mutator.mutate(e);
 }

--- a/src/StrictifyFloat.h
+++ b/src/StrictifyFloat.h
@@ -25,6 +25,9 @@ Expr strictify_float(const Expr &e);
 /** Replace a strict float intrinsic with its non-strict equivalent. Non-recursive. */
 Expr unstrictify_float(const Call *op);
 
+/** Replace all of the strict float intrinsics with its non-strict equivalent in a given expression. */
+Expr unstrictify_all(const Expr& e);
+
 /** If the StrictFloat target feature is set, replace add, sub, mul, div, etc
  * operations with strict float intrinsics for all Funcs in the environment. If
  * StrictFloat is not set does nothing. Returns whether or not there's any usage

--- a/src/StrictifyFloat.h
+++ b/src/StrictifyFloat.h
@@ -26,7 +26,7 @@ Expr strictify_float(const Expr &e);
 Expr unstrictify_float(const Call *op);
 
 /** Replace all of the strict float intrinsics with its non-strict equivalent in a given expression. */
-Expr unstrictify_all(const Expr& e);
+Expr unstrictify_all(const Expr &e);
 
 /** If the StrictFloat target feature is set, replace add, sub, mul, div, etc
  * operations with strict float intrinsics for all Funcs in the environment. If

--- a/src/autoschedulers/adams2019/FunctionDAG.cpp
+++ b/src/autoschedulers/adams2019/FunctionDAG.cpp
@@ -674,7 +674,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const Target &target) 
                 node.region_computed.resize(consumer.dimensions());
             }
 
-            FuncValueBounds func_value_bounds = compute_function_value_bounds(order, env);
+            FuncValueBounds func_value_bounds = compute_function_value_bounds(order, env, false);
             for (int j = 0; j < consumer.dimensions(); j++) {
                 // The region computed always uses the full extent of the rvars
                 Interval in = bounds_of_expr_in_scope(def.args()[j], stage_scope_with_concrete_rvar_bounds, func_value_bounds);

--- a/src/autoschedulers/anderson2021/FunctionDAG.cpp
+++ b/src/autoschedulers/anderson2021/FunctionDAG.cpp
@@ -666,7 +666,7 @@ FunctionDAG::FunctionDAG(const vector<Function> &outputs, const Target &target) 
                 node.region_computed.resize(consumer.dimensions());
             }
 
-            FuncValueBounds func_value_bounds = compute_function_value_bounds(order, env);
+            FuncValueBounds func_value_bounds = compute_function_value_bounds(order, env, false);
             for (int j = 0; j < consumer.dimensions(); j++) {
                 // The region computed always uses the full extent of the rvars
                 Interval in = bounds_of_expr_in_scope(def.args()[j], stage_scope_with_concrete_rvar_bounds, func_value_bounds);

--- a/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
+++ b/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
@@ -3940,7 +3940,7 @@ string generate_schedules(const vector<Function> &outputs, const Target &target,
 
     // Compute the bounds of function values which are used for dependence analysis.
     debug(2) << "Computing function value bounds...\n";
-    FuncValueBounds func_val_bounds = compute_function_value_bounds(order, env);
+    FuncValueBounds func_val_bounds = compute_function_value_bounds(order, env, false);
 
     // Initialize the cost model.
     // Compute the expression costs for each function in the pipeline.
@@ -3979,7 +3979,7 @@ string generate_schedules(const vector<Function> &outputs, const Target &target,
         order = realization_order(outputs, env).first;
 
         debug(2) << "Re-computing function value bounds...\n";
-        func_val_bounds = compute_function_value_bounds(order, env);
+        func_val_bounds = compute_function_value_bounds(order, env, false);
         debug(2) << "Re-initializing region costs...\n";
         RegionCosts costs(env, order);
         debug(2) << "Re-initializing dependence analysis...\n";


### PR DESCRIPTION
This is to address #8686.

There is a reproducer in a bug report, but I'm not sure what would be a good way to add it? just a correctness test and if it hangs it hangs?