### PR TITLE
Allow llvm-ar in BundleStatic.cmake

### DIFF
--- a/cmake/BundleStatic.cmake
+++ b/cmake/BundleStatic.cmake
@@ -98,7 +98,7 @@ function(bundle_static TARGET)
     endif ()
 
     _bundle_static_check_output(version_info "${CMAKE_AR}" V)
-    if (version_info MATCHES "GNU")
+    if (version_info MATCHES "GNU|LLVM")
         string(CONFIGURE [[
             create $<TARGET_FILE:@TARGET@>
             addlib $<TARGET_FILE:@TARGET@>.tmp


### PR DESCRIPTION
When building Halide with `Halide_BUNDLE_STATIC` enabled and with a Clang toolchain, the detected `llvm-ar` for `CMAKE_AR` does not print `GNU` (unsurprisingly), so CMake configuration hits a fatal error:

```
bundle_static_libs not implemented for the present toolchain
```

Fortunately, `llvm-ar` supports the same MRI scripts GNU `ar` does, so it can follow that code path, too.