### PR TITLE
Enable modernize-loop-convert

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -116,7 +116,6 @@ Checks: >
     -misc-use-internal-linkage,
     -modernize-avoid-c-arrays,
     -modernize-concat-nested-namespaces,
-    -modernize-loop-convert,
     -modernize-macro-to-enum,
     -modernize-pass-by-value,
     -modernize-raw-string-literal,

--- a/src/RealizationOrder.cpp
+++ b/src/RealizationOrder.cpp
@@ -258,8 +258,7 @@ void sort_funcs_by_name_and_counter(vector<string> *funcs,
                                     const map<string, uint64_t> &visitation_order) {
     vector<std::tuple<string, uint64_t, string>> items;
     items.reserve(funcs->size());
-    for (size_t i = 0; i < funcs->size(); i++) {
-        const string &full_name = (*funcs)[i];
+    for (const auto &full_name : *funcs) {
         string prefix = split_string(full_name, "$")[0];
         while (!prefix.empty() && std::isdigit(prefix.back())) {
             prefix.pop_back();

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1310,14 +1310,14 @@ protected:
                     _found_store_levels_for_funcs.insert(funcs[i].name());
                 }
             }
-            for (size_t i = 0; i < funcs.size(); i++) {
-                if (funcs[i].schedule().hoist_storage_level().match(for_loop->name)) {
-                    debug(3) << "Found hoist storage level for " << funcs[i].name() << " at " << for_loop->name << "\n";
-                    if (funcs[i].schedule().hoist_storage_level() != funcs[i].schedule().store_level()) {
-                        body = HoistedStorage::make(funcs[i].name(), body);
+            for (const auto &func : funcs) {
+                if (func.schedule().hoist_storage_level().match(for_loop->name)) {
+                    debug(3) << "Found hoist storage level for " << func.name() << " at " << for_loop->name << "\n";
+                    if (func.schedule().hoist_storage_level() != func.schedule().store_level()) {
+                        body = HoistedStorage::make(func.name(), body);
                     } else {
                     }
-                    _found_hoist_storage_levels_for_funcs.insert(funcs[i].name());
+                    _found_hoist_storage_levels_for_funcs.insert(func.name());
                 }
             }
         }

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -987,7 +987,7 @@ class VectorSubs : public IRMutator {
             update_replacements();
             // Go over lets which were vectorized in the order of their occurrence and update
             // them according to the current loop level.
-            for (auto &[var, val] : containing_lets) {
+            for (const auto &[var, val] : containing_lets) {
                 // Skip if this var wasn't vectorized.
                 if (!scope.contains(var)) {
                     continue;

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -987,13 +987,13 @@ class VectorSubs : public IRMutator {
             update_replacements();
             // Go over lets which were vectorized in the order of their occurrence and update
             // them according to the current loop level.
-            for (auto let = containing_lets.begin(); let != containing_lets.end(); let++) {
+            for (auto &[var, val] : containing_lets) {
                 // Skip if this var wasn't vectorized.
-                if (!scope.contains(let->first)) {
+                if (!scope.contains(var)) {
                     continue;
                 }
-                string vectorized_name = get_widened_var_name(let->first);
-                Expr vectorized_value = mutate(scope.get(let->first));
+                string vectorized_name = get_widened_var_name(var);
+                Expr vectorized_value = mutate(scope.get(var));
                 vector_scope.push(vectorized_name, vectorized_value);
             }
 


### PR DESCRIPTION
This cleaned up a few loops and is generally a good idea. Shouldn't apply it to tutorials, though, where we have some plain-C loops that _could_ be rewritten this way, but doing so would mar the exposition. We also don't want `// NOLINT` line-noise in there.