### PR TITLE
Delay storage hoisting into its own mutator

### DIFF
--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -500,14 +500,16 @@ class HoistStorage : public IRMutator {
             << "Couldn't find a matching Allocate node for hoisted storage " << op->name << "\n";
         const auto &alloc_info = hoisted_storages.back().hoisted_allocations.front();
         vector<Expr> extents = alloc_info.extents;
+        Expr condition = alloc_info.condition;
         for (int i = 1; i < (int)hoisted_storages.back().hoisted_allocations.size(); i++) {
             const auto &ai = hoisted_storages.back().hoisted_allocations[i];
             internal_assert(ai.extents.size() == alloc_info.extents.size());
             for (int j = 0; j < (int)extents.size(); j++) {
                 extents[j] = Max::make(extents[j], ai.extents[j]);
             }
+            condition = condition || ai.condition;
         }
-        body = Allocate::make(alloc_info.name, alloc_info.type, alloc_info.memory_type, extents, alloc_info.condition, body);
+        body = Allocate::make(alloc_info.name, alloc_info.type, alloc_info.memory_type, extents, condition, body);
         hoisted_storages_map.erase(op->name);
         hoisted_storages.pop_back();
         return body;

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -26,35 +26,6 @@ using std::vector;
 
 namespace {
 
-class ExpandExpr : public IRMutator {
-    using IRMutator::visit;
-    const Scope<Expr> &scope;
-
-    Expr visit(const Variable *var) override {
-        if (const Expr *e = scope.find(var->name)) {
-            // Mutate the expression, so lets can get replaced recursively.
-            Expr expr = mutate(*e);
-            debug(4) << "Fully expanded " << var->name << " -> " << expr << "\n";
-            return expr;
-        } else {
-            return var;
-        }
-    }
-
-public:
-    ExpandExpr(const Scope<Expr> &s)
-        : scope(s) {
-    }
-};
-
-// Perform all the substitutions in a scope
-Expr expand_expr(const Expr &e, const Scope<Expr> &scope) {
-    ExpandExpr ee(scope);
-    Expr result = ee.mutate(e);
-    debug(4) << "Expanded " << e << " into " << result << "\n";
-    return result;
-}
-
 class FlattenDimensions : public IRMutator {
 public:
     FlattenDimensions(const map<string, pair<Function, int>> &e,
@@ -66,44 +37,12 @@ public:
         }
     }
 
-private:
-    struct HoistedAllocationInfo {
-        string name;
-        Type type;
-        MemoryType memory_type;
-        vector<Expr> extents;
-        Expr condition;
-
-        HoistedAllocationInfo(const string &name, Type type,
-                              MemoryType memory_type,
-                              const vector<Expr> &extents, Expr condition)
-            : name(name),
-              type(type),
-              memory_type(memory_type),
-              extents(extents),
-              condition(std::move(condition)) {
-        }
-    };
-
-    struct HoistedStorageData {
-        string name;
-        vector<HoistedAllocationInfo> hoisted_allocations;
-        vector<pair<string, Interval>> loop_vars;
-        Scope<Expr> scope;
-
-        HoistedStorageData(const string &n)
-            : name(n) {
-        }
-    };
-
     const map<string, pair<Function, int>> &env;
     set<string> outputs;
     set<string> textures;
     const Target &target;
     Scope<> realizations;
     bool in_gpu = false;
-    vector<HoistedStorageData> hoisted_storages;
-    map<string, int> hoisted_storages_map;
 
     Expr make_shape_var(string name, const string &field, size_t dim,
                         const Buffer<> &buf, const Parameter &param) {
@@ -168,27 +107,6 @@ private:
     }
 
     using IRMutator::visit;
-
-    Stmt visit(const HoistedStorage *op) override {
-        hoisted_storages.emplace_back(op->name);
-        // Record index in the stack.
-        hoisted_storages_map[op->name] = hoisted_storages.size() - 1;
-        Stmt body = mutate(op->body);
-        internal_assert(!hoisted_storages.back().hoisted_allocations.empty()) << "Couldn't find a matching Realize node for Hoisted storage " << op->name << "\n";
-        const auto &alloc_info = hoisted_storages.back().hoisted_allocations.front();
-        vector<Expr> extents = alloc_info.extents;
-        for (int i = 1; i < (int)hoisted_storages.back().hoisted_allocations.size(); i++) {
-            const auto &ai = hoisted_storages.back().hoisted_allocations[i];
-            internal_assert(ai.extents.size() == alloc_info.extents.size());
-            for (int j = 0; j < (int)extents.size(); j++) {
-                extents[j] = Max::make(extents[j], ai.extents[j]);
-            }
-        }
-        body = Allocate::make(alloc_info.name, alloc_info.type, alloc_info.memory_type, extents, alloc_info.condition, body);
-        hoisted_storages_map.erase(op->name);
-        hoisted_storages.pop_back();
-        return body;
-    }
 
     Stmt visit(const Realize *op) override {
         realizations.push(op->name);
@@ -291,54 +209,9 @@ private:
             builder.strides.push_back(stride_var[i]);
         }
         stmt = LetStmt::make(op->name + ".buffer", builder.build(), stmt);
-        if (hoisted_storages_map.count(op->name) > 0) {
-            HoistedStorageData &hoisted_storage_data = hoisted_storages[hoisted_storages_map[op->name]];
 
-            auto expand_and_bound = [&](Expr e) {
-                // Iterate from innermost outwards
-                for (const auto &storage : reverse_view(hoisted_storages)) {
-                    e = expand_expr(e, storage.scope);
-                    if (storage.name == op->name) {
-                        break;
-                    }
-                }
-
-                e = simplify(common_subexpression_elimination(e));
-                // Find bounds of expression using the intervals of the loop variables. The loop variables may depend on
-                // the other loop variables, so we just call bounds_of_expr_in_scope for each loop variable separately
-                // in a reverse order.
-                for (const auto &[var, interval] : reverse_view(hoisted_storage_data.loop_vars)) {
-                    Scope<Interval> one_loop_var;
-                    one_loop_var.push(var, interval);
-                    Interval bounds = bounds_of_expr_in_scope(e, one_loop_var);
-                    e = bounds.max;
-                }
-
-                return e;
-            };
-
-            vector<Expr> bounded_extents;
-            for (const auto &e : allocation_extents) {
-                Expr expanded_extent = expand_and_bound(e);
-                user_assert(expanded_extent.defined() &&
-                            !expanded_extent.same_as(Interval::pos_inf()))
-                    << "Couldn't infer the upper bound for the storage size of " << op->name << ", consider using bound_storage.\n";
-                bounded_extents.push_back(expanded_extent);
-            }
-
-            Expr expanded_condition = expand_and_bound(condition);
-            if (!expanded_condition.defined() ||
-                expanded_condition.same_as(Interval::pos_inf())) {
-                expanded_condition = const_true();
-            }
-
-            HoistedAllocationInfo hoisted_alloc(op->name, op->types[0], op->memory_type, bounded_extents, expanded_condition);
-
-            hoisted_storage_data.hoisted_allocations.push_back(hoisted_alloc);
-        } else {
-            // Make the allocation node
-            stmt = Allocate::make(op->name, op->types[0], op->memory_type, allocation_extents, condition, stmt);
-        }
+        // Make the allocation node
+        stmt = Allocate::make(op->name, op->types[0], op->memory_type, allocation_extents, condition, stmt);
 
         // Wrap it into storage bound asserts.
         if (!bound_asserts.empty()) {
@@ -535,25 +408,75 @@ private:
     }
 
     Stmt visit(const For *op) override {
-        Expr expanded_min = op->min;
-        Expr expanded_extent = op->extent;
-        // Iterate from innermost outwards
-        for (auto &storage : reverse_view(hoisted_storages)) {
-            expanded_min = simplify(expand_expr(expanded_min, storage.scope));
-            expanded_extent = expand_expr(expanded_extent, storage.scope);
-            auto loop_bounds = Interval(expanded_min, simplify(expanded_min + expanded_extent - 1));
-            storage.loop_vars.emplace_back(op->name, loop_bounds);
-        }
-
         ScopedValue<bool> old_in_gpu(in_gpu, in_gpu || is_gpu(op->for_type));
-        Stmt stmt = IRMutator::visit(op);
+        return IRMutator::visit(op);
+    }
+};
 
-        for (auto &p : hoisted_storages) {
-            p.loop_vars.pop_back();
+class HoistStorage : public IRMutator {
+
+    struct HoistedAllocationInfo {
+        string name;
+        Type type;
+        MemoryType memory_type;
+        vector<Expr> extents;
+        Expr condition;
+
+        HoistedAllocationInfo(const string &name, Type type,
+                              MemoryType memory_type,
+                              const vector<Expr> &extents, Expr condition)
+            : name(name),
+              type(type),
+              memory_type(memory_type),
+              extents(extents),
+              condition(std::move(condition)) {
+        }
+    };
+
+    struct HoistedStorageData {
+        string name;
+        vector<HoistedAllocationInfo> hoisted_allocations;
+        vector<pair<string, Interval>> loop_vars;
+        Scope<Expr> scope;
+
+        HoistedStorageData(const string &n)
+            : name(n) {
+        }
+    };
+
+    vector<HoistedStorageData> hoisted_storages;
+    map<string, int> hoisted_storages_map;
+
+    class ExpandExpr : public IRMutator {
+        using IRMutator::visit;
+        const Scope<Expr> &scope;
+
+        Expr visit(const Variable *var) override {
+            if (const Expr *e = scope.find(var->name)) {
+                // Mutate the expression, so lets can get replaced recursively.
+                Expr expr = mutate(*e);
+                debug(4) << "Fully expanded " << var->name << " -> " << expr << "\n";
+                return expr;
+            } else {
+                return var;
+            }
         }
 
-        return stmt;
+    public:
+        ExpandExpr(const Scope<Expr> &s)
+            : scope(s) {
+        }
+    };
+
+    // Perform all the substitutions in a scope
+    Expr expand_expr(const Expr &e, const Scope<Expr> &scope) {
+        ExpandExpr ee(scope);
+        Expr result = ee.mutate(e);
+        debug(4) << "Expanded " << e << " into " << result << "\n";
+        return result;
     }
+
+    using IRMutator::visit;
 
     Stmt visit(const LetStmt *op) override {
         if (!hoisted_storages.empty()) {
@@ -565,6 +488,100 @@ private:
         if (!hoisted_storages.empty()) {
             hoisted_storages.back().scope.pop(op->name);
         }
+        return stmt;
+    }
+
+    Stmt visit(const HoistedStorage *op) override {
+        hoisted_storages.emplace_back(op->name);
+        // Record index in the stack.
+        hoisted_storages_map[op->name] = hoisted_storages.size() - 1;
+        Stmt body = mutate(op->body);
+        internal_assert(!hoisted_storages.back().hoisted_allocations.empty())
+            << "Couldn't find a matching Allocate node for hoisted storage " << op->name << "\n";
+        const auto &alloc_info = hoisted_storages.back().hoisted_allocations.front();
+        vector<Expr> extents = alloc_info.extents;
+        for (int i = 1; i < (int)hoisted_storages.back().hoisted_allocations.size(); i++) {
+            const auto &ai = hoisted_storages.back().hoisted_allocations[i];
+            internal_assert(ai.extents.size() == alloc_info.extents.size());
+            for (int j = 0; j < (int)extents.size(); j++) {
+                extents[j] = Max::make(extents[j], ai.extents[j]);
+            }
+        }
+        body = Allocate::make(alloc_info.name, alloc_info.type, alloc_info.memory_type, extents, alloc_info.condition, body);
+        hoisted_storages_map.erase(op->name);
+        hoisted_storages.pop_back();
+        return body;
+    }
+
+    Stmt visit(const Allocate *op) override {
+        if (hoisted_storages_map.count(op->name) > 0) {
+            HoistedStorageData &hoisted_storage_data = hoisted_storages[hoisted_storages_map[op->name]];
+
+            auto expand_and_bound = [&](Expr e) {
+                // Iterate from innermost outwards
+                for (const auto &storage : reverse_view(hoisted_storages)) {
+                    e = expand_expr(e, storage.scope);
+                    if (storage.name == op->name) {
+                        break;
+                    }
+                }
+
+                e = simplify(common_subexpression_elimination(e));
+                // Find bounds of expression using the intervals of the loop
+                // variables. The loop variables may depend on the other loop
+                // variables, so we just call bounds_of_expr_in_scope for each
+                // loop variable separately in a reverse order.
+                for (const auto &[var, interval] : reverse_view(hoisted_storage_data.loop_vars)) {
+                    Scope<Interval> one_loop_var;
+                    one_loop_var.push(var, interval);
+                    Interval bounds = bounds_of_expr_in_scope(e, one_loop_var);
+                    e = bounds.max;
+                }
+
+                return e;
+            };
+
+            vector<Expr> bounded_extents;
+            for (const auto &e : op->extents) {
+                Expr expanded_extent = expand_and_bound(e);
+                user_assert(expanded_extent.defined() &&
+                            !expanded_extent.same_as(Interval::pos_inf()))
+                    << "Couldn't infer the upper bound for the storage size of " << op->name << ", consider using bound_storage.\n";
+                bounded_extents.push_back(expanded_extent);
+            }
+
+            Expr expanded_condition = expand_and_bound(op->condition);
+            if (!expanded_condition.defined() ||
+                expanded_condition.same_as(Interval::pos_inf())) {
+                expanded_condition = const_true();
+            }
+
+            HoistedAllocationInfo hoisted_alloc(op->name, op->type, op->memory_type, bounded_extents, expanded_condition);
+
+            hoisted_storage_data.hoisted_allocations.push_back(hoisted_alloc);
+            return mutate(op->body);
+        } else {
+            return IRMutator::visit(op);
+        }
+    }
+
+    Stmt visit(const For *op) override {
+        Expr expanded_min = op->min;
+        Expr expanded_extent = op->extent;
+        // Iterate from innermost outwards
+        for (auto &storage : reverse_view(hoisted_storages)) {
+            expanded_min = simplify(expand_expr(expanded_min, storage.scope));
+            expanded_extent = expand_expr(expanded_extent, storage.scope);
+            auto loop_bounds = Interval(expanded_min, simplify(expanded_min + expanded_extent - 1));
+            storage.loop_vars.emplace_back(op->name, loop_bounds);
+        }
+
+        Stmt stmt = IRMutator::visit(op);
+
+        for (auto &p : hoisted_storages) {
+            p.loop_vars.pop_back();
+        }
+
         return stmt;
     }
 };
@@ -633,6 +650,7 @@ Stmt storage_flattening(Stmt s,
         }
     }
     s = FlattenDimensions(tuple_env, outputs, target).mutate(s);
+    s = HoistStorage().mutate(s);
     s = PromoteToMemoryType().mutate(s);
 
     return s;


### PR DESCRIPTION
No changes to any of the logic, just moving code around so that hoist storage happens in its own mutator.

The goal is to make the FlattenDimensions class easier to modify by removing a responsibility from it.