### PR TITLE
fix(stmt-html): Fix embedded Buffer processing performance issue.

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -184,11 +184,12 @@ private:
         Bounds *const self;
         BoundsLogger(Bounds *self, const char *pretty_function)
             : self(self) {
-            string name = replace_all(pretty_function, "(anonymous namespace)::", "");
-            name = replace_all(name, "virtual void Halide::Internal::", "");
-            name = replace_all(name, "(const Halide::Internal::", "(");
-            name = replace_all(name, "::visit", "");
-            name = replace_all(name, " *)", ")");
+            string name = pretty_function;
+            name = replace_all(std::move(name), "(anonymous namespace)::", "");
+            name = replace_all(std::move(name), "virtual void Halide::Internal::", "");
+            name = replace_all(std::move(name), "(const Halide::Internal::", "(");
+            name = replace_all(std::move(name), "::visit", "");
+            name = replace_all(std::move(name), " *)", ")");
             log_line(name, " {");
             self->log_indent++;
         }
@@ -2197,16 +2198,17 @@ private:
 
         BoxesTouchedLogger(BoxesTouched *self, const char *pretty_function)
             : self(self), parent_logger(self->current_logger), boxes(self->boxes) {
-            string name = replace_all(pretty_function, "(anonymous namespace)::", "");
-            name = replace_all(name, "virtual void Halide::Internal::", "");
-            name = replace_all(name, "(const Halide::Internal::", "(");
-            name = replace_all(name, "::visit", "");
-            name = replace_all(name, " *)", ")");
+            string name = pretty_function;
+            name = replace_all(std::move(name), "(anonymous namespace)::", "");
+            name = replace_all(std::move(name), "virtual void Halide::Internal::", "");
+            name = replace_all(std::move(name), "(const Halide::Internal::", "(");
+            name = replace_all(std::move(name), "::visit", "");
+            name = replace_all(std::move(name), " *)", ")");
 
             if (self->consider_calls && !self->consider_provides) {
-                name = replace_all(name, "BoxesTouched", "BoxesRequired");
+                name = replace_all(std::move(name), "BoxesTouched", "BoxesRequired");
             } else if (!self->consider_calls && self->consider_provides) {
-                name = replace_all(name, "BoxesTouched", "BoxesProvided");
+                name = replace_all(std::move(name), "BoxesTouched", "BoxesProvided");
             }
 
             log_line(name, " {");

--- a/src/CompilerLogger.cpp
+++ b/src/CompilerLogger.cpp
@@ -179,8 +179,8 @@ std::ostream &emit_value(std::ostream &o, const VALUE &value) {
 template<>
 std::ostream &emit_value<std::string>(std::ostream &o, const std::string &value) {
     std::string v = value;
-    v = replace_all(v, "\\", "\\\\");
-    v = replace_all(v, "\"", "\\\"");
+    v = replace_all(std::move(v), "\\", "\\\\");
+    v = replace_all(std::move(v), "\"", "\\\"");
     o << "\"" << v << "\"";
     return o;
 }

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -223,10 +223,10 @@ static Registerer registerer;
             }
             std::string nsreg = "halide_nsreg_" + replace_all(f.name, "::", "_");
             std::string s = replace_all(registration_template, "$NAMESPACEOPEN$", nsopen);
-            s = replace_all(s, "$SHORTNAME$", simple_name);
-            s = replace_all(s, "$NAMESPACECLOSE$", nsclose);
-            s = replace_all(s, "$FULLNAME$", f.name);
-            s = replace_all(s, "$NREGS$", nsreg);
+            s = replace_all(std::move(s), "$SHORTNAME$", simple_name);
+            s = replace_all(std::move(s), "$NAMESPACECLOSE$", nsclose);
+            s = replace_all(std::move(s), "$FULLNAME$", f.name);
+            s = replace_all(std::move(s), "$NREGS$", nsreg);
             stream << s;
         }
     }
@@ -305,15 +305,15 @@ $NAMESPACECLOSE$
         target_string += t.to_string();
     }
     std::string body_text = indent_string(body, "    ");
