### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -202,7 +202,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_BUILD: "cp3*-${{ matrix.platform_tag }}"
-          CIBW_SKIP: "cp3{5,6,7,8}*"
+          CIBW_SKIP: "cp3{5,6,7,8,9}*"
           # Suppress the git version tag (necessary for TestPyPI)
           CIBW_ENVIRONMENT: >
             SETUPTOOLS_SCM_OVERRIDES_FOR_HALIDE='{local_scheme="no-local-version"}'

--- a/doc/BuildingHalideWithCMake.md
+++ b/doc/BuildingHalideWithCMake.md
@@ -148,7 +148,7 @@ building the core pieces of Halide.
 | [flatbuffers] | `~=23.5.26`        | `WITH_SERIALIZATION=ON`    |                                                     |
 | [wabt]        | `==1.0.36`         | `Halide_WASM_BACKEND=wabt` | Does not have a stable API; exact version required. |
 | [V8]          | trunk              | `Halide_WASM_BACKEND=V8`   | Difficult to build. See [WebAssembly.md]            |
-| [Python]      | `>=3.9`            | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
+| [Python]      | `>=3.10`           | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
 | [pybind11]    | `~=2.11.1`         | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
 
 Halide maintains the following compatibility policy with LLVM: Halide version

--- a/doc/Python.md
+++ b/doc/Python.md
@@ -31,7 +31,7 @@
   * [License](#license)
 <!-- TOC -->
 
-Halide provides Python bindings for most of its public API. Python 3.9 (or
+Halide provides Python bindings for most of its public API. Python 3.10 (or
 higher) is required. The Python bindings are supported on 64-bit Linux, OSX, and
 Windows systems.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [{ name = "Alex Reinking", email = "areinking@adobe.com" }]
 description = "Halide is a programming language designed to make it easier to write high-performance image and array processing code."
 license = { file = "LICENSE.txt" }
 readme = "./packaging/pip/README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "imageio>=2",
     "numpy>=1.26",
@@ -46,11 +46,11 @@ classifiers = [
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Scientific/Engineering",
@@ -108,8 +108,7 @@ WITH_TUTORIALS = false
 # Don't version libHalide.so/dylib -- wheels are zip files that do
 # not understand symbolic links. Including version information here
 # causes the final wheel to have three copies of our library. Not good.
-Halide_VERSION_OVERRIDE = ""
-Halide_SOVERSION_OVERRIDE = ""
+CMAKE_PLATFORM_NO_VERSIONED_SONAME = true
 
 [[tool.scikit-build.overrides]]
 if.platform-system = "^win32"

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -44,7 +44,7 @@ cmake_dependent_option(
 # Development.Module and Development.Embed. We don't need the Embed
 # part, so only requesting Module avoids failures when Embed is not
 # available, as is the case in the manylinux Docker images.
-find_package(Python 3.9 REQUIRED Interpreter Development.Module)
+find_package(Python 3.10 REQUIRED Interpreter Development.Module)
 
 if (WITH_PYTHON_BINDINGS)
     find_package(pybind11 2.11.1 REQUIRED)

--- a/python_bindings/src/halide/_generator_helpers.py
+++ b/python_bindings/src/halide/_generator_helpers.py
@@ -865,10 +865,6 @@ def alias(**kwargs):
 
 
 def generator(name: str = ""):
-    # This code relies on dicts preserving key-insertion order, which is only
-    # guaranteed for all Python implementations as of v3.7.
-    _check(sys.version_info >= (3, 7), "Halide Generators require Python 3.7 or later.")
-
     def generator_impl(cls):
         n = name if name else _fqname(cls)
         _check_generator_name_in_use(n)

--- a/python_bindings/src/halide/halide_/PyHalide.cpp
+++ b/python_bindings/src/halide/halide_/PyHalide.cpp
@@ -27,13 +27,8 @@
 #include "PyType.h"
 #include "PyVar.h"
 
-#if !defined(PYBIND11_VERSION_HEX) || PYBIND11_VERSION_HEX < 0x02060000
-#error "Halide requires PyBind 2.6+"
-#endif
-
-// Note: This check will be redundant when PyBind 2.10 becomes the minimum version.
-#if PY_VERSION_HEX < 0x03000000
-#error "We appear to be compiling against Python 2.x rather than 3.x, which is not supported."
+#if !defined(PYBIND11_VERSION_HEX) || PYBIND11_VERSION_HEX < 0x020B0000
+#error "Halide requires PyBind 2.11+"
 #endif
 
 #ifndef HALIDE_PYBIND_MODULE_NAME

--- a/python_bindings/test/correctness/memoize.py
+++ b/python_bindings/test/correctness/memoize.py
@@ -13,7 +13,7 @@ def test_memoize():
     output[x] = f[x]
 
     result = output.realize([3])
-    assert list(result) == [1., 1., 1.]
+    assert list(result) == [1.0, 1.0, 1.0]
 
 
 def main():

--- a/test/autoschedulers/li2018/CMakeLists.txt
+++ b/test/autoschedulers/li2018/CMakeLists.txt
@@ -26,7 +26,7 @@ if (WITH_PYTHON_BINDINGS)
     if (Halide_TARGET MATCHES "webgpu")
         message(WARNING "li2018_gradient_autoscheduler_test_py is not supported with WebGPU.")
     else()
-        find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development.Module)
+        find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 
         add_test(
             NAME li2018_gradient_autoscheduler_test_py


### PR DESCRIPTION
[Python 3.9 will be EOL](https://devguide.python.org/versions/) in the next couple weeks. This PR formally drops support for it.

For comparison, see: #8678 