### PR TITLE
Manage Dawn dependency via vcpkg

### DIFF
--- a/cmake/FindHalide_WebGPU.cmake
+++ b/cmake/FindHalide_WebGPU.cmake
@@ -1,27 +1,23 @@
 cmake_minimum_required(VERSION 3.28)
 
-# tip: uncomment this line to get better debugging information if find_library() fails
-# set(CMAKE_FIND_DEBUG_MODE TRUE)
-
-if (EXISTS "$ENV{HL_WEBGPU_NATIVE_LIB}")
-  set(Halide_WebGPU_NATIVE_LIB "$ENV{HL_WEBGPU_NATIVE_LIB}"
-      CACHE FILEPATH "")
-endif ()
-
-find_library(Halide_WebGPU_NATIVE_LIB NAMES webgpu_dawn wgpu)
+find_library(
+    Halide_WebGPU_LIBRARY
+    NAMES webgpu_dawn wgpu
+    HINTS ENV HL_WEBGPU_NATIVE_LIB
+)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  Halide_WebGPU
-  REQUIRED_VARS Halide_WebGPU_NATIVE_LIB
-  HANDLE_COMPONENTS
+    Halide_WebGPU
+    REQUIRED_VARS Halide_WebGPU_LIBRARY
+    HANDLE_COMPONENTS
 )
 
-if (Halide_WebGPU_NATIVE_LIB AND NOT TARGET Halide::WebGPU)
-  add_library(Halide::WebGPU UNKNOWN IMPORTED)
-  set_target_properties(
-    Halide::WebGPU
-    PROPERTIES
-    IMPORTED_LOCATION "${Halide_WebGPU_NATIVE_LIB}"
-  )
+if (Halide_WebGPU_LIBRARY AND NOT TARGET Halide::WebGPU)
+    add_library(Halide::WebGPU UNKNOWN IMPORTED)
+    set_target_properties(
+        Halide::WebGPU
+        PROPERTIES
+        IMPORTED_LOCATION "${Halide_WebGPU_LIBRARY}"
+    )
 endif ()

--- a/cmake/vcpkg/dawn/patches/add-dawn-node-install.patch
+++ b/cmake/vcpkg/dawn/patches/add-dawn-node-install.patch
@@ -1,0 +1,13 @@
+--- a/src/dawn/node/CMakeLists.txt
++++ b/src/dawn/node/CMakeLists.txt
+@@ -189,5 +189,10 @@ macro(javascript file)
+             "$<TARGET_FILE_DIR:dawn_node>/${file}")
+ endmacro()
+ 
+ javascript("index.js")
+ javascript("cts.js")
++
++# Install the dawn.node shared library
++if (DAWN_ENABLE_INSTALL)
++    install(TARGETS dawn_node LIBRARY DESTINATION lib/node_modules)
++endif ()