-    s = replace_all(s, "$SCHEDULER$", scheduler_name);
-    s = replace_all(s, "$NAMESPACEOPEN$", nsopen);
-    s = replace_all(s, "$SHORTNAME$", simple_name);
-    s = replace_all(s, "$CLEANNAME$", clean_name);
-    s = replace_all(s, "$NAMESPACECLOSE$", nsclose);
-    s = replace_all(s, "$TARGET$", target_string);
-    s = replace_all(s, "$BODY$", body_text);
-    s = replace_all(s, "$MPNAME$", "autoscheduler_params");
-    s = replace_all(s, "$MACHINEPARAMS$", autoscheduler_params_string);
+    s = replace_all(std::move(s), "$SCHEDULER$", scheduler_name);
+    s = replace_all(std::move(s), "$NAMESPACEOPEN$", nsopen);
+    s = replace_all(std::move(s), "$SHORTNAME$", simple_name);
+    s = replace_all(std::move(s), "$CLEANNAME$", clean_name);
+    s = replace_all(std::move(s), "$NAMESPACECLOSE$", nsclose);
+    s = replace_all(std::move(s), "$TARGET$", target_string);
+    s = replace_all(std::move(s), "$BODY$", body_text);
+    s = replace_all(std::move(s), "$MPNAME$", "autoscheduler_params");
+    s = replace_all(std::move(s), "$MACHINEPARAMS$", autoscheduler_params_string);
     stream << s;
 }
 

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -692,12 +692,7 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
         debug(1) << "Module.compile(): device_code " << output_files.at(OutputFileType::device_code) << "\n";
         Buffer<> buf = get_device_code_buffer();
         if (buf.defined()) {
-            int length = buf.size_in_bytes();
-            while (length > 0 && ((const char *)buf.data())[length - 1] == '\0') {
-                length--;
-            }
-            std::string str((const char *)buf.data(), length);
-            std::string device_code = std::string((const char *)buf.data(), buf.size_in_bytes());
+            std::string_view device_code((const char *)buf.data(), buf.size_in_bytes());
             while (!device_code.empty() && device_code.back() == '\0') {
                 device_code = device_code.substr(0, device_code.length() - 1);
             }

--- a/src/StmtToHTML.cpp
+++ b/src/StmtToHTML.cpp
@@ -2551,12 +2551,13 @@ private:
 
         // Slurp the code into asm_stream...
         std::string line;
+        line.reserve(128);
         while (getline(assembly, line)) {
             if (line.length() > 500) {
                 // Very long lines in the assembly are typically the _gpu_kernel_sources
                 // or other buffers (such as static LUTs) as a raw ASCII block in the
                 // assembly. Let's chop that off to make browsers faster when dealing with this.
-                asm_buffer.append(line.begin(), line.begin() + 200);
+                asm_buffer.append(line.data(), 200);
                 asm_buffer.append("\" # omitted the remainder of the buffer\n");
             } else {
                 asm_buffer.append(line);

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -1133,7 +1133,7 @@ std::string Target::to_string() const {
     // Use has_feature() multiple times (rather than features_any_of())
     // to avoid constructing a temporary vector for this rather-common call.
     if (has_feature(Target::TraceLoads) && has_feature(Target::TraceStores) && has_feature(Target::TraceRealizations)) {
-        result = Internal::replace_all(result, "trace_loads-trace_realizations-trace_stores", "trace_all");
+        result = Internal::replace_all(std::move(result), "trace_loads-trace_realizations-trace_stores", "trace_all");
     }
     if (vector_bits != 0) {
         result += "-vector_bits_" + std::to_string(vector_bits);

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -264,12 +264,11 @@ bool ends_with(const string &str, const string &suffix) {
 
 string replace_all(string str, const string &find, const string &replace) {
     size_t pos = 0;
-    string result = str;
-    while ((pos = result.find(find, pos)) != string::npos) {
-        result.replace(pos, find.length(), replace);
+    while ((pos = str.find(find, pos)) != string::npos) {
+        str.replace(pos, find.length(), replace);
         pos += replace.length();
     }
-    return result;
+    return str;
 }
 
 std::vector<std::string> split_string(const std::string &source, const std::string &delim) {

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -262,7 +262,7 @@ bool ends_with(const string &str, const string &suffix) {
     return true;
 }
 
-string replace_all(const string &str, const string &find, const string &replace) {
+string replace_all(string str, const string &find, const string &replace) {
     size_t pos = 0;
     string result = str;
     while ((pos = result.find(find, pos)) != string::npos) {
@@ -388,7 +388,7 @@ std::string get_windows_tmp_dir() {
     std::string tmp = from_utf16(wlocal_path);
     CoTaskMemFree(wlocal_path);
 
-    tmp = replace_all(tmp, "\\", "/");
+    tmp = replace_all(std::move(tmp), "\\", "/");
     if (tmp.back() != '/') tmp += '/';
     tmp += "Temp/";
     return tmp;

--- a/src/Util.h
+++ b/src/Util.h
@@ -176,8 +176,12 @@ bool starts_with(const std::string &str, const std::string &prefix);
 /** Test if the first string ends with the second string */
 bool ends_with(const std::string &str, const std::string &suffix);
 
-/** Replace all matches of the second string in the first string with the last string */
-std::string replace_all(const std::string &str, const std::string &find, const std::string &replace);
+/** Replace all matches of the second string in the first string with the last string.
+ * The string to search-and-replace in is passed by value, offering the ability to
+ * std::move() a string in if you're not interested in keeping the original string.
+ * This is useful when the original string does not contain the find-string, causing
+ * this function to return the same string without any copies being made. */
+std::string replace_all(std::string str, const std::string &find, const std::string &replace);
 
 /** Split the source string using 'delim' as the divider. */
 std::vector<std::string> split_string(const std::string &source, const std::string &delim);

--- a/test/correctness/pytorch.cpp
+++ b/test/correctness/pytorch.cpp
@@ -6,16 +6,6 @@ using namespace Halide;
 
 namespace {
 
-std::string replace_all(const std::string &str, const std::string &find, const std::string &replace) {
-    size_t pos = 0;
-    std::string result = str;
-    while ((pos = result.find(find, pos)) != std::string::npos) {
-        result.replace(pos, find.length(), replace);
-        pos += replace.length();
-    }
-    return result;
-}
-
 std::string read_entire_file(const std::string &pathname) {
     std::ifstream f(pathname, std::ios::in | std::ios::binary);
     std::string result;
@@ -31,7 +21,7 @@ std::string read_entire_file(const std::string &pathname) {
     }
     f.close();
     // Normalize file to Unix line endings
-    result = replace_all(result, "\r\n", "\n");
+    result = Internal::replace_all(result, "\r\n", "\n");
     return result;
 }
 


### PR DESCRIPTION
Initial changes to address #8717.

This does not address the Module deep-copy behavior copying Buffer contents. This merely addresses the string processing and avoids some copies.

Fixes [#8752](https://github.com/halide/Halide/issues/8752)

----

Drive-by optimization: Change the signature of replace_all() to take the subject-string to be passed by value. This now allows for making replace-chains in this pattern:

```cpp
std::string s = ...;
s = replace_all(std::move(s), ..., ...);
s = replace_all(std::move(s), ..., ...);
s = replace_all(std::move(s), ..., ...);
s = replace_all(std::move(s), ..., ...);
```
Without making copies in case the target string is not found in the subject string.


