### PR TITLE
Fix halide_as_onnx_backend_test

### DIFF
--- a/apps/onnx/halide_as_onnx_backend_test.py
+++ b/apps/onnx/halide_as_onnx_backend_test.py
@@ -5,34 +5,25 @@ import onnx.backend.test
 import halide_as_onnx_backend as halide_backend
 import halide_as_onnx_backend_failures_table
 
+backend_test = onnx.backend.test.BackendTest(halide_backend, __name__)
 
-# This is a pytest magic variable to load extra plugins
-# pytest_plugins = 'onnx.backend.test.report',
+# These tests are simply too slow.
+backend_test.exclude(r"test_densenet121_.*")
+backend_test.exclude(r"test_inception_v1_.*")
+backend_test.exclude(r"test_inception_v2_.*")
+backend_test.exclude(r"test_resnet50_.*")
+backend_test.exclude(r"test_squeezenet_.*")
+backend_test.exclude(r"test_vgg19_.*")
+backend_test.exclude(r"test_zfnet512_.*")
 
+exclude_patterns = getattr(
+    halide_as_onnx_backend_failures_table, "HALIDE_ONNX_KNOWN_TEST_FAILURES", []
+)
+for _, _, pattern in exclude_patterns:
+    backend_test.exclude(pattern)
 
-def main():
-    backend_test = onnx.backend.test.BackendTest(halide_backend, __name__)
-
-    # These tests are simply too slow.
-    backend_test.exclude(r"test_densenet121_.*")
-    backend_test.exclude(r"test_inception_v1_.*")
-    backend_test.exclude(r"test_inception_v2_.*")
-    backend_test.exclude(r"test_resnet50_.*")
-    backend_test.exclude(r"test_squeezenet_.*")
-    backend_test.exclude(r"test_vgg19_.*")
-    backend_test.exclude(r"test_zfnet512_.*")
-
-    exclude_patterns = getattr(
-        halide_as_onnx_backend_failures_table, "HALIDE_ONNX_KNOWN_TEST_FAILURES", []
-    )
-    for _, _, pattern in exclude_patterns:
-        backend_test.exclude(pattern)
-
-    # import all test cases at global scope to make them visible to python.unittest
-    globals().update(backend_test.enable_report().test_cases)
-
-    unittest.main()
-
+# import all test cases at global scope to make them visible to python.unittest
+globals().update(backend_test.test_cases)
 
 if __name__ == "__main__":
-    main()
+    unittest.main()


### PR DESCRIPTION
We need these to be global for the unittest runner to find them. Should fix a CI failure where this test was considered failed for not running any tests.