### PR TITLE
Rework clang-tidy infrastructure to increase coverage

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -5,6 +5,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/google/flatbuffers.git
     GIT_TAG 0100f6a5779831fa7a651e4b67ef389a8752bd9b # v23.5.26
     GIT_SHALLOW TRUE
+    SYSTEM
 )
 
 FetchContent_Declare(
@@ -12,6 +13,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
     GIT_TAG 8a099e44b3d5f85b20f05828d919d2332a8de841 # v2.11.1
     GIT_SHALLOW TRUE
+    SYSTEM
 )
 
 FetchContent_Declare(
@@ -19,6 +21,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/WebAssembly/wabt.git
     GIT_TAG 3e826ecde1adfba5f88d10d361131405637e65a3 # 1.0.36
     GIT_SHALLOW TRUE
+    SYSTEM
 )
 
 macro(Halide_provide_dependency method dep_name)
@@ -50,10 +53,20 @@ macro(Halide_provide_dependency method dep_name)
             if (NOT TARGET flatbuffers::flatbuffers)
                 add_library(flatbuffers::flatbuffers ALIAS flatbuffers)
                 add_executable(flatbuffers::flatc ALIAS flatc)
+                set_target_properties(
+                    flatbuffers flatc
+                    PROPERTIES
+                    EXPORT_COMPILE_COMMANDS OFF
+                )
             endif ()
         endif ()
         if ("${dep_name}" STREQUAL "wabt")
-            set_target_properties(wabt PROPERTIES POSITION_INDEPENDENT_CODE ON)
+            set_target_properties(
+                wabt wasm-rt-impl
+                PROPERTIES
+                POSITION_INDEPENDENT_CODE ON
+                EXPORT_COMPILE_COMMANDS OFF
+            )
         endif ()
     endif ()
 endmacro()

--- a/doc/BuildingHalideWithCMake.md
+++ b/doc/BuildingHalideWithCMake.md
@@ -448,7 +448,6 @@ escape hatches for third-party packagers.
 
 | Option                      | Default                                                            | Description                                                                              |
 |-----------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-| `Halide_CLANG_TIDY_BUILD`   | `OFF`                                                              | Used internally to generate fake compile jobs for runtime files when running clang-tidy. |
 | `Halide_CCACHE_BUILD`       | `OFF`                                                              | Use ccache with Halide-recommended settings to accelerate rebuilds.                      |
 | `Halide_CCACHE_PARAMS`      | `CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines` | Options to pass to `ccache` when using `Halide_CCACHE_BUILD`.                            |
 | `Halide_VERSION_OVERRIDE`   | `${Halide_VERSION}`                                                | Override the VERSION for libHalide.                                                      |

--- a/python_bindings/tutorial/CMakeLists.txt
+++ b/python_bindings/tutorial/CMakeLists.txt
@@ -68,6 +68,10 @@ else ()
                        lesson_10_halide.py.cpp
                        lesson_10_halide.o)
 
+    # TODO: the EXCLUDE_FROM_ALL above is a bit of a hack - even a normal build won't
+    #   prepare this file for linting. Disable export of compile commands for this target.
+    set_target_properties(lesson_10_halide PROPERTIES EXPORT_COMPILE_COMMANDS OFF)
+
     target_link_libraries(lesson_10_halide PRIVATE Halide::Runtime)
 
     # Undocumented function in HalideGeneratorHelpers. Do not call in external code.

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -70,13 +70,18 @@ else
     exit 1
 fi
 
-
 # Use a temp folder for the CMake stuff here, so it's fresh & correct every time
 CLANG_TIDY_BUILD_DIR=$(mktemp -d)
 echo "CLANG_TIDY_BUILD_DIR = ${CLANG_TIDY_BUILD_DIR}"
+trap "rm -rf ${CLANG_TIDY_BUILD_DIR}" EXIT
 
 export CC="${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang"
 export CXX="${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang++"
+
+export CMAKE_GENERATOR=Ninja
+export CMAKE_BUILD_TYPE=Debug
+export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+export Halide_LLVM_ROOT="${CLANG_TIDY_LLVM_INSTALL_DIR}"
 
 if [[ $(${CC} --version) =~ .*Homebrew.* ]]; then
   # Homebrew clang 21 is badly misconfigured and needs help finding the
