### PR TITLE
Fix wrong type of the bound

### DIFF
--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1699,10 +1699,9 @@ private:
         } else if (op->call_type == Call::Halide) {
             bounds_of_func(op->name, op->value_index, op->type);
         } else if (!const_bound &&
-                   op->call_type == Call::PureIntrinsic) {
+                   op->call_type == Call::PureIntrinsic && handle_const_arg_call()) {
             // It was some other pure intrinsic that we don't lower. If the args
             // are const we can just preserve it.
-            handle_const_arg_call();
         } else {
             // Just use the bounds of the type
             bounds_of_type(t);


### PR DESCRIPTION
This is adressing a following error which we started to get after updating Halide internally:

```
“Error: Min of (uint16)lerp((uint16)0, uint16((max(min((float32)scale_fine, 1.000000f), 0.000000f)*16384.000000f) + 0.500000f), (uint8)mask_im(x, y)) should have been a scalar of type uint16: (uint8)0” 
```

I *think* the issue is that when ```handle_const_arg_call``` returns ```false```, the Call visitor just exits instead of hitting the else branch. This is problematic, because ```handle_const_arg_call``` will visit each of the arguments and each of their visitors will set ```interval```, so in the end ```interval``` will be set to the interval of the last argument of the Call. In this case, it has a different type causing the error above.