### PR TITLE
Run internally-threaded tests serially with other tests

### DIFF
--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -455,3 +455,19 @@ set_target_properties(correctness_async
                       correctness_sliding_window
                       correctness_storage_folding
                       PROPERTIES ENABLE_EXPORTS TRUE)
+
+# Tests which are internally parallelized should not be run at the
+# same time as other tests, or they may time out
+
+set_target_properties(correctness_mul_div_mod
+                      correctness_simd_op_check_arm
+                      correctness_simd_op_check_hvx
+                      correctness_simd_op_check_powerpc
+                      correctness_simd_op_check_riscv
+                      correctness_simd_op_check_sve2
+                      correctness_simd_op_check_wasm
+                      correctness_simd_op_check_x86
+                      correctness_vector_cast
+                      correctness_vector_math
+                      correctness_vector_reductions
+                      PROPERTIES RUN_SERIAL TRUE)

--- a/test/correctness/mul_div_mod.cpp
+++ b/test/correctness/mul_div_mod.cpp
@@ -1,4 +1,5 @@
 #include "Halide.h"
+#include "halide_thread_pool.h"
 #include "test_sharding.h"
 
 #include <algorithm>
@@ -574,11 +575,19 @@ int main(int argc, char **argv) {
 
     using Sharder = Halide::Internal::Test::Sharder;
     Sharder sharder;
+
+    std::vector<std::future<bool>> futures;
+
+    Halide::Tools::ThreadPool<bool> pool;
     for (size_t t = 0; t < tasks.size(); t++) {
         if (!sharder.should_run(t)) continue;
         const auto &task = tasks.at(t);
-        if (!task.fn()) {
-            exit(-1);
+        futures.push_back(pool.async(task.fn));
+    }
+
+    for (auto &f : futures) {
+        if (!f.get()) {
+            return 1;
         }
     }
 


### PR DESCRIPTION
They're internally threaded because they're slow. If we make them compete with other tests, that reduces them back to one thread and they risk timing out entirely.