### PR TITLE
Query SVE vector register length in host target computation for ARM cpus with SVE/SVE2.

### DIFF
--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -57,6 +57,15 @@ using std::vector;
 
 namespace {
 
+#if defined(__aarch64__)
+__attribute__((target("+sve")))
+int get_sve_vector_length() {
+    register int result asm("w0");
+    __asm__ ("cntb %x0, all, mul #8" : "=r"(result));
+    return result;
+}
+#endif
+
 #if defined(_M_IX86) || defined(_M_AMD64)
 
 void cpuid(int info[4], int infoType, int extra) {
@@ -232,6 +241,7 @@ Target calculate_host_target() {
 #else
 #if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
     Target::Arch arch = Target::ARM;
+    bool has_scalable_vector = false;
 
 #ifdef __APPLE__
     if (is_armv7s()) {
@@ -261,10 +271,12 @@ Target calculate_host_target() {
 
     if (hwcaps & HWCAP_SVE) {
         initial_features.push_back(Target::SVE);
+        has_scalable_vector = true;
     }
 
     if (hwcaps2 & HWCAP2_SVE2) {
         initial_features.push_back(Target::SVE2);
+        has_scalable_vector = true;
     }
 #endif
 
@@ -286,8 +298,15 @@ Target calculate_host_target() {
 
     if (IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE)) {
         initial_features.push_back(Target::SVE);
+        has_scalable_vector = true;
     }
 
+#endif
+
+#if defined(__aarch64__)
+    if (has_scalable_vector) {
+        vector_bits = get_sve_vector_length();
+    }
 #endif
 
 #else


### PR DESCRIPTION
Attempts to fix automatic target resolution setting SVE/SVE2 flags without a vector length as reported in issue https://github.com/halide/Halide/issues/8529 .

Someone will need to test this on hardware that supports (at least) SVE. E.g. an AWS Graviton 3 or 4 system. I will not be able to do that personally in less than two weeks or so.