### PR TITLE
Always insert set_host_dirty(), even is there is no GPU target.

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -326,6 +326,10 @@ void lower_impl(const vector<Function> &output_funcs,
         debug(1) << "Selecting a GPU API for extern stages...\n";
         s = select_gpu_api(s, t);
         log("Lowering after selecting a GPU API for extern stages:", s);
+    } else {
+        debug(1) << "Injecting host-dirty marking...\n";
+        s = inject_host_dev_buffer_copies(s, t);
+        log("Lowering after injecting host-dirty marking:", s);
     }
 
     debug(1) << "Simplifying...\n";


### PR DESCRIPTION
Always insert `set_host_dirty()`, even is there is no GPU target. This allows mixing CPU-only and GPU-compatible pipelines.

This is done by simply calling the inject buffer copies lowering pass, which normally does this in the case of GPU targets. The nice thing here is that it doesn't do anything besides adding those calls to `set_host_dirty()`.

cc @abadams 