### PR TITLE
Disable FetchContent when vcpkg in use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,22 @@
 cmake_minimum_required(VERSION 3.28)
 
+# TODO: remove this after updating build bots.
+if (CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg")
+    if (NOT DEFINED VCPKG_OVERLAY_PORTS)
+        set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/cmake/vcpkg")
+    endif ()
+
+    if (NOT DEFINED VCPKG_MANIFEST_FEATURES)
+        set(VCPKG_MANIFEST_FEATURES developer)
+    endif ()
+
+    # vcpkg and FetchContent are incompatible
+    set(Halide_USE_FETCHCONTENT OFF)
+endif ()
+
 option(Halide_USE_FETCHCONTENT "When Halide is top-level, use FetchContent for build-time dependencies." ON)
 if (Halide_USE_FETCHCONTENT)
     list(APPEND CMAKE_PROJECT_TOP_LEVEL_INCLUDES "${CMAKE_CURRENT_LIST_DIR}/cmake/dependencies.cmake")
-endif ()
-
-# TODO: remove this after updating build bots.
-if (NOT DEFINED VCPKG_OVERLAY_PORTS)
-    set(VCPKG_OVERLAY_PORTS "${CMAKE_CURRENT_LIST_DIR}/cmake/vcpkg")
-endif ()
-
-# TODO: remove this after updating build bots.
-if (NOT DEFINED VCPKG_MANIFEST_FEATURES)
-    set(VCPKG_MANIFEST_FEATURES developer)
 endif ()
 
 project(Halide


### PR DESCRIPTION
The two are incompatible and can result in finding an inconsistent set of dependencies (as seen while working on #8816)