### PR TITLE
Prefer to build against libjpeg-turbo and document this.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -157,8 +157,7 @@
         "rhs": "Darwin"
       },
       "cacheVariables": {
-        "Halide_LLVM_ROOT": "/opt/homebrew/opt/llvm",
-        "CMAKE_PREFIX_PATH": "/opt/homebrew;/opt/homebrew/opt/jpeg"
+        "Halide_LLVM_ROOT": "/opt/homebrew/opt/llvm"
       }
     },
     {
@@ -168,10 +167,7 @@
         "vcpkg"
       ],
       "displayName": "macOS (vcpkg)",
-      "description": "macOS build with vcpkg dependencies",
-      "cacheVariables": {
-        "CMAKE_PREFIX_PATH": ""
-      }
+      "description": "macOS build with vcpkg dependencies"
     },
     {
       "name": "macOS-vcpkg-full",
@@ -180,10 +176,7 @@
         "vcpkg-full"
       ],
       "displayName": "macOS (vcpkg-full)",
-      "description": "macOS build with vcpkg-full dependencies",
-      "cacheVariables": {
-        "CMAKE_PREFIX_PATH": ""
-      }
+      "description": "macOS build with vcpkg-full dependencies"
     },
     {
       "name": "package",

--- a/apps/support/Makefile.inc
+++ b/apps/support/Makefile.inc
@@ -192,19 +192,10 @@ endif
 # Find libjpeg and libpng. The code to set IMAGE_IO_LIBS is duplicated
 # in the root Makefile and any changes here should be repeated there.
 
-ifneq (,$(shell command -v brew))
-# Get png and jpeg paths from brew
-LIBPNG_LIBS_DEFAULT = -L $(shell brew --prefix libpng)/lib -lpng
-LIBPNG_CXX_FLAGS ?= -I $(shell brew --prefix libpng)/include
-LIBJPEG_LIBS ?= -L $(shell brew --prefix libjpeg)/lib -ljpeg
-LIBJPEG_CXX_FLAGS ?= -I $(shell brew --prefix libjpeg)/include
-else
-# Get png and jpeg paths from pkg-config
 LIBPNG_LIBS_DEFAULT = $(shell pkg-config libpng --libs)
 LIBPNG_CXX_FLAGS ?= $(shell pkg-config libpng --cflags)
 LIBJPEG_LIBS ?= $(shell pkg-config libjpeg --libs)
 LIBJPEG_CXX_FLAGS ?= $(shell pkg-config libjpeg --cflags)
-endif
 
 # Workaround for libpng-config pointing to 64-bit versions on linux even when we're building for 32-bit
 ifneq (,$(findstring -m32,$(CXX)))
@@ -264,4 +255,3 @@ $(BIN)/%.run: $(BIN)/%.rungen
 .PHONY: %.benchmark
 %.benchmark: $(BIN)/$(HL_TARGET)/%.rungen
 	@$^ --benchmarks=all --estimate_all --parsable_output
-

--- a/doc/BuildingHalideWithCMake.md
+++ b/doc/BuildingHalideWithCMake.md
@@ -244,15 +244,17 @@ from the root of the repository.
 On macOS, it is possible to install all dependencies via [Homebrew][homebrew]:
 
 ```shell
-$ brew install llvm flatbuffers wabt python pybind11 doxygen eigen libpng libjpeg openblas
+$ brew install llvm flatbuffers wabt python pybind11 doxygen eigen libpng libjpeg-turbo openblas
 ```
 
 The `llvm` package includes `clang`, `clang-format`, and `lld`, too. To ensure
-CMake can find the keg-only dependencies, set the following:
+CMake can find LLVM, set the following cache variable:
 
 ```shell
-$ export CMAKE_PREFIX_PATH="/opt/homebrew:/opt/homebrew/opt/llvm:/opt/homebrew/opt/jpeg"
+$ cmake ... -DHalide_ROOT=/opt/homebrew/opt/llvm
 ```
+
+Or use the `macOS` CMake preset, which does this for you.
 
 ### Ubuntu / Debian
 
@@ -520,7 +522,7 @@ Python and C++ `find_package` workflows.
 Because Python's build infrastructure creates temporary CMake build directories,
 simply setting `CMAKE_CXX_COMPILER_LAUNCHER` to `ccache` is insufficient to
 produce a well-cached build. The following settings should serve as a starting
-point to configure your environment (assuming `$PWD` is the repository root) 
+point to configure your environment (assuming `$PWD` is the repository root)
 for using `ccache` with `pip install .`.
 
 ```shell
@@ -545,7 +547,7 @@ export TMPDIR=$PWD/build/tmp
 export UV_NO_BUILD_ISOLATION=1
 ```
 
-See the CCache documentation on [compiling in different directories] and on 
+See the CCache documentation on [compiling in different directories] and on
 using [precompiled headers] for more information about these settings. To check
 that ccache is working, run,
 
@@ -578,7 +580,7 @@ Local storage:
   Misses:             0 / 1079 ( 0.00%)
 ```
 
-On this test system (an M3 MacBook Pro), the build is three times faster, 
+On this test system (an M3 MacBook Pro), the build is three times faster,
 with a 100% cache hit rate!
 
 [ATLAS]: http://math-atlas.sourceforge.net/


### PR DESCRIPTION
Thanks to a schism between libjpeg and libjpeg-turbo, Homebrew and many other distributions (Ubuntu, Debian, Fedora, Firefox, Chrome, etc.) refuse to use the IJG's libjpeg. Instead, the open-source world appears to have adopted libjpeg-turbo.

The buildbots have been updated to include both libraries. When and if this is merged, I'll remove libjpeg-9f.

See: https://libjpeg-turbo.org/About/Jpeg-9
See: https://github.com/Homebrew/homebrew-core/pull/107511
See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=717076