--- a/cmake/vcpkg/dawn/portfile.cmake
+++ b/cmake/vcpkg/dawn/portfile.cmake
@@ -1,0 +1,83 @@
+vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+
+vcpkg_from_git(
+    OUT_SOURCE_PATH SOURCE_PATH
+    URL https://dawn.googlesource.com/dawn
+    REF 40ddf3b135d952082cdd6e0d03539e924c18221b # chromium/7350
+    FETCH_REF chromium/${VERSION}
+    PATCHES
+        patches/add-dawn-node-install.patch
+)
+
+vcpkg_find_acquire_program(PYTHON3)
+vcpkg_find_acquire_program(GIT)
+
+function(clone_submodule)
+    cmake_parse_arguments(PARSE_ARGV 0 ARG "" "SOURCE_PATH;URL;REF" "")
+    get_filename_component(name "${ARG_SOURCE_PATH}" NAME)
+    vcpkg_execute_required_process(
+        COMMAND "${GIT}" clone "${ARG_URL}" "${ARG_SOURCE_PATH}"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "clone-${name}"
+    )
+    vcpkg_execute_required_process(
+        COMMAND "${GIT}" -C "${ARG_SOURCE_PATH}" checkout "${ARG_REF}"
+        WORKING_DIRECTORY "${SOURCE_PATH}"
+        LOGNAME "checkout-${name}"
+    )
+endfunction()
+
+# Fetch Dawn's dependencies using their script
+vcpkg_execute_required_process(
+    COMMAND "${PYTHON3}" tools/fetch_dawn_dependencies.py
+    WORKING_DIRECTORY "${SOURCE_PATH}"
+    LOGNAME fetch-deps
+)
+
+# Manually clone the remaining dependencies that fetch_dawn_dependencies.py doesn't handle
+# using the specific commit hashes that chromium/7350 expects
+clone_submodule(
+    SOURCE_PATH third_party/gpuweb
+    URL https://chromium.googlesource.com/external/github.com/gpuweb/gpuweb
+    REF a2637f7b880c2556919cdb288fe89815e0ed1c41
+)
+
+clone_submodule(
+    SOURCE_PATH third_party/node-addon-api
+    URL https://chromium.googlesource.com/external/github.com/nodejs/node-addon-api
+    REF 1e26dcb52829a74260ec262edb41fc22998669b6
+)
+
+clone_submodule(
+    SOURCE_PATH third_party/node-api-headers
+    URL https://chromium.googlesource.com/external/github.com/nodejs/node-api-headers
+    REF d5cfe19da8b974ca35764dd1c73b91d57cd3c4ce
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DDAWN_BUILD_MONOLITHIC_LIBRARY=SHARED
+        -DDAWN_BUILD_NODE_BINDINGS=ON
+        -DDAWN_BUILD_PROTOBUF=OFF
+        -DDAWN_BUILD_SAMPLES=OFF
+        -DDAWN_BUILD_TESTS=OFF
+        -DDAWN_ENABLE_INSTALL=ON
+        -DDAWN_ENABLE_PIC=ON
+        -DTINT_BUILD_CMD_TOOLS=OFF
+        -DTINT_BUILD_TESTS=OFF
+    OPTIONS_RELEASE
+        -DBUILD_SHARED_LIBS=OFF
+    OPTIONS_DEBUG
+        -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/dawn)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/cmake/vcpkg/dawn/vcpkg.json
+++ b/cmake/vcpkg/dawn/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "dawn",
+  "version": "7350",
+  "port-version": 0,
+  "description": "Dawn, a WebGPU implementation",
+  "homepage": "https://dawn.googlesource.com/dawn",
+  "license": "BSD-3-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/tools/launch_wasm_test.js
+++ b/tools/launch_wasm_test.js
@@ -5,16 +5,11 @@
 const target_js_path = process.argv[2];
 const halide_target_string = process.argv[3];
 
-console.log("target_js_path is ", target_js_path)
-console.log("halide_target_string is ", halide_target_string)
 if (halide_target_string.includes("webgpu")) {
-    const webgpu_node_bindings = process.env["HL_WEBGPU_NODE_BINDINGS"];
-    if (!webgpu_node_bindings) {
-        console.log("You must define the env var HL_WEBGPU_NODE_BINDINGS=/path/to/dawn.node when running WebGPU tests for Halide");
-    }
-    const provider = require(webgpu_node_bindings);
+    const provider = require("dawn");
     const gpu = provider.create([]);
     // Not const: we want to redefine the global 'navigator' var
-    navigator = { gpu: gpu };
+    navigator = {gpu: gpu};
 }
+
 require(target_js_path);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/halide/Halide",
   "license": "MIT",
   "supports": "!uwp",
-  "builtin-baseline": "d567b667adba0e72c5c3931ddbe745b66aa34b73",
+  "builtin-baseline": "dd3097e305afa53f7b4312371f62058d2e665320",
   "default-features": [
     "jit",
     "serialization"
@@ -39,7 +39,8 @@
             "serialization",
             "target-all",
             "tests",
-            "wasm-executor"
+            "wasm-executor",
+            "webgpu"
           ]
         },
         {
@@ -203,6 +204,12 @@
       "description": "Include built-in WASM executor",
       "dependencies": [
         "wabt"
+      ]
+    },
+    "webgpu": {
+      "description": "Include WebGPU runtime support",
+      "dependencies": [
+        "dawn"
       ]
     }
   }


### PR DESCRIPTION
For a while, we've had the buildbots equipped with hand-built installations of Dawn. This has made our webgpu testing limited and brittle. This PR manages the Dawn dependency via vcpkg, encoding our knowledge of how to build Dawn just right into an executable format.

Forthcoming buildbot changes will move more dependency management to vcpkg and CMake presets (only for CMake-specific dependencies and builders, of course).