### PR TITLE
Enable bugprone-return-const-ref-from-parameter

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,6 @@ Checks: >
     -bugprone-multi-level-implicit-pointer-conversion,
     -bugprone-narrowing-conversions,
     -bugprone-reserved-identifier,
-    -bugprone-return-const-ref-from-parameter,
     -bugprone-signed-char-misuse,
     -bugprone-unchecked-optional-access,
     -bugprone-unintended-char-ostream-output,

--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -62,13 +62,16 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
     collect_region(collected_args, std::forward<Args>(args)...);
 }
 
-inline const Func &func_like_to_func(const Func &func) {
-    return func;
-}
-
+// Perfectly forward const Func references, even to temporaries, without invoking
+// a move constructor or copy constructor. In other func-like cases, construct the
+// necessary lambda.
 template<typename T>
-inline HALIDE_NO_USER_CODE_INLINE Func func_like_to_func(const T &func_like) {
-    return lambda(_, func_like(_));
+Func forward_as_func(const T &func_like, const std::function<Func(const Func &)> &cb) {
+    if constexpr (std::is_same_v<T, Func>) {
+        return cb(func_like);
+    } else {
+        return cb(lambda(_, func_like(_)));
+    }
 }
 
 }  // namespace Internal
@@ -99,12 +102,16 @@ Func constant_exterior(const Func &source, const Expr &value,
 
 template<typename T>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tuple &value, const Region &bounds) {
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return constant_exterior(func, value, bounds);
+    });
 }
 
 template<typename T>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value, const Region &bounds) {
-    return constant_exterior(Internal::func_like_to_func(func_like), value, bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return constant_exterior(func, value, bounds);
+    });
 }
 
 template<typename T>
@@ -113,9 +120,11 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tupl
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.emplace_back(Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()));
     }
-
-    return constant_exterior(Internal::func_like_to_func(func_like), value, object_bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return constant_exterior(func, value, object_bounds);
+    });
 }
+
 template<typename T>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value) {
     return constant_exterior(func_like, Tuple(value));
@@ -127,8 +136,11 @@ HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Tupl
                                                   Bounds &&...bounds) {
     Region collected_bounds;
     Internal::collect_region(collected_bounds, std::forward<Bounds>(bounds)...);
-    return constant_exterior(Internal::func_like_to_func(func_like), value, collected_bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return constant_exterior(func, value, collected_bounds);
+    });
 }
+
 template<typename T, typename... Bounds,
          typename std::enable_if<Halide::Internal::all_are_convertible<Expr, Bounds...>::value>::type * = nullptr>
 HALIDE_NO_USER_CODE_INLINE Func constant_exterior(const T &func_like, const Expr &value,
@@ -154,7 +166,9 @@ Func repeat_edge(const Func &source, const Region &bounds);
 
 template<typename T>
 HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like, const Region &bounds) {
-    return repeat_edge(Internal::func_like_to_func(func_like), bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return repeat_edge(func, bounds);
+    });
 }
 
 template<typename T>
@@ -163,8 +177,9 @@ HALIDE_NO_USER_CODE_INLINE Func repeat_edge(const T &func_like) {
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.emplace_back(Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()));
     }
-
-    return repeat_edge(Internal::func_like_to_func(func_like), object_bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return repeat_edge(func, object_bounds);
+    });
 }
 // @}
 
@@ -185,7 +200,9 @@ Func repeat_image(const Func &source, const Region &bounds);
 
 template<typename T>
 HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like, const Region &bounds) {
-    return repeat_image(Internal::func_like_to_func(func_like), bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return repeat_image(func, bounds);
+    });
 }
 
 template<typename T>
@@ -194,9 +211,11 @@ HALIDE_NO_USER_CODE_INLINE Func repeat_image(const T &func_like) {
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.emplace_back(Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()));
     }
-
-    return repeat_image(Internal::func_like_to_func(func_like), object_bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return repeat_image(func, object_bounds);
+    });
 }
+// @}
 
 /** Impose a boundary condition such that the entire coordinate space is
  *  tiled with copies of the image abutted against each other, but mirror
@@ -216,7 +235,9 @@ Func mirror_image(const Func &source, const Region &bounds);
 
 template<typename T>
 HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like, const Region &bounds) {
-    return mirror_image(Internal::func_like_to_func(func_like), bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return mirror_image(func, bounds);
+    });
 }
 
 template<typename T>
@@ -225,10 +246,10 @@ HALIDE_NO_USER_CODE_INLINE Func mirror_image(const T &func_like) {
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.emplace_back(Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()));
     }
-
-    return mirror_image(Internal::func_like_to_func(func_like), object_bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return mirror_image(func, object_bounds);
+    });
 }
-
 // @}
 
 /** Impose a boundary condition such that the entire coordinate space is
@@ -251,7 +272,9 @@ Func mirror_interior(const Func &source, const Region &bounds);
 
 template<typename T>
 HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like, const Region &bounds) {
-    return mirror_interior(Internal::func_like_to_func(func_like), bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return mirror_interior(func, bounds);
+    });
 }
 
 template<typename T>
@@ -260,10 +283,10 @@ HALIDE_NO_USER_CODE_INLINE Func mirror_interior(const T &func_like) {
     for (int i = 0; i < func_like.dimensions(); i++) {
         object_bounds.emplace_back(Expr(func_like.dim(i).min()), Expr(func_like.dim(i).extent()));
     }
-
-    return mirror_interior(Internal::func_like_to_func(func_like), object_bounds);
+    return Internal::forward_as_func(func_like, [&](const Func &func) {
+        return mirror_interior(func, object_bounds);
+    });
 }
-
 // @}
 
 }  // namespace BoundaryConditions


### PR DESCRIPTION
The original implementation of `func_like_to_func` could genuinely return a dangling reference if the function was misused. The new implementation has been renamed to `forward_as_func` and is impossible to misuse. It perfectly forwards const-references as before, but to a callback, which avoids lifetime issues.

Here's an example of a real crash from misusing `func_like_to_func`.

```c++
#include <Halide.h>
using namespace Halide;

Func get_func() {
    Var x{"x"};
    Func f{"f"};
    f(x) = x;
    return f;
}

int main() {
    const Func &f = BoundaryConditions::Internal::func_like_to_func(get_func());
    std::cout << f.name() << '\n'; // crash!
    return 0;
}
```

The callback approach here is the only safe way I know to _perfectly_ forward the const-ref. Using an rvalue-reference with `std::forward` still invokes a move-constructor at least.