@@ -101,66 +106,36 @@ EOF
   export CMAKE_TOOLCHAIN_FILE="${CLANG_TIDY_BUILD_DIR}/toolchain.cmake"
 fi
 
-echo Building compile_commands.json...
-cmake -G Ninja -S "${ROOT_DIR}" -B "${CLANG_TIDY_BUILD_DIR}" -Wno-dev \
-      -DCMAKE_BUILD_TYPE=Debug \
-      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-      -DHalide_CLANG_TIDY_BUILD=ON \
-      -DHalide_LLVM_ROOT="${CLANG_TIDY_LLVM_INSTALL_DIR}" \
-      > /dev/null
+echo Configuring Halide...
+cmake -S "${ROOT_DIR}" -B "${CLANG_TIDY_BUILD_DIR}" -Wno-dev -DWITH_TESTS=OFF
 
 [ -a "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" ]
 
-# We need to remove -arch flags where -target flags also exist. These break our fake runtime compilation steps on macOS
-echo Patching compile_commands.json...
-patch_file '/-target/ s/-arch *[^ ]+//' "${CLANG_TIDY_BUILD_DIR}/compile_commands.json"
+echo Building Halide...
+cmake --build "${CLANG_TIDY_BUILD_DIR}" -j "${J}"
 
-# We must populate the includes directory to check things outside of src/
-echo Building HalideIncludes...
-cmake --build "${CLANG_TIDY_BUILD_DIR}" -j "${J}" --target HalideIncludes
+echo Building runtime compilation database...
+temp_file=$(mktemp)
+trap "rm -f $temp_file" EXIT
+cat "${CLANG_TIDY_BUILD_DIR}"/src/runtime/*.json > "$temp_file"
+{
+  echo '['
+  patch_file '$ s/,$//' "$temp_file"
+  echo ']'
+} > "${CLANG_TIDY_BUILD_DIR}/src/runtime/compile_commands.json"
 
-echo Building flatbuffer stuff...
-cmake --build "${CLANG_TIDY_BUILD_DIR}" -j "${J}" --target generate_fb_header
-
-RUN_CLANG_TIDY=${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/run-clang-tidy
-
-# We deliberately skip apps/ and test/ for now, as the compile commands won't include
-# generated headers files from Generators.
-#
-# Skip DefaultCostModel.cpp as it relies on cost_model.h.
-# Skip GenGen.cpp and RunGenMain.cpp as they bring clang-tidy to its knees,
-# for reasons that aren't entirely clear yet.
-echo Finding targets...
-CLANG_TIDY_TARGETS=$(find \
-     "${ROOT_DIR}/src" \
-     "${ROOT_DIR}/python_bindings" \
-     "${ROOT_DIR}/tools" \
-     "${ROOT_DIR}/util" \
-     \( -name "*.cpp" -o -name "*.h" -o -name "*.c" \) -and -not -wholename "*/.*" \
-     ! -name DefaultCostModel.cpp \
-     ! -name GenGen.cpp \
-     ! -name RunGenMain.cpp)
-
-# clang-tidy doesn't have a sane way to exclude third-party headers (e.g. pybind11),
-# so we will instead build an include filter
-CLANG_TIDY_HEADER_FILTER=".*/src/.*|.*/python_bindings/.*|.*/tools/.*|.*/util/.*"
+echo Merging compilation databases...
+jq -s 'add' "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" \
+    "${CLANG_TIDY_BUILD_DIR}/src/runtime/compile_commands.json" \
+    > "${CLANG_TIDY_BUILD_DIR}/compile_commands_merged.json"
+mv "${CLANG_TIDY_BUILD_DIR}/compile_commands_merged.json" "${CLANG_TIDY_BUILD_DIR}/compile_commands.json"
 
 echo Running clang-tidy...
-${RUN_CLANG_TIDY} \
+"${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/run-clang-tidy" \
     ${FIX} \
     -j "${J}" \
     -header-filter="${CLANG_TIDY_HEADER_FILTER}" \
     -quiet \
     -p "${CLANG_TIDY_BUILD_DIR}" \
     -clang-tidy-binary "${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-tidy" \
-    -clang-apply-replacements-binary "${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-apply-replacements" \
-    ${CLANG_TIDY_TARGETS} \
-    2>&1 | grep -v "warnings generated" | sed "s|.*/||"
-
-RESULT=${PIPESTATUS[0]}
-
-echo "run-clang-tidy finished with status ${RESULT}"
-
-rm -rf "${CLANG_TIDY_BUILD_DIR}"
-
-exit "${RESULT}"
+    -clang-apply-replacements-binary "${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-apply-replacements"

--- a/src/autoschedulers/adams2019/DefaultCostModel.cpp
+++ b/src/autoschedulers/adams2019/DefaultCostModel.cpp
@@ -57,7 +57,9 @@ void DefaultCostModel::set_pipeline_features(const Internal::Autoscheduler::Func
                   "Incorrect size for pipeline features");
     int num_stages = 0;
     for (const auto &n : dag.nodes) {
-        if (!n.is_input) num_stages += (int)n.stages.size();
+        if (!n.is_input) {
+            num_stages += (int)n.stages.size();
+        }
     }
     Runtime::Buffer<float> pipeline_features(head1_w, head1_h, num_stages);
     int stage = 0;
@@ -107,7 +109,9 @@ void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
     for (const auto &n : dag.nodes) {
 
         // Inputs are computed outside of the pipeline and don't count.
-        if (n.is_input) continue;
+        if (n.is_input) {
+            continue;
+        }
 
         // The remaining stages are not yet
         // scheduled. Optimistically assume their internal costs
@@ -117,7 +121,9 @@ void DefaultCostModel::enqueue(const Internal::Autoscheduler::FunctionDAG &dag,
         // cost for loading from these unscheduled stages is
         // already baked into the scheduled stages that consume
         // them.
-        if (stage >= num_stages) break;
+        if (stage >= num_stages) {
+            break;
+        }
 
         // Load up the schedule features for all stages of this Func.
         for (const auto &s : Internal::reverse_view(n.stages)) {
@@ -235,14 +241,14 @@ float DefaultCostModel::backprop(const Runtime::Buffer<const float> &true_runtim
             any_nans = true;
             aslog(1) << "Prediction " << i << " is NaN. True runtime is " << true_runtimes(i) << "\n";
             aslog(1) << "Checking pipeline features for NaNs...\n";
-            pipeline_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
+            pipeline_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) { abort(); } });
             aslog(1) << "None found\n";
             aslog(1) << "Checking schedule features for NaNs...\n";
-            schedule_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
+            schedule_feat_queue.for_each_value([&](float f) { if (std::isnan(f)) { abort(); } });
             aslog(1) << "None found\n";
             aslog(1) << "Checking network weights for NaNs...\n";
             weights.for_each_buffer([&](const Runtime::Buffer<float> &buf) {
-                buf.for_each_value([&](float f) { if (std::isnan(f)) abort(); });
+                buf.for_each_value([&](float f) { if (std::isnan(f)) { abort(); } });
             });
             aslog(1) << "None found\n";
         }
@@ -383,7 +389,7 @@ void DefaultCostModel::reset() {
 std::unique_ptr<DefaultCostModel> make_default_cost_model(const std::string &weights_in_path,
                                                           const std::string &weights_out_path,
                                                           bool randomize_weights) {
-    return std::unique_ptr<DefaultCostModel>(new DefaultCostModel(weights_in_path, weights_out_path, randomize_weights));
+    return std::make_unique<DefaultCostModel>(weights_in_path, weights_out_path, randomize_weights);
 }
 
 }  // namespace Halide

--- a/src/autoschedulers/anderson2021/DefaultCostModel.cpp
+++ b/src/autoschedulers/anderson2021/DefaultCostModel.cpp
@@ -29,11 +29,12 @@ namespace {
 using Halide::Internal::aslog;
 using Halide::Internal::PipelineFeatures;
 using Halide::Internal::ScheduleFeatures;
-using Halide::Internal::Weights;
 using Halide::Runtime::Buffer;
 
 bool ends_with(const std::string &str, const std::string &suffix) {
-    if (str.size() < suffix.size()) return false;
+    if (str.size() < suffix.size()) {
+        return false;
+    }
     size_t off = str.size() - suffix.size();
     for (size_t i = 0; i < suffix.size(); i++) {
         if (str[off + i] != suffix[i]) {
@@ -379,7 +380,7 @@ void DefaultCostModel::load_weights() {
     }
 
     if (need_randomize) {
-        auto seed = time(NULL);
+        auto seed = time(nullptr);
         std::cout << "Randomizing weights using seed = " << seed << "\n";
         weights.randomize((uint32_t)seed);
     }
@@ -412,7 +413,7 @@ std::unique_ptr<DefaultCostModel> make_default_cost_model(Internal::Autoschedule
                                                           const std::string &weights_in_path,
                                                           const std::string &weights_out_path,
                                                           bool randomize_weights) {
-    return std::unique_ptr<DefaultCostModel>(new DefaultCostModel(weights_in_path, weights_out_path, randomize_weights, stats));
+    return std::make_unique<DefaultCostModel>(weights_in_path, weights_out_path, randomize_weights, stats);
 }
 
 }  // namespace Halide

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -186,11 +186,6 @@ set(RUNTIME_CXX_FLAGS
     -isystem "${VulkanHeaders_INCLUDE_DIR}"
 )
 
-Halide_feature(
-    Halide_CLANG_TIDY_BUILD "Generate fake compile jobs for runtime files when running clang-tidy." OFF
-    ADVANCED
-)
-
 foreach (i IN LISTS RUNTIME_CPP)
     foreach (j IN ITEMS 32 64)
         # -fpic needs special treatment; see below on windows 64bits
@@ -270,33 +265,15 @@ foreach (i IN LISTS RUNTIME_CPP)
 
             set(clang_flags ${RUNTIME_CXX_FLAGS} ${fpic} ${fshort-wchar} ${RUNTIME_DEFINES${SUFFIX}} -m${j} -target ${TARGET} -emit-llvm -S -MD -MF "${basename}.d")
 
-            if (Halide_CLANG_TIDY_BUILD)
-                # Create a 'fake' entry just so that clang-tidy will see a C++ compilation command
-                # that it can use for tidy-checking. (This branch should never be taken by 'normal'
-                # compilations.)
-                if (NOT i MATCHES "vulkan")
-                    # On macOS (at least), the vulkan runtime file needs some sort of threading API
-                    # to be defined. Otherwise, we get errors like:
-                    #
-                    # __config:858:8: error: "No thread API" [clang-diagnostic-error]
-                    # 858 | #      error "No thread API"
-                    #     |        ^
-                    # availability.h:292:4: error: "It looks like you're trying to enable vendor availability markup, but you haven't defined the corresponding macros yet!" [clang-diagnostic-error]
-                    # 292 | #  error                                                                                                               \
-                    #     |    ^
-                    #
-                    # TODO: see if we can fix this somehow.
-                    add_library(${basename} STATIC "${SOURCE}")
-                    target_compile_options(${basename} PRIVATE ${RUNTIME_CXX_FLAGS} ${fpic} ${fshort-wchar} -m${j} -target ${TARGET})
-                    target_compile_definitions(${basename} PRIVATE ${RUNTIME_DEFINES})
-                endif ()
-            else ()
-                add_custom_command(OUTPUT "${LL}"
-                                   COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_C_COMPILER_LAUNCHER} $<TARGET_FILE:clang> ${clang_flags} -o "${LL}" "$<SHELL_PATH:${SOURCE}>"
-                                   DEPENDS $<TARGET_NAME:clang> "${SOURCE}"
-                                   DEPFILE "${basename}.d"
-                                   VERBATIM)
+            if (CMAKE_EXPORT_COMPILE_COMMANDS)
+                list(PREPEND clang_flags -MJ "${basename}.json")
             endif ()
+
+            add_custom_command(OUTPUT "${LL}"
+                               COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_C_COMPILER_LAUNCHER} $<TARGET_FILE:clang> ${clang_flags} -o "${LL}" "$<SHELL_PATH:${SOURCE}>"
+                               DEPENDS $<TARGET_NAME:clang> "${SOURCE}"
+                               DEPFILE "${basename}.d"
+                               VERBATIM)
 
             add_custom_command(OUTPUT "${BC}"
                                COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:llvm-as> "${LL}" -o "${BC}"
@@ -377,7 +354,6 @@ target_sources(Halide_Runtime
 
 Halide_feature(
     Halide_BUILD_HEXAGON_REMOTE_RUNTIME "Build the hexagon remote runtime for offloading to Hexagon (HVX)" OFF
-    DEPENDS NOT Halide_CLANG_TIDY_BUILD
     ADVANCED
 )
 if (Halide_BUILD_HEXAGON_REMOTE_RUNTIME)

--- a/tutorial/lesson_01_basics.cpp
+++ b/tutorial/lesson_01_basics.cpp
@@ -20,7 +20,7 @@
 #include "Halide.h"
 
 // We'll also include stdio for printf.
-#include <stdio.h>
+#include <cstdio>
 
 int main(int argc, char **argv) {
 

--- a/tutorial/lesson_03_debugging_1.cpp
+++ b/tutorial/lesson_03_debugging_1.cpp
@@ -17,7 +17,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 // This time we'll just import the entire Halide namespace
 using namespace Halide;

--- a/tutorial/lesson_04_debugging_2.cpp
+++ b/tutorial/lesson_04_debugging_2.cpp
@@ -17,7 +17,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 using namespace Halide;
 
 int main(int argc, char **argv) {

--- a/tutorial/lesson_05_scheduling_1.cpp
+++ b/tutorial/lesson_05_scheduling_1.cpp
@@ -20,7 +20,7 @@
 
 #include "Halide.h"
 #include <algorithm>
-#include <stdio.h>
+#include <cstdio>
 using namespace Halide;
 
 int main(int argc, char **argv) {
@@ -377,7 +377,7 @@ int main(int argc, char **argv) {
                     // evaluate points outside of the 7x2 box. We'll
                     // clamp x to be at most 4 (7 minus the split
                     // factor).
-                    if (x > 4) x = 4;
+                    if (x > 4) { x = 4; }
                     x += x_inner;
                     printf("Evaluating at x = %d, y = %d: %d\n", x, y, x + y);
                 }

--- a/tutorial/lesson_06_realizing_over_shifted_domains.cpp
+++ b/tutorial/lesson_06_realizing_over_shifted_domains.cpp
@@ -18,7 +18,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 

--- a/tutorial/lesson_07_multi_stage_pipelines.cpp
+++ b/tutorial/lesson_07_multi_stage_pipelines.cpp
@@ -15,7 +15,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 

--- a/tutorial/lesson_08_scheduling_2.cpp
+++ b/tutorial/lesson_08_scheduling_2.cpp
@@ -15,7 +15,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 
@@ -316,7 +316,7 @@ int main(int argc, char **argv) {
 
                 // Skip over rows of producer that we've already
                 // computed in a previous iteration.
-                if (y > 0 && py == y) continue;
+                if (y > 0 && py == y) { continue; }
 
                 for (int px = 0; px < 5; px++) {
                     producer_storage[py][px] = sin(px * py);
@@ -359,7 +359,7 @@ int main(int argc, char **argv) {
             float producer_storage[2][5];
             for (int y = 0; y < 4; y++) {
                 for (int py = y; py < y + 2; py++) {
-                    if (y > 0 && py == y) continue;
+                    if (y > 0 && py == y) { continue; }
                     for (int px = 0; px < 5; px++) {
                         // Stores to producer_storage have their y coordinate bit-masked.
                         producer_storage[py & 1][px] = sin(px * py);
@@ -608,14 +608,14 @@ int main(int argc, char **argv) {
 
                 for (int py = y; py < y + 2; py++) {
                     // Skip scanlines already computed *within this task*
-                    if (yi > 0 && py == y) continue;
+                    if (yi > 0 && py == y) { continue; }
 
                     // Compute this scanline of the producer in 4-wide vectors
                     for (int x_vec = 0; x_vec < 160 / 4 + 1; x_vec++) {
                         int x_base = x_vec * 4;
                         // 4 doesn't divide 161, so push the last vector left
                         // (see lesson 05).
-                        if (x_base > 161 - 4) x_base = 161 - 4;
+                        if (x_base > 161 - 4) { x_base = 161 - 4; }
                         // If you're on x86, Halide generates SSE code for this part:
                         int x[] = {x_base, x_base + 1, x_base + 2, x_base + 3};
                         float vec[4] = {sinf(x[0] * py), sinf(x[1] * py),

--- a/tutorial/lesson_09_update_definitions.cpp
+++ b/tutorial/lesson_09_update_definitions.cpp
@@ -15,7 +15,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 // We're going to be using x86 SSE intrinsics later on in this lesson.
 #ifdef __SSE2__

--- a/tutorial/lesson_10_aot_compilation_generate.cpp
+++ b/tutorial/lesson_10_aot_compilation_generate.cpp
@@ -32,7 +32,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 using namespace Halide;
 
 int main(int argc, char **argv) {

--- a/tutorial/lesson_10_aot_compilation_run.cpp
+++ b/tutorial/lesson_10_aot_compilation_run.cpp
@@ -15,7 +15,7 @@
 // doesn't require libHalide.
 #include "HalideBuffer.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 int main(int argc, char **argv) {
     // Have a look in the header file above (it won't exist until you've run

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -16,9 +16,9 @@
 // in a shell with the current directory at the top of the halide
 // source tree.
 
-#include <stdio.h>
-
 #include "Halide.h"
+
+#include <cstdio>
 
 // Include a clock to do performance testing.
 #include "clock.h"
@@ -43,7 +43,7 @@ public:
     Buffer<uint8_t> input;
 
     MyPipeline(Buffer<uint8_t> in)
-        : input(in) {
+        : input(std::move(in)) {
         // For this lesson, we'll use a two-stage pipeline that sharpens
         // and then applies a look-up-table (LUT).
 

--- a/tutorial/lesson_13_tuples.cpp
+++ b/tutorial/lesson_13_tuples.cpp
@@ -19,7 +19,7 @@
 
 #include "Halide.h"
 #include <algorithm>
-#include <stdio.h>
+#include <cstdio>
 using namespace Halide;
 
 int main(int argc, char **argv) {
@@ -214,11 +214,11 @@ int main(int argc, char **argv) {
 
             // Construct from a pair of Exprs
             Complex(Expr r, Expr i)
-                : real(r), imag(i) {
+                : real(std::move(r)), imag(std::move(i)) {
             }
 
             // Construct from a call to a Func by treating it as a Tuple
-            Complex(FuncRef t)
+            Complex(const FuncRef &t)
                 : Complex(Tuple(t)) {
             }
 

--- a/tutorial/lesson_14_types.cpp
+++ b/tutorial/lesson_14_types.cpp
@@ -17,7 +17,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 using namespace Halide;
 
 // This function is used to demonstrate generic code at the end of
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
         // 2) If the types are the same, then no type conversions occur.
         for (Type t : valid_halide_types) {
             // Skip the handle type.
-            if (t.is_handle()) continue;
+            if (t.is_handle()) { continue; }
             Expr e = cast(t, x);
             assert((e + e).type() == e.type());
         }

--- a/tutorial/lesson_15_generators.cpp
+++ b/tutorial/lesson_15_generators.cpp
@@ -18,7 +18,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 

--- a/tutorial/lesson_16_rgb_generate.cpp
+++ b/tutorial/lesson_16_rgb_generate.cpp
@@ -23,7 +23,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 

--- a/tutorial/lesson_16_rgb_run.cpp
+++ b/tutorial/lesson_16_rgb_run.cpp
@@ -16,10 +16,10 @@
 // the pipeline.
 #include "HalideBuffer.h"
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "halide_benchmark.h"
 

--- a/tutorial/lesson_17_predicated_rdom.cpp
+++ b/tutorial/lesson_17_predicated_rdom.cpp
@@ -18,7 +18,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 

--- a/tutorial/lesson_18_parallel_associative_reductions.cpp
+++ b/tutorial/lesson_18_parallel_associative_reductions.cpp
@@ -18,7 +18,8 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
+#include <random>
 
 using namespace Halide;
 
@@ -28,9 +29,13 @@ int main(int argc, char **argv) {
 
     // Create an input with random values.
     Buffer<uint8_t> input(8, 8, "input");
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> dis(0, 255);
+
     for (int y = 0; y < 8; ++y) {
         for (int x = 0; x < 8; ++x) {
-            input(x, y) = (rand() % 256);
+            input(x, y) = dis(gen);
         }
     }
 

--- a/tutorial/lesson_19_wrapper_funcs.cpp
+++ b/tutorial/lesson_19_wrapper_funcs.cpp
@@ -21,7 +21,7 @@
 #include "Halide.h"
 
 // We'll also include stdio for printf.
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 

--- a/tutorial/lesson_20_cloning_funcs.cpp
+++ b/tutorial/lesson_20_cloning_funcs.cpp
@@ -20,7 +20,7 @@
 #include "Halide.h"
 
 // We'll also include stdio for printf.
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 

--- a/tutorial/lesson_21_auto_scheduler_generate.cpp
+++ b/tutorial/lesson_21_auto_scheduler_generate.cpp
@@ -22,7 +22,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 
@@ -35,7 +35,7 @@ public:
     Output<Buffer<float, 2>> output1{"output1"};
     Output<Buffer<float, 2>> output2{"output2"};
 
-    Expr sum3x3(Func f, Var x, Var y) {
+    static Expr sum3x3(const Func &f, const Var &x, const Var &y) {
         return f(x - 1, y - 1) + f(x - 1, y) + f(x - 1, y + 1) +
                f(x, y - 1) + f(x, y) + f(x, y + 1) +
                f(x + 1, y - 1) + f(x + 1, y) + f(x + 1, y + 1);

--- a/tutorial/lesson_21_auto_scheduler_run.cpp
+++ b/tutorial/lesson_21_auto_scheduler_run.cpp
@@ -15,19 +15,24 @@
 #include "HalideBuffer.h"
 #include "halide_benchmark.h"
 
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
 
 int main(int argc, char **argv) {
     // Let's declare and initialize the input images
     Halide::Runtime::Buffer<float> input(1024, 1024, 3);
 
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<float> dis(0.0f, 1.0f);
+
     for (int c = 0; c < input.channels(); ++c) {
         for (int y = 0; y < input.height(); ++y) {
             for (int x = 0; x < input.width(); ++x) {
-                input(x, y, c) = rand();
+                input(x, y, c) = dis(gen);
             }
         }
     }

--- a/tutorial/lesson_22_jit_performance.cpp
+++ b/tutorial/lesson_22_jit_performance.cpp
@@ -18,7 +18,7 @@
 
 #include "Halide.h"
 #include "halide_benchmark.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 using namespace Halide::Tools; // for benchmark()

--- a/tutorial/lesson_23_serialization.cpp
+++ b/tutorial/lesson_23_serialization.cpp
@@ -27,7 +27,7 @@
 
 #include "Halide.h"
 #include <algorithm>
-#include <stdio.h>
+#include <cstdio>
 using namespace Halide;
 
 // Support code for loading pngs.
@@ -77,8 +77,8 @@ int main(int argc, char **argv) {
 
         // The call to serialize_pipeline populates the params map with any input or output parameters
         // that were found ... object's we'll need to attach to buffers if we wish to execute the pipeline
-        for(auto named_param: params) {
-            std::cout << "Found Param: " << named_param.first << std::endl;
+        for(const auto &[name, _param]: params) {
+            std::cout << "Found Param: " << name << "\n";
         } 
     }
 

--- a/tutorial/lesson_24_async.cpp
+++ b/tutorial/lesson_24_async.cpp
@@ -18,7 +18,7 @@
 // source tree.
 
 #include "Halide.h"
-#include <stdio.h>
+#include <cstdio>
 
 using namespace Halide;
 


### PR DESCRIPTION
While upgrading clang-tidy in #8815 I noticed that our coverage was rather sporadic. I decided it's worth our while to run the build once in full so that all our intermediate build artifacts get generated before running clang-tidy.

Better: this allows us to replace our hack for generating a compilation database for the runtime with a purpose-made clang flag for this, `-MJ`. This outputs a compilation database entry that our `run-clang-tidy.sh` script now merges into the top-level one.

The net effect is to increase coverage as far as we want. I use standard CMake mechanisms for excluding entries that should not be scanned (like our FetchContent dependencies, ugh).

This PR sets the stage for removing clang-tidy suppressions and increasing coverage to the test suite.