### PR TITLE
Add halide_host_cpu_count() to public API

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -380,6 +380,9 @@ extern int halide_default_semaphore_release(struct halide_semaphore_t *, int n);
 extern bool halide_default_semaphore_try_acquire(struct halide_semaphore_t *, int n);
 // @}
 
+/** Obtain the number of logical cores on the system. */
+extern int halide_host_cpu_count();
+
 struct halide_thread;
 
 /** Spawn a thread. Returns a handle to the thread for the purposes of

--- a/src/runtime/runtime_api.cpp
+++ b/src/runtime/runtime_api.cpp
@@ -115,6 +115,7 @@ extern "C" __attribute__((used)) void *halide_runtime_api_functions[] = {
     (void *)&halide_hexagon_set_performance_mode,
     (void *)&halide_hexagon_set_thread_priority,
     (void *)&halide_hexagon_wrap_device_handle,
+    (void *)&halide_host_cpu_count,
     (void *)&halide_int64_to_string,
     (void *)&halide_join_thread,
     (void *)&halide_load_library,


### PR DESCRIPTION
We have some uses where we want to share the Halide threadpool with non-Halide code; in those cases, it is useful to have this function available to know what Halide's default parallelism would be.  In general, since all of our default parallel runtimes use this function, it seems no issue to expose it via the runtime.

I made sure the description was specific about "logical" cores, but let me know if there's better language to use here.