### PR TITLE
Speed up simd_op_check_wasm

### DIFF
--- a/test/correctness/simd_op_check_wasm.cpp
+++ b/test/correctness/simd_op_check_wasm.cpp
@@ -13,7 +13,7 @@ namespace {
 
 class SimdOpCheckWASM : public SimdOpCheckTest {
 public:
-    SimdOpCheckWASM(Target t, int w = 768, int h = 128)
+    SimdOpCheckWASM(Target t, int w = 768, int h = 1)
         : SimdOpCheckTest(t, w, h) {
         use_wasm_simd128 = target.has_feature(Target::WasmSimd128);
         use_wasm_sign_ext = !target.has_feature(Target::WasmMvpOnly);
@@ -74,7 +74,7 @@ public:
         }
 
         if (use_wasm_simd128) {
-            for (int w = 1; w <= 4; w <<= 1) {
+            for (int w = 1; w <= 2; w <<= 1) {
                 // create arbitrary 16-byte constant
                 check("v128.const", 16 * w, u8_1 * u8(42 + x));
 
@@ -141,21 +141,19 @@ public:
                 check("i64x2.neg", 2 * w, -i64_1);
 
                 // Extended (widening) integer multiplication
-                if (w > 1) {
-                    // Need a register wider than 128 bits for us to generate these
-                    check("i16x8.extmul_low_i8x16_s", 8 * w, i16(i8_1) * i8_2);
-                    check("i32x4.extmul_low_i16x8_s", 4 * w, i32(i16_1) * i16_2);
-                    check("i64x2.extmul_low_i32x4_s", 2 * w, i64(i32_1) * i32_2);
-                    check("i16x8.extmul_low_i8x16_u", 8 * w, u16(u8_1) * u8_2);
-                    check("i32x4.extmul_low_i16x8_u", 4 * w, u32(u16_1) * u16_2);
-                    check("i64x2.extmul_low_i32x4_u", 2 * w, u64(u32_1) * u32_2);
-                    check("i16x8.extmul_high_i8x16_s", 8 * w, i16(i8_1) * i8_2);
-                    check("i32x4.extmul_high_i16x8_s", 4 * w, i32(i16_1) * i16_2);
-                    check("i64x2.extmul_high_i32x4_s", 2 * w, i64(i32_1) * i32_2);
-                    check("i16x8.extmul_high_i8x16_u", 8 * w, u16(u8_1) * u8_2);
-                    check("i32x4.extmul_high_i16x8_u", 4 * w, u32(u16_1) * u16_2);
-                    check("i64x2.extmul_high_i32x4_u", 2 * w, u64(u32_1) * u32_2);
-                }
+                // Need a register wider than 128 bits for us to generate these
+                check("i16x8.extmul_low_i8x16_s", 16 * w, i16(i8_1) * i8_2);
+                check("i32x4.extmul_low_i16x8_s", 8 * w, i32(i16_1) * i16_2);
+                check("i64x2.extmul_low_i32x4_s", 4 * w, i64(i32_1) * i32_2);
+                check("i16x8.extmul_low_i8x16_u", 16 * w, u16(u8_1) * u8_2);
+                check("i32x4.extmul_low_i16x8_u", 8 * w, u32(u16_1) * u16_2);
+                check("i64x2.extmul_low_i32x4_u", 4 * w, u64(u32_1) * u32_2);
+                check("i16x8.extmul_high_i8x16_s", 16 * w, i16(i8_1) * i8_2);
+                check("i32x4.extmul_high_i16x8_s", 8 * w, i32(i16_1) * i16_2);
+                check("i64x2.extmul_high_i32x4_s", 4 * w, i64(i32_1) * i32_2);
+                check("i16x8.extmul_high_i8x16_u", 16 * w, u16(u8_1) * u8_2);
+                check("i32x4.extmul_high_i16x8_u", 8 * w, u32(u16_1) * u16_2);
+                check("i64x2.extmul_high_i32x4_u", 4 * w, u64(u32_1) * u32_2);
 
                 // Extended pairwise integer addition
                 for (int f : {2, 4}) {


### PR DESCRIPTION
It is currently timing out on some bots because running the generated wasm is slow. This speeds it up by only checking one row and by cutting down on the number of vector sizes tested - just native and double native.