### PR TITLE
Enable modernize-use-scoped-lock

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -129,7 +129,6 @@ Checks: >
     -modernize-unary-static-assert,
     -modernize-use-auto,
     -modernize-use-nodiscard,
-    -modernize-use-scoped-lock,
     -modernize-use-std-print,
     -modernize-use-trailing-return-type,
     -modernize-use-transparent-functors,

--- a/src/AssociativeOpsTable.cpp
+++ b/src/AssociativeOpsTable.cpp
@@ -352,7 +352,7 @@ const vector<AssociativePattern> &get_ops_table(const vector<Expr> &exprs) {
         // get_ops_table_helper() lazily initializes the table, so ensure
         // that multiple threads can't try to do so at the same time.
         static std::mutex ops_table_lock;
-        std::lock_guard<std::mutex> lock_guard(ops_table_lock);
+        std::scoped_lock lock_guard(ops_table_lock);
 
         const vector<AssociativePattern> &table = get_ops_table_helper(types, exprs[0].node_type(), exprs.size());
         debug(7) << "Table size: " << table.size() << "\n";

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1194,7 +1194,7 @@ void GeneratorRegistry::register_factory(const std::string &name,
                                          GeneratorFactory generator_factory) {
     user_assert(is_valid_name(name)) << "Invalid Generator name: " << name;
     GeneratorRegistry &registry = get_registry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::scoped_lock lock(registry.mutex);
     internal_assert(registry.factories.find(name) == registry.factories.end())
         << "Duplicate Generator name: " << name;
     registry.factories[name] = std::move(generator_factory);
@@ -1203,7 +1203,7 @@ void GeneratorRegistry::register_factory(const std::string &name,
 /* static */
 void GeneratorRegistry::unregister_factory(const std::string &name) {
     GeneratorRegistry &registry = get_registry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::scoped_lock lock(registry.mutex);
     internal_assert(registry.factories.find(name) != registry.factories.end())
         << "Generator not found: " << name;
     registry.factories.erase(name);
@@ -1213,7 +1213,7 @@ void GeneratorRegistry::unregister_factory(const std::string &name) {
 AbstractGeneratorPtr GeneratorRegistry::create(const std::string &name,
                                                const GeneratorContext &context) {
     GeneratorRegistry &registry = get_registry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::scoped_lock lock(registry.mutex);
     auto it = registry.factories.find(name);
     if (it == registry.factories.end()) {
         return nullptr;
@@ -1228,7 +1228,7 @@ AbstractGeneratorPtr GeneratorRegistry::create(const std::string &name,
 /* static */
 std::vector<std::string> GeneratorRegistry::enumerate() {
     GeneratorRegistry &registry = get_registry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::scoped_lock lock(registry.mutex);
     std::vector<std::string> result;
     result.reserve(registry.factories.size());
     for (const auto &i : registry.factories) {

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -1000,7 +1000,7 @@ JITModule &make_module(llvm::Module *for_module, Target target,
  * JITSharedRuntime::release_all is called, the global state is reset
  * and any newly compiled Funcs will get a new runtime. */
 std::vector<JITModule> JITSharedRuntime::get(llvm::Module *for_module, const Target &target, bool create) {
-    std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
+    std::scoped_lock lock(shared_runtimes_mutex);
 
     std::vector<JITModule> result;
 
@@ -1074,7 +1074,7 @@ void JITSharedRuntime::populate_jit_handlers(JITUserContext *jit_user_context, c
 }
 
 void JITSharedRuntime::release_all() {
-    std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
+    std::scoped_lock lock(shared_runtimes_mutex);
 
     for (int i = MaxRuntimeKind; i > 0; i--) {
         shared_runtimes((RuntimeKind)(i - 1)) = JITModule();
@@ -1090,7 +1090,7 @@ JITHandlers JITSharedRuntime::set_default_handlers(const JITHandlers &handlers) 
 }
 
 void JITSharedRuntime::memoization_cache_set_size(int64_t size) {
-    std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
+    std::scoped_lock lock(shared_runtimes_mutex);
 
     if (size != default_cache_size) {
         default_cache_size = size;
@@ -1099,22 +1099,22 @@ void JITSharedRuntime::memoization_cache_set_size(int64_t size) {
 }
 
 void JITSharedRuntime::memoization_cache_evict(uint64_t eviction_key) {
-    std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
+    std::scoped_lock lock(shared_runtimes_mutex);
     shared_runtimes(MainShared).memoization_cache_evict(eviction_key);
 }
 
 void JITSharedRuntime::reuse_device_allocations(bool b) {
-    std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
+    std::scoped_lock lock(shared_runtimes_mutex);
     shared_runtimes(MainShared).reuse_device_allocations(b);
 }
 
 int JITSharedRuntime::get_num_threads() {
-    std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
+    std::scoped_lock lock(shared_runtimes_mutex);
     return shared_runtimes(MainShared).get_num_threads();
 }
 
 int JITSharedRuntime::set_num_threads(int n) {
-    std::lock_guard<std::mutex> lock(shared_runtimes_mutex);
+    std::scoped_lock lock(shared_runtimes_mutex);
     return shared_runtimes(MainShared).set_num_threads(n);
 }
 

--- a/src/ObjectInstanceRegistry.cpp
+++ b/src/ObjectInstanceRegistry.cpp
@@ -14,7 +14,7 @@ ObjectInstanceRegistry &ObjectInstanceRegistry::get_registry() {
 void ObjectInstanceRegistry::register_instance(void *this_ptr, size_t size, Kind kind,
                                                void *subject_ptr) {
     ObjectInstanceRegistry &registry = get_registry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::scoped_lock lock(registry.mutex);
     uintptr_t key = (uintptr_t)this_ptr;
     internal_assert(registry.instances.find(key) == registry.instances.end());
     registry.instances[key] = InstanceInfo(size, kind, subject_ptr);
@@ -23,7 +23,7 @@ void ObjectInstanceRegistry::register_instance(void *this_ptr, size_t size, Kind
 /* static */
 void ObjectInstanceRegistry::unregister_instance(void *this_ptr) {
     ObjectInstanceRegistry &registry = get_registry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::scoped_lock lock(registry.mutex);
     uintptr_t key = (uintptr_t)this_ptr;
     std::map<uintptr_t, InstanceInfo>::iterator it = registry.instances.find(key);
     internal_assert(it != registry.instances.end());
@@ -36,7 +36,7 @@ ObjectInstanceRegistry::instances_in_range(void *start, size_t size) {
     std::vector<std::pair<void *, ObjectInstanceRegistry::Kind>> results;
 
     ObjectInstanceRegistry &registry = get_registry();
-    std::lock_guard<std::mutex> lock(registry.mutex);
+    std::scoped_lock lock(registry.mutex);
 
     std::map<uintptr_t, InstanceInfo>::const_iterator it =
         registry.instances.lower_bound((uintptr_t)start);

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -277,7 +277,7 @@ constexpr size_t kExtraMallocSlop = 32;
 
 std::vector<char> compile_to_wasm(const Module &module, const std::string &fn_name) {
     static std::mutex link_lock;
-    std::lock_guard<std::mutex> lock(link_lock);
+    std::scoped_lock lock(link_lock);
 
     llvm::LLVMContext context;
     std::unique_ptr<llvm::Module> fn_module;


### PR DESCRIPTION
This replaces usages of C++11's `lock_guard` with the newer `scoped_lock`. We can take or leave this one; it sounds like `scoped_lock` admits a more efficient implementation, but that this mostly applies to locking multiple locks at once, which we don't seem to do.

See: https://rules.sonarsource.com/cpp/tag/since-c++17/RSPEC-5997/