### PR TITLE
Bump the LLVM version in the pip package to 20.1.8

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # TODO: detect this from repo somehow: https://github.com/halide/Halide/issues/8406
-  LLVM_VERSION: 19.1.6
+  LLVM_VERSION: 20.1.8
   FLATBUFFERS_VERSION: 23.5.26
   WABT_VERSION: 1.0.36
 


### PR DESCRIPTION
https://github.com/halide/docker-images has already been updated.