### PR TITLE
Enable performance-inefficient-vector-operation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -137,7 +137,6 @@ Checks: >
     -modernize-use-using,
     -performance-enum-size,
     -performance-inefficient-string-concatenation,
-    -performance-inefficient-vector-operation,
     -performance-no-int-to-ptr,
     -portability-avoid-pragma-once,
     -portability-template-virtual-member-function,

--- a/python_bindings/src/halide/halide_/PyBuffer.cpp
+++ b/python_bindings/src/halide/halide_/PyBuffer.cpp
@@ -39,6 +39,7 @@ std::vector<halide_dimension_t> get_buffer_shape(const Buffer<> &b) {
         return {};
     }
     std::vector<halide_dimension_t> s;
+    s.reserve(b.dimensions());
     for (int i = 0; i < b.dimensions(); ++i) {
         s.push_back(b.raw_buffer()->dim[i]);
     }
@@ -423,6 +424,7 @@ void define_buffer(py::module &m) {
             .def("reverse_axes", [](Buffer<> &b) -> Buffer<> {
                 const int d = b.dimensions();
                 std::vector<int> order;
+                order.reserve(b.dimensions());
                 for (int i = 0; i < b.dimensions(); i++) {
                     order.push_back(d - i - 1);
                 }

--- a/src/AbstractGenerator.cpp
+++ b/src/AbstractGenerator.cpp
@@ -189,6 +189,7 @@ Module AbstractGenerator::build_gradient_module(const std::string &function_name
                     // just replace with a dummy Func that is all zeros. This ensures
                     // that the signature of the Pipeline we produce is always predictable.
                     std::vector<Var> vars;
+                    vars.reserve(d_output.dimensions());
                     for (int i = 0; i < d_output.dimensions(); i++) {
                         vars.push_back(Var::implicit(i));
                     }

--- a/src/AutoScheduleUtils.cpp
+++ b/src/AutoScheduleUtils.cpp
@@ -154,6 +154,7 @@ DimBounds get_stage_bounds(const Function &f, int stage_num, const DimBounds &pu
 vector<DimBounds> get_stage_bounds(const Function &f, const DimBounds &pure_bounds) {
     vector<DimBounds> stage_bounds;
     size_t num_stages = f.updates().size() + 1;
+    stage_bounds.reserve(num_stages);
     for (size_t s = 0; s < num_stages; s++) {
         stage_bounds.push_back(get_stage_bounds(f, s, pure_bounds));
     }

--- a/src/BoundaryConditions.cpp
+++ b/src/BoundaryConditions.cpp
@@ -64,6 +64,7 @@ Func constant_exterior(const Func &source, const Tuple &value,
     Func bounded("constant_exterior");
     if (value.as_vector().size() > 1) {
         std::vector<Expr> def;
+        def.reserve(value.as_vector().size());
         for (size_t i = 0; i < value.as_vector().size(); i++) {
             def.push_back(select(out_of_bounds, value[i], likely(repeat_edge(source, bounds)(args)[i])));
         }

--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -1346,6 +1346,7 @@ Stmt bounds_inference(Stmt s,
     vector<vector<Function>> fused_func_groups;
     for (const vector<string> &group : fused_groups) {
         vector<Function> fs;
+        fs.reserve(group.size());
         for (const string &fname : group) {
             fs.push_back(env.find(fname)->second);
         }

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -990,7 +990,6 @@ void cplusplus_mangle_test() {
     {
         // Test a whole ton of substitutions on type.
         std::vector<halide_handle_cplusplus_type> type_info;
-        std::vector<ExternFuncArgument> args;
         for (int i = 0; i < 100; i++) {
             std::stringstream oss;
             oss << i;
@@ -1002,6 +1001,8 @@ void cplusplus_mangle_test() {
                 {}, {halide_handle_cplusplus_type::Pointer}));
             type_info.push_back(t);
         }
+        std::vector<ExternFuncArgument> args;
+        args.reserve(200);
         for (int i = 0; i < 200; i++) {
             args.emplace_back(make_zero(Handle(1, &type_info[i % 100])));
         }
@@ -1016,7 +1017,6 @@ void cplusplus_mangle_test() {
     {
         // Test a whole ton of substitutions on names.
         std::vector<halide_handle_cplusplus_type> type_info;
-        std::vector<ExternFuncArgument> args;
         for (int i = 0; i < 25; i++) {
             std::stringstream oss;
             oss << i;
@@ -1028,6 +1028,8 @@ void cplusplus_mangle_test() {
                 {}, {halide_handle_cplusplus_type::Pointer}));
             type_info.push_back(t);
         }
+        std::vector<ExternFuncArgument> args;
+        args.reserve(50);
         for (int i = 0; i < 50; i++) {
             args.emplace_back(make_zero(Handle(1, &type_info[i % 25])));
         }
@@ -1043,9 +1045,9 @@ void cplusplus_mangle_test() {
         // Stack up a bunch of pointers and qualifiers.
         // int test_function(int * const, int *const*const, int *const*const*const*, ...);
         std::vector<halide_handle_cplusplus_type> type_info;
-        std::vector<ExternFuncArgument> args;
         for (size_t i = 1; i <= 8; i++) {
             std::vector<uint8_t> mods;
+            mods.reserve(i);
             for (size_t j = 0; j < i; j++) {
                 mods.push_back(halide_handle_cplusplus_type::Pointer | halide_handle_cplusplus_type::Const);
             }
@@ -1054,6 +1056,8 @@ void cplusplus_mangle_test() {
                 {}, {}, mods));
             type_info.push_back(t);
         }
+        std::vector<ExternFuncArgument> args;
+        args.reserve(type_info.size());
         for (const auto &ti : type_info) {
             args.emplace_back(make_zero(Handle(1, &ti)));
         }

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -2361,6 +2361,7 @@ bool CodeGen_ARM::codegen_across_vector_reduce(const VectorReduce *op, const Exp
         // call will assume that the args should scalarize.
         if (!module->getFunction(intrin_name)) {
             vector<llvm::Type *> arg_types;
+            arg_types.reserve(args.size());
             for (const Expr &e : args) {
                 arg_types.push_back(llvm_type_with_constraint(e.type(), false, VectorTypeConstraint::VScale));
             }
@@ -2435,6 +2436,7 @@ Type CodeGen_ARM::upgrade_type_for_storage(const Type &t) const {
 Value *CodeGen_ARM::codegen_with_lanes(int slice_lanes, int total_lanes,
                                        const std::vector<Expr> &args, codegen_func_t &cg_func) {
     std::vector<Value *> llvm_args;
+    llvm_args.reserve(args.size());
     // codegen args
     for (const auto &arg : args) {
         llvm_args.push_back(codegen(arg));

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -1650,6 +1650,7 @@ void CodeGen_C::visit(const Call *op) {
 
             // Get the args
             vector<string> values;
+            values.reserve(op->args.size());
             for (const auto &arg : op->args) {
                 values.push_back(print_expr(arg));
             }
@@ -1683,6 +1684,7 @@ void CodeGen_C::visit(const Call *op) {
 
             // Get the args
             vector<string> values;
+            values.reserve(op->args.size());
             for (const auto &arg : op->args) {
                 values.push_back(print_expr(arg));
             }
@@ -2470,6 +2472,7 @@ void CodeGen_C::visit(const Shuffle *op) {
     }
 
     std::vector<string> vecs;
+    vecs.reserve(op->vectors.size());
     for (const Expr &v : op->vectors) {
         vecs.push_back(print_expr(v));
     }

--- a/src/CodeGen_GPU_Dev.cpp
+++ b/src/CodeGen_GPU_Dev.cpp
@@ -156,6 +156,7 @@ void CodeGen_GPU_C::visit(const Shuffle *op) {
 
         // Traverse all the vector args
         std::vector<std::string> vecs;
+        vecs.reserve(op->vectors.size());
         for (const Expr &v : op->vectors) {
             vecs.push_back(print_expr(v));
         }

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3428,6 +3428,7 @@ void CodeGen_LLVM::visit(const Call *op) {
             std::vector<std::string> namespaces;
             name = extract_namespaces(op->name, namespaces);
             std::vector<ExternFuncArgument> mangle_args;
+            mangle_args.reserve(op->args.size());
             for (const auto &arg : op->args) {
                 mangle_args.emplace_back(arg);
             }
@@ -4072,6 +4073,7 @@ void CodeGen_LLVM::visit(const Evaluate *op) {
 
 void CodeGen_LLVM::visit(const Shuffle *op) {
     vector<Value *> vecs;
+    vecs.reserve(op->vectors.size());
     for (const Expr &e : op->vectors) {
         vecs.push_back(codegen(e));
     }
@@ -4129,6 +4131,7 @@ void CodeGen_LLVM::visit(const Shuffle *op) {
             if (interleave_of_slices) {
                 value = codegen(op->vectors[0]);
                 vector<Value *> slices;
+                slices.reserve(f);
                 for (int i = 0; i < f; i++) {
                     slices.push_back(slice_vector(value, i * step, step));
                 }
@@ -4377,6 +4380,7 @@ void CodeGen_LLVM::codegen_vector_reduce(const VectorReduce *op, const Expr &ini
                 // call will assume that the args should scalarize.
                 if (!module->getFunction(intrin_name)) {
                     vector<llvm::Type *> arg_types;
+                    arg_types.reserve(args.size());
                     for (const Expr &e : args) {
                         arg_types.push_back(llvm_type_of(e.type()));
                     }

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -286,6 +286,7 @@ private:
         // Uh-oh, we don't know how to deinterleave this vector expression
         // Make llvm do it
         std::vector<int> indices;
+        indices.reserve(new_lanes);
         for (int i = 0; i < new_lanes; i++) {
             indices.push_back(starting_lane + lane_stride * i);
         }

--- a/src/DeviceArgument.cpp
+++ b/src/DeviceArgument.cpp
@@ -9,8 +9,9 @@ std::vector<DeviceArgument> HostClosure::arguments() {
     debug(2) << *this;
 
     std::vector<DeviceArgument> res;
-    for (const auto &v : vars) {
-        res.emplace_back(v.first, false, MemoryType::Auto, v.second, 0);
+    res.reserve(vars.size());
+    for (const auto &[name, type] : vars) {
+        res.emplace_back(name, false, MemoryType::Auto, type, 0);
     }
     for (const auto &b : buffers) {
         DeviceArgument arg(b.first, true, b.second.memory_type, b.second.type, b.second.dimensions, b.second.size);

--- a/src/Elf.cpp
+++ b/src/Elf.cpp
@@ -763,12 +763,9 @@ std::vector<char> write_shared_object_internal(Object &obj, Linker *linker, cons
 
     // Ensure that we output the symbols deterministically, since a map of pointers
     // will vary in ordering from run to tun.
-    std::vector<std::pair<const Symbol *, const Symbol *>> sorted_symbols;
-    for (const auto &i : symbols) {
-        sorted_symbols.emplace_back(i);
-    }
+    std::vector<std::pair<const Symbol *, const Symbol *>> sorted_symbols(symbols.begin(), symbols.end());
     std::sort(sorted_symbols.begin(), sorted_symbols.end(),
-              [&](const std::pair<const Symbol *, const Symbol *> &lhs, const std::pair<const Symbol *, const Symbol *> &rhs) {
+              [&](const auto &lhs, const auto &rhs) {
                   return lhs.first->get_name() < rhs.first->get_name();
               });
 
@@ -924,6 +921,7 @@ std::vector<char> write_shared_object_internal(Object &obj, Linker *linker, cons
     uint16_t strtab_idx = write_section(strtab, 0);
 
     std::vector<Dyn<T>> dyn;
+    dyn.reserve(dependencies.size() + 16);
     auto make_dyn = [](int32_t tag, addr_t val) {
         Dyn<T> d;
         d.d_tag = tag;

--- a/src/FlattenNestedRamps.cpp
+++ b/src/FlattenNestedRamps.cpp
@@ -20,6 +20,7 @@ class FlattenRamps : public IRMutator {
             Expr base = mutate(op->base);
             Expr stride = mutate(op->stride);
             std::vector<Expr> ramp_elems;
+            ramp_elems.reserve(op->lanes);
             for (int ix = 0; ix < op->lanes; ix++) {
                 ramp_elems.push_back(base + ix * stride);
             }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -612,6 +612,7 @@ vector<Expr> substitute_self_reference(const vector<Expr> &values, const string 
                                        const Function &substitute, const vector<Var> &new_args) {
     SubstituteSelfReference subs(func, substitute, new_args);
     vector<Expr> result;
+    result.reserve(values.size());
     for (const auto &val : values) {
         result.push_back(subs.mutate(val));
     }
@@ -1785,6 +1786,7 @@ Stage &Stage::tile(const std::vector<VarOrRVar> &previous,
                    const std::vector<Expr> &factors,
                    TailStrategy tail) {
     std::vector<TailStrategy> tails;
+    tails.reserve(previous.size());
     for (unsigned int i = 0; i < previous.size(); i++) {
         tails.push_back(tail);
     }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -767,6 +767,7 @@ gengen
 
     const auto build_targets = [](const std::vector<std::string> &target_strings) {
         std::vector<Target> targets;
+        targets.reserve(target_strings.size());
         for (const auto &s : target_strings) {
             targets.emplace_back(s);
         }

--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -848,6 +848,7 @@ Expr Shuffle::make_slice(Expr vector, int begin, int stride, int size) {
     }
 
     std::vector<int> indices;
+    indices.reserve(size);
     for (int i = 0; i < size; i++) {
         indices.push_back(begin + i * stride);
     }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -963,6 +963,7 @@ Pipeline::make_externs_jit_module(const Target &target,
             free_standing_jit_externs.add_symbol_for_export(iter.first, pipeline_contents.jit_cache.jit_module.entrypoint_symbol());
             void *address = pipeline_contents.jit_cache.jit_module.entrypoint_symbol().address;
             std::vector<Type> arg_types;
+            arg_types.reserve(pipeline_contents.inferred_args.size() + pipeline_contents.outputs.size());
             // Add the arguments to the compiled pipeline
             for (const InferredArgument &arg : pipeline_contents.inferred_args) {
                 // TODO: it's not clear whether arg.arg.type is correct for

--- a/src/RDom.cpp
+++ b/src/RDom.cpp
@@ -22,15 +22,16 @@ const char *const dom_var_names[] = {"$x", "$y", "$z", "$w"};
 
 // T is an ImageParam, Buffer<>, Input<Buffer<>>
 template<typename T>
-Internal::ReductionDomain make_dom_from_dimensions(const T &t, const std::string &name) {
-    std::vector<Internal::ReductionVariable> vars;
+ReductionDomain make_dom_from_dimensions(const T &t, const std::string &name) {
+    std::vector<ReductionVariable> vars;
+    vars.reserve(t.dimensions());
     for (int i = 0; i < t.dimensions(); i++) {
         vars.push_back({name + dom_var_names[i],
                         t.dim(i).min(),
                         t.dim(i).extent()});
     }
 
-    return Internal::ReductionDomain(vars);
+    return ReductionDomain(vars);
 }
 
 }  // namespace

--- a/src/RegionCosts.cpp
+++ b/src/RegionCosts.cpp
@@ -668,8 +668,9 @@ vector<Cost> RegionCosts::get_func_cost(const Function &f, const set<string> &in
         return {Cost()};
     }
 
-    vector<Cost> func_costs;
     size_t num_stages = f.updates().size() + 1;
+    vector<Cost> func_costs;
+    func_costs.reserve(num_stages);
     for (size_t s = 0; s < num_stages; s++) {
         func_costs.push_back(get_func_stage_cost(f, s, inlines));
     }

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -381,6 +381,7 @@ Expr simplify(const Expr &e, bool remove_dead_let_stmts,
               const std::vector<Expr> &assumptions) {
     Simplify m(remove_dead_let_stmts, &bounds, &alignment);
     std::vector<Simplify::ScopedFact> facts;
+    facts.reserve(assumptions.size());
     for (const Expr &a : assumptions) {
         facts.push_back(m.scoped_truth(a));
     }
@@ -397,6 +398,7 @@ Stmt simplify(const Stmt &s, bool remove_dead_let_stmts,
               const std::vector<Expr> &assumptions) {
     Simplify m(remove_dead_let_stmts, &bounds, &alignment);
     std::vector<Simplify::ScopedFact> facts;
+    facts.reserve(assumptions.size());
     for (const Expr &a : assumptions) {
         facts.push_back(m.scoped_truth(a));
     }

--- a/src/StmtToHTML.cpp
+++ b/src/StmtToHTML.cpp
@@ -367,6 +367,7 @@ private:
     void visit(const Call *op) override {
         IRVisitor::visit(op);
         std::vector<const IRNode *> args;
+        args.reserve(op->args.size());
         for (const auto &arg : op->args) {
             args.push_back(arg.get());
         }
@@ -385,6 +386,7 @@ private:
     void visit(const Shuffle *op) override {
         IRVisitor::visit(op);
         std::vector<const IRNode *> args;
+        args.reserve(op->vectors.size());
         for (const auto &arg : op->vectors) {
             args.push_back(arg.get());
         }
@@ -441,6 +443,7 @@ private:
     void visit(const Provide *op) override {
         IRVisitor::visit(op);
         std::vector<const IRNode *> args;
+        args.reserve(op->values.size() + op->args.size() + 1);
         for (const auto &arg : op->values) {
             args.push_back(arg.get());
         }
@@ -456,6 +459,7 @@ private:
         // We do not model allocation/de-allocation costs
         IRVisitor::visit(op);
         std::vector<const IRNode *> args_inline;
+        args_inline.reserve(op->extents.size() + 2);
         for (const auto &arg : op->extents) {
             args_inline.push_back(arg.get());
         }

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1034,6 +1034,8 @@ class VectorSubs : public IRMutator {
 
     Stmt visit(const Allocate *op) override {
         vector<Expr> new_extents;
+        new_extents.reserve(vectorized_vars.size() + op->extents.size());
+
         Expr new_expr;
 
         // The new expanded dimensions are innermost.

--- a/src/autoschedulers/adams2019/DefaultCostModel.cpp
+++ b/src/autoschedulers/adams2019/DefaultCostModel.cpp
@@ -187,6 +187,7 @@ float DefaultCostModel::backprop(const Runtime::Buffer<const float> &true_runtim
     if (!head1_filter_update.data()) {
         auto weight_update_buffer = [](const Runtime::Buffer<float> &w) {
             std::vector<int> size;
+            size.reserve(w.dimensions() + 1);
             for (int i = 0; i < w.dimensions(); i++) {
                 size.push_back(w.dim(i).extent());
             }

--- a/src/autoschedulers/adams2019/LoopNest.cpp
+++ b/src/autoschedulers/adams2019/LoopNest.cpp
@@ -509,11 +509,8 @@ void LoopNest::compute_features(const FunctionDAG &dag,
         // done by Funcs inside this loop to values computed
         // outside of it to figure out how much data we'll be
         // streaming onto the core.
-        vector<const FunctionDAG::Edge *> pending;
+        vector<const FunctionDAG::Edge *> pending(stage->incoming_edges.begin(), stage->incoming_edges.end());
         set<const FunctionDAG::Node *> done;
-        for (const auto *e : stage->incoming_edges) {
-            pending.push_back(e);
-        }
         while (!pending.empty()) {
             const auto *e = pending.back();
             pending.pop_back();

--- a/src/autoschedulers/adams2019/retrain_cost_model.cpp
+++ b/src/autoschedulers/adams2019/retrain_cost_model.cpp
@@ -374,6 +374,7 @@ int main(int argc, char **argv) {
 
     // Iterate through the pipelines
     vector<std::unique_ptr<DefaultCostModel>> tpp;
+    tpp.reserve(kModels);
     for (int i = 0; i < kModels; i++) {
         tpp.emplace_back(make_default_cost_model(flags.initial_weights_path, flags.weights_out_path, flags.randomize_weights));
     }

--- a/src/autoschedulers/anderson2021/DefaultCostModel.cpp
+++ b/src/autoschedulers/anderson2021/DefaultCostModel.cpp
@@ -196,6 +196,7 @@ float DefaultCostModel::backprop(const Runtime::Buffer<const float> &true_runtim
     if (!head1_filter_update.data()) {
         auto weight_update_buffer = [](const Runtime::Buffer<float> &w) {
             std::vector<int> size;
+            size.reserve(w.dimensions() + 1);
             for (int i = 0; i < w.dimensions(); i++) {
                 size.push_back(w.dim(i).extent());
             }

--- a/src/autoschedulers/anderson2021/LoopNest.cpp
+++ b/src/autoschedulers/anderson2021/LoopNest.cpp
@@ -2191,11 +2191,8 @@ void LoopNest::compute_features(const FunctionDAG &dag,
         // done by Funcs inside this loop to values computed
         // outside of it to figure out how much data we'll be
         // streaming onto the core.
-        vector<const FunctionDAG::Edge *> pending;
+        vector<const FunctionDAG::Edge *> pending(stage->incoming_edges.begin(), stage->incoming_edges.end());
         set<const FunctionDAG::Node *> done;
-        for (const auto *e : stage->incoming_edges) {
-            pending.push_back(e);
-        }
         while (!pending.empty()) {
             const auto *e = pending.back();
             pending.pop_back();

--- a/src/autoschedulers/anderson2021/retrain_cost_model.cpp
+++ b/src/autoschedulers/anderson2021/retrain_cost_model.cpp
@@ -464,6 +464,7 @@ int main(int argc, char **argv) {
 
     // Iterate through the pipelines
     vector<std::unique_ptr<DefaultCostModel>> tpp;
+    tpp.reserve(kModels);
     Internal::Autoscheduler::Statistics stats;
     for (int i = 0; i < kModels; i++) {
         tpp.emplace_back(make_default_cost_model(stats, flags.initial_weights_path, flags.weights_out_path, flags.randomize_weights || flags.reset_weights));

--- a/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
+++ b/src/autoschedulers/mullapudi2016/AutoSchedule.cpp
@@ -2643,6 +2643,7 @@ Partitioner::GroupAnalysis Partitioner::analyze_group(const Group &g, bool show_
 Partitioner::Group Partitioner::merge_groups(const Group &prod_group,
                                              const Group &cons_group) {
     vector<FStage> group_members;
+    group_members.reserve(prod_group.members.size() + cons_group.members.size());
     for (const auto &s : prod_group.members) {
         group_members.push_back(s);
     }
@@ -3336,6 +3337,7 @@ void Partitioner::generate_group_cpu_schedule(
     if (!outer_dims.empty()) {
 
         vector<VarOrRVar> ordering;
+        ordering.reserve(inner_dims.size() + outer_dims.size());
         for (const auto &v : inner_dims) {
             ordering.push_back(v);
         }

--- a/util/HalideTraceDump.cpp
+++ b/util/HalideTraceDump.cpp
@@ -89,6 +89,7 @@ struct FuncInfo {
 
     void allocate() {
         std::vector<int> extents;
+        extents.reserve(dimensions);
         for (int i = 0; i < dimensions; i++) {
             extents.push_back(max_coords[i] - min_coords[i] + 1);
         }

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1428,19 +1428,12 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
         info() << dumps.str();
 
         // Print stats about the Func gleaned from the trace.
-        std::vector<std::pair<std::string, FuncInfo>> funcs;
-        for (const auto &p : state.funcs) {
-            funcs.emplace_back(p);
-        }
-        struct by_first_packet_idx {
-            bool operator()(const std::pair<std::string, FuncInfo> &a,
-                            const std::pair<std::string, FuncInfo> &b) const {
-                return a.second.stats.first_packet_idx < b.second.stats.first_packet_idx;
-            }
-        };
-        std::sort(funcs.begin(), funcs.end(), by_first_packet_idx());
-        for (std::pair<std::string, FuncInfo> p : funcs) {
-            p.second.stats.report();
+        std::vector<std::pair<std::string, FuncInfo>> funcs(state.funcs.begin(), state.funcs.end());
+        std::sort(funcs.begin(), funcs.end(), [](const auto &a, const auto &b) {
+            return a.second.stats.first_packet_idx < b.second.stats.first_packet_idx;
+        });
+        for (auto [_, func_info] : funcs) {
+            func_info.stats.report();
         }
     }
 


### PR DESCRIPTION
Just adds a bunch of reserves. Took the opportunity to tidy up some `std::sort` functors while I was addressing these diagnostics.