### PR TITLE
Enable modernize-type-traits

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -125,7 +125,6 @@ Checks: >
     -modernize-replace-random-shuffle,
     -modernize-return-braced-init-list,
     -modernize-shrink-to-fit,
-    -modernize-type-traits,
     -modernize-unary-static-assert,
     -modernize-use-auto,
     -modernize-use-nodiscard,

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -122,7 +122,7 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr
 }
 
 template<typename T, typename... Bounds,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
+         std::enable_if_t<Halide::Internal::all_are_convertible<Expr, Bounds...>::value> * = nullptr>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tuple &value,
                                                   Bounds &&...bounds) {
     Region collected_bounds;
@@ -130,7 +130,7 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tupl
     return constant_exterior(Internal::func_like_to_func(func_like), value, collected_bounds);
 }
 template<typename T, typename... Bounds,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
+         std::enable_if_t<Halide::Internal::all_are_convertible<Expr, Bounds...>::value> * = nullptr>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value,
                                                   Bounds &&...bounds) {
     return constant_exterior(func_like, Tuple(value), std::forward<Bounds>(bounds)...);

--- a/src/Buffer.h
+++ b/src/Buffer.h
@@ -40,7 +40,7 @@ template<>
 struct all_ints_and_optional_name<> : std::true_type {};
 
 template<typename T,
-         typename = typename std::enable_if<!std::is_convertible<T, std::string>::value>::type>
+         typename = std::enable_if_t<!std::is_convertible_v<T, std::string>>>
 std::string get_name_from_end_of_parameter_pack(T &&) {
     return "";
 }
@@ -80,7 +80,7 @@ std::vector<int> get_shape_from_start_of_parameter_pack(Args &&...args) {
 }
 
 template<typename T, typename T2>
-using add_const_if_T_is_const = typename std::conditional<std::is_const<T>::value, const T2, T2>::type;
+using add_const_if_T_is_const = std::conditional_t<std::is_const_v<T>, const T2, T2>;
 
 // Helpers to produce the name of a Buffer element type (a Halide
 // scalar type, or void, possibly with const). Useful for an error
@@ -98,10 +98,10 @@ inline void buffer_type_name_non_const<void>(std::ostream &s) {
 template<typename T>
 std::string buffer_type_name() {
     std::ostringstream oss;
-    if (std::is_const<T>::value) {
+    if (std::is_const_v<T>) {
         oss << "const ";
     }
-    buffer_type_name_non_const<typename std::remove_const<T>::type>(oss);
+    buffer_type_name_non_const<std::remove_const_t<T>>(oss);
     return oss.str();
 }
 
@@ -129,12 +129,11 @@ class Buffer {
     static void assert_can_convert_from(const Buffer<T2, D2> &other) {
         if (!other.defined()) {
             // Avoid UB of deferencing offset of a null contents ptr
-            static_assert((!std::is_const<T2>::value || std::is_const<T>::value),
+            static_assert(!std::is_const_v<T2> || std::is_const_v<T>,
                           "Can't convert from a Buffer<const T> to a Buffer<T>");
-            static_assert(std::is_same<typename std::remove_const<T>::type,
-                                       typename std::remove_const<T2>::type>::value ||
-                              std::is_void<T>::value ||
-                              std::is_void<T2>::value,
+            static_assert(std::is_same_v<std::remove_const_t<T>, std::remove_const_t<T2>> ||
+                              std::is_void_v<T> ||
+                              std::is_void_v<T2>,
                           "type mismatch constructing Buffer");
             static_assert(Dims == AnyDims || D2 == AnyDims || Dims == D2,
                           "Can't convert from a Buffer with static dimensionality to a Buffer with different static dimensionality");
@@ -208,7 +207,7 @@ public:
      */
     // @{
     template<typename... Args,
-             typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
+             typename = std::enable_if_t<Internal::all_ints_and_optional_name<Args...>::value>>
     explicit Buffer(Type t,
                     int first, Args... rest)
         : Buffer(Runtime::Buffer<T, Dims>(t, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
@@ -221,7 +220,7 @@ public:
     }
 
     template<typename... Args,
-             typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
+             typename = std::enable_if_t<Internal::all_ints_and_optional_name<Args...>::value>>
     explicit Buffer(int first, const Args &...rest)
         : Buffer(Runtime::Buffer<T, Dims>(Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
                  Internal::get_name_from_end_of_parameter_pack(rest...)) {
@@ -258,7 +257,7 @@ public:
     }
 
     template<typename... Args,
-             typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
+             typename = std::enable_if_t<Internal::all_ints_and_optional_name<Args...>::value>>
     explicit Buffer(Type t,
                     Internal::add_const_if_T_is_const<T, void> *data,
                     int first, Args &&...rest)
@@ -267,7 +266,7 @@ public:
     }
 
     template<typename... Args,
-             typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
+             typename = std::enable_if_t<Internal::all_ints_and_optional_name<Args...>::value>>
     explicit Buffer(Type t,
                     Internal::add_const_if_T_is_const<T, void> *data,
                     const std::vector<int> &sizes,
@@ -276,7 +275,7 @@ public:
     }
 
     template<typename... Args,
-             typename = typename std::enable_if<Internal::all_ints_and_optional_name<Args...>::value>::type>
+             typename = std::enable_if_t<Internal::all_ints_and_optional_name<Args...>::value>>
     explicit Buffer(T *data,
                     int first, Args &&...rest)
         : Buffer(Runtime::Buffer<T, Dims>(data, Internal::get_shape_from_start_of_parameter_pack(first, rest...)),
@@ -583,13 +582,13 @@ public:
      * given symbolic coordinate. */
     // @{
     template<typename... Args>
-    const Expr operator()(const Expr &first, Args... rest) const {  // NOLINT
+    const Expr operator()(const Expr &first, const Args &...rest) const {  // NOLINT(readability-const-return-type)
         std::vector<Expr> args = {first, rest...};
         return (*this)(args);
     }
 
     template<typename... Args>
-    const Expr operator()(const std::vector<Expr> &args) const {  // NOLINT
+    const Expr operator()(const std::vector<Expr> &args) const {  // NOLINT(readability-const-return-type)
         return buffer_accessor(Buffer<>(*this), args);
     }
     // @}

--- a/src/Callable.h
+++ b/src/Callable.h
@@ -117,13 +117,13 @@ private:
 
     template<typename T>
     static constexpr QuickCallCheckInfo make_qcci() {
-        using T0 = typename std::remove_const<typename std::remove_reference<T>::type>::type;
-        if constexpr (std::is_same<T0, JITUserContext *>::value) {
+        using T0 = std::remove_const_t<std::remove_reference_t<T>>;
+        if constexpr (std::is_same_v<T0, JITUserContext *>) {
             return make_ucon_qcci();
         } else if constexpr (Internal::IsHalideBuffer<T0>::value) {
             // Don't bother checking type-and-dimensions here (the callee will do that)
             return make_buffer_qcci();
-        } else if constexpr (std::is_arithmetic<T0>::value || std::is_pointer<T0>::value) {
+        } else if constexpr (std::is_arithmetic_v<T0> || std::is_pointer_v<T0>) {
             return make_scalar_qcci(halide_type_of<T0>());
         } else {
             // static_assert(false) will fail all the time, even inside constexpr,
@@ -187,11 +187,11 @@ private:
 
     template<typename T>
     static constexpr FullCallCheckInfo make_fcci() {
-        using T0 = typename std::remove_const<typename std::remove_reference<T>::type>::type;
+        using T0 = std::remove_const_t<std::remove_reference_t<T>>;
         if constexpr (Internal::IsHalideBuffer<T0>::value) {
             using TypeAndDims = Internal::HalideBufferStaticTypeAndDims<T0>;
             return make_buffer_fcci(TypeAndDims::type(), TypeAndDims::dims());
-        } else if constexpr (std::is_arithmetic<T0>::value || std::is_pointer<T0>::value) {
+        } else if constexpr (std::is_arithmetic_v<T0> || std::is_pointer_v<T0>) {
             return make_scalar_fcci(halide_type_of<T0>());
         } else {
             // static_assert(false) will fail all the time, even inside constexpr,

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -1529,13 +1529,13 @@ bool CodeGen_LLVM::try_to_fold_vector_reduce(const Expr &a, Expr b) {
         b = a;
     }
     if (red &&
-        ((std::is_same<Op, Add>::value && red->op == VectorReduce::Add) ||
-         (std::is_same<Op, Min>::value && red->op == VectorReduce::Min) ||
-         (std::is_same<Op, Max>::value && red->op == VectorReduce::Max) ||
-         (std::is_same<Op, Mul>::value && red->op == VectorReduce::Mul) ||
-         (std::is_same<Op, And>::value && red->op == VectorReduce::And) ||
-         (std::is_same<Op, Or>::value && red->op == VectorReduce::Or) ||
-         (std::is_same<Op, Call>::value && red->op == VectorReduce::SaturatingAdd))) {
+        ((std::is_same_v<Op, Add> && red->op == VectorReduce::Add) ||
+         (std::is_same_v<Op, Min> && red->op == VectorReduce::Min) ||
+         (std::is_same_v<Op, Max> && red->op == VectorReduce::Max) ||
+         (std::is_same_v<Op, Mul> && red->op == VectorReduce::Mul) ||
+         (std::is_same_v<Op, And> && red->op == VectorReduce::And) ||
+         (std::is_same_v<Op, Or> && red->op == VectorReduce::Or) ||
+         (std::is_same_v<Op, Call> && red->op == VectorReduce::SaturatingAdd))) {
         codegen_vector_reduce(red, b);
         return true;
     }

--- a/src/Func.h
+++ b/src/Func.h
@@ -382,21 +382,21 @@ public:
     Stage &reorder(const std::vector<VarOrRVar> &vars);
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>
     reorder(const VarOrRVar &x, const VarOrRVar &y, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
     }
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>
     never_partition(const VarOrRVar &x, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
         return never_partition(collected_args);
     }
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<VarOrRVar, Args...>::value, Stage &>
     always_partition(const VarOrRVar &x, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
         return always_partition(collected_args);
@@ -1233,7 +1233,7 @@ public:
     FuncRef operator()(std::vector<Var>) const;
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, FuncRef>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<Var, Args...>::value, FuncRef>
     operator()(Args &&...args) const {
         std::vector<Var> collected_args{std::forward<Args>(args)...};
         return this->operator()(collected_args);
@@ -1250,7 +1250,7 @@ public:
     FuncRef operator()(std::vector<Expr>) const;
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Expr, Args...>::value, FuncRef>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<Expr, Args...>::value, FuncRef>
     operator()(const Expr &x, Args &&...args) const {
         std::vector<Expr> collected_args{x, std::forward<Args>(args)...};
         return (*this)(collected_args);
@@ -1475,7 +1475,7 @@ public:
 
     /** Set the loop partition policy to Never for some number of Vars and RVars. */
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>
     never_partition(const VarOrRVar &x, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
         return never_partition(collected_args);
@@ -1492,7 +1492,7 @@ public:
 
     /** Set the loop partition policy to Always for some number of Vars and RVars. */
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>
     always_partition(const VarOrRVar &x, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, std::forward<Args>(args)...};
         return always_partition(collected_args);
@@ -1596,7 +1596,7 @@ public:
     Func &reorder(const std::vector<VarOrRVar> &vars);
 
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<VarOrRVar, Args...>::value, Func &>
     reorder(const VarOrRVar &x, const VarOrRVar &y, Args &&...args) {
         std::vector<VarOrRVar> collected_args{x, y, std::forward<Args>(args)...};
         return reorder(collected_args);
@@ -2072,7 +2072,7 @@ public:
 
     Func &reorder_storage(const Var &x, const Var &y);
     template<typename... Args>
-    HALIDE_NO_USER_CODE_INLINE typename std::enable_if<Internal::all_are_convertible<Var, Args...>::value, Func &>::type
+    HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<Var, Args...>::value, Func &>
     reorder_storage(const Var &x, const Var &y, Args &&...args) {
         std::vector<Var> collected_args{x, y, std::forward<Args>(args)...};
         return reorder_storage(collected_args);
@@ -2617,7 +2617,7 @@ namespace Internal {
 
 template<typename Last>
 inline void check_types(const Tuple &t, int idx) {
-    using T = typename std::remove_pointer<typename std::remove_reference<Last>::type>::type;
+    using T = std::remove_pointer_t<std::remove_reference_t<Last>>;
     user_assert(t[idx].type() == type_of<T>())
         << "Can't evaluate expression "
         << t[idx] << " of type " << t[idx].type()
@@ -2632,7 +2632,7 @@ inline void check_types(const Tuple &t, int idx) {
 
 template<typename Last>
 inline void assign_results(Realization &r, int idx, Last last) {
-    using T = typename std::remove_pointer<typename std::remove_reference<Last>::type>::type;
+    using T = std::remove_pointer_t<std::remove_reference_t<Last>>;
     *last = Buffer<T>(r[idx])();
 }
 

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -397,7 +397,7 @@ struct PrintTypeList {
         }
         const char *comma = "";
         for (const auto &t : self.list_) {
-            if constexpr (std::is_same<Type, T>::value) {
+            if constexpr (std::is_same_v<Type, T>) {
                 s << comma << t;
             } else {
                 s << comma << t.type();

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2196,14 +2196,14 @@ void generator_test() {
 
         Tester tester_instance;
 
-        static_assert(std::is_same<decltype(tester_instance.expr_array_input[0]), const Expr &>::value, "type mismatch");
-        static_assert(std::is_same<decltype(tester_instance.expr_array_output[0]), const Expr &>::value, "type mismatch");
+        static_assert(std::is_same_v<decltype(tester_instance.expr_array_input[0]), const Expr &>, "type mismatch");
+        static_assert(std::is_same_v<decltype(tester_instance.expr_array_output[0]), const Expr &>, "type mismatch");
 
-        static_assert(std::is_same<decltype(tester_instance.func_array_input[0]), const Func &>::value, "type mismatch");
-        static_assert(std::is_same<decltype(tester_instance.func_array_output[0]), Func &>::value, "type mismatch");
+        static_assert(std::is_same_v<decltype(tester_instance.func_array_input[0]), const Func &>, "type mismatch");
+        static_assert(std::is_same_v<decltype(tester_instance.func_array_output[0]), Func &>, "type mismatch");
 
-        static_assert(std::is_same<decltype(tester_instance.buffer_array_input[0]), ImageParam>::value, "type mismatch");
-        static_assert(std::is_same<decltype(tester_instance.buffer_array_output[0]), Func>::value, "type mismatch");
+        static_assert(std::is_same_v<decltype(tester_instance.buffer_array_input[0]), ImageParam>, "type mismatch");
+        static_assert(std::is_same_v<decltype(tester_instance.buffer_array_output[0]), Func>, "type mismatch");
     }
 
     class GPTester : public Generator<GPTester> {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -342,12 +342,15 @@ Expr unwrap_tags(const Expr &e);
 
 template<typename T>
 struct is_printable_arg {
-    static constexpr bool value = std::is_convertible<T, const char *>::value ||
-                                  std::is_convertible<T, Halide::Expr>::value;
+    static constexpr bool value = std::is_convertible_v<T, const char *> ||
+                                  std::is_convertible_v<T, Halide::Expr>;
 };
 
 template<typename... Args>
 struct all_are_printable_args : meta_and<is_printable_arg<Args>...> {};
+
+template<typename... Args>
+inline constexpr bool all_are_printable_args_v = all_are_printable_args<Args...>::value;
 
 // Secondary args to print can be Exprs or const char *
 inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &args) {
@@ -671,7 +674,7 @@ inline Expr max(Expr a, float b) {
  * The expressions are folded from right ie. max(.., max(.., ..)).
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Rest...>::value>::type * = nullptr>
+         std::enable_if_t<Internal::all_are_convertible<Expr, Rest...>::value> * = nullptr>
 inline Expr max(A &&a, B &&b, C &&c, Rest &&...rest) {
     return max(std::forward<A>(a), max(std::forward<B>(b), std::forward<C>(c), std::forward<Rest>(rest)...));
 }
@@ -706,7 +709,7 @@ inline Expr min(Expr a, float b) {
  * The expressions are folded from right ie. min(.., min(.., ..)).
  * The arguments can be any mix of types but must all be convertible to Expr. */
 template<typename A, typename B, typename C, typename... Rest,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Rest...>::value>::type * = nullptr>
+         std::enable_if_t<Internal::all_are_convertible<Expr, Rest...>::value> * = nullptr>
 inline Expr min(A &&a, B &&b, C &&c, Rest &&...rest) {
     return min(std::forward<A>(a), min(std::forward<B>(b), std::forward<C>(c), std::forward<Rest>(rest)...));
 }
@@ -811,7 +814,7 @@ Expr select(Expr condition, Expr true_value, Expr false_value);
  * to the first value for which the condition is true. Returns the
  * final value if all conditions are false. */
 template<typename... Args,
-         typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Args...>::value>::type * = nullptr>
+         std::enable_if_t<Internal::all_are_convertible<Expr, Args...>::value> * = nullptr>
 inline Expr select(Expr c0, Expr v0, Expr c1, Expr v1, Args &&...args) {
     return select(std::move(c0), std::move(v0), select(std::move(c1), std::move(v1), std::forward<Args>(args)...));
 }

--- a/src/Param.h
+++ b/src/Param.h
@@ -29,7 +29,7 @@ class Param {
     struct DynamicParamType;
 
     /** T unless T is (const) void, in which case pointer-to-useless-type.` */
-    using not_void_T = typename std::conditional<std::is_void<T>::value, DynamicParamType *, T>::type;
+    using not_void_T = std::conditional_t<std::is_void_v<T>, DynamicParamType *, T>;
 
     void check_name() const {
         user_assert(param.name() != "__user_context")
@@ -45,7 +45,7 @@ class Param {
 
 public:
     /** True if the Halide type is not void (or const void). */
-    static constexpr bool has_static_type = !std::is_void<T>::value;
+    static constexpr bool has_static_type = !std::is_void_v<T>;
 
     /** Get the Halide type of T. Callers should not use the result if
      * has_static_halide_type is false. */
@@ -88,7 +88,7 @@ public:
 
     /** Construct a scalar parameter of type T an initial value of
      * 'val'. Only triggers for non-pointer types. */
-    template<typename T2 = T, typename std::enable_if<!std::is_pointer<T2>::value>::type * = nullptr>
+    template<typename T2 = T, std::enable_if_t<!std::is_pointer_v<T2>> * = nullptr>
     explicit Param(not_void_T val)
         : param(type_of<T>(), false, 0, Internal::unique_name('p')) {
         static_assert(has_static_type, "Cannot use this ctor without an explicit type.");
@@ -124,7 +124,7 @@ public:
     }
 
     /** Construct a Param<void> from any other Param. */
-    template<typename OTHER_TYPE, typename T2 = T, typename std::enable_if<std::is_void<T2>::value>::type * = nullptr>
+    template<typename OTHER_TYPE, typename T2 = T, std::enable_if_t<std::is_void_v<T2>> * = nullptr>
     Param(const Param<OTHER_TYPE> &other)
         : param(other.param) {
         // empty
@@ -132,7 +132,7 @@ public:
 
     /** Construct a Param<non-void> from a Param with matching type.
      * (Do the check at runtime so that we can assign from Param<void> if the types are compatible.) */
-    template<typename OTHER_TYPE, typename T2 = T, typename std::enable_if<!std::is_void<T2>::value>::type * = nullptr>
+    template<typename OTHER_TYPE, typename T2 = T, std::enable_if_t<!std::is_void_v<T2>> * = nullptr>
     Param(const Param<OTHER_TYPE> &other)
         : param(other.param) {
         user_assert(other.type() == type_of<T>())
@@ -140,7 +140,7 @@ public:
     }
 
     /** Copy a Param<void> from any other Param. */
-    template<typename OTHER_TYPE, typename T2 = T, typename std::enable_if<std::is_void<T2>::value>::type * = nullptr>
+    template<typename OTHER_TYPE, typename T2 = T, std::enable_if_t<std::is_void_v<T2>> * = nullptr>
     Param<T> &operator=(const Param<OTHER_TYPE> &other) {
         param = other.param;
         return *this;
@@ -148,7 +148,7 @@ public:
 
     /** Copy a Param<non-void> from a Param with matching type.
      * (Do the check at runtime so that we can assign from Param<void> if the types are compatible.) */
-    template<typename OTHER_TYPE, typename T2 = T, typename std::enable_if<!std::is_void<T2>::value>::type * = nullptr>
+    template<typename OTHER_TYPE, typename T2 = T, std::enable_if_t<!std::is_void_v<T2>> * = nullptr>
     Param<T> &operator=(const Param<OTHER_TYPE> &other) {
         user_assert(other.type() == type_of<T>())
             << "Param<" << type_of<T>() << "> cannot be copied from a Param with type " << other.type();
@@ -172,7 +172,7 @@ public:
         Asserts if type is not losslessly-convertible to Parameter's type. */
     template<typename SOME_TYPE>
     HALIDE_NO_USER_CODE_INLINE void set(const SOME_TYPE &val) {
-        if constexpr (!std::is_void<T>::value) {
+        if constexpr (!std::is_void_v<T>) {
             user_assert(Internal::IsRoundtrippable<T>::value(val))
                 << "The value " << val << " cannot be losslessly converted to type " << type();
             param.set_scalar<T>(val);
@@ -252,7 +252,7 @@ public:
 
     template<typename SOME_TYPE>
     HALIDE_NO_USER_CODE_INLINE void set_estimate(const SOME_TYPE &val) {
-        if constexpr (!std::is_void<T>::value) {
+        if constexpr (!std::is_void_v<T>) {
             user_assert(Internal::IsRoundtrippable<T>::value(val))
                 << "The value " << val << " cannot be losslessly converted to type " << type();
             param.set_estimate(Expr(val));

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -130,7 +130,7 @@ public:
             : buf(dst.raw_buffer()) {
         }
         template<typename T, int Dims, typename... Args,
-                 typename = typename std::enable_if<Internal::all_are_convertible<Buffer<>, Args...>::value>::type>
+                 typename = std::enable_if_t<Internal::all_are_convertible<Buffer<>, Args...>::value>>
         RealizationArg(Buffer<T, Dims> &a, Args &&...args)
             : buffer_list(std::make_unique<std::vector<Buffer<>>>(std::initializer_list<Buffer<>>{a, std::forward<Args>(args)...})) {
         }
@@ -483,7 +483,7 @@ public:
     void add_requirement(const Expr &condition, const std::vector<Expr> &error_args);
 
     template<typename... Args,
-             typename = typename std::enable_if<Internal::all_are_printable_args<Args...>::value>::type>
+             typename = std::enable_if_t<Internal::all_are_printable_args<Args...>::value>>
     HALIDE_NO_USER_CODE_INLINE void add_requirement(const Expr &condition, Args &&...error_args) {
         std::vector<Expr> collected_args;
         Internal::collect_print_args(collected_args, std::forward<Args>(error_args)...);
@@ -517,7 +517,7 @@ public:
     template<typename RT, typename... Args>
     explicit ExternSignature(RT (*f)(Args... args))
         : ret_type_(type_of<RT>()),
-          is_void_return_(std::is_void<RT>::value),
+          is_void_return_(std::is_void_v<RT>),
           arg_types_({type_of<Args>()...}) {
     }
 

--- a/src/Scope.h
+++ b/src/Scope.h
@@ -124,7 +124,7 @@ public:
 
     /** Retrieve the value referred to by a name */
     template<typename T2 = T,
-             typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+             typename = std::enable_if_t<!std::is_void_v<T2>>>
     T2 get(const std::string &name) const {
         typename std::map<std::string, SmallStack<T>>::const_iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
@@ -140,7 +140,7 @@ public:
 
     /** Return a reference to an entry. Does not consider the containing scope. */
     template<typename T2 = T,
-             typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+             typename = std::enable_if_t<!std::is_void_v<T2>>>
     T2 &ref(const std::string &name) {
         typename std::map<std::string, SmallStack<T>>::iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
@@ -155,7 +155,7 @@ public:
      * (scope.contains(foo)) { ... scope.get(foo) ... } to avoid doing two
      * lookups. */
     template<typename T2 = T,
-             typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+             typename = std::enable_if_t<!std::is_void_v<T2>>>
     const T2 *find(const std::string &name) const {
         typename std::map<std::string, SmallStack<T>>::const_iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
@@ -171,7 +171,7 @@ public:
     /** A version of find that returns a non-const pointer, but ignores
      * containing scope. */
     template<typename T2 = T,
-             typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+             typename = std::enable_if_t<!std::is_void_v<T2>>>
     T2 *shallow_find(const std::string &name) {
         typename std::map<std::string, SmallStack<T>>::iterator iter = table.find(name);
         if (iter == table.end() || iter->second.empty()) {
@@ -219,7 +219,7 @@ public:
      * to pop the same value without doing a fresh lookup.
      */
     template<typename T2 = T,
-             typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+             typename = std::enable_if_t<!std::is_void_v<T2>>>
     PushToken push(const std::string &name, T2 &&value) {
         auto it = table.try_emplace(name).first;
         it->second.push(std::forward<T2>(value));
@@ -227,7 +227,7 @@ public:
     }
 
     template<typename T2 = T,
-             typename = typename std::enable_if<std::is_same<T2, void>::value>::type>
+             typename = std::enable_if_t<std::is_void_v<T2>>>
     PushToken push(const std::string &name) {
         auto it = table.try_emplace(name).first;
         it->second.push();
@@ -283,7 +283,7 @@ public:
         }
 
         template<typename T2 = T,
-                 typename = typename std::enable_if<!std::is_same<T2, void>::value>::type>
+                 typename = std::enable_if_t<!std::is_void_v<T2>>>
         const T2 &value() {
             return iter->second.top_ref();
         }

--- a/src/Simplify_Let.cpp
+++ b/src/Simplify_Let.cpp
@@ -293,7 +293,7 @@ Body Simplify::simplify_let(const LetOrLetStmt *op, ExprInfo *info) {
             find_var_uses(frame.new_value, unused_vars);
         }
 
-        if ((!remove_dead_code && std::is_same<LetOrLetStmt, LetStmt>::value) ||
+        if ((!remove_dead_code && std::is_same_v<LetOrLetStmt, LetStmt>) ||
             (frame.info.old_uses > 0 && !unused_vars.count(frame.op->name))) {
             // The old name is still in use. We'd better keep it as well.
             result = LetOrLetStmt::make(frame.op->name, frame.value, result);

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -533,7 +533,7 @@ protected:
                 body = T::make(op->name, op->value, std::move(body));
                 changed = true;
             }
-        } else if (std::is_same<T, LetStmt>::value) {
+        } else if (std::is_same_v<T, LetStmt>) {
             auto new_body = mutate(body);
             changed = !new_body.same_as(body);
             body = std::move(new_body);

--- a/src/SpirvIR.cpp
+++ b/src/SpirvIR.cpp
@@ -119,7 +119,7 @@ const std::string &spirv_op_name(SpvId op);
 
 template<typename T, typename S>
 T constexpr rotl(const T n, const S i) {
-    static_assert(std::is_unsigned<T>::value, "rotl only works on unsigned types");
+    static_assert(std::is_unsigned_v<T>, "rotl only works on unsigned types");
     const T m = (std::numeric_limits<T>::digits - 1);
     const T c = i & m;
     return (n << c) | (n >> ((T(0) - c) & m));
@@ -1866,11 +1866,11 @@ SpvId SpvBuilder::declare_scalar_constant_of_type(const Type &scalar_type, const
              << "data=" << stringify_constant(value) << "\n";
 
     // small signed integers have to be sign extended to fit 32-bits
-    if constexpr (std::is_same<int8_t, T>::value) {
+    if constexpr (std::is_same_v<int8_t, T>) {
         uint32_t sext_value = uint32_t(value);
         SpvInstruction inst = SpvFactory::constant(result_id, type_id, sizeof(uint32_t), &sext_value, value_type);
         module.add_constant(inst);
-    } else if constexpr (std::is_same<int16_t, T>::value) {
+    } else if constexpr (std::is_same_v<int16_t, T>) {
         uint32_t sext_value = uint32_t(value);
         SpvInstruction inst = SpvFactory::constant(result_id, type_id, sizeof(uint32_t), &sext_value, value_type);
         module.add_constant(inst);

--- a/src/Type.h
+++ b/src/Type.h
@@ -198,34 +198,34 @@ HALIDE_DECLARE_EXTERN_STRUCT_TYPE(halide_parallel_task_t);
 
 template<typename T>
 /*static*/ halide_handle_cplusplus_type halide_handle_cplusplus_type::make() {
-    constexpr bool is_ptr = std::is_pointer<T>::value;
-    constexpr bool is_lvalue_reference = std::is_lvalue_reference<T>::value;
-    constexpr bool is_rvalue_reference = std::is_rvalue_reference<T>::value;
+    constexpr bool is_ptr = std::is_pointer_v<T>;
+    constexpr bool is_lvalue_reference = std::is_lvalue_reference_v<T>;
+    constexpr bool is_rvalue_reference = std::is_rvalue_reference_v<T>;
 
-    using TNoRef = typename std::remove_reference<T>::type;
-    using TNoRefNoPtr = typename std::remove_pointer<TNoRef>::type;
-    constexpr bool is_function_pointer = std::is_pointer<TNoRef>::value &&
-                                         std::is_function<TNoRefNoPtr>::value;
+    using TNoRef = std::remove_reference_t<T>;
+    using TNoRefNoPtr = std::remove_pointer_t<TNoRef>;
+    constexpr bool is_function_pointer = std::is_pointer_v<TNoRef> &&
+                                         std::is_function_v<TNoRefNoPtr>;
 
     // Don't remove the pointer-ness from a function pointer.
-    using TBase = typename std::conditional<is_function_pointer, TNoRef, TNoRefNoPtr>::type;
-    constexpr bool is_const = std::is_const<TBase>::value;
-    constexpr bool is_volatile = std::is_volatile<TBase>::value;
+    using TBase = std::conditional_t<is_function_pointer, TNoRef, TNoRefNoPtr>;
+    constexpr bool is_const = std::is_const_v<TBase>;
+    constexpr bool is_volatile = std::is_volatile_v<TBase>;
 
     constexpr uint8_t modifiers = static_cast<uint8_t>(
-        (is_function_pointer ? halide_handle_cplusplus_type::FunctionTypedef : 0) |
-        (is_ptr ? halide_handle_cplusplus_type::Pointer : 0) |
-        (is_const ? halide_handle_cplusplus_type::Const : 0) |
-        (is_volatile ? halide_handle_cplusplus_type::Volatile : 0));
+        (is_function_pointer ? FunctionTypedef : 0) |
+        (is_ptr ? Pointer : 0) |
+        (is_const ? Const : 0) |
+        (is_volatile ? Volatile : 0));
 
     // clang-format off
-    constexpr halide_handle_cplusplus_type::ReferenceType ref_type =
-        (is_lvalue_reference ? halide_handle_cplusplus_type::LValueReference :
-         is_rvalue_reference ? halide_handle_cplusplus_type::RValueReference :
-                               halide_handle_cplusplus_type::NotReference);
+    constexpr ReferenceType ref_type =
+        (is_lvalue_reference ? LValueReference :
+         is_rvalue_reference ? RValueReference :
+                               NotReference);
     // clang-format on
 
-    using TNonCVBase = typename std::remove_cv<TBase>::type;
+    using TNonCVBase = std::remove_cv_t<TBase>;
     constexpr bool known_type = halide_c_type_to_name<TNonCVBase>::known_type;
     static_assert(!(!known_type && !is_ptr), "Unknown types must be pointers");
 
@@ -257,9 +257,9 @@ struct halide_handle_traits {
     // This trait must return a pointer to a global structure. I.e. it should never be freed.
     // A return value of nullptr here means "void *".
     HALIDE_ALWAYS_INLINE static const halide_handle_cplusplus_type *type_info() {
-        if (std::is_pointer<T>::value ||
-            std::is_lvalue_reference<T>::value ||
-            std::is_rvalue_reference<T>::value) {
+        if (std::is_pointer_v<T> ||
+            std::is_lvalue_reference_v<T> ||
+            std::is_rvalue_reference_v<T>) {
             static const halide_handle_cplusplus_type the_info = halide_handle_cplusplus_type::make<T>();
             return &the_info;
         }

--- a/src/Util.h
+++ b/src/Util.h
@@ -95,9 +95,9 @@ namespace Internal {
  * common implementation behavior as much as possible.
  */
 template<typename DST, typename SRC,
-         typename std::enable_if<std::is_floating_point<SRC>::value>::type * = nullptr>
+         std::enable_if_t<std::is_floating_point_v<SRC>> * = nullptr>
 DST safe_numeric_cast(SRC s) {
-    if (std::is_integral<DST>::value) {
+    if (std::is_integral_v<DST>) {
         // Treat float -> int as a saturating cast; this is handled
         // in different ways by different compilers, so an arbitrary but safe
         // choice like this is reasonable.
@@ -112,9 +112,9 @@ DST safe_numeric_cast(SRC s) {
 }
 
 template<typename DST, typename SRC,
-         typename std::enable_if<std::is_integral<SRC>::value>::type * = nullptr>
+         std::enable_if_t<std::is_integral_v<SRC>> * = nullptr>
 DST safe_numeric_cast(SRC s) {
-    if (std::is_integral<DST>::value) {
+    if (std::is_integral_v<DST>) {
         // any-int -> signed-int is technically UB if value won't fit;
         // in practice, common compilers implement such conversions as done below
         // (as verified by exhaustive testing on Clang for x86-64). We could
@@ -122,8 +122,8 @@ DST safe_numeric_cast(SRC s) {
         // avoids possible wrather of UBSan and similar debug helpers.
         // (Yes, using sizeof for this comparison is a little odd for the uint->int
         // case, but the intent is to match existing common behavior, which this does.)
-        if (std::is_integral<SRC>::value && std::is_signed<DST>::value && sizeof(DST) < sizeof(SRC)) {
-            using UnsignedSrc = typename std::make_unsigned<SRC>::type;
+        if (std::is_integral_v<SRC> && std::is_signed_v<DST> && sizeof(DST) < sizeof(SRC)) {
+            using UnsignedSrc = std::make_unsigned_t<SRC>;
             return (DST)(s & (UnsignedSrc)(-1));
         }
     }
@@ -431,7 +431,7 @@ template<typename TO>
 struct StaticCast {
     template<typename FROM>
     constexpr static TO value(const FROM &from) {
-        if constexpr (std::is_same<TO, bool>::value) {
+        if constexpr (std::is_same_v<TO, bool>) {
             return from != 0;
         } else {
             return static_cast<TO>(from);
@@ -446,10 +446,10 @@ template<typename TO>
 struct IsRoundtrippable {
     template<typename FROM>
     constexpr static bool value(const FROM &from) {
-        if constexpr (std::is_convertible<FROM, TO>::value) {
-            if constexpr (std::is_arithmetic<TO>::value &&
-                          std::is_arithmetic<FROM>::value &&
-                          !std::is_same<TO, FROM>::value) {
+        if constexpr (std::is_convertible_v<FROM, TO>) {
+            if constexpr (std::is_arithmetic_v<TO> &&
+                          std::is_arithmetic_v<FROM> &&
+                          !std::is_same_v<TO, FROM>) {
                 const TO to = static_cast<TO>(from);
                 const FROM roundtripped = static_cast<FROM>(to);
                 return roundtripped == from;

--- a/src/autoschedulers/common/ParamParser.h
+++ b/src/autoschedulers/common/ParamParser.h
@@ -21,7 +21,7 @@ class ParamParser {
         // All one-byte ints int8 and uint8 should be parsed as integers, not chars --
         // including 'char' itself. (Note that sizeof(bool) is often-but-not-always-1,
         // so be sure to exclude that case.)
-        if constexpr (sizeof(T) == sizeof(char) && !std::is_same<T, bool>::value) {
+        if constexpr (sizeof(T) == sizeof(char) && !std::is_same_v<T, bool>) {
             int i;
             iss >> i;
             t = (T)i;

--- a/src/runtime/HalideBuffer.h
+++ b/src/runtime/HalideBuffer.h
@@ -133,7 +133,7 @@ struct AllInts<> : std::true_type {};
 
 template<typename T, typename... Args>
 struct AllInts<T, Args...> {
-    static const bool value = std::is_convertible<T, int>::value && AllInts<Args...>::value;
+    static const bool value = std::is_convertible_v<T, int> && AllInts<Args...>::value;
 };
 
 // Floats and doubles are technically implicitly int-convertible, but
@@ -237,26 +237,26 @@ class Buffer {
     mutable DeviceRefCount *dev_ref_count = nullptr;
 
     /** True if T is of type void or const void */
-    static const bool T_is_void = std::is_same<typename std::remove_const<T>::type, void>::value;
+    static const bool T_is_void = std::is_same_v<std::remove_const_t<T>, void>;
 
     /** A type function that adds a const qualifier if T is a const type. */
     template<typename T2>
-    using add_const_if_T_is_const = typename std::conditional<std::is_const<T>::value, const T2, T2>::type;
+    using add_const_if_T_is_const = std::conditional_t<std::is_const_v<T>, const T2, T2>;
 
     /** T unless T is (const) void, in which case (const)
      * uint8_t. Useful for providing return types for operator() */
-    using not_void_T = typename std::conditional<T_is_void,
-                                                 add_const_if_T_is_const<uint8_t>,
-                                                 T>::type;
+    using not_void_T = std::conditional_t<T_is_void,
+                                          add_const_if_T_is_const<uint8_t>,
+                                          T>;
 
     /** T with constness removed. Useful for return type of copy(). */
-    using not_const_T = typename std::remove_const<T>::type;
+    using not_const_T = std::remove_const_t<T>;
 
     /** The type the elements are stored as. Equal to not_void_T
      * unless T is a pointer, in which case uint64_t. Halide stores
      * all pointer types as uint64s internally, even on 32-bit
      * systems. */
-    using storage_T = typename std::conditional<std::is_pointer<T>::value, uint64_t, not_void_T>::type;
+    using storage_T = std::conditional_t<std::is_pointer_v<T>, uint64_t, not_void_T>;
 
 public:
     /** True if the Halide type is not void (or const void). */
@@ -265,7 +265,7 @@ public:
     /** Get the Halide type of T. Callers should not use the result if
      * has_static_halide_type is false. */
     static constexpr halide_type_t static_halide_type() {
-        return halide_type_of<typename std::remove_cv<not_void_T>::type>();
+        return halide_type_of<std::remove_cv_t<not_void_T>>();
     }
 
     /** Does this Buffer own the host memory it refers to? */
@@ -495,7 +495,7 @@ private:
 
     template<typename T2>
     static halide_type_t scalar_type_of_array(const T2 &) {
-        return halide_type_of<typename std::remove_cv<T2>::type>();
+        return halide_type_of<std::remove_cv_t<T2>>();
     }
 
     /** Crop a single dimension without handling device allocation. */
@@ -716,10 +716,9 @@ public:
 private:
     template<typename T2, int D2, int S2>
     static void static_assert_can_convert_from() {
-        static_assert((!std::is_const<T2>::value || std::is_const<T>::value),
+        static_assert((!std::is_const_v<T2> || std::is_const_v<T>),
                       "Can't convert from a Buffer<const T> to a Buffer<T>");
-        static_assert(std::is_same<typename std::remove_const<T>::type,
-                                   typename std::remove_const<T2>::type>::value ||
+        static_assert(std::is_same_v<std::remove_const_t<T>, std::remove_const_t<T2>> ||
                           T_is_void || Buffer<T2, D2, S2>::T_is_void,
                       "type mismatch constructing Buffer");
         static_assert(Dims == AnyDims || D2 == AnyDims || Dims == D2,
@@ -974,7 +973,7 @@ public:
      * don't know statically what type the elements are. Pass zeros
      * to make a buffer suitable for bounds query calls. */
     template<typename... Args,
-             typename = typename std::enable_if<AllInts<Args...>::value>::type>
+             typename = std::enable_if_t<AllInts<Args...>::value>>
     Buffer(halide_type_t t, int first, Args... rest) {
         if (!T_is_void) {
             assert(static_halide_type() == t);
@@ -1011,7 +1010,7 @@ public:
     }
 
     template<typename... Args,
-             typename = typename std::enable_if<AllInts<Args...>::value>::type>
+             typename = std::enable_if_t<AllInts<Args...>::value>>
     Buffer(int first, int second, Args... rest) {
         static_assert(!T_is_void,
                       "To construct an Buffer<void>, pass a halide_type_t as the first argument to the constructor");
@@ -1088,7 +1087,7 @@ public:
      * zero. Does not take ownership of the data and does not set the
      * host_dirty flag. */
     template<typename... Args,
-             typename = typename std::enable_if<AllInts<Args...>::value>::type>
+             typename = std::enable_if_t<AllInts<Args...>::value>>
     explicit Buffer(halide_type_t t, add_const_if_T_is_const<void> *data, int first, Args &&...rest) {
         if (!T_is_void) {
             assert(static_halide_type() == t);
@@ -1105,11 +1104,11 @@ public:
      * dense row-major packing and a min coordinate of zero. Does not
      * take ownership of the data and does not set the host_dirty flag. */
     template<typename... Args,
-             typename = typename std::enable_if<AllInts<Args...>::value>::type>
+             typename = std::enable_if_t<AllInts<Args...>::value>>
     explicit Buffer(T *data, int first, Args &&...rest) {
         int extents[] = {first, (int)rest...};
         buf.type = static_halide_type();
-        buf.host = (uint8_t *)const_cast<typename std::remove_const<T>::type *>(data);
+        buf.host = (uint8_t *)const_cast<std::remove_const_t<T> *>(data);
         constexpr int buf_dimensions = 1 + (int)(sizeof...(rest));
         make_static_shape_storage<buf_dimensions>();
         initialize_shape(extents);
@@ -1121,7 +1120,7 @@ public:
      * host_dirty flag. */
     explicit Buffer(T *data, const std::vector<int> &sizes) {
         buf.type = static_halide_type();
-        buf.host = (uint8_t *)const_cast<typename std::remove_const<T>::type *>(data);
+        buf.host = (uint8_t *)const_cast<std::remove_const_t<T> *>(data);
         make_shape_storage((int)sizes.size());
         initialize_shape(sizes);
     }
@@ -1168,7 +1167,7 @@ public:
      * data and does not set the host_dirty flag. */
     explicit Buffer(T *data, int d, const halide_dimension_t *shape) {
         buf.type = static_halide_type();
-        buf.host = (uint8_t *)const_cast<typename std::remove_const<T>::type *>(data);
+        buf.host = (uint8_t *)const_cast<std::remove_const_t<T> *>(data);
         make_shape_storage(d);
         for (int i = 0; i < d; i++) {
             buf.dim[i] = shape[i];
@@ -1250,27 +1249,27 @@ public:
      * to recapitulate the type argument. */
     // @{
     HALIDE_ALWAYS_INLINE
-    Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> &as_const() & {
+    Buffer<std::add_const_t<T>, Dims, InClassDimStorage> &as_const() & {
         // Note that we can skip the assert_can_convert_from(), since T -> const T
         // conversion is always legal.
-        return *((Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
+        return *reinterpret_cast<Buffer<std::add_const_t<T>, Dims, InClassDimStorage> *>(this);
     }
 
     HALIDE_ALWAYS_INLINE
-    const Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> &as_const() const & {
-        return *((const Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
+    const Buffer<std::add_const_t<T>, Dims, InClassDimStorage> &as_const() const & {
+        return *reinterpret_cast<const Buffer<std::add_const_t<T>, Dims, InClassDimStorage> *>(this);
     }
 
     HALIDE_ALWAYS_INLINE
-    Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> as_const() && {
-        return *((Buffer<typename std::add_const<T>::type, Dims, InClassDimStorage> *)this);
+    Buffer<std::add_const_t<T>, Dims, InClassDimStorage> as_const() && {
+        return *reinterpret_cast<Buffer<std::add_const_t<T>, Dims, InClassDimStorage> *>(this);
     }
     // @}
 
     /** Add some syntactic sugar to allow autoconversion from Buffer<T> to Buffer<const T>& when
      * passing arguments */
-    template<typename T2 = T, typename = typename std::enable_if<!std::is_const<T2>::value>::type>
-    operator Buffer<typename std::add_const<T2>::type, Dims, InClassDimStorage> &() & {
+    template<typename T2 = T, typename = std::enable_if_t<!std::is_const_v<T2>>>
+    operator Buffer<std::add_const_t<T2>, Dims, InClassDimStorage> &() & {
         return as_const();
     }
 
@@ -1278,9 +1277,9 @@ public:
      * passing arguments */
     template<typename TVoid,
              typename T2 = T,
-             typename = typename std::enable_if<std::is_same<TVoid, void>::value &&
-                                                !std::is_void<T2>::value &&
-                                                !std::is_const<T2>::value>::type>
+             typename = std::enable_if_t<std::is_same_v<TVoid, void> &&
+                                         !std::is_void_v<T2> &&
+                                         !std::is_const_v<T2>>>
     operator Buffer<TVoid, Dims, InClassDimStorage> &() & {
         return as<TVoid, Dims>();
     }
@@ -1289,9 +1288,9 @@ public:
      * passing arguments */
     template<typename TVoid,
              typename T2 = T,
-             typename = typename std::enable_if<std::is_same<TVoid, void>::value &&
-                                                !std::is_void<T2>::value &&
-                                                std::is_const<T2>::value>::type>
+             typename = std::enable_if_t<std::is_same_v<TVoid, void> &&
+                                         !std::is_void_v<T2> &&
+                                         std::is_const_v<T2>>>
     operator Buffer<const TVoid, Dims, InClassDimStorage> &() & {
         return as<const TVoid, Dims>();
     }
@@ -1409,7 +1408,7 @@ public:
      */
     template<typename T2, int D2, int S2>
     void copy_from(Buffer<T2, D2, S2> src) {
-        static_assert(!std::is_const<T>::value, "Cannot call copy_from() on a Buffer<const T>");
+        static_assert(!std::is_const_v<T>, "Cannot call copy_from() on a Buffer<const T>");
         assert(!device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty destination.");
         assert(!src.device_dirty() && "Cannot call Halide::Runtime::Buffer::copy_from on a device dirty source.");
 
@@ -2000,7 +1999,7 @@ public:
         // Note that src is taken by value because its dims are mutated
         // in-place by the helper. Do not change to taking it by reference.
         static_assert(Dims == D2 || Dims == AnyDims);
-        const halide_type_t dst_type = T_is_void ? src.type() : halide_type_of<typename std::remove_cv<not_void_T>::type>();
+        const halide_type_t dst_type = T_is_void ? src.type() : halide_type_of<std::remove_cv_t<not_void_T>>();
         return Buffer<>::make_with_shape_of_helper(dst_type, src.dimensions(), src.buf.dim,
                                                    allocate_fn, deallocate_fn);
     }
@@ -2108,7 +2107,7 @@ public:
      */
     //@{
     template<typename... Args,
-             typename = typename std::enable_if<AllInts<Args...>::value>::type>
+             typename = std::enable_if_t<AllInts<Args...>::value>>
     HALIDE_ALWAYS_INLINE const not_void_T &operator()(int first, Args... rest) const {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
@@ -2138,7 +2137,7 @@ public:
     }
 
     template<typename... Args,
-             typename = typename std::enable_if<AllInts<Args...>::value>::type>
+             typename = std::enable_if_t<AllInts<Args...>::value>>
     HALIDE_ALWAYS_INLINE not_void_T &operator()(int first, Args... rest) {
         static_assert(!T_is_void,
                       "Cannot use operator() on Buffer<void> types");
@@ -2405,7 +2404,7 @@ private:
      * std::enable_if. */
     template<int d,
              typename Fn,
-             typename = typename std::enable_if<(d >= 0)>::type>
+             typename = std::enable_if_t<(d >= 0)>>
     HALIDE_ALWAYS_INLINE static void for_each_element_array_helper(int, const for_each_element_task_dim *t, Fn &&f, int *pos) {
         for (pos[d] = t[d].min; pos[d] <= t[d].max; pos[d]++) {
             for_each_element_array_helper<d - 1>(0, t, f, pos);
@@ -2415,7 +2414,7 @@ private:
     /** Base case for recursion above. */
     template<int d,
              typename Fn,
-             typename = typename std::enable_if<(d < 0)>::type>
+             typename = std::enable_if_t<(d < 0)>>
     HALIDE_ALWAYS_INLINE static void for_each_element_array_helper(double, const for_each_element_task_dim *t, Fn &&f, int *pos) {
         f(pos);
     }
@@ -2577,7 +2576,7 @@ public:
      * for_each_element, but it should return the value that should be
      * stored to the coordinate corresponding to the arguments. */
     template<typename Fn,
-             typename = typename std::enable_if<!std::is_arithmetic<typename std::decay<Fn>::type>::value>::type>
+             typename = std::enable_if_t<!std::is_arithmetic_v<std::decay_t<Fn>>>>
     Buffer<T, Dims, InClassDimStorage> &fill(Fn &&f) {
         // We'll go via for_each_element. We need a variadic wrapper lambda.
         FillHelper<Fn> wrapper(std::forward<Fn>(f), this);

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -842,7 +842,7 @@ void read_big_endian_row(const uint8_t *src, int y, ImageType *im) {
 // Multibyte elements are written in big-endian layout.
 template<typename ElemType, typename ImageType>
 void write_big_endian_row(const ImageType &im, int y, uint8_t *dst) {
-    auto im_typed = im.template as<typename std::add_const<ElemType>::type, AnyDims>();
+    auto im_typed = im.template as<std::add_const_t<ElemType>, AnyDims>();
     const int xmin = im_typed.dim(0).min();
     const int xmax = im_typed.dim(0).max();
     if (im_typed.dimensions() > 2) {
@@ -2367,7 +2367,7 @@ struct ImageTypeWithElemType {
 // Given something like ImageType<Foo>, produce typedef ImageType<const Bar, AnyDims>
 template<typename ImageType, typename ElemType>
 struct ImageTypeWithConstElemType {
-    using type = decltype(std::declval<ImageType>().template as<typename std::add_const<ElemType>::type, AnyDims>());
+    using type = decltype(std::declval<ImageType>().template as<std::add_const_t<ElemType>, AnyDims>());
 };
 
 template<typename ImageType, Internal::CheckFunc check>
@@ -2455,7 +2455,7 @@ struct ImageTypeConversion {
     //     Buffer<uint8_t> src = ...;
     //     Buffer<float> dst = convert_image<float>(src);
     template<typename DstElemType, typename ImageType,
-             typename std::enable_if<ImageType::has_static_halide_type && !std::is_void<DstElemType>::value>::type * = nullptr>
+             std::enable_if_t<ImageType::has_static_halide_type && !std::is_void_v<DstElemType>> * = nullptr>
     static auto convert_image(const ImageType &src) ->
         typename Internal::ImageTypeWithElemType<ImageType, DstElemType>::type {
         // The enable_if ensures this will never fire; this is here primarily
@@ -2485,7 +2485,7 @@ struct ImageTypeConversion {
     //     Buffer<uint8_t> src = ...;
     //     Buffer<float> dst = convert_image<float>(src);
     template<typename DstElemType, typename ImageType,
-             typename std::enable_if<!ImageType::has_static_halide_type && !std::is_void<DstElemType>::value>::type * = nullptr>
+             std::enable_if_t<!ImageType::has_static_halide_type && !std::is_void_v<DstElemType>> * = nullptr>
     static auto convert_image(const ImageType &src) ->
         typename Internal::ImageTypeWithElemType<ImageType, DstElemType>::type {
         // The enable_if ensures this will never fire; this is here primarily
@@ -2534,7 +2534,7 @@ struct ImageTypeConversion {
     // (e.g. Buffer<uint8_t> -> Buffer<>(halide_type_t)).
     template<typename DstElemType = void,
              typename ImageType,
-             typename std::enable_if<ImageType::has_static_halide_type && std::is_void<DstElemType>::value>::type * = nullptr>
+             std::enable_if_t<ImageType::has_static_halide_type && std::is_void_v<DstElemType>> * = nullptr>
     static auto convert_image(const ImageType &src, const halide_type_t &dst_type) ->
         typename Internal::ImageTypeWithElemType<ImageType, void>::type {
         // The enable_if ensures this will never fire; this is here primarily
@@ -2583,7 +2583,7 @@ struct ImageTypeConversion {
     // (e.g. Buffer<>(halide_type_t) -> Buffer<>(halide_type_t)).
     template<typename DstElemType = void,
              typename ImageType,
-             typename std::enable_if<!ImageType::has_static_halide_type && std::is_void<DstElemType>::value>::type * = nullptr>
+             std::enable_if_t<!ImageType::has_static_halide_type && std::is_void_v<DstElemType>> * = nullptr>
     static auto convert_image(const ImageType &src, const halide_type_t &dst_type) ->
         typename Internal::ImageTypeWithElemType<ImageType, void>::type {
         // The enable_if ensures this will never fire; this is here primarily


### PR DESCRIPTION
Exactly what it says on the tin. It really reduces the line-noise in our templates. This was mostly done automatically via `-fix`.