### PR TITLE
Use AArch64 assembly syntax on macOS with LLVM<22

### DIFF
--- a/src/CodeGen_Internal.cpp
+++ b/src/CodeGen_Internal.cpp
@@ -670,6 +670,16 @@ std::unique_ptr<llvm::TargetMachine> make_target_machine(const llvm::Module &mod
     std::string mattrs =
         get_md_string(module.getModuleFlag("halide_mattrs")).value_or(std::string{});
 
+#if LLVM_VERSION < 200
+    if (triple.isMacOSX() && triple.isAArch64()) {
+        // The generic syntax variant is able to display the arguments to SDOT
+        // while the Apple-specific one is bugged. See this GitHub issue for
+        // more info: https://github.com/llvm/llvm-project/issues/151330
+        const char *args[] = {"llc", "-aarch64-neon-syntax=generic"};
+        cl::ParseCommandLineOptions(2, args, "Halide compiler\n");
+    }
+#endif
+
     auto *tm = llvm_target->createTargetMachine(
 #if LLVM_VERSION >= 210
         triple,

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -406,7 +406,8 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
         // The AArch64 syntax variant is able to display the arguments to SDOT
         // while the Darwin-specific one is bugged. See this GitHub issue for
         // more info: https://github.com/llvm/llvm-project/issues/151330
-        enum AsmVariant { AArch64 = 0, Darwin = 1 } variant = AArch64;
+        enum { AArch64 = 0,
+               Darwin = 1 } variant = AArch64;
         target_machine->Options.MCOptions.OutputAsmVariant = variant;
     }
 #endif

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -388,7 +388,8 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
     // https://groups.google.com/g/llvm-dev/c/HoS07gXx0p8
     llvm::legacy::PassManager pass_manager;
 
-    pass_manager.add(new llvm::TargetLibraryInfoWrapperPass(llvm::Triple(module->getTargetTriple())));
+    const auto &triple = llvm::Triple(module->getTargetTriple());
+    pass_manager.add(new llvm::TargetLibraryInfoWrapperPass(triple));
 
     // Make sure things marked as always-inline get inlined
     pass_manager.add(llvm::createAlwaysInlinerLegacyPass());
@@ -399,6 +400,15 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
 
     // Override default to generate verbose assembly.
     target_machine->Options.MCOptions.AsmVerbose = true;
+
+#if LLVM_VERSION < 220
+    if (triple.isMacOSX() && triple.isAArch64()) {
+        // The default syntax variant is able to display the arguments to SDOT
+        // while the Apple-specific one is bugged. See this GitHub issue for
+        // more info: https://github.com/llvm/llvm-project/issues/151330
+        target_machine->Options.MCOptions.OutputAsmVariant = 0;
+    }
+#endif
 
     // Ask the target to add backend passes as necessary.
     target_machine->addPassesToEmitFile(pass_manager, out, nullptr, file_type);

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -401,13 +401,13 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
     // Override default to generate verbose assembly.
     target_machine->Options.MCOptions.AsmVerbose = true;
 
-#if LLVM_VERSION < 220
+#if 200 <= LLVM_VERSION && LLVM_VERSION < 220
     if (triple.isMacOSX() && triple.isAArch64()) {
         // The AArch64 syntax variant is able to display the arguments to SDOT
         // while the Darwin-specific one is bugged. See this GitHub issue for
         // more info: https://github.com/llvm/llvm-project/issues/151330
-        enum { AArch64 = 0,
-               Darwin = 1 } variant = AArch64;
+        enum { Generic = 0,
+               Apple = 1 } variant = Generic;
         target_machine->Options.MCOptions.OutputAsmVariant = variant;
     }
 #endif

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -403,10 +403,11 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
 
 #if LLVM_VERSION < 220
     if (triple.isMacOSX() && triple.isAArch64()) {
-        // The default syntax variant is able to display the arguments to SDOT
-        // while the Apple-specific one is bugged. See this GitHub issue for
+        // The AArch64 syntax variant is able to display the arguments to SDOT
+        // while the Darwin-specific one is bugged. See this GitHub issue for
         // more info: https://github.com/llvm/llvm-project/issues/151330
-        target_machine->Options.MCOptions.OutputAsmVariant = 0;
+        enum AsmVariant { AArch64 = 0, Darwin = 1 } variant = AArch64;
+        target_machine->Options.MCOptions.OutputAsmVariant = variant;
     }
 #endif
 


### PR DESCRIPTION
Following the discussion on https://github.com/llvm/llvm-project/issues/151330, it was determined that the reason SDOT arguments were missing in the assembly output was that the AArch64InstrFormats table was missing some entries for the Apple/Darwin-specific format.

This PR uses the AArch64 format on older LLVM versions that won't receive the upstream patch.

This fix was derived by reading the upstream patch that fixes this issue: https://github.com/llvm/llvm-project/pull/152111

ATTN @rtzam 

Fixes #8697