### PR TITLE
New feature flag to keep the frame pointer for LLVM-generated functions.

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -401,6 +401,7 @@ void CodeGen_LLVM::init_codegen(const std::string &name) {
     module->setModuleIdentifier(name);
 
     // Add some target specific info to the module as metadata.
+    module->addModuleFlag(llvm::Module::Warning, "halide_keep_frame_pointer", target.has_feature(Target::Feature::KeepFramePointer) ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_use_soft_float_abi", use_soft_float_abi() ? 1 : 0);
     module->addModuleFlag(llvm::Module::Warning, "halide_mcpu_target", MDString::get(*context, mcpu_target()));
     module->addModuleFlag(llvm::Module::Warning, "halide_mcpu_tune", MDString::get(*context, mcpu_tune()));

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -646,6 +646,7 @@ bool lookup_processor(const std::string &tok, Target::Processor &result) {
 const std::map<std::string, Target::Feature> feature_name_map = {
     {"jit", Target::JIT},
     {"debug", Target::Debug},
+    {"keep_frame_pointer", Target::KeepFramePointer},
     {"no_asserts", Target::NoAsserts},
     {"no_bounds_query", Target::NoBoundsQuery},
     {"sse41", Target::SSE41},

--- a/src/Target.h
+++ b/src/Target.h
@@ -84,6 +84,7 @@ struct Target {
     enum Feature {
         JIT = halide_target_feature_jit,
         Debug = halide_target_feature_debug,
+        KeepFramePointer = halide_target_feature_keep_frame_pointer,
         NoAsserts = halide_target_feature_no_asserts,
         NoBoundsQuery = halide_target_feature_no_bounds_query,
         SSE41 = halide_target_feature_sse41,

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1355,10 +1355,11 @@ extern int halide_error_vscale_invalid(void *user_context, const char *func_name
  * get_runtime_compatible_target in Target.cpp if you add a new feature.
  */
 typedef enum halide_target_feature_t {
-    halide_target_feature_jit = 0,          ///< Generate code that will run immediately inside the calling process.
-    halide_target_feature_debug,            ///< Turn on debug info and output for runtime code.
-    halide_target_feature_no_asserts,       ///< Disable all runtime checks, for slightly tighter code.
-    halide_target_feature_no_bounds_query,  ///< Disable the bounds querying functionality.
+    halide_target_feature_jit = 0,             ///< Generate code that will run immediately inside the calling process.
+    halide_target_feature_debug,               ///< Turn on debug info and output for runtime code.
+    halide_target_feature_keep_frame_pointer,  ///< Keep the frame pointer in tact in functions produced by LLVM.
+    halide_target_feature_no_asserts,          ///< Disable all runtime checks, for slightly tighter code.
+    halide_target_feature_no_bounds_query,     ///< Disable the bounds querying functionality.
 
     halide_target_feature_sse41,    ///< Use SSE 4.1 and earlier instructions. Only relevant on x86.
     halide_target_feature_avx,      ///< Use AVX 1 instructions. Only relevant on x86.


### PR DESCRIPTION
I implemented this as a target feature flag. This way we can still disable this for actual performance optimized releases of software.