### PR TITLE
More simplifications for And and Or nodes

### DIFF
--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -2110,6 +2110,13 @@ void CodeGen_Hexagon::visit(const Select *op) {
         value = codegen(Call::make(op->type, Call::if_then_else,
                                    {b->value, op->true_value, op->false_value},
                                    Call::PureIntrinsic));
+    } else if (op->type.is_vector() && op->type.is_bool()) {
+        // Lower selects on bools to bit math
+        std::string cond_name = unique_name('c');
+        Expr cond = Variable::make(op->condition.type(), cond_name);
+        Expr equiv = Let::make(cond_name, op->condition,
+                               (op->true_value & cond) | (op->false_value & ~cond));
+        value = codegen(equiv);
     } else {
         CodeGen_Posix::visit(op);
     }

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1666,6 +1666,65 @@ inline std::ostream &operator<<(std::ostream &s, const NotOp<A> &op) {
     return s;
 }
 
+// The simplified negation of some already-bound boolean wildcard. So if x
+// matched to v < 3, this will bind to 3 <= v. If x matched to v == 3, this will
+// bind to v != 3, etc. Will also bind to !x.
+template<int i>
+struct SimplifiedNegateOp {
+    struct pattern_tag {};
+
+    constexpr static uint32_t binds = 0;
+
+    constexpr static IRNodeType min_node_type = IRNodeType::EQ;
+    constexpr static IRNodeType max_node_type = IRNodeType::Not;
+    constexpr static bool canonical = true;
+
+    template<uint32_t bound>
+    HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {
+        static_assert(bound & Wild<i>::binds, "neg must be applied to an already-bound expr");
+        const BaseExprNode &b = *state.get_binding(i);
+
+        switch (b.node_type) {
+        case IRNodeType::EQ:
+            return (e.node_type == IRNodeType::NE &&
+                    ((equal(*((const NE &)e).a.get(), *((const EQ &)b).a.get()) &&
+                      equal(*((const NE &)e).b.get(), *((const EQ &)b).b.get())) ||
+                     (equal(*((const NE &)e).a.get(), *((const EQ &)b).b.get()) &&
+                      equal(*((const NE &)e).b.get(), *((const EQ &)b).a.get()))));
+        case IRNodeType::NE:
+            return (e.node_type == IRNodeType::EQ &&
+                    ((equal(*((const EQ &)e).a.get(), *((const NE &)b).a.get()) &&
+                      equal(*((const EQ &)e).b.get(), *((const NE &)b).b.get())) ||
+                     (equal(*((const EQ &)e).a.get(), *((const NE &)b).b.get()) &&
+                      equal(*((const EQ &)e).b.get(), *((const NE &)b).a.get()))));
+        case IRNodeType::LT:
+            return (e.node_type == IRNodeType::LE &&
+                    equal(*((const LE &)e).a.get(), *((const LT &)b).b.get()) &&
+                    equal(*((const LE &)e).b.get(), *((const LT &)b).a.get()));
+        case IRNodeType::LE:
+            return (e.node_type == IRNodeType::LT &&
+                    equal(*((const LT &)e).a.get(), *((const LE &)b).b.get()) &&
+                    equal(*((const LT &)e).b.get(), *((const LE &)b).a.get()));
+        case IRNodeType::Not:
+            return equal(e, *((const Not &)b).a.get());
+        default:
+            return (e.node_type == IRNodeType::Not &&
+                    equal(*((const Not &)e).a.get(), b));
+        }
+    }
+};
+
+template<int i>
+HALIDE_ALWAYS_INLINE auto neg(const Wild<i> &a) -> SimplifiedNegateOp<i> {
+    return SimplifiedNegateOp<i>();
+}
+
+template<int i>
+inline std::ostream &operator<<(std::ostream &s, const SimplifiedNegateOp<i> &op) {
+    s << "neg(" << Wild<i>{} << ")";
+    return s;
+}
+
 template<typename C, typename T, typename F>
 struct SelectOp {
     struct pattern_tag {};

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -1678,6 +1678,7 @@ struct SimplifiedNegateOp {
     constexpr static IRNodeType min_node_type = IRNodeType::EQ;
     constexpr static IRNodeType max_node_type = IRNodeType::Not;
     constexpr static bool canonical = true;
+    constexpr static bool foldable = false;
 
     template<uint32_t bound>
     HALIDE_ALWAYS_INLINE bool match(const BaseExprNode &e, MatcherState &state) const noexcept {

--- a/src/Simplify_And.cpp
+++ b/src/Simplify_And.cpp
@@ -27,65 +27,39 @@ Expr Simplify::visit(const And *op, ExprInfo *info) {
     // Cases that fold to a constant
     if (EVAL_IN_LAMBDA
         (rewrite(x && false, false) ||
-         rewrite(x != y && x == y, false) ||
-         rewrite(x != y && y == x, false) ||
-         rewrite((z && x != y) && x == y, false) ||
-         rewrite((z && x != y) && y == x, false) ||
-         rewrite((x != y && z) && x == y, false) ||
-         rewrite((x != y && z) && y == x, false) ||
-         rewrite((z && x == y) && x != y, false) ||
-         rewrite((z && x == y) && y != x, false) ||
-         rewrite((x == y && z) && x != y, false) ||
-         rewrite((x == y && z) && y != x, false) ||
 
-         rewrite((!x && x), false) ||
-         rewrite((x && !x), false) ||
-         rewrite((!x && (x && y)), false) ||
-         rewrite((!x && (y && x)), false) ||
-         rewrite((x && !(x || y)), false) ||
-         rewrite((x && (!x && y)), false) ||
-         rewrite((x && (y && !x)), false) ||
-         rewrite((!(x || y) && x), false) ||
-         rewrite(((!x && y) && x), false) ||
-         rewrite(((y && !x) && x), false) ||
-         rewrite((!x && ((x && z) && y)), false) ||
-         rewrite((!x && (y && (x && z))), false) ||
-         rewrite((!x && ((z && x) && y)), false) ||
-         rewrite((!x && (y && (z && x))), false) ||
-         rewrite((x && !((x || z) || y)), false) ||
-         rewrite((x && (!(x || z) && y)), false) ||
-         rewrite((x && (y && !(x || z))), false) ||
-         rewrite((x && (!(z || x) && y)), false) ||
-         rewrite((x && (y && !(z || x))), false) ||
-         rewrite((x && ((!x && z) && y)), false) ||
-         rewrite((x && (y && (!x && z))), false) ||
-         rewrite((!x && (!(!x || z) && y)), false) ||
-         rewrite((!x && (y && !(!x || z))), false) ||
-         rewrite((x && ((z && !x) && y)), false) ||
-         rewrite((x && (y && (z && !x))), false) ||
-         rewrite((!x && (!(z || !x) && y)), false) ||
-         rewrite((!x && (y && !(z || !x))), false) ||
-         rewrite(((x && y) && (!x && z)), false) ||
-         rewrite(((x && y) && (z && !x)), false) ||
-         rewrite(((y && x) && (!x && z)), false) ||
-         rewrite(((y && x) && (z && !x)), false) ||
-         rewrite((!(x || y) && (x && z)), false) ||
-         rewrite((!(x || y) && (z && x)), false) ||
-         rewrite(((!x && y) && (x && z)), false) ||
-         rewrite(((!x && y) && (z && x)), false) ||
-         rewrite(((y && !x) && (x && z)), false) ||
-         rewrite(((y && !x) && (z && x)), false) ||
-         rewrite((!((x || z) || y) && x), false) ||
-         rewrite(((!(x || z) && y) && x), false) ||
-         rewrite(((y && !(x || z)) && x), false) ||
-         rewrite(((!(z || x) && y) && x), false) ||
-         rewrite(((y && !(z || x)) && x), false) ||
-         rewrite((((!x && z) && y) && x), false) ||
-         rewrite(((y && (!x && z)) && x), false) ||
-         rewrite((((z && !x) && y) && x), false) ||
-         rewrite(((y && (z && !x)) && x), false) ||
+         rewrite(x && neg(x), false) ||
+         rewrite(x && (neg(x) && y), false) ||
+         rewrite(x && (y && neg(x)), false) ||
+         rewrite(x && !(x || y), false) ||
+         rewrite((x && y) && neg(x), false) ||
+         rewrite((y && x) && neg(x), false) ||
+         rewrite(!(x || y) && x, false) ||
+         rewrite(x && ((neg(x) && z) && y), false) ||
+         rewrite(x && (y && (neg(x) && z)), false) ||
+         rewrite(x && ((z && neg(x)) && y), false) ||
+         rewrite(x && (y && (z && neg(x))), false) ||
+         rewrite(x && !((x || z) || y), false) ||
+         rewrite(x && (!(x || z) && y), false) ||
+         rewrite(x && (y && !(x || z)), false) ||
+         rewrite(x && (!(z || x) && y), false) ||
+         rewrite(x && (y && !(z || x)), false) ||
+         rewrite((x && y) && (neg(x) && z), false) ||
+         rewrite((x && y) && (z && neg(x)), false) ||
+         rewrite((y && x) && (neg(x) && z), false) ||
+         rewrite((y && x) && (z && neg(x)), false) ||
+         rewrite(!(x || y) && (x && z), false) ||
+         rewrite(!(x || y) && (z && x), false) ||
+         rewrite(((x && z) && y) && neg(x), false) ||
+         rewrite((y && (x && z)) && neg(x), false) ||
+         rewrite(((z && x) && y) && neg(x), false) ||
+         rewrite((y && (z && x)) && neg(x), false) ||
+         rewrite(!((x || z) || y) && x, false) ||
+         rewrite((!(x || z) && y) && x, false) ||
+         rewrite((y && !(x || z)) && x, false) ||
+         rewrite((!(z || x) && y) && x, false) ||
+         rewrite((y && !(z || x)) && x, false) ||
 
-         rewrite(y <= x && x < y, false) ||
          rewrite(y < x && x < y, false) ||
          rewrite(x == c0 && x == c1, false, c0 != c1) ||
          // Note: In the predicate below, if undefined overflow
@@ -107,83 +81,51 @@ Expr Simplify::visit(const And *op, ExprInfo *info) {
     if (EVAL_IN_LAMBDA
         (rewrite(x && true, a) ||
 
-         rewrite((x && x), a) ||
-         rewrite((x && (x && y)), b) ||
-         rewrite((x && (y && x)), b) ||
-         rewrite((x && (x || y)), a) ||
-         rewrite((x && (y || x)), a) ||
-         rewrite((!x && (!x && y)), b) ||
-         rewrite((!x && (!x || y)), a) ||
-         rewrite((!x && (y && !x)), b) ||
-         rewrite((!x && (y || !x)), a) ||
-         rewrite(((x && y) && x), a) ||
-         rewrite(((y && x) && x), a) ||
-         rewrite(((x || y) && x), b) ||
-         rewrite(((y || x) && x), b) ||
-         rewrite((x && ((x && z) && y)), b) ||
-         rewrite((x && (y && (x && z))), b) ||
-         rewrite((!x && (!(x && z) || y)), a) ||
-         rewrite((!x && (y || !(x && z))), a) ||
-         rewrite((x && ((z && x) && y)), b) ||
-         rewrite((x && (y && (z && x))), b) ||
-         rewrite((!x && (!(z && x) || y)), a) ||
-         rewrite((!x && (y || !(z && x))), a) ||
-         rewrite((x && ((x || z) || y)), a) ||
-         rewrite((x && (y || (x || z))), a) ||
-         rewrite((!x && (!(x || z) && y)), b) ||
-         rewrite((!x && (y && !(x || z))), b) ||
-         rewrite((x && ((z || x) || y)), a) ||
-         rewrite((x && (y || (z || x))), a) ||
-         rewrite((!x && (!(z || x) && y)), b) ||
-         rewrite((!x && (y && !(z || x))), b) ||
-         rewrite((!x && ((!x && z) && y)), b) ||
-         rewrite((x && !((!x && z) && y)), a) ||
-         rewrite((!x && (y && (!x && z))), b) ||
-         rewrite((x && (!(!x && z) || y)), a) ||
-         rewrite((x && (y || !(!x && z))), a) ||
-         rewrite((!x && ((!x || z) || y)), a) ||
-         rewrite((x && !((!x || z) || y)), b) ||
-         rewrite((!x && (y || (!x || z))), a) ||
-         rewrite((x && (!(!x || z) && y)), b) ||
-         rewrite((x && (y && !(!x || z))), b) ||
-         rewrite((!x && ((z && !x) && y)), b) ||
-         rewrite((!x && (y && (z && !x))), b) ||
-         rewrite((x && (!(z && !x) || y)), a) ||
-         rewrite((x && (y || !(z && !x))), a) ||
-         rewrite((!x && ((z || !x) || y)), a) ||
-         rewrite((!x && (y || (z || !x))), a) ||
-         rewrite((x && (!(z || !x) && y)), b) ||
-         rewrite((x && (y && !(z || !x))), b) ||
-         rewrite((!(x && y) && (!x && z)), b) ||
-         rewrite((!(x && y) && (z && !x)), b) ||
-         rewrite(((x || y) && (x && z)), b) ||
-         rewrite(((x || y) && (z && x)), b) ||
-         rewrite((!(x || y) && (!x || z)), a) ||
-         rewrite((!(x || y) && (z || !x)), a) ||
-         rewrite(((y || x) && (x && z)), b) ||
-         rewrite(((y || x) && (z && x)), b) ||
-         rewrite(((!x || y) && (!x && z)), b) ||
-         rewrite(((!x || y) && (z && !x)), b) ||
-         rewrite(((y || !x) && (!x && z)), b) ||
-         rewrite(((y || !x) && (z && !x)), b) ||
-         rewrite((((x && z) && y) && x), a) ||
-         rewrite(((y && (x && z)) && x), a) ||
-         rewrite((((z && x) && y) && x), a) ||
-         rewrite(((y && (z && x)) && x), a) ||
-         rewrite((((x || z) || y) && x), b) ||
-         rewrite(((y || (x || z)) && x), b) ||
-         rewrite((((z || x) || y) && x), b) ||
-         rewrite(((y || (z || x)) && x), b) ||
-         rewrite((!((!x && z) && y) && x), b) ||
-         rewrite(((!(!x && z) || y) && x), b) ||
-         rewrite(((y || !(!x && z)) && x), b) ||
-         rewrite((!((!x || z) || y) && x), a) ||
-         rewrite(((!(!x || z) && y) && x), a) ||
-         rewrite(((y && !(!x || z)) && x), a) ||
-         rewrite(((!(z && !x) || y) && x), b) ||
-         rewrite(((y || !(z && !x)) && x), b) ||
-         rewrite(((!(z || !x) && y) && x), a) ||
-         rewrite(((y && !(z || !x)) && x), a) ||
+         rewrite(x && x, a) ||
+         rewrite(x && (x && y), b) ||
+         rewrite(x && (y && x), b) ||
+         rewrite(x && (x || y), a) ||
+         rewrite(x && (y || x), a) ||
+         rewrite((x && y) && x, a) ||
+         rewrite((y && x) && x, a) ||
+         rewrite((x || y) && x, b) ||
+         rewrite((y || x) && x, b) ||
+         rewrite(x && ((x && z) && y), b) ||
+         rewrite(x && (y && (x && z)), b) ||
+         rewrite(x && (!(neg(x) && z) || y), a) ||
+         rewrite(x && (y || !(neg(x) && z)), a) ||
+         rewrite(x && ((z && x) && y), b) ||
+         rewrite(x && (y && (z && x)), b) ||
+         rewrite(x && (!(z && neg(x)) || y), a) ||
+         rewrite(x && (y || !(z && neg(x))), a) ||
+         rewrite(x && ((x || z) || y), a) ||
+         rewrite(x && (y || (x || z)), a) ||
+         rewrite(x && (!(neg(x) || z) && y), b) ||
+         rewrite(x && (y && !(neg(x) || z)), b) ||
+         rewrite(x && ((z || x) || y), a) ||
+         rewrite(x && (y || (z || x)), a) ||
+         rewrite(x && (!(z || neg(x)) && y), b) ||
+         rewrite(x && (y && !(z || neg(x))), b) ||
+         rewrite((x || y) && (x && z), b) ||
+         rewrite((x || y) && (z && x), b) ||
+         rewrite((y || x) && (x && z), b) ||
+         rewrite((y || x) && (z && x), b) ||
+         rewrite(((x && z) && y) && x, a) ||
+         rewrite((y && (x && z)) && x, a) ||
+         rewrite((!(x && z) || y) && neg(x), b) ||
+         rewrite((y || !(x && z)) && neg(x), b) ||
+         rewrite(((z && x) && y) && x, a) ||
+         rewrite((y && (z && x)) && x, a) ||
+         rewrite((!(z && x) || y) && neg(x), b) ||
+         rewrite((y || !(z && x)) && neg(x), b) ||
+         rewrite(((x || z) || y) && x, b) ||
+         rewrite((y || (x || z)) && x, b) ||
+         rewrite((!(x || z) && y) && neg(x), a) ||
+         rewrite((y && !(x || z)) && neg(x), a) ||
+         rewrite(((z || x) || y) && x, b) ||
+         rewrite((y || (z || x)) && x, b) ||
+         rewrite((!(z || x) && y) && neg(x), a) ||
+         rewrite((y && !(z || x)) && neg(x), a) ||
 
          rewrite(x != c0 && x == c1, b, c0 != c1) ||
          rewrite(c0 < x && c1 < x, fold(max(c0, c1)) < x) ||
@@ -203,186 +145,120 @@ Expr Simplify::visit(const And *op, ExprInfo *info) {
 
          rewrite(!x && !y, !(x || y)) ||
 
-         rewrite((x && !(x && y)), (!y && x)) ||
-         rewrite((!x && (x || y)), (!x && y)) ||
-         rewrite((!x && (y || x)), (!x && y)) ||
-         rewrite((x && (!x || y)), (x && y)) ||
-         rewrite((x && (y || !x)), (x && y)) ||
-         rewrite((!(x && y) && x), (!y && x)) ||
-         rewrite(((!x || y) && x), (x && y)) ||
-         rewrite(((y || !x) && x), (x && y)) ||
-         rewrite((x && !((x && z) && y)), ((!y || !z) && x)) ||
-         rewrite((x && ((x && z) || y)), ((y || z) && x)) ||
-         rewrite((!x && ((x && z) || y)), (!x && y)) ||
-         rewrite((x && !((x && z) || y)), (!(y || z) && x)) ||
-         rewrite((x && (y || (x && z))), ((y || z) && x)) ||
-         rewrite((!x && (y || (x && z))), (!x && y)) ||
-         rewrite((x && (!(x && z) && y)), ((!z && y) && x)) ||
-         rewrite((!x && (!(x && z) && y)), (!x && y)) ||
-         rewrite((x && (!(x && z) || y)), ((!z || y) && x)) ||
-         rewrite((x && (y && !(x && z))), ((!z && y) && x)) ||
-         rewrite((!x && (y && !(x && z))), (!x && y)) ||
-         rewrite((x && (y || !(x && z))), ((!z || y) && x)) ||
-         rewrite((x && ((z && x) || y)), ((y || z) && x)) ||
-         rewrite((!x && ((z && x) || y)), (!x && y)) ||
-         rewrite((x && (y || (z && x))), ((y || z) && x)) ||
-         rewrite((!x && (y || (z && x))), (!x && y)) ||
-         rewrite((x && (!(z && x) && y)), ((!z && y) && x)) ||
-         rewrite((!x && (!(z && x) && y)), (!x && y)) ||
-         rewrite((x && (!(z && x) || y)), ((!z || y) && x)) ||
-         rewrite((x && (y && !(z && x))), ((!z && y) && x)) ||
-         rewrite((!x && (y && !(z && x))), (!x && y)) ||
-         rewrite((x && (y || !(z && x))), ((!z || y) && x)) ||
-         rewrite((x && ((x || z) && y)), (x && y)) ||
-         rewrite((!x && ((x || z) && y)), (!x && (y && z))) ||
-         rewrite((x && !((x || z) && y)), (!y && x)) ||
-         rewrite((x && (y && (x || z))), (x && y)) ||
-         rewrite((!x && (y && (x || z))), (!x && (y && z))) ||
-         rewrite((!x && ((x || z) || y)), (!x && (y || z))) ||
-         rewrite((!x && (y || (x || z))), (!x && (y || z))) ||
-         rewrite((x && (!(x || z) || y)), (x && y)) ||
-         rewrite((!x && (!(x || z) || y)), (!x && (!z || y))) ||
-         rewrite((x && (y || !(x || z))), (x && y)) ||
-         rewrite((!x && (y || !(x || z))), (!x && (!z || y))) ||
-         rewrite((x && ((z || x) && y)), (x && y)) ||
-         rewrite((!x && ((z || x) && y)), (!x && (y && z))) ||
-         rewrite((x && (y && (z || x))), (x && y)) ||
-         rewrite((!x && (y && (z || x))), (!x && (y && z))) ||
-         rewrite((!x && ((z || x) || y)), (!x && (y || z))) ||
-         rewrite((!x && (y || (z || x))), (!x && (y || z))) ||
-         rewrite((x && (!(z || x) || y)), (x && y)) ||
-         rewrite((!x && (!(z || x) || y)), (!x && (!z || y))) ||
-         rewrite((x && (y || !(z || x))), (x && y)) ||
-         rewrite((!x && (y || !(z || x))), (!x && (!z || y))) ||
-         rewrite((x && ((!x && z) || y)), (x && y)) ||
-         rewrite((!x && ((!x && z) || y)), (!x && (y || z))) ||
-         rewrite((x && !((!x && z) || y)), (!y && x)) ||
-         rewrite((x && (y || (!x && z))), (x && y)) ||
-         rewrite((!x && (y || (!x && z))), (!x && (y || z))) ||
-         rewrite((x && (!(!x && z) && y)), (x && y)) ||
-         rewrite((!x && (!(!x && z) && y)), (!x && (!z && y))) ||
-         rewrite((!x && (!(!x && z) || y)), (!x && (!z || y))) ||
-         rewrite((x && (y && !(!x && z))), (x && y)) ||
-         rewrite((!x && (y && !(!x && z))), (!x && (!z && y))) ||
-         rewrite((!x && (y || !(!x && z))), (!x && (!z || y))) ||
-         rewrite((x && ((!x || z) && y)), ((y && z) && x)) ||
-         rewrite((!x && ((!x || z) && y)), (!x && y)) ||
-         rewrite((x && !((!x || z) && y)), ((!y || !z) && x)) ||
-         rewrite((x && (y && (!x || z))), ((y && z) && x)) ||
-         rewrite((!x && (y && (!x || z))), (!x && y)) ||
-         rewrite((x && ((!x || z) || y)), ((y || z) && x)) ||
-         rewrite((x && (y || (!x || z))), ((y || z) && x)) ||
-         rewrite((x && (!(!x || z) || y)), ((!z || y) && x)) ||
-         rewrite((!x && (!(!x || z) || y)), (!x && y)) ||
-         rewrite((x && (y || !(!x || z))), ((!z || y) && x)) ||
-         rewrite((!x && (y || !(!x || z))), (!x && y)) ||
-         rewrite((x && ((z && !x) || y)), (x && y)) ||
-         rewrite((!x && ((z && !x) || y)), (!x && (y || z))) ||
-         rewrite((x && (y || (z && !x))), (x && y)) ||
-         rewrite((!x && (y || (z && !x))), (!x && (y || z))) ||
-         rewrite((x && (!(z && !x) && y)), (x && y)) ||
-         rewrite((!x && (!(z && !x) && y)), (!x && (!z && y))) ||
-         rewrite((!x && (!(z && !x) || y)), (!x && (!z || y))) ||
-         rewrite((x && (y && !(z && !x))), (x && y)) ||
-         rewrite((!x && (y && !(z && !x))), (!x && (!z && y))) ||
-         rewrite((!x && (y || !(z && !x))), (!x && (!z || y))) ||
-         rewrite((x && ((z || !x) && y)), ((y && z) && x)) ||
-         rewrite((!x && ((z || !x) && y)), (!x && y)) ||
-         rewrite((x && (y && (z || !x))), ((y && z) && x)) ||
-         rewrite((!x && (y && (z || !x))), (!x && y)) ||
-         rewrite((x && ((z || !x) || y)), ((y || z) && x)) ||
-         rewrite((x && (y || (z || !x))), ((y || z) && x)) ||
-         rewrite((x && (!(z || !x) || y)), ((!z || y) && x)) ||
-         rewrite((!x && (!(z || !x) || y)), (!x && y)) ||
-         rewrite((x && (y || !(z || !x))), ((!z || y) && x)) ||
-         rewrite((!x && (y || !(z || !x))), (!x && y)) ||
-         rewrite(((x && y) && (x && z)), ((y && z) && x)) ||
-         rewrite((!(x && y) && (x && z)), ((!y && z) && x)) ||
-         rewrite(((x && y) && (z && x)), ((y && z) && x)) ||
-         rewrite((!(x && y) && (z && x)), ((!y && z) && x)) ||
-         rewrite((!(x && y) && (x || z)), select(x, !y, z)) ||
-         rewrite((!(x && y) && (z || x)), select(x, !y, z)) ||
-         rewrite((!(x && y) && (!x || z)), (!x || (!y && z))) ||
-         rewrite((!(x && y) && (z || !x)), (!x || (!y && z))) ||
-         rewrite(((y && x) && (x && z)), ((y && z) && x)) ||
-         rewrite(((y && x) && (z && x)), ((y && z) && x)) ||
-         rewrite(((x || y) && (x || z)), ((y && z) || x)) ||
-         rewrite((!(x || y) && (x || z)), (!x && (!y && z))) ||
-         rewrite(((x || y) && (z || x)), ((y && z) || x)) ||
-         rewrite((!(x || y) && (z || x)), (!x && (!y && z))) ||
-         rewrite(((x || y) && (!x && z)), (!x && (y && z))) ||
-         rewrite((!(x || y) && (!x && z)), (!x && (!y && z))) ||
-         rewrite(((x || y) && (!x || z)), select(x, z, y)) ||
-         rewrite(((x || y) && (z && !x)), (!x && (y && z))) ||
-         rewrite((!(x || y) && (z && !x)), (!x && (!y && z))) ||
-         rewrite(((x || y) && (z || !x)), select(x, z, y)) ||
-         rewrite(((y || x) && (x || z)), ((y && z) || x)) ||
-         rewrite(((y || x) && (z || x)), ((y && z) || x)) ||
-         rewrite(((y || x) && (!x && z)), (!x && (y && z))) ||
-         rewrite(((y || x) && (!x || z)), select(x, z, y)) ||
-         rewrite(((y || x) && (z && !x)), (!x && (y && z))) ||
-         rewrite(((y || x) && (z || !x)), select(x, z, y)) ||
-         rewrite(((!x && y) && (!x && z)), (!x && (y && z))) ||
-         rewrite(((!x && y) && (z && !x)), (!x && (y && z))) ||
-         rewrite(((!x || y) && (x && z)), ((y && z) && x)) ||
-         rewrite(((!x || y) && (z && x)), ((y && z) && x)) ||
-         rewrite(((!x || y) && (x || z)), select(x, y, z)) ||
-         rewrite(((!x || y) && (z || x)), select(x, y, z)) ||
-         rewrite(((!x || y) && (!x || z)), (!x || (y && z))) ||
-         rewrite(((!x || y) && (z || !x)), (!x || (y && z))) ||
-         rewrite(((y && !x) && (!x && z)), (!x && (y && z))) ||
-         rewrite(((y && !x) && (z && !x)), (!x && (y && z))) ||
-         rewrite(((y || !x) && (x && z)), ((y && z) && x)) ||
-         rewrite(((y || !x) && (z && x)), ((y && z) && x)) ||
-         rewrite(((y || !x) && (x || z)), select(x, y, z)) ||
-         rewrite(((y || !x) && (z || x)), select(x, y, z)) ||
-         rewrite(((y || !x) && (!x || z)), (!x || (y && z))) ||
-         rewrite(((y || !x) && (z || !x)), (!x || (y && z))) ||
-         rewrite((!((x && z) && y) && x), ((!y || !z) && x)) ||
-         rewrite((((x && z) || y) && x), ((y || z) && x)) ||
-         rewrite((!((x && z) || y) && x), (!(y || z) && x)) ||
-         rewrite(((y || (x && z)) && x), ((y || z) && x)) ||
-         rewrite(((!(x && z) && y) && x), ((!z && y) && x)) ||
-         rewrite(((!(x && z) || y) && x), ((!z || y) && x)) ||
-         rewrite(((y && !(x && z)) && x), ((!z && y) && x)) ||
-         rewrite(((y || !(x && z)) && x), ((!z || y) && x)) ||
-         rewrite((((z && x) || y) && x), ((y || z) && x)) ||
-         rewrite(((y || (z && x)) && x), ((y || z) && x)) ||
-         rewrite(((!(z && x) && y) && x), ((!z && y) && x)) ||
-         rewrite(((!(z && x) || y) && x), ((!z || y) && x)) ||
-         rewrite(((y && !(z && x)) && x), ((!z && y) && x)) ||
-         rewrite(((y || !(z && x)) && x), ((!z || y) && x)) ||
-         rewrite((((x || z) && y) && x), (x && y)) ||
-         rewrite((!((x || z) && y) && x), (!y && x)) ||
-         rewrite(((y && (x || z)) && x), (x && y)) ||
-         rewrite(((!(x || z) || y) && x), (x && y)) ||
-         rewrite(((y || !(x || z)) && x), (x && y)) ||
-         rewrite((((z || x) && y) && x), (x && y)) ||
-         rewrite(((y && (z || x)) && x), (x && y)) ||
-         rewrite(((!(z || x) || y) && x), (x && y)) ||
-         rewrite(((y || !(z || x)) && x), (x && y)) ||
-         rewrite((((!x && z) || y) && x), (x && y)) ||
-         rewrite((!((!x && z) || y) && x), (!y && x)) ||
-         rewrite(((y || (!x && z)) && x), (x && y)) ||
-         rewrite(((!(!x && z) && y) && x), (x && y)) ||
-         rewrite(((y && !(!x && z)) && x), (x && y)) ||
-         rewrite((((!x || z) && y) && x), ((y && z) && x)) ||
-         rewrite((!((!x || z) && y) && x), ((!y || !z) && x)) ||
-         rewrite(((y && (!x || z)) && x), ((y && z) && x)) ||
-         rewrite((((!x || z) || y) && x), ((y || z) && x)) ||
-         rewrite(((y || (!x || z)) && x), ((y || z) && x)) ||
-         rewrite(((!(!x || z) || y) && x), ((!z || y) && x)) ||
-         rewrite(((y || !(!x || z)) && x), ((!z || y) && x)) ||
-         rewrite((((z && !x) || y) && x), (x && y)) ||
-         rewrite(((y || (z && !x)) && x), (x && y)) ||
-         rewrite(((!(z && !x) && y) && x), (x && y)) ||
-         rewrite(((y && !(z && !x)) && x), (x && y)) ||
-         rewrite((((z || !x) && y) && x), ((y && z) && x)) ||
-         rewrite(((y && (z || !x)) && x), ((y && z) && x)) ||
-         rewrite((((z || !x) || y) && x), ((y || z) && x)) ||
-         rewrite(((y || (z || !x)) && x), ((y || z) && x)) ||
-         rewrite(((!(z || !x) || y) && x), ((!z || y) && x)) ||
-         rewrite(((y || !(z || !x)) && x), ((!z || y) && x)) ||
+         rewrite(x && !(x && y), !y && x) ||
+         rewrite(x && (neg(x) || y), x && y) ||
+         rewrite(x && (y || neg(x)), x && y) ||
+         rewrite(!(x && y) && x, !y && x) ||
+         rewrite((x || y) && neg(x), !x && y) ||
+         rewrite((y || x) && neg(x), !x && y) ||
+         rewrite(x && !((x && z) && y), (!y || !z) && x) ||
+         rewrite(x && ((x && z) || y), (y || z) && x) ||
+         rewrite(x && ((neg(x) && z) || y), x && y) ||
+         rewrite(x && !((x && z) || y), !(y || z) && x) ||
+         rewrite(x && (y || (x && z)), (y || z) && x) ||
+         rewrite(x && (y || (neg(x) && z)), x && y) ||
+         rewrite(x && (!(x && z) && y), (!z && y) && x) ||
+         rewrite(x && (!(neg(x) && z) && y), x && y) ||
+         rewrite(x && (!(x && z) || y), (!z || y) && x) ||
+         rewrite(x && (y && !(x && z)), (!z && y) && x) ||
+         rewrite(x && (y && !(neg(x) && z)), x && y) ||
+         rewrite(x && (y || !(x && z)), (!z || y) && x) ||
+         rewrite(x && ((z && x) || y), (y || z) && x) ||
+         rewrite(x && ((z && neg(x)) || y), x && y) ||
+         rewrite(x && (y || (z && x)), (y || z) && x) ||
+         rewrite(x && (y || (z && neg(x))), x && y) ||
+         rewrite(x && (!(z && x) && y), (!z && y) && x) ||
+         rewrite(x && (!(z && neg(x)) && y), x && y) ||
+         rewrite(x && (!(z && x) || y), (!z || y) && x) ||
+         rewrite(x && (y && !(z && x)), (!z && y) && x) ||
+         rewrite(x && (y && !(z && neg(x))), x && y) ||
+         rewrite(x && (y || !(z && x)), (!z || y) && x) ||
+         rewrite(x && ((x || z) && y), x && y) ||
+         rewrite(x && ((neg(x) || z) && y), (y && z) && x) ||
+         rewrite(x && !((x || z) && y), !y && x) ||
+         rewrite(x && (y && (x || z)), x && y) ||
+         rewrite(x && (y && (neg(x) || z)), (y && z) && x) ||
+         rewrite(x && ((neg(x) || z) || y), (y || z) && x) ||
+         rewrite(x && (y || (neg(x) || z)), (y || z) && x) ||
+         rewrite(x && (!(x || z) || y), x && y) ||
+         rewrite(x && (!(neg(x) || z) || y), (!z || y) && x) ||
+         rewrite(x && (y || !(x || z)), x && y) ||
+         rewrite(x && (y || !(neg(x) || z)), (!z || y) && x) ||
+         rewrite(x && ((z || x) && y), x && y) ||
+         rewrite(x && ((z || neg(x)) && y), (y && z) && x) ||
+         rewrite(x && (y && (z || x)), x && y) ||
+         rewrite(x && (y && (z || neg(x))), (y && z) && x) ||
+         rewrite(x && ((z || neg(x)) || y), (y || z) && x) ||
+         rewrite(x && (y || (z || neg(x))), (y || z) && x) ||
+         rewrite(x && (!(z || x) || y), x && y) ||
+         rewrite(x && (!(z || neg(x)) || y), (!z || y) && x) ||
+         rewrite(x && (y || !(z || x)), x && y) ||
+         rewrite(x && (y || !(z || neg(x))), (!z || y) && x) ||
+         rewrite((x && y) && (x && z), (y && z) && x) ||
+         rewrite(!(x && y) && (x && z), (!y && z) && x) ||
+         rewrite((x && y) && (z && x), (y && z) && x) ||
+         rewrite(!(x && y) && (z && x), (!y && z) && x) ||
+         rewrite(!(x && y) && (x || z), select(x, !y, z)) ||
+         rewrite(!(x && y) && (z || x), select(x, !y, z)) ||
+         rewrite((y && x) && (x && z), (y && z) && x) ||
+         rewrite((y && x) && (z && x), (y && z) && x) ||
+         rewrite((x || y) && (neg(x) && z), !x && (y && z)) ||
+         rewrite((x || y) && (z && neg(x)), !x && (y && z)) ||
+         rewrite((x || y) && (x || z), (y && z) || x) ||
+         rewrite((x || y) && (neg(x) || z), select(x, z, y)) ||
+         rewrite(!(x || y) && (x || z), !x && (!y && z)) ||
+         rewrite((x || y) && (z || x), (y && z) || x) ||
+         rewrite((x || y) && (z || neg(x)), select(x, z, y)) ||
+         rewrite(!(x || y) && (z || x), !x && (!y && z)) ||
+         rewrite((y || x) && (neg(x) && z), !x && (y && z)) ||
+         rewrite((y || x) && (z && neg(x)), !x && (y && z)) ||
+         rewrite((y || x) && (x || z), (y && z) || x) ||
+         rewrite((y || x) && (neg(x) || z), select(x, z, y)) ||
+         rewrite((y || x) && (z || x), (y && z) || x) ||
+         rewrite((y || x) && (z || neg(x)), select(x, z, y)) ||
+         rewrite(!((x && z) && y) && x, (!y || !z) && x) ||
+         rewrite(((x && z) || y) && x, (y || z) && x) ||
+         rewrite(((x && z) || y) && neg(x), !x && y) ||
+         rewrite(!((x && z) || y) && x, !(y || z) && x) ||
+         rewrite((y || (x && z)) && x, (y || z) && x) ||
+         rewrite((y || (x && z)) && neg(x), !x && y) ||
+         rewrite((!(x && z) && y) && x, (!z && y) && x) ||
+         rewrite((!(x && z) && y) && neg(x), !x && y) ||
+         rewrite((!(x && z) || y) && x, (!z || y) && x) ||
+         rewrite((y && !(x && z)) && x, (!z && y) && x) ||
+         rewrite((y && !(x && z)) && neg(x), !x && y) ||
+         rewrite((y || !(x && z)) && x, (!z || y) && x) ||
+         rewrite(((z && x) || y) && x, (y || z) && x) ||
+         rewrite(((z && x) || y) && neg(x), !x && y) ||
+         rewrite((y || (z && x)) && x, (y || z) && x) ||
+         rewrite((y || (z && x)) && neg(x), !x && y) ||
+         rewrite((!(z && x) && y) && x, (!z && y) && x) ||
+         rewrite((!(z && x) && y) && neg(x), !x && y) ||
+         rewrite((!(z && x) || y) && x, (!z || y) && x) ||
+         rewrite((y && !(z && x)) && x, (!z && y) && x) ||
+         rewrite((y && !(z && x)) && neg(x), !x && y) ||
+         rewrite((y || !(z && x)) && x, (!z || y) && x) ||
+         rewrite(((x || z) && y) && x, x && y) ||
+         rewrite(((x || z) && y) && neg(x), !x && (y && z)) ||
+         rewrite(!((x || z) && y) && x, !y && x) ||
+         rewrite((y && (x || z)) && x, x && y) ||
+         rewrite((y && (x || z)) && neg(x), !x && (y && z)) ||
+         rewrite(((x || z) || y) && neg(x), !x && (y || z)) ||
+         rewrite((y || (x || z)) && neg(x), !x && (y || z)) ||
+         rewrite((!(x || z) || y) && x, x && y) ||
+         rewrite((!(x || z) || y) && neg(x), !x && (!z || y)) ||
+         rewrite((y || !(x || z)) && x, x && y) ||
+         rewrite((y || !(x || z)) && neg(x), !x && (!z || y)) ||
+         rewrite(((z || x) && y) && x, x && y) ||
+         rewrite(((z || x) && y) && neg(x), !x && (y && z)) ||
+         rewrite((y && (z || x)) && x, x && y) ||
+         rewrite((y && (z || x)) && neg(x), !x && (y && z)) ||
+         rewrite(((z || x) || y) && neg(x), !x && (y || z)) ||
+         rewrite((y || (z || x)) && neg(x), !x && (y || z)) ||
+         rewrite((!(z || x) || y) && x, x && y) ||
+         rewrite((!(z || x) || y) && neg(x), !x && (!z || y)) ||
+         rewrite((y || !(z || x)) && x, x && y) ||
+         rewrite((y || !(z || x)) && neg(x), !x && (!z || y)) ||
 
          rewrite(x < y && x < z, x < min(y, z)) ||
          rewrite(y < x && z < x, max(y, z) < x) ||

--- a/src/Simplify_And.cpp
+++ b/src/Simplify_And.cpp
@@ -37,8 +37,54 @@ Expr Simplify::visit(const And *op, ExprInfo *info) {
          rewrite((z && x == y) && y != x, false) ||
          rewrite((x == y && z) && x != y, false) ||
          rewrite((x == y && z) && y != x, false) ||
-         rewrite(x && !x, false) ||
-         rewrite(!x && x, false) ||
+
+         rewrite((!x && x), false) ||
+         rewrite((x && !x), false) ||
+         rewrite((!x && (x && y)), false) ||
+         rewrite((!x && (y && x)), false) ||
+         rewrite((x && !(x || y)), false) ||
+         rewrite((x && (!x && y)), false) ||
+         rewrite((x && (y && !x)), false) ||
+         rewrite((!(x || y) && x), false) ||
+         rewrite(((!x && y) && x), false) ||
+         rewrite(((y && !x) && x), false) ||
+         rewrite((!x && ((x && z) && y)), false) ||
+         rewrite((!x && (y && (x && z))), false) ||
+         rewrite((!x && ((z && x) && y)), false) ||
+         rewrite((!x && (y && (z && x))), false) ||
+         rewrite((x && !((x || z) || y)), false) ||
+         rewrite((x && (!(x || z) && y)), false) ||
+         rewrite((x && (y && !(x || z))), false) ||
+         rewrite((x && (!(z || x) && y)), false) ||
+         rewrite((x && (y && !(z || x))), false) ||
+         rewrite((x && ((!x && z) && y)), false) ||
+         rewrite((x && (y && (!x && z))), false) ||
+         rewrite((!x && (!(!x || z) && y)), false) ||
+         rewrite((!x && (y && !(!x || z))), false) ||
+         rewrite((x && ((z && !x) && y)), false) ||
+         rewrite((x && (y && (z && !x))), false) ||
+         rewrite((!x && (!(z || !x) && y)), false) ||
+         rewrite((!x && (y && !(z || !x))), false) ||
+         rewrite(((x && y) && (!x && z)), false) ||
+         rewrite(((x && y) && (z && !x)), false) ||
+         rewrite(((y && x) && (!x && z)), false) ||
+         rewrite(((y && x) && (z && !x)), false) ||
+         rewrite((!(x || y) && (x && z)), false) ||
+         rewrite((!(x || y) && (z && x)), false) ||
+         rewrite(((!x && y) && (x && z)), false) ||
+         rewrite(((!x && y) && (z && x)), false) ||
+         rewrite(((y && !x) && (x && z)), false) ||
+         rewrite(((y && !x) && (z && x)), false) ||
+         rewrite((!((x || z) || y) && x), false) ||
+         rewrite(((!(x || z) && y) && x), false) ||
+         rewrite(((y && !(x || z)) && x), false) ||
+         rewrite(((!(z || x) && y) && x), false) ||
+         rewrite(((y && !(z || x)) && x), false) ||
+         rewrite((((!x && z) && y) && x), false) ||
+         rewrite(((y && (!x && z)) && x), false) ||
+         rewrite((((z && !x) && y) && x), false) ||
+         rewrite(((y && (z && !x)) && x), false) ||
+
          rewrite(y <= x && x < y, false) ||
          rewrite(y < x && x < y, false) ||
          rewrite(x == c0 && x == c1, false, c0 != c1) ||
@@ -60,69 +106,294 @@ Expr Simplify::visit(const And *op, ExprInfo *info) {
     // Cases that fold to one of the args
     if (EVAL_IN_LAMBDA
         (rewrite(x && true, a) ||
-         rewrite(x && x, a) ||
 
-         rewrite((x && y) && x, a) ||
-         rewrite(x && (x && y), b) ||
-         rewrite((x && y) && y, a) ||
-         rewrite(y && (x && y), b) ||
-
-         rewrite(((x && y) && z) && x, a) ||
-         rewrite(x && ((x && y) && z), b) ||
-         rewrite((z && (x && y)) && x, a) ||
-         rewrite(x && (z && (x && y)), b) ||
-         rewrite(((x && y) && z) && y, a) ||
-         rewrite(y && ((x && y) && z), b) ||
-         rewrite((z && (x && y)) && y, a) ||
-         rewrite(y && (z && (x && y)), b) ||
-
-         rewrite((x || y) && x, b) ||
-         rewrite(x && (x || y), a) ||
-         rewrite((x || y) && y, b) ||
-         rewrite(y && (x || y), a) ||
+         rewrite((x && x), a) ||
+         rewrite((x && (x && y)), b) ||
+         rewrite((x && (y && x)), b) ||
+         rewrite((x && (x || y)), a) ||
+         rewrite((x && (y || x)), a) ||
+         rewrite((!x && (!x && y)), b) ||
+         rewrite((!x && (!x || y)), a) ||
+         rewrite((!x && (y && !x)), b) ||
+         rewrite((!x && (y || !x)), a) ||
+         rewrite(((x && y) && x), a) ||
+         rewrite(((y && x) && x), a) ||
+         rewrite(((x || y) && x), b) ||
+         rewrite(((y || x) && x), b) ||
+         rewrite((x && ((x && z) && y)), b) ||
+         rewrite((x && (y && (x && z))), b) ||
+         rewrite((!x && (!(x && z) || y)), a) ||
+         rewrite((!x && (y || !(x && z))), a) ||
+         rewrite((x && ((z && x) && y)), b) ||
+         rewrite((x && (y && (z && x))), b) ||
+         rewrite((!x && (!(z && x) || y)), a) ||
+         rewrite((!x && (y || !(z && x))), a) ||
+         rewrite((x && ((x || z) || y)), a) ||
+         rewrite((x && (y || (x || z))), a) ||
+         rewrite((!x && (!(x || z) && y)), b) ||
+         rewrite((!x && (y && !(x || z))), b) ||
+         rewrite((x && ((z || x) || y)), a) ||
+         rewrite((x && (y || (z || x))), a) ||
+         rewrite((!x && (!(z || x) && y)), b) ||
+         rewrite((!x && (y && !(z || x))), b) ||
+         rewrite((!x && ((!x && z) && y)), b) ||
+         rewrite((x && !((!x && z) && y)), a) ||
+         rewrite((!x && (y && (!x && z))), b) ||
+         rewrite((x && (!(!x && z) || y)), a) ||
+         rewrite((x && (y || !(!x && z))), a) ||
+         rewrite((!x && ((!x || z) || y)), a) ||
+         rewrite((x && !((!x || z) || y)), b) ||
+         rewrite((!x && (y || (!x || z))), a) ||
+         rewrite((x && (!(!x || z) && y)), b) ||
+         rewrite((x && (y && !(!x || z))), b) ||
+         rewrite((!x && ((z && !x) && y)), b) ||
+         rewrite((!x && (y && (z && !x))), b) ||
+         rewrite((x && (!(z && !x) || y)), a) ||
+         rewrite((x && (y || !(z && !x))), a) ||
+         rewrite((!x && ((z || !x) || y)), a) ||
+         rewrite((!x && (y || (z || !x))), a) ||
+         rewrite((x && (!(z || !x) && y)), b) ||
+         rewrite((x && (y && !(z || !x))), b) ||
+         rewrite((!(x && y) && (!x && z)), b) ||
+         rewrite((!(x && y) && (z && !x)), b) ||
+         rewrite(((x || y) && (x && z)), b) ||
+         rewrite(((x || y) && (z && x)), b) ||
+         rewrite((!(x || y) && (!x || z)), a) ||
+         rewrite((!(x || y) && (z || !x)), a) ||
+         rewrite(((y || x) && (x && z)), b) ||
+         rewrite(((y || x) && (z && x)), b) ||
+         rewrite(((!x || y) && (!x && z)), b) ||
+         rewrite(((!x || y) && (z && !x)), b) ||
+         rewrite(((y || !x) && (!x && z)), b) ||
+         rewrite(((y || !x) && (z && !x)), b) ||
+         rewrite((((x && z) && y) && x), a) ||
+         rewrite(((y && (x && z)) && x), a) ||
+         rewrite((((z && x) && y) && x), a) ||
+         rewrite(((y && (z && x)) && x), a) ||
+         rewrite((((x || z) || y) && x), b) ||
+         rewrite(((y || (x || z)) && x), b) ||
+         rewrite((((z || x) || y) && x), b) ||
+         rewrite(((y || (z || x)) && x), b) ||
+         rewrite((!((!x && z) && y) && x), b) ||
+         rewrite(((!(!x && z) || y) && x), b) ||
+         rewrite(((y || !(!x && z)) && x), b) ||
+         rewrite((!((!x || z) || y) && x), a) ||
+         rewrite(((!(!x || z) && y) && x), a) ||
+         rewrite(((y && !(!x || z)) && x), a) ||
+         rewrite(((!(z && !x) || y) && x), b) ||
+         rewrite(((y || !(z && !x)) && x), b) ||
+         rewrite(((!(z || !x) && y) && x), a) ||
+         rewrite(((y && !(z || !x)) && x), a) ||
 
          rewrite(x != c0 && x == c1, b, c0 != c1) ||
          rewrite(c0 < x && c1 < x, fold(max(c0, c1)) < x) ||
          rewrite(c0 <= x && c1 <= x, fold(max(c0, c1)) <= x) ||
          rewrite(x < c0 && x < c1, x < fold(min(c0, c1))) ||
-         rewrite(x <= c0 && x <= c1, x <= fold(min(c0, c1))))) {
+         rewrite(x <= c0 && x < c1, a, c0 < c1) ||
+         rewrite(x <= c0 && x < c1, b, c1 <= c0) ||
+         rewrite(x <= c0 && x <= c1, x <= fold(min(c0, c1))) ||
+         false)) {
         return rewrite.result;
     }
-    // clang-format on
 
-    if (rewrite(broadcast(x, c0) && broadcast(y, c0), broadcast(x && y, c0)) ||
-        rewrite((x || (y && z)) && y, (x || z) && y) ||
-        rewrite((x || (z && y)) && y, (x || z) && y) ||
-        rewrite(y && (x || (y && z)), y && (x || z)) ||
-        rewrite(y && (x || (z && y)), y && (x || z)) ||
+    if (EVAL_IN_LAMBDA
+        (rewrite(broadcast(x, c0) && broadcast(y, c0), broadcast(x && y, c0)) ||
+         rewrite((x && broadcast(y, c0)) && broadcast(z, c0), x && broadcast(y && z, c0)) ||
+         rewrite((broadcast(x, c0) && y) && broadcast(z, c0), broadcast(x && z, c0) && y) ||
 
-        rewrite(((y && z) || x) && y, (z || x) && y) ||
-        rewrite(((z && y) || x) && y, (z || x) && y) ||
-        rewrite(y && ((y && z) || x), y && (z || x)) ||
-        rewrite(y && ((z && y) || x), y && (z || x)) ||
+         rewrite(!x && !y, !(x || y)) ||
 
-        rewrite((x && (y || z)) && y, x && y) ||
-        rewrite((x && (z || y)) && y, x && y) ||
-        rewrite(y && (x && (y || z)), y && x) ||
-        rewrite(y && (x && (z || y)), y && x) ||
+         rewrite((x && !(x && y)), (!y && x)) ||
+         rewrite((!x && (x || y)), (!x && y)) ||
+         rewrite((!x && (y || x)), (!x && y)) ||
+         rewrite((x && (!x || y)), (x && y)) ||
+         rewrite((x && (y || !x)), (x && y)) ||
+         rewrite((!(x && y) && x), (!y && x)) ||
+         rewrite(((!x || y) && x), (x && y)) ||
+         rewrite(((y || !x) && x), (x && y)) ||
+         rewrite((x && !((x && z) && y)), ((!y || !z) && x)) ||
+         rewrite((x && ((x && z) || y)), ((y || z) && x)) ||
+         rewrite((!x && ((x && z) || y)), (!x && y)) ||
+         rewrite((x && !((x && z) || y)), (!(y || z) && x)) ||
+         rewrite((x && (y || (x && z))), ((y || z) && x)) ||
+         rewrite((!x && (y || (x && z))), (!x && y)) ||
+         rewrite((x && (!(x && z) && y)), ((!z && y) && x)) ||
+         rewrite((!x && (!(x && z) && y)), (!x && y)) ||
+         rewrite((x && (!(x && z) || y)), ((!z || y) && x)) ||
+         rewrite((x && (y && !(x && z))), ((!z && y) && x)) ||
+         rewrite((!x && (y && !(x && z))), (!x && y)) ||
+         rewrite((x && (y || !(x && z))), ((!z || y) && x)) ||
+         rewrite((x && ((z && x) || y)), ((y || z) && x)) ||
+         rewrite((!x && ((z && x) || y)), (!x && y)) ||
+         rewrite((x && (y || (z && x))), ((y || z) && x)) ||
+         rewrite((!x && (y || (z && x))), (!x && y)) ||
+         rewrite((x && (!(z && x) && y)), ((!z && y) && x)) ||
+         rewrite((!x && (!(z && x) && y)), (!x && y)) ||
+         rewrite((x && (!(z && x) || y)), ((!z || y) && x)) ||
+         rewrite((x && (y && !(z && x))), ((!z && y) && x)) ||
+         rewrite((!x && (y && !(z && x))), (!x && y)) ||
+         rewrite((x && (y || !(z && x))), ((!z || y) && x)) ||
+         rewrite((x && ((x || z) && y)), (x && y)) ||
+         rewrite((!x && ((x || z) && y)), (!x && (y && z))) ||
+         rewrite((x && !((x || z) && y)), (!y && x)) ||
+         rewrite((x && (y && (x || z))), (x && y)) ||
+         rewrite((!x && (y && (x || z))), (!x && (y && z))) ||
+         rewrite((!x && ((x || z) || y)), (!x && (y || z))) ||
+         rewrite((!x && (y || (x || z))), (!x && (y || z))) ||
+         rewrite((x && (!(x || z) || y)), (x && y)) ||
+         rewrite((!x && (!(x || z) || y)), (!x && (!z || y))) ||
+         rewrite((x && (y || !(x || z))), (x && y)) ||
+         rewrite((!x && (y || !(x || z))), (!x && (!z || y))) ||
+         rewrite((x && ((z || x) && y)), (x && y)) ||
+         rewrite((!x && ((z || x) && y)), (!x && (y && z))) ||
+         rewrite((x && (y && (z || x))), (x && y)) ||
+         rewrite((!x && (y && (z || x))), (!x && (y && z))) ||
+         rewrite((!x && ((z || x) || y)), (!x && (y || z))) ||
+         rewrite((!x && (y || (z || x))), (!x && (y || z))) ||
+         rewrite((x && (!(z || x) || y)), (x && y)) ||
+         rewrite((!x && (!(z || x) || y)), (!x && (!z || y))) ||
+         rewrite((x && (y || !(z || x))), (x && y)) ||
+         rewrite((!x && (y || !(z || x))), (!x && (!z || y))) ||
+         rewrite((x && ((!x && z) || y)), (x && y)) ||
+         rewrite((!x && ((!x && z) || y)), (!x && (y || z))) ||
+         rewrite((x && !((!x && z) || y)), (!y && x)) ||
+         rewrite((x && (y || (!x && z))), (x && y)) ||
+         rewrite((!x && (y || (!x && z))), (!x && (y || z))) ||
+         rewrite((x && (!(!x && z) && y)), (x && y)) ||
+         rewrite((!x && (!(!x && z) && y)), (!x && (!z && y))) ||
+         rewrite((!x && (!(!x && z) || y)), (!x && (!z || y))) ||
+         rewrite((x && (y && !(!x && z))), (x && y)) ||
+         rewrite((!x && (y && !(!x && z))), (!x && (!z && y))) ||
+         rewrite((!x && (y || !(!x && z))), (!x && (!z || y))) ||
+         rewrite((x && ((!x || z) && y)), ((y && z) && x)) ||
+         rewrite((!x && ((!x || z) && y)), (!x && y)) ||
+         rewrite((x && !((!x || z) && y)), ((!y || !z) && x)) ||
+         rewrite((x && (y && (!x || z))), ((y && z) && x)) ||
+         rewrite((!x && (y && (!x || z))), (!x && y)) ||
+         rewrite((x && ((!x || z) || y)), ((y || z) && x)) ||
+         rewrite((x && (y || (!x || z))), ((y || z) && x)) ||
+         rewrite((x && (!(!x || z) || y)), ((!z || y) && x)) ||
+         rewrite((!x && (!(!x || z) || y)), (!x && y)) ||
+         rewrite((x && (y || !(!x || z))), ((!z || y) && x)) ||
+         rewrite((!x && (y || !(!x || z))), (!x && y)) ||
+         rewrite((x && ((z && !x) || y)), (x && y)) ||
+         rewrite((!x && ((z && !x) || y)), (!x && (y || z))) ||
+         rewrite((x && (y || (z && !x))), (x && y)) ||
+         rewrite((!x && (y || (z && !x))), (!x && (y || z))) ||
+         rewrite((x && (!(z && !x) && y)), (x && y)) ||
+         rewrite((!x && (!(z && !x) && y)), (!x && (!z && y))) ||
+         rewrite((!x && (!(z && !x) || y)), (!x && (!z || y))) ||
+         rewrite((x && (y && !(z && !x))), (x && y)) ||
+         rewrite((!x && (y && !(z && !x))), (!x && (!z && y))) ||
+         rewrite((!x && (y || !(z && !x))), (!x && (!z || y))) ||
+         rewrite((x && ((z || !x) && y)), ((y && z) && x)) ||
+         rewrite((!x && ((z || !x) && y)), (!x && y)) ||
+         rewrite((x && (y && (z || !x))), ((y && z) && x)) ||
+         rewrite((!x && (y && (z || !x))), (!x && y)) ||
+         rewrite((x && ((z || !x) || y)), ((y || z) && x)) ||
+         rewrite((x && (y || (z || !x))), ((y || z) && x)) ||
+         rewrite((x && (!(z || !x) || y)), ((!z || y) && x)) ||
+         rewrite((!x && (!(z || !x) || y)), (!x && y)) ||
+         rewrite((x && (y || !(z || !x))), ((!z || y) && x)) ||
+         rewrite((!x && (y || !(z || !x))), (!x && y)) ||
+         rewrite(((x && y) && (x && z)), ((y && z) && x)) ||
+         rewrite((!(x && y) && (x && z)), ((!y && z) && x)) ||
+         rewrite(((x && y) && (z && x)), ((y && z) && x)) ||
+         rewrite((!(x && y) && (z && x)), ((!y && z) && x)) ||
+         rewrite((!(x && y) && (x || z)), select(x, !y, z)) ||
+         rewrite((!(x && y) && (z || x)), select(x, !y, z)) ||
+         rewrite((!(x && y) && (!x || z)), (!x || (!y && z))) ||
+         rewrite((!(x && y) && (z || !x)), (!x || (!y && z))) ||
+         rewrite(((y && x) && (x && z)), ((y && z) && x)) ||
+         rewrite(((y && x) && (z && x)), ((y && z) && x)) ||
+         rewrite(((x || y) && (x || z)), ((y && z) || x)) ||
+         rewrite((!(x || y) && (x || z)), (!x && (!y && z))) ||
+         rewrite(((x || y) && (z || x)), ((y && z) || x)) ||
+         rewrite((!(x || y) && (z || x)), (!x && (!y && z))) ||
+         rewrite(((x || y) && (!x && z)), (!x && (y && z))) ||
+         rewrite((!(x || y) && (!x && z)), (!x && (!y && z))) ||
+         rewrite(((x || y) && (!x || z)), select(x, z, y)) ||
+         rewrite(((x || y) && (z && !x)), (!x && (y && z))) ||
+         rewrite((!(x || y) && (z && !x)), (!x && (!y && z))) ||
+         rewrite(((x || y) && (z || !x)), select(x, z, y)) ||
+         rewrite(((y || x) && (x || z)), ((y && z) || x)) ||
+         rewrite(((y || x) && (z || x)), ((y && z) || x)) ||
+         rewrite(((y || x) && (!x && z)), (!x && (y && z))) ||
+         rewrite(((y || x) && (!x || z)), select(x, z, y)) ||
+         rewrite(((y || x) && (z && !x)), (!x && (y && z))) ||
+         rewrite(((y || x) && (z || !x)), select(x, z, y)) ||
+         rewrite(((!x && y) && (!x && z)), (!x && (y && z))) ||
+         rewrite(((!x && y) && (z && !x)), (!x && (y && z))) ||
+         rewrite(((!x || y) && (x && z)), ((y && z) && x)) ||
+         rewrite(((!x || y) && (z && x)), ((y && z) && x)) ||
+         rewrite(((!x || y) && (x || z)), select(x, y, z)) ||
+         rewrite(((!x || y) && (z || x)), select(x, y, z)) ||
+         rewrite(((!x || y) && (!x || z)), (!x || (y && z))) ||
+         rewrite(((!x || y) && (z || !x)), (!x || (y && z))) ||
+         rewrite(((y && !x) && (!x && z)), (!x && (y && z))) ||
+         rewrite(((y && !x) && (z && !x)), (!x && (y && z))) ||
+         rewrite(((y || !x) && (x && z)), ((y && z) && x)) ||
+         rewrite(((y || !x) && (z && x)), ((y && z) && x)) ||
+         rewrite(((y || !x) && (x || z)), select(x, y, z)) ||
+         rewrite(((y || !x) && (z || x)), select(x, y, z)) ||
+         rewrite(((y || !x) && (!x || z)), (!x || (y && z))) ||
+         rewrite(((y || !x) && (z || !x)), (!x || (y && z))) ||
+         rewrite((!((x && z) && y) && x), ((!y || !z) && x)) ||
+         rewrite((((x && z) || y) && x), ((y || z) && x)) ||
+         rewrite((!((x && z) || y) && x), (!(y || z) && x)) ||
+         rewrite(((y || (x && z)) && x), ((y || z) && x)) ||
+         rewrite(((!(x && z) && y) && x), ((!z && y) && x)) ||
+         rewrite(((!(x && z) || y) && x), ((!z || y) && x)) ||
+         rewrite(((y && !(x && z)) && x), ((!z && y) && x)) ||
+         rewrite(((y || !(x && z)) && x), ((!z || y) && x)) ||
+         rewrite((((z && x) || y) && x), ((y || z) && x)) ||
+         rewrite(((y || (z && x)) && x), ((y || z) && x)) ||
+         rewrite(((!(z && x) && y) && x), ((!z && y) && x)) ||
+         rewrite(((!(z && x) || y) && x), ((!z || y) && x)) ||
+         rewrite(((y && !(z && x)) && x), ((!z && y) && x)) ||
+         rewrite(((y || !(z && x)) && x), ((!z || y) && x)) ||
+         rewrite((((x || z) && y) && x), (x && y)) ||
+         rewrite((!((x || z) && y) && x), (!y && x)) ||
+         rewrite(((y && (x || z)) && x), (x && y)) ||
+         rewrite(((!(x || z) || y) && x), (x && y)) ||
+         rewrite(((y || !(x || z)) && x), (x && y)) ||
+         rewrite((((z || x) && y) && x), (x && y)) ||
+         rewrite(((y && (z || x)) && x), (x && y)) ||
+         rewrite(((!(z || x) || y) && x), (x && y)) ||
+         rewrite(((y || !(z || x)) && x), (x && y)) ||
+         rewrite((((!x && z) || y) && x), (x && y)) ||
+         rewrite((!((!x && z) || y) && x), (!y && x)) ||
+         rewrite(((y || (!x && z)) && x), (x && y)) ||
+         rewrite(((!(!x && z) && y) && x), (x && y)) ||
+         rewrite(((y && !(!x && z)) && x), (x && y)) ||
+         rewrite((((!x || z) && y) && x), ((y && z) && x)) ||
+         rewrite((!((!x || z) && y) && x), ((!y || !z) && x)) ||
+         rewrite(((y && (!x || z)) && x), ((y && z) && x)) ||
+         rewrite((((!x || z) || y) && x), ((y || z) && x)) ||
+         rewrite(((y || (!x || z)) && x), ((y || z) && x)) ||
+         rewrite(((!(!x || z) || y) && x), ((!z || y) && x)) ||
+         rewrite(((y || !(!x || z)) && x), ((!z || y) && x)) ||
+         rewrite((((z && !x) || y) && x), (x && y)) ||
+         rewrite(((y || (z && !x)) && x), (x && y)) ||
+         rewrite(((!(z && !x) && y) && x), (x && y)) ||
+         rewrite(((y && !(z && !x)) && x), (x && y)) ||
+         rewrite((((z || !x) && y) && x), ((y && z) && x)) ||
+         rewrite(((y && (z || !x)) && x), ((y && z) && x)) ||
+         rewrite((((z || !x) || y) && x), ((y || z) && x)) ||
+         rewrite(((y || (z || !x)) && x), ((y || z) && x)) ||
+         rewrite(((!(z || !x) || y) && x), ((!z || y) && x)) ||
+         rewrite(((y || !(z || !x)) && x), ((!z || y) && x)) ||
 
-        rewrite(((y || z) && x) && y, x && y) ||
-        rewrite(((z || y) && x) && y, x && y) ||
-        rewrite(y && ((y || z) && x), y && x) ||
-        rewrite(y && ((z || y) && x), y && x) ||
+         rewrite(x < y && x < z, x < min(y, z)) ||
+         rewrite(y < x && z < x, max(y, z) < x) ||
+         rewrite(x <= y && x <= z, x <= min(y, z)) ||
+         rewrite(y <= x && z <= x, max(y, z) <= x) ||
 
-        rewrite((x || y) && (x || z), x || (y && z)) ||
-        rewrite((x || y) && (z || x), x || (y && z)) ||
-        rewrite((y || x) && (x || z), x || (y && z)) ||
-        rewrite((y || x) && (z || x), x || (y && z)) ||
-
-        rewrite(x < y && x < z, x < min(y, z)) ||
-        rewrite(y < x && z < x, max(y, z) < x) ||
-        rewrite(x <= y && x <= z, x <= min(y, z)) ||
-        rewrite(y <= x && z <= x, max(y, z) <= x)) {
+         false)) {
 
         return mutate(rewrite.result, info);
     }
+    // clang-format on
 
     if (a.same_as(op->a) &&
         b.same_as(op->b)) {

--- a/src/Simplify_Or.cpp
+++ b/src/Simplify_Or.cpp
@@ -36,8 +36,54 @@ Expr Simplify::visit(const Or *op, ExprInfo *info) {
          rewrite((z || x == y) || y != x, true) ||
          rewrite((x == y || z) || x != y, true) ||
          rewrite((x == y || z) || y != x, true) ||
-         rewrite(x || !x, true) ||
-         rewrite(!x || x, true) ||
+
+         rewrite((!x || x), true) ||
+         rewrite((x || !x), true) ||
+         rewrite((x || !(x && y)), true) ||
+         rewrite((!x || (x || y)), true) ||
+         rewrite((!x || (y || x)), true) ||
+         rewrite((x || (!x || y)), true) ||
+         rewrite((x || (y || !x)), true) ||
+         rewrite((!(x && y) || x), true) ||
+         rewrite(((!x || y) || x), true) ||
+         rewrite(((y || !x) || x), true) ||
+         rewrite((x || !((x && z) && y)), true) ||
+         rewrite((x || (!(x && z) || y)), true) ||
+         rewrite((x || (y || !(x && z))), true) ||
+         rewrite((x || (!(z && x) || y)), true) ||
+         rewrite((x || (y || !(z && x))), true) ||
+         rewrite((!x || ((x || z) || y)), true) ||
+         rewrite((!x || (y || (x || z))), true) ||
+         rewrite((!x || ((z || x) || y)), true) ||
+         rewrite((!x || (y || (z || x))), true) ||
+         rewrite((!x || (!(!x && z) || y)), true) ||
+         rewrite((!x || (y || !(!x && z))), true) ||
+         rewrite((x || ((!x || z) || y)), true) ||
+         rewrite((x || (y || (!x || z))), true) ||
+         rewrite((!x || (!(z && !x) || y)), true) ||
+         rewrite((!x || (y || !(z && !x))), true) ||
+         rewrite((x || ((z || !x) || y)), true) ||
+         rewrite((x || (y || (z || !x))), true) ||
+         rewrite((!(x && y) || (x || z)), true) ||
+         rewrite((!(x && y) || (z || x)), true) ||
+         rewrite(((x || y) || (!x || z)), true) ||
+         rewrite(((x || y) || (z || !x)), true) ||
+         rewrite(((y || x) || (!x || z)), true) ||
+         rewrite(((y || x) || (z || !x)), true) ||
+         rewrite(((!x || y) || (x || z)), true) ||
+         rewrite(((!x || y) || (z || x)), true) ||
+         rewrite(((y || !x) || (x || z)), true) ||
+         rewrite(((y || !x) || (z || x)), true) ||
+         rewrite((!((x && z) && y) || x), true) ||
+         rewrite(((!(x && z) || y) || x), true) ||
+         rewrite(((y || !(x && z)) || x), true) ||
+         rewrite(((!(z && x) || y) || x), true) ||
+         rewrite(((y || !(z && x)) || x), true) ||
+         rewrite((((!x || z) || y) || x), true) ||
+         rewrite(((y || (!x || z)) || x), true) ||
+         rewrite((((z || !x) || y) || x), true) ||
+         rewrite(((y || (z || !x)) || x), true) ||
+
          rewrite(y <= x || x < y, true) ||
          rewrite(x <= c0 || c1 <= x, true, !is_float(x) && c1 <= c0 + 1) ||
          rewrite(c1 <= x || x <= c0, true, !is_float(x) && c1 <= c0 + 1) ||
@@ -52,26 +98,84 @@ Expr Simplify::visit(const Or *op, ExprInfo *info) {
     // Cases that fold to one of the args
     if (EVAL_IN_LAMBDA
         (rewrite(x || false, a) ||
-         rewrite(x || x, a) ||
 
-         rewrite((x || y) || x, a) ||
-         rewrite(x || (x || y), b) ||
-         rewrite((x || y) || y, a) ||
-         rewrite(y || (x || y), b) ||
-
-         rewrite(((x || y) || z) || x, a) ||
-         rewrite(x || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || x, a) ||
-         rewrite(x || (z || (x || y)), b) ||
-         rewrite(((x || y) || z) || y, a) ||
-         rewrite(y || ((x || y) || z), b) ||
-         rewrite((z || (x || y)) || y, a) ||
-         rewrite(y || (z || (x || y)), b) ||
-
-         rewrite((x && y) || x, b) ||
-         rewrite(x || (x && y), a) ||
-         rewrite((x && y) || y, b) ||
-         rewrite(y || (x && y), a) ||
+         rewrite((x || x), a) ||
+         rewrite((x || (x && y)), a) ||
+         rewrite((x || (y && x)), a) ||
+         rewrite((x || (x || y)), b) ||
+         rewrite((x || (y || x)), b) ||
+         rewrite((!x || (!x && y)), a) ||
+         rewrite((!x || (!x || y)), b) ||
+         rewrite((!x || (y && !x)), a) ||
+         rewrite((!x || (y || !x)), b) ||
+         rewrite(((x && y) || x), b) ||
+         rewrite(((y && x) || x), b) ||
+         rewrite(((x || y) || x), a) ||
+         rewrite(((y || x) || x), a) ||
+         rewrite((x || ((x && z) && y)), a) ||
+         rewrite((x || (y && (x && z))), a) ||
+         rewrite((!x || (!(x && z) || y)), b) ||
+         rewrite((!x || (y || !(x && z))), b) ||
+         rewrite((x || ((z && x) && y)), a) ||
+         rewrite((x || (y && (z && x))), a) ||
+         rewrite((!x || (!(z && x) || y)), b) ||
+         rewrite((!x || (y || !(z && x))), b) ||
+         rewrite((x || ((x || z) || y)), b) ||
+         rewrite((x || (y || (x || z))), b) ||
+         rewrite((!x || (!(x || z) && y)), a) ||
+         rewrite((!x || (y && !(x || z))), a) ||
+         rewrite((x || ((z || x) || y)), b) ||
+         rewrite((x || (y || (z || x))), b) ||
+         rewrite((!x || (!(z || x) && y)), a) ||
+         rewrite((!x || (y && !(z || x))), a) ||
+         rewrite((!x || ((!x && z) && y)), a) ||
+         rewrite((x || !((!x && z) && y)), b) ||
+         rewrite((!x || (y && (!x && z))), a) ||
+         rewrite((x || (!(!x && z) || y)), b) ||
+         rewrite((x || (y || !(!x && z))), b) ||
+         rewrite((!x || ((!x || z) || y)), b) ||
+         rewrite((x || !((!x || z) || y)), a) ||
+         rewrite((!x || (y || (!x || z))), b) ||
+         rewrite((x || (!(!x || z) && y)), a) ||
+         rewrite((x || (y && !(!x || z))), a) ||
+         rewrite((!x || ((z && !x) && y)), a) ||
+         rewrite((!x || (y && (z && !x))), a) ||
+         rewrite((x || (!(z && !x) || y)), b) ||
+         rewrite((x || (y || !(z && !x))), b) ||
+         rewrite((!x || ((z || !x) || y)), b) ||
+         rewrite((!x || (y || (z || !x))), b) ||
+         rewrite((x || (!(z || !x) && y)), a) ||
+         rewrite((x || (y && !(z || !x))), a) ||
+         rewrite((!(x && y) || (!x && z)), a) ||
+         rewrite((!(x && y) || (z && !x)), a) ||
+         rewrite(((x || y) || (x && z)), a) ||
+         rewrite(((x || y) || (z && x)), a) ||
+         rewrite((!(x || y) || (!x || z)), b) ||
+         rewrite((!(x || y) || (z || !x)), b) ||
+         rewrite(((y || x) || (x && z)), a) ||
+         rewrite(((y || x) || (z && x)), a) ||
+         rewrite(((!x || y) || (!x && z)), a) ||
+         rewrite(((!x || y) || (z && !x)), a) ||
+         rewrite(((y || !x) || (!x && z)), a) ||
+         rewrite(((y || !x) || (z && !x)), a) ||
+         rewrite((((x && z) && y) || x), b) ||
+         rewrite(((y && (x && z)) || x), b) ||
+         rewrite((((z && x) && y) || x), b) ||
+         rewrite(((y && (z && x)) || x), b) ||
+         rewrite((((x || z) || y) || x), a) ||
+         rewrite(((y || (x || z)) || x), a) ||
+         rewrite((((z || x) || y) || x), a) ||
+         rewrite(((y || (z || x)) || x), a) ||
+         rewrite((!((!x && z) && y) || x), a) ||
+         rewrite(((!(!x && z) || y) || x), a) ||
+         rewrite(((y || !(!x && z)) || x), a) ||
+         rewrite((!((!x || z) || y) || x), b) ||
+         rewrite(((!(!x || z) && y) || x), b) ||
+         rewrite(((y && !(!x || z)) || x), b) ||
+         rewrite(((!(z && !x) || y) || x), a) ||
+         rewrite(((y || !(z && !x)) || x), a) ||
+         rewrite(((!(z || !x) && y) || x), b) ||
+         rewrite(((y && !(z || !x)) || x), b) ||
 
          rewrite(x != c0 || x == c1, a, c0 != c1) ||
          rewrite(c0 < x || c1 < x, fold(min(c0, c1)) < x) ||
@@ -80,42 +184,208 @@ Expr Simplify::visit(const Or *op, ExprInfo *info) {
          rewrite(x <= c0 || x <= c1, x <= fold(max(c0, c1))))) {
         return rewrite.result;
     }
-    // clang-format on
+
 
     // Cases that need remutation
-    if (rewrite(broadcast(x, c0) || broadcast(y, c0), broadcast(x || y, c0)) ||
-        rewrite((x && (y || z)) || y, (x && z) || y) ||
-        rewrite((x && (z || y)) || y, (x && z) || y) ||
-        rewrite(y || (x && (y || z)), y || (x && z)) ||
-        rewrite(y || (x && (z || y)), y || (x && z)) ||
+    if (EVAL_IN_LAMBDA
+        (rewrite(broadcast(x, c0) || broadcast(y, c0), broadcast(x || y, c0)) ||
+         rewrite((x || broadcast(y, c0)) || broadcast(z, c0), x || broadcast(y || z, c0)) ||
+         rewrite((broadcast(x, c0) || y) || broadcast(z, c0), broadcast(x || z, c0) || y) ||
 
-        rewrite(((y || z) && x) || y, (z && x) || y) ||
-        rewrite(((z || y) && x) || y, (z && x) || y) ||
-        rewrite(y || ((y || z) && x), y || (z && x)) ||
-        rewrite(y || ((z || y) && x), y || (z && x)) ||
+         rewrite(!x && !y, !(x || y)) ||
 
-        rewrite((x || (y && z)) || y, x || y) ||
-        rewrite((x || (z && y)) || y, x || y) ||
-        rewrite(y || (x || (y && z)), y || x) ||
-        rewrite(y || (x || (z && y)), y || x) ||
+         rewrite((!x || (x && y)), (!x || y)) ||
+         rewrite((!x || (y && x)), (!x || y)) ||
+         rewrite((x || !(x || y)), (!y || x)) ||
+         rewrite((x || (!x && y)), (x || y)) ||
+         rewrite((x || (y && !x)), (x || y)) ||
+         rewrite((!(x || y) || x), (!y || x)) ||
+         rewrite(((!x && y) || x), (x || y)) ||
+         rewrite(((y && !x) || x), (x || y)) ||
+         rewrite((!x || ((x && z) && y)), (!x || (y && z))) ||
+         rewrite((!x || (y && (x && z))), (!x || (y && z))) ||
+         rewrite((x || ((x && z) || y)), (x || y)) ||
+         rewrite((!x || ((x && z) || y)), (!x || (y || z))) ||
+         rewrite((x || !((x && z) || y)), (!y || x)) ||
+         rewrite((x || (y || (x && z))), (x || y)) ||
+         rewrite((!x || (y || (x && z))), (!x || (y || z))) ||
+         rewrite((x || (!(x && z) && y)), (x || y)) ||
+         rewrite((!x || (!(x && z) && y)), (!x || (!z && y))) ||
+         rewrite((x || (y && !(x && z))), (x || y)) ||
+         rewrite((!x || (y && !(x && z))), (!x || (!z && y))) ||
+         rewrite((!x || ((z && x) && y)), (!x || (y && z))) ||
+         rewrite((!x || (y && (z && x))), (!x || (y && z))) ||
+         rewrite((x || ((z && x) || y)), (x || y)) ||
+         rewrite((!x || ((z && x) || y)), (!x || (y || z))) ||
+         rewrite((x || (y || (z && x))), (x || y)) ||
+         rewrite((!x || (y || (z && x))), (!x || (y || z))) ||
+         rewrite((x || (!(z && x) && y)), (x || y)) ||
+         rewrite((!x || (!(z && x) && y)), (!x || (!z && y))) ||
+         rewrite((x || (y && !(z && x))), (x || y)) ||
+         rewrite((!x || (y && !(z && x))), (!x || (!z && y))) ||
+         rewrite((x || ((x || z) && y)), ((y && z) || x)) ||
+         rewrite((!x || ((x || z) && y)), (!x || y)) ||
+         rewrite((x || !((x || z) && y)), ((!y || !z) || x)) ||
+         rewrite((x || (y && (x || z))), ((y && z) || x)) ||
+         rewrite((!x || (y && (x || z))), (!x || y)) ||
+         rewrite((x || !((x || z) || y)), (!(y || z) || x)) ||
+         rewrite((x || (!(x || z) && y)), ((!z && y) || x)) ||
+         rewrite((x || (!(x || z) || y)), ((!z || y) || x)) ||
+         rewrite((!x || (!(x || z) || y)), (!x || y)) ||
+         rewrite((x || (y && !(x || z))), ((!z && y) || x)) ||
+         rewrite((x || (y || !(x || z))), ((!z || y) || x)) ||
+         rewrite((!x || (y || !(x || z))), (!x || y)) ||
+         rewrite((x || ((z || x) && y)), ((y && z) || x)) ||
+         rewrite((!x || ((z || x) && y)), (!x || y)) ||
+         rewrite((x || (y && (z || x))), ((y && z) || x)) ||
+         rewrite((!x || (y && (z || x))), (!x || y)) ||
+         rewrite((x || (!(z || x) && y)), ((!z && y) || x)) ||
+         rewrite((x || (!(z || x) || y)), ((!z || y) || x)) ||
+         rewrite((!x || (!(z || x) || y)), (!x || y)) ||
+         rewrite((x || (y && !(z || x))), ((!z && y) || x)) ||
+         rewrite((x || (y || !(z || x))), ((!z || y) || x)) ||
+         rewrite((!x || (y || !(z || x))), (!x || y)) ||
+         rewrite((x || ((!x && z) && y)), ((y && z) || x)) ||
+         rewrite((x || (y && (!x && z))), ((y && z) || x)) ||
+         rewrite((x || ((!x && z) || y)), ((y || z) || x)) ||
+         rewrite((!x || ((!x && z) || y)), (!x || y)) ||
+         rewrite((x || !((!x && z) || y)), (!(y || z) || x)) ||
+         rewrite((x || (y || (!x && z))), ((y || z) || x)) ||
+         rewrite((!x || (y || (!x && z))), (!x || y)) ||
+         rewrite((x || (!(!x && z) && y)), ((!z && y) || x)) ||
+         rewrite((!x || (!(!x && z) && y)), (!x || y)) ||
+         rewrite((x || (y && !(!x && z))), ((!z && y) || x)) ||
+         rewrite((!x || (y && !(!x && z))), (!x || y)) ||
+         rewrite((x || ((!x || z) && y)), (x || y)) ||
+         rewrite((!x || ((!x || z) && y)), (!x || (y && z))) ||
+         rewrite((x || !((!x || z) && y)), (!y || x)) ||
+         rewrite((x || (y && (!x || z))), (x || y)) ||
+         rewrite((!x || (y && (!x || z))), (!x || (y && z))) ||
+         rewrite((!x || (!(!x || z) && y)), (!x || (!z && y))) ||
+         rewrite((x || (!(!x || z) || y)), (x || y)) ||
+         rewrite((!x || (!(!x || z) || y)), (!x || (!z || y))) ||
+         rewrite((!x || (y && !(!x || z))), (!x || (!z && y))) ||
+         rewrite((x || (y || !(!x || z))), (x || y)) ||
+         rewrite((!x || (y || !(!x || z))), (!x || (!z || y))) ||
+         rewrite((x || ((z && !x) && y)), ((y && z) || x)) ||
+         rewrite((x || (y && (z && !x))), ((y && z) || x)) ||
+         rewrite((x || ((z && !x) || y)), ((y || z) || x)) ||
+         rewrite((!x || ((z && !x) || y)), (!x || y)) ||
+         rewrite((x || (y || (z && !x))), ((y || z) || x)) ||
+         rewrite((!x || (y || (z && !x))), (!x || y)) ||
+         rewrite((x || (!(z && !x) && y)), ((!z && y) || x)) ||
+         rewrite((!x || (!(z && !x) && y)), (!x || y)) ||
+         rewrite((x || (y && !(z && !x))), ((!z && y) || x)) ||
+         rewrite((!x || (y && !(z && !x))), (!x || y)) ||
+         rewrite((x || ((z || !x) && y)), (x || y)) ||
+         rewrite((!x || ((z || !x) && y)), (!x || (y && z))) ||
+         rewrite((x || (y && (z || !x))), (x || y)) ||
+         rewrite((!x || (y && (z || !x))), (!x || (y && z))) ||
+         rewrite((!x || (!(z || !x) && y)), (!x || (!z && y))) ||
+         rewrite((x || (!(z || !x) || y)), (x || y)) ||
+         rewrite((!x || (!(z || !x) || y)), (!x || (!z || y))) ||
+         rewrite((!x || (y && !(z || !x))), (!x || (!z && y))) ||
+         rewrite((x || (y || !(z || !x))), (x || y)) ||
+         rewrite((!x || (y || !(z || !x))), (!x || (!z || y))) ||
+         rewrite(((x && y) || (x && z)), ((y || z) && x)) ||
+         rewrite((!(x && y) || (x && z)), (!x || (!y || z))) ||
+         rewrite(((x && y) || (z && x)), ((y || z) && x)) ||
+         rewrite((!(x && y) || (z && x)), (!x || (!y || z))) ||
+         rewrite(((x && y) || (!x && z)), select(x, y, z)) ||
+         rewrite((!(x && y) || (!x || z)), (!x || (!y || z))) ||
+         rewrite(((x && y) || (z && !x)), select(x, y, z)) ||
+         rewrite((!(x && y) || (z || !x)), (!x || (!y || z))) ||
+         rewrite(((y && x) || (x && z)), ((y || z) && x)) ||
+         rewrite(((y && x) || (z && x)), ((y || z) && x)) ||
+         rewrite(((y && x) || (!x && z)), select(x, y, z)) ||
+         rewrite(((y && x) || (z && !x)), select(x, y, z)) ||
+         rewrite((!(x || y) || (x && z)), select(x, z, !y)) ||
+         rewrite((!(x || y) || (z && x)), select(x, z, !y)) ||
+         rewrite(((x || y) || (x || z)), ((y || z) || x)) ||
+         rewrite((!(x || y) || (x || z)), ((!y || z) || x)) ||
+         rewrite(((x || y) || (z || x)), ((y || z) || x)) ||
+         rewrite((!(x || y) || (z || x)), ((!y || z) || x)) ||
+         rewrite(((x || y) || (!x && z)), ((y || z) || x)) ||
+         rewrite((!(x || y) || (!x && z)), (!x && (!y || z))) ||
+         rewrite(((x || y) || (z && !x)), ((y || z) || x)) ||
+         rewrite((!(x || y) || (z && !x)), (!x && (!y || z))) ||
+         rewrite(((y || x) || (x || z)), ((y || z) || x)) ||
+         rewrite(((y || x) || (z || x)), ((y || z) || x)) ||
+         rewrite(((y || x) || (!x && z)), ((y || z) || x)) ||
+         rewrite(((y || x) || (z && !x)), ((y || z) || x)) ||
+         rewrite(((!x && y) || (x && z)), select(x, z, y)) ||
+         rewrite(((!x && y) || (z && x)), select(x, z, y)) ||
+         rewrite(((!x && y) || (!x && z)), (!x && (y || z))) ||
+         rewrite(((!x && y) || (z && !x)), (!x && (y || z))) ||
+         rewrite(((!x || y) || (x && z)), (!x || (y || z))) ||
+         rewrite(((!x || y) || (z && x)), (!x || (y || z))) ||
+         rewrite(((!x || y) || (!x || z)), (!x || (y || z))) ||
+         rewrite(((!x || y) || (z || !x)), (!x || (y || z))) ||
+         rewrite(((y && !x) || (x && z)), select(x, z, y)) ||
+         rewrite(((y && !x) || (z && x)), select(x, z, y)) ||
+         rewrite(((y && !x) || (!x && z)), (!x && (y || z))) ||
+         rewrite(((y && !x) || (z && !x)), (!x && (y || z))) ||
+         rewrite(((y || !x) || (x && z)), (!x || (y || z))) ||
+         rewrite(((y || !x) || (z && x)), (!x || (y || z))) ||
+         rewrite(((y || !x) || (!x || z)), (!x || (y || z))) ||
+         rewrite(((y || !x) || (z || !x)), (!x || (y || z))) ||
+         rewrite((((x && z) || y) || x), (x || y)) ||
+         rewrite((!((x && z) || y) || x), (!y || x)) ||
+         rewrite(((y || (x && z)) || x), (x || y)) ||
+         rewrite(((!(x && z) && y) || x), (x || y)) ||
+         rewrite(((y && !(x && z)) || x), (x || y)) ||
+         rewrite((((z && x) || y) || x), (x || y)) ||
+         rewrite(((y || (z && x)) || x), (x || y)) ||
+         rewrite(((!(z && x) && y) || x), (x || y)) ||
+         rewrite(((y && !(z && x)) || x), (x || y)) ||
+         rewrite((((x || z) && y) || x), ((y && z) || x)) ||
+         rewrite((!((x || z) && y) || x), ((!y || !z) || x)) ||
+         rewrite(((y && (x || z)) || x), ((y && z) || x)) ||
+         rewrite((!((x || z) || y) || x), (!(y || z) || x)) ||
+         rewrite(((!(x || z) && y) || x), ((!z && y) || x)) ||
+         rewrite(((!(x || z) || y) || x), ((!z || y) || x)) ||
+         rewrite(((y && !(x || z)) || x), ((!z && y) || x)) ||
+         rewrite(((y || !(x || z)) || x), ((!z || y) || x)) ||
+         rewrite((((z || x) && y) || x), ((y && z) || x)) ||
+         rewrite(((y && (z || x)) || x), ((y && z) || x)) ||
+         rewrite(((!(z || x) && y) || x), ((!z && y) || x)) ||
+         rewrite(((!(z || x) || y) || x), ((!z || y) || x)) ||
+         rewrite(((y && !(z || x)) || x), ((!z && y) || x)) ||
+         rewrite(((y || !(z || x)) || x), ((!z || y) || x)) ||
+         rewrite((((!x && z) && y) || x), ((y && z) || x)) ||
+         rewrite(((y && (!x && z)) || x), ((y && z) || x)) ||
+         rewrite((((!x && z) || y) || x), ((y || z) || x)) ||
+         rewrite((!((!x && z) || y) || x), (!(y || z) || x)) ||
+         rewrite(((y || (!x && z)) || x), ((y || z) || x)) ||
+         rewrite(((!(!x && z) && y) || x), ((!z && y) || x)) ||
+         rewrite(((y && !(!x && z)) || x), ((!z && y) || x)) ||
+         rewrite((((!x || z) && y) || x), (x || y)) ||
+         rewrite((!((!x || z) && y) || x), (!y || x)) ||
+         rewrite(((y && (!x || z)) || x), (x || y)) ||
+         rewrite(((!(!x || z) || y) || x), (x || y)) ||
+         rewrite(((y || !(!x || z)) || x), (x || y)) ||
+         rewrite((((z && !x) && y) || x), ((y && z) || x)) ||
+         rewrite(((y && (z && !x)) || x), ((y && z) || x)) ||
+         rewrite((((z && !x) || y) || x), ((y || z) || x)) ||
+         rewrite(((y || (z && !x)) || x), ((y || z) || x)) ||
+         rewrite(((!(z && !x) && y) || x), ((!z && y) || x)) ||
+         rewrite(((y && !(z && !x)) || x), ((!z && y) || x)) ||
+         rewrite((((z || !x) && y) || x), (x || y)) ||
+         rewrite(((y && (z || !x)) || x), (x || y)) ||
+         rewrite(((!(z || !x) || y) || x), (x || y)) ||
+         rewrite(((y || !(z || !x)) || x), (x || y)) ||
 
-        rewrite(((y && z) || x) || y, x || y) ||
-        rewrite(((z && y) || x) || y, x || y) ||
-        rewrite(y || ((y && z) || x), y || x) ||
-        rewrite(y || ((z && y) || x), y || x) ||
+         rewrite(x < y || x < z, x < max(y, z)) ||
+         rewrite(y < x || z < x, min(y, z) < x) ||
+         rewrite(x <= y || x <= z, x <= max(y, z)) ||
+         rewrite(y <= x || z <= x, min(y, z) <= x) ||
 
-        rewrite((x && y) || (x && z), x && (y || z)) ||
-        rewrite((x && y) || (z && x), x && (y || z)) ||
-        rewrite((y && x) || (x && z), x && (y || z)) ||
-        rewrite((y && x) || (z && x), x && (y || z)) ||
-
-        rewrite(x < y || x < z, x < max(y, z)) ||
-        rewrite(y < x || z < x, min(y, z) < x) ||
-        rewrite(x <= y || x <= z, x <= max(y, z)) ||
-        rewrite(y <= x || z <= x, min(y, z) <= x)) {
+         false)) {
 
         return mutate(rewrite.result, info);
     }
+
+    // clang-format on
 
     if (a.same_as(op->a) &&
         b.same_as(op->b)) {

--- a/src/Simplify_Or.cpp
+++ b/src/Simplify_Or.cpp
@@ -26,65 +26,39 @@ Expr Simplify::visit(const Or *op, ExprInfo *info) {
     // Cases that fold to a constant
     if (EVAL_IN_LAMBDA
         (rewrite(x || true, true) ||
-         rewrite(x != y || x == y, true) ||
-         rewrite(x != y || y == x, true) ||
-         rewrite((z || x != y) || x == y, true) ||
-         rewrite((z || x != y) || y == x, true) ||
-         rewrite((x != y || z) || x == y, true) ||
-         rewrite((x != y || z) || y == x, true) ||
-         rewrite((z || x == y) || x != y, true) ||
-         rewrite((z || x == y) || y != x, true) ||
-         rewrite((x == y || z) || x != y, true) ||
-         rewrite((x == y || z) || y != x, true) ||
 
-         rewrite((!x || x), true) ||
-         rewrite((x || !x), true) ||
-         rewrite((x || !(x && y)), true) ||
-         rewrite((!x || (x || y)), true) ||
-         rewrite((!x || (y || x)), true) ||
-         rewrite((x || (!x || y)), true) ||
-         rewrite((x || (y || !x)), true) ||
-         rewrite((!(x && y) || x), true) ||
-         rewrite(((!x || y) || x), true) ||
-         rewrite(((y || !x) || x), true) ||
-         rewrite((x || !((x && z) && y)), true) ||
-         rewrite((x || (!(x && z) || y)), true) ||
-         rewrite((x || (y || !(x && z))), true) ||
-         rewrite((x || (!(z && x) || y)), true) ||
-         rewrite((x || (y || !(z && x))), true) ||
-         rewrite((!x || ((x || z) || y)), true) ||
-         rewrite((!x || (y || (x || z))), true) ||
-         rewrite((!x || ((z || x) || y)), true) ||
-         rewrite((!x || (y || (z || x))), true) ||
-         rewrite((!x || (!(!x && z) || y)), true) ||
-         rewrite((!x || (y || !(!x && z))), true) ||
-         rewrite((x || ((!x || z) || y)), true) ||
-         rewrite((x || (y || (!x || z))), true) ||
-         rewrite((!x || (!(z && !x) || y)), true) ||
-         rewrite((!x || (y || !(z && !x))), true) ||
-         rewrite((x || ((z || !x) || y)), true) ||
-         rewrite((x || (y || (z || !x))), true) ||
-         rewrite((!(x && y) || (x || z)), true) ||
-         rewrite((!(x && y) || (z || x)), true) ||
-         rewrite(((x || y) || (!x || z)), true) ||
-         rewrite(((x || y) || (z || !x)), true) ||
-         rewrite(((y || x) || (!x || z)), true) ||
-         rewrite(((y || x) || (z || !x)), true) ||
-         rewrite(((!x || y) || (x || z)), true) ||
-         rewrite(((!x || y) || (z || x)), true) ||
-         rewrite(((y || !x) || (x || z)), true) ||
-         rewrite(((y || !x) || (z || x)), true) ||
-         rewrite((!((x && z) && y) || x), true) ||
-         rewrite(((!(x && z) || y) || x), true) ||
-         rewrite(((y || !(x && z)) || x), true) ||
-         rewrite(((!(z && x) || y) || x), true) ||
-         rewrite(((y || !(z && x)) || x), true) ||
-         rewrite((((!x || z) || y) || x), true) ||
-         rewrite(((y || (!x || z)) || x), true) ||
-         rewrite((((z || !x) || y) || x), true) ||
-         rewrite(((y || (z || !x)) || x), true) ||
+         rewrite(x || neg(x), true) ||
+         rewrite(x || !(x && y), true) ||
+         rewrite(x || (neg(x) || y), true) ||
+         rewrite(x || (y || neg(x)), true) ||
+         rewrite(!(x && y) || x, true) ||
+         rewrite((x || y) || neg(x), true) ||
+         rewrite((y || x) || neg(x), true) ||
+         rewrite(x || !((x && z) && y), true) ||
+         rewrite(x || (!(x && z) || y), true) ||
+         rewrite(x || (y || !(x && z)), true) ||
+         rewrite(x || (!(z && x) || y), true) ||
+         rewrite(x || (y || !(z && x)), true) ||
+         rewrite(x || ((neg(x) || z) || y), true) ||
+         rewrite(x || (y || (neg(x) || z)), true) ||
+         rewrite(x || ((z || neg(x)) || y), true) ||
+         rewrite(x || (y || (z || neg(x))), true) ||
+         rewrite(!(x && y) || (x || z), true) ||
+         rewrite(!(x && y) || (z || x), true) ||
+         rewrite((x || y) || (neg(x) || z), true) ||
+         rewrite((x || y) || (z || neg(x)), true) ||
+         rewrite((y || x) || (neg(x) || z), true) ||
+         rewrite((y || x) || (z || neg(x)), true) ||
+         rewrite(!((x && z) && y) || x, true) ||
+         rewrite((!(x && z) || y) || x, true) ||
+         rewrite((y || !(x && z)) || x, true) ||
+         rewrite((!(z && x) || y) || x, true) ||
+         rewrite((y || !(z && x)) || x, true) ||
+         rewrite(((x || z) || y) || neg(x), true) ||
+         rewrite((y || (x || z)) || neg(x), true) ||
+         rewrite(((z || x) || y) || neg(x), true) ||
+         rewrite((y || (z || x)) || neg(x), true) ||
 
-         rewrite(y <= x || x < y, true) ||
          rewrite(x <= c0 || c1 <= x, true, !is_float(x) && c1 <= c0 + 1) ||
          rewrite(c1 <= x || x <= c0, true, !is_float(x) && c1 <= c0 + 1) ||
          rewrite(x <= c0 || c1 < x, true, c1 <= c0) ||
@@ -99,83 +73,51 @@ Expr Simplify::visit(const Or *op, ExprInfo *info) {
     if (EVAL_IN_LAMBDA
         (rewrite(x || false, a) ||
 
-         rewrite((x || x), a) ||
-         rewrite((x || (x && y)), a) ||
-         rewrite((x || (y && x)), a) ||
-         rewrite((x || (x || y)), b) ||
-         rewrite((x || (y || x)), b) ||
-         rewrite((!x || (!x && y)), a) ||
-         rewrite((!x || (!x || y)), b) ||
-         rewrite((!x || (y && !x)), a) ||
-         rewrite((!x || (y || !x)), b) ||
-         rewrite(((x && y) || x), b) ||
-         rewrite(((y && x) || x), b) ||
-         rewrite(((x || y) || x), a) ||
-         rewrite(((y || x) || x), a) ||
-         rewrite((x || ((x && z) && y)), a) ||
-         rewrite((x || (y && (x && z))), a) ||
-         rewrite((!x || (!(x && z) || y)), b) ||
-         rewrite((!x || (y || !(x && z))), b) ||
-         rewrite((x || ((z && x) && y)), a) ||
-         rewrite((x || (y && (z && x))), a) ||
-         rewrite((!x || (!(z && x) || y)), b) ||
-         rewrite((!x || (y || !(z && x))), b) ||
-         rewrite((x || ((x || z) || y)), b) ||
-         rewrite((x || (y || (x || z))), b) ||
-         rewrite((!x || (!(x || z) && y)), a) ||
-         rewrite((!x || (y && !(x || z))), a) ||
-         rewrite((x || ((z || x) || y)), b) ||
-         rewrite((x || (y || (z || x))), b) ||
-         rewrite((!x || (!(z || x) && y)), a) ||
-         rewrite((!x || (y && !(z || x))), a) ||
-         rewrite((!x || ((!x && z) && y)), a) ||
-         rewrite((x || !((!x && z) && y)), b) ||
-         rewrite((!x || (y && (!x && z))), a) ||
-         rewrite((x || (!(!x && z) || y)), b) ||
-         rewrite((x || (y || !(!x && z))), b) ||
-         rewrite((!x || ((!x || z) || y)), b) ||
-         rewrite((x || !((!x || z) || y)), a) ||
-         rewrite((!x || (y || (!x || z))), b) ||
-         rewrite((x || (!(!x || z) && y)), a) ||
-         rewrite((x || (y && !(!x || z))), a) ||
-         rewrite((!x || ((z && !x) && y)), a) ||
-         rewrite((!x || (y && (z && !x))), a) ||
-         rewrite((x || (!(z && !x) || y)), b) ||
-         rewrite((x || (y || !(z && !x))), b) ||
-         rewrite((!x || ((z || !x) || y)), b) ||
-         rewrite((!x || (y || (z || !x))), b) ||
-         rewrite((x || (!(z || !x) && y)), a) ||
-         rewrite((x || (y && !(z || !x))), a) ||
-         rewrite((!(x && y) || (!x && z)), a) ||
-         rewrite((!(x && y) || (z && !x)), a) ||
-         rewrite(((x || y) || (x && z)), a) ||
-         rewrite(((x || y) || (z && x)), a) ||
-         rewrite((!(x || y) || (!x || z)), b) ||
-         rewrite((!(x || y) || (z || !x)), b) ||
-         rewrite(((y || x) || (x && z)), a) ||
-         rewrite(((y || x) || (z && x)), a) ||
-         rewrite(((!x || y) || (!x && z)), a) ||
-         rewrite(((!x || y) || (z && !x)), a) ||
-         rewrite(((y || !x) || (!x && z)), a) ||
-         rewrite(((y || !x) || (z && !x)), a) ||
-         rewrite((((x && z) && y) || x), b) ||
-         rewrite(((y && (x && z)) || x), b) ||
-         rewrite((((z && x) && y) || x), b) ||
-         rewrite(((y && (z && x)) || x), b) ||
-         rewrite((((x || z) || y) || x), a) ||
-         rewrite(((y || (x || z)) || x), a) ||
-         rewrite((((z || x) || y) || x), a) ||
-         rewrite(((y || (z || x)) || x), a) ||
-         rewrite((!((!x && z) && y) || x), a) ||
-         rewrite(((!(!x && z) || y) || x), a) ||
-         rewrite(((y || !(!x && z)) || x), a) ||
-         rewrite((!((!x || z) || y) || x), b) ||
-         rewrite(((!(!x || z) && y) || x), b) ||
-         rewrite(((y && !(!x || z)) || x), b) ||
-         rewrite(((!(z && !x) || y) || x), a) ||
-         rewrite(((y || !(z && !x)) || x), a) ||
-         rewrite(((!(z || !x) && y) || x), b) ||
-         rewrite(((y && !(z || !x)) || x), b) ||
+         rewrite(x || x, a) ||
+         rewrite(x || (x && y), a) ||
+         rewrite(x || (y && x), a) ||
+         rewrite(x || (x || y), b) ||
+         rewrite(x || (y || x), b) ||
+         rewrite((x && y) || x, b) ||
+         rewrite((y && x) || x, b) ||
+         rewrite((x || y) || x, a) ||
+         rewrite((y || x) || x, a) ||
+         rewrite(x || ((x && z) && y), a) ||
+         rewrite(x || (y && (x && z)), a) ||
+         rewrite(x || (!(neg(x) && z) || y), b) ||
+         rewrite(x || (y || !(neg(x) && z)), b) ||
+         rewrite(x || ((z && x) && y), a) ||
+         rewrite(x || (y && (z && x)), a) ||
+         rewrite(x || (!(z && neg(x)) || y), b) ||
+         rewrite(x || (y || !(z && neg(x))), b) ||
+         rewrite(x || ((x || z) || y), b) ||
+         rewrite(x || (y || (x || z)), b) ||
+         rewrite(x || (!(neg(x) || z) && y), a) ||
+         rewrite(x || (y && !(neg(x) || z)), a) ||
+         rewrite(x || ((z || x) || y), b) ||
+         rewrite(x || (y || (z || x)), b) ||
+         rewrite(x || (!(z || neg(x)) && y), a) ||
+         rewrite(x || (y && !(z || neg(x))), a) ||
+         rewrite((x || y) || (x && z), a) ||
+         rewrite((x || y) || (z && x), a) ||
+         rewrite((y || x) || (x && z), a) ||
+         rewrite((y || x) || (z && x), a) ||
+         rewrite(((x && z) && y) || x, b) ||
+         rewrite((y && (x && z)) || x, b) ||
+         rewrite((!(x && z) || y) || neg(x), a) ||
+         rewrite((y || !(x && z)) || neg(x), a) ||
+         rewrite(((z && x) && y) || x, b) ||
+         rewrite((y && (z && x)) || x, b) ||
+         rewrite((!(z && x) || y) || neg(x), a) ||
+         rewrite((y || !(z && x)) || neg(x), a) ||
+         rewrite(((x || z) || y) || x, a) ||
+         rewrite((y || (x || z)) || x, a) ||
+         rewrite((!(x || z) && y) || neg(x), b) ||
+         rewrite((y && !(x || z)) || neg(x), b) ||
+         rewrite(((z || x) || y) || x, a) ||
+         rewrite((y || (z || x)) || x, a) ||
+         rewrite((!(z || x) && y) || neg(x), b) ||
+         rewrite((y && !(z || x)) || neg(x), b) ||
 
          rewrite(x != c0 || x == c1, a, c0 != c1) ||
          rewrite(c0 < x || c1 < x, fold(min(c0, c1)) < x) ||
@@ -194,186 +136,120 @@ Expr Simplify::visit(const Or *op, ExprInfo *info) {
 
          rewrite(!x && !y, !(x || y)) ||
 
-         rewrite((!x || (x && y)), (!x || y)) ||
-         rewrite((!x || (y && x)), (!x || y)) ||
-         rewrite((x || !(x || y)), (!y || x)) ||
-         rewrite((x || (!x && y)), (x || y)) ||
-         rewrite((x || (y && !x)), (x || y)) ||
-         rewrite((!(x || y) || x), (!y || x)) ||
-         rewrite(((!x && y) || x), (x || y)) ||
-         rewrite(((y && !x) || x), (x || y)) ||
-         rewrite((!x || ((x && z) && y)), (!x || (y && z))) ||
-         rewrite((!x || (y && (x && z))), (!x || (y && z))) ||
-         rewrite((x || ((x && z) || y)), (x || y)) ||
-         rewrite((!x || ((x && z) || y)), (!x || (y || z))) ||
-         rewrite((x || !((x && z) || y)), (!y || x)) ||
-         rewrite((x || (y || (x && z))), (x || y)) ||
-         rewrite((!x || (y || (x && z))), (!x || (y || z))) ||
-         rewrite((x || (!(x && z) && y)), (x || y)) ||
-         rewrite((!x || (!(x && z) && y)), (!x || (!z && y))) ||
-         rewrite((x || (y && !(x && z))), (x || y)) ||
-         rewrite((!x || (y && !(x && z))), (!x || (!z && y))) ||
-         rewrite((!x || ((z && x) && y)), (!x || (y && z))) ||
-         rewrite((!x || (y && (z && x))), (!x || (y && z))) ||
-         rewrite((x || ((z && x) || y)), (x || y)) ||
-         rewrite((!x || ((z && x) || y)), (!x || (y || z))) ||
-         rewrite((x || (y || (z && x))), (x || y)) ||
-         rewrite((!x || (y || (z && x))), (!x || (y || z))) ||
-         rewrite((x || (!(z && x) && y)), (x || y)) ||
-         rewrite((!x || (!(z && x) && y)), (!x || (!z && y))) ||
-         rewrite((x || (y && !(z && x))), (x || y)) ||
-         rewrite((!x || (y && !(z && x))), (!x || (!z && y))) ||
-         rewrite((x || ((x || z) && y)), ((y && z) || x)) ||
-         rewrite((!x || ((x || z) && y)), (!x || y)) ||
-         rewrite((x || !((x || z) && y)), ((!y || !z) || x)) ||
-         rewrite((x || (y && (x || z))), ((y && z) || x)) ||
-         rewrite((!x || (y && (x || z))), (!x || y)) ||
-         rewrite((x || !((x || z) || y)), (!(y || z) || x)) ||
-         rewrite((x || (!(x || z) && y)), ((!z && y) || x)) ||
-         rewrite((x || (!(x || z) || y)), ((!z || y) || x)) ||
-         rewrite((!x || (!(x || z) || y)), (!x || y)) ||
-         rewrite((x || (y && !(x || z))), ((!z && y) || x)) ||
-         rewrite((x || (y || !(x || z))), ((!z || y) || x)) ||
-         rewrite((!x || (y || !(x || z))), (!x || y)) ||
-         rewrite((x || ((z || x) && y)), ((y && z) || x)) ||
-         rewrite((!x || ((z || x) && y)), (!x || y)) ||
-         rewrite((x || (y && (z || x))), ((y && z) || x)) ||
-         rewrite((!x || (y && (z || x))), (!x || y)) ||
-         rewrite((x || (!(z || x) && y)), ((!z && y) || x)) ||
-         rewrite((x || (!(z || x) || y)), ((!z || y) || x)) ||
-         rewrite((!x || (!(z || x) || y)), (!x || y)) ||
-         rewrite((x || (y && !(z || x))), ((!z && y) || x)) ||
-         rewrite((x || (y || !(z || x))), ((!z || y) || x)) ||
-         rewrite((!x || (y || !(z || x))), (!x || y)) ||
-         rewrite((x || ((!x && z) && y)), ((y && z) || x)) ||
-         rewrite((x || (y && (!x && z))), ((y && z) || x)) ||
-         rewrite((x || ((!x && z) || y)), ((y || z) || x)) ||
-         rewrite((!x || ((!x && z) || y)), (!x || y)) ||
-         rewrite((x || !((!x && z) || y)), (!(y || z) || x)) ||
-         rewrite((x || (y || (!x && z))), ((y || z) || x)) ||
-         rewrite((!x || (y || (!x && z))), (!x || y)) ||
-         rewrite((x || (!(!x && z) && y)), ((!z && y) || x)) ||
-         rewrite((!x || (!(!x && z) && y)), (!x || y)) ||
-         rewrite((x || (y && !(!x && z))), ((!z && y) || x)) ||
-         rewrite((!x || (y && !(!x && z))), (!x || y)) ||
-         rewrite((x || ((!x || z) && y)), (x || y)) ||
-         rewrite((!x || ((!x || z) && y)), (!x || (y && z))) ||
-         rewrite((x || !((!x || z) && y)), (!y || x)) ||
-         rewrite((x || (y && (!x || z))), (x || y)) ||
-         rewrite((!x || (y && (!x || z))), (!x || (y && z))) ||
-         rewrite((!x || (!(!x || z) && y)), (!x || (!z && y))) ||
-         rewrite((x || (!(!x || z) || y)), (x || y)) ||
-         rewrite((!x || (!(!x || z) || y)), (!x || (!z || y))) ||
-         rewrite((!x || (y && !(!x || z))), (!x || (!z && y))) ||
-         rewrite((x || (y || !(!x || z))), (x || y)) ||
-         rewrite((!x || (y || !(!x || z))), (!x || (!z || y))) ||
-         rewrite((x || ((z && !x) && y)), ((y && z) || x)) ||
-         rewrite((x || (y && (z && !x))), ((y && z) || x)) ||
-         rewrite((x || ((z && !x) || y)), ((y || z) || x)) ||
-         rewrite((!x || ((z && !x) || y)), (!x || y)) ||
-         rewrite((x || (y || (z && !x))), ((y || z) || x)) ||
-         rewrite((!x || (y || (z && !x))), (!x || y)) ||
-         rewrite((x || (!(z && !x) && y)), ((!z && y) || x)) ||
-         rewrite((!x || (!(z && !x) && y)), (!x || y)) ||
-         rewrite((x || (y && !(z && !x))), ((!z && y) || x)) ||
-         rewrite((!x || (y && !(z && !x))), (!x || y)) ||
-         rewrite((x || ((z || !x) && y)), (x || y)) ||
-         rewrite((!x || ((z || !x) && y)), (!x || (y && z))) ||
-         rewrite((x || (y && (z || !x))), (x || y)) ||
-         rewrite((!x || (y && (z || !x))), (!x || (y && z))) ||
-         rewrite((!x || (!(z || !x) && y)), (!x || (!z && y))) ||
-         rewrite((x || (!(z || !x) || y)), (x || y)) ||
-         rewrite((!x || (!(z || !x) || y)), (!x || (!z || y))) ||
-         rewrite((!x || (y && !(z || !x))), (!x || (!z && y))) ||
-         rewrite((x || (y || !(z || !x))), (x || y)) ||
-         rewrite((!x || (y || !(z || !x))), (!x || (!z || y))) ||
-         rewrite(((x && y) || (x && z)), ((y || z) && x)) ||
-         rewrite((!(x && y) || (x && z)), (!x || (!y || z))) ||
-         rewrite(((x && y) || (z && x)), ((y || z) && x)) ||
-         rewrite((!(x && y) || (z && x)), (!x || (!y || z))) ||
-         rewrite(((x && y) || (!x && z)), select(x, y, z)) ||
-         rewrite((!(x && y) || (!x || z)), (!x || (!y || z))) ||
-         rewrite(((x && y) || (z && !x)), select(x, y, z)) ||
-         rewrite((!(x && y) || (z || !x)), (!x || (!y || z))) ||
-         rewrite(((y && x) || (x && z)), ((y || z) && x)) ||
-         rewrite(((y && x) || (z && x)), ((y || z) && x)) ||
-         rewrite(((y && x) || (!x && z)), select(x, y, z)) ||
-         rewrite(((y && x) || (z && !x)), select(x, y, z)) ||
-         rewrite((!(x || y) || (x && z)), select(x, z, !y)) ||
-         rewrite((!(x || y) || (z && x)), select(x, z, !y)) ||
-         rewrite(((x || y) || (x || z)), ((y || z) || x)) ||
-         rewrite((!(x || y) || (x || z)), ((!y || z) || x)) ||
-         rewrite(((x || y) || (z || x)), ((y || z) || x)) ||
-         rewrite((!(x || y) || (z || x)), ((!y || z) || x)) ||
-         rewrite(((x || y) || (!x && z)), ((y || z) || x)) ||
-         rewrite((!(x || y) || (!x && z)), (!x && (!y || z))) ||
-         rewrite(((x || y) || (z && !x)), ((y || z) || x)) ||
-         rewrite((!(x || y) || (z && !x)), (!x && (!y || z))) ||
-         rewrite(((y || x) || (x || z)), ((y || z) || x)) ||
-         rewrite(((y || x) || (z || x)), ((y || z) || x)) ||
-         rewrite(((y || x) || (!x && z)), ((y || z) || x)) ||
-         rewrite(((y || x) || (z && !x)), ((y || z) || x)) ||
-         rewrite(((!x && y) || (x && z)), select(x, z, y)) ||
-         rewrite(((!x && y) || (z && x)), select(x, z, y)) ||
-         rewrite(((!x && y) || (!x && z)), (!x && (y || z))) ||
-         rewrite(((!x && y) || (z && !x)), (!x && (y || z))) ||
-         rewrite(((!x || y) || (x && z)), (!x || (y || z))) ||
-         rewrite(((!x || y) || (z && x)), (!x || (y || z))) ||
-         rewrite(((!x || y) || (!x || z)), (!x || (y || z))) ||
-         rewrite(((!x || y) || (z || !x)), (!x || (y || z))) ||
-         rewrite(((y && !x) || (x && z)), select(x, z, y)) ||
-         rewrite(((y && !x) || (z && x)), select(x, z, y)) ||
-         rewrite(((y && !x) || (!x && z)), (!x && (y || z))) ||
-         rewrite(((y && !x) || (z && !x)), (!x && (y || z))) ||
-         rewrite(((y || !x) || (x && z)), (!x || (y || z))) ||
-         rewrite(((y || !x) || (z && x)), (!x || (y || z))) ||
-         rewrite(((y || !x) || (!x || z)), (!x || (y || z))) ||
-         rewrite(((y || !x) || (z || !x)), (!x || (y || z))) ||
-         rewrite((((x && z) || y) || x), (x || y)) ||
-         rewrite((!((x && z) || y) || x), (!y || x)) ||
-         rewrite(((y || (x && z)) || x), (x || y)) ||
-         rewrite(((!(x && z) && y) || x), (x || y)) ||
-         rewrite(((y && !(x && z)) || x), (x || y)) ||
-         rewrite((((z && x) || y) || x), (x || y)) ||
-         rewrite(((y || (z && x)) || x), (x || y)) ||
-         rewrite(((!(z && x) && y) || x), (x || y)) ||
-         rewrite(((y && !(z && x)) || x), (x || y)) ||
-         rewrite((((x || z) && y) || x), ((y && z) || x)) ||
-         rewrite((!((x || z) && y) || x), ((!y || !z) || x)) ||
-         rewrite(((y && (x || z)) || x), ((y && z) || x)) ||
-         rewrite((!((x || z) || y) || x), (!(y || z) || x)) ||
-         rewrite(((!(x || z) && y) || x), ((!z && y) || x)) ||
-         rewrite(((!(x || z) || y) || x), ((!z || y) || x)) ||
-         rewrite(((y && !(x || z)) || x), ((!z && y) || x)) ||
-         rewrite(((y || !(x || z)) || x), ((!z || y) || x)) ||
-         rewrite((((z || x) && y) || x), ((y && z) || x)) ||
-         rewrite(((y && (z || x)) || x), ((y && z) || x)) ||
-         rewrite(((!(z || x) && y) || x), ((!z && y) || x)) ||
-         rewrite(((!(z || x) || y) || x), ((!z || y) || x)) ||
-         rewrite(((y && !(z || x)) || x), ((!z && y) || x)) ||
-         rewrite(((y || !(z || x)) || x), ((!z || y) || x)) ||
-         rewrite((((!x && z) && y) || x), ((y && z) || x)) ||
-         rewrite(((y && (!x && z)) || x), ((y && z) || x)) ||
-         rewrite((((!x && z) || y) || x), ((y || z) || x)) ||
-         rewrite((!((!x && z) || y) || x), (!(y || z) || x)) ||
-         rewrite(((y || (!x && z)) || x), ((y || z) || x)) ||
-         rewrite(((!(!x && z) && y) || x), ((!z && y) || x)) ||
-         rewrite(((y && !(!x && z)) || x), ((!z && y) || x)) ||
-         rewrite((((!x || z) && y) || x), (x || y)) ||
-         rewrite((!((!x || z) && y) || x), (!y || x)) ||
-         rewrite(((y && (!x || z)) || x), (x || y)) ||
-         rewrite(((!(!x || z) || y) || x), (x || y)) ||
-         rewrite(((y || !(!x || z)) || x), (x || y)) ||
-         rewrite((((z && !x) && y) || x), ((y && z) || x)) ||
-         rewrite(((y && (z && !x)) || x), ((y && z) || x)) ||
-         rewrite((((z && !x) || y) || x), ((y || z) || x)) ||
-         rewrite(((y || (z && !x)) || x), ((y || z) || x)) ||
-         rewrite(((!(z && !x) && y) || x), ((!z && y) || x)) ||
-         rewrite(((y && !(z && !x)) || x), ((!z && y) || x)) ||
-         rewrite((((z || !x) && y) || x), (x || y)) ||
-         rewrite(((y && (z || !x)) || x), (x || y)) ||
-         rewrite(((!(z || !x) || y) || x), (x || y)) ||
-         rewrite(((y || !(z || !x)) || x), (x || y)) ||
+         rewrite(x || (neg(x) && y), x || y) ||
+         rewrite(x || (y && neg(x)), x || y) ||
+         rewrite(x || !(x || y), !y || x) ||
+         rewrite((x && y) || neg(x), !x || y) ||
+         rewrite((y && x) || neg(x), !x || y) ||
+         rewrite(!(x || y) || x, !y || x) ||
+         rewrite(x || ((neg(x) && z) && y), (y && z) || x) ||
+         rewrite(x || (y && (neg(x) && z)), (y && z) || x) ||
+         rewrite(x || ((x && z) || y), x || y) ||
+         rewrite(x || ((neg(x) && z) || y), (y || z) || x) ||
+         rewrite(x || !((x && z) || y), !y || x) ||
+         rewrite(x || (y || (x && z)), x || y) ||
+         rewrite(x || (y || (neg(x) && z)), (y || z) || x) ||
+         rewrite(x || (!(x && z) && y), x || y) ||
+         rewrite(x || (!(neg(x) && z) && y), (!z && y) || x) ||
+         rewrite(x || (y && !(x && z)), x || y) ||
+         rewrite(x || (y && !(neg(x) && z)), (!z && y) || x) ||
+         rewrite(x || ((z && neg(x)) && y), (y && z) || x) ||
+         rewrite(x || (y && (z && neg(x))), (y && z) || x) ||
+         rewrite(x || ((z && x) || y), x || y) ||
+         rewrite(x || ((z && neg(x)) || y), (y || z) || x) ||
+         rewrite(x || (y || (z && x)), x || y) ||
+         rewrite(x || (y || (z && neg(x))), (y || z) || x) ||
+         rewrite(x || (!(z && x) && y), x || y) ||
+         rewrite(x || (!(z && neg(x)) && y), (!z && y) || x) ||
+         rewrite(x || (y && !(z && x)), x || y) ||
+         rewrite(x || (y && !(z && neg(x))), (!z && y) || x) ||
+         rewrite(x || ((x || z) && y), (y && z) || x) ||
+         rewrite(x || ((neg(x) || z) && y), x || y) ||
+         rewrite(x || !((x || z) && y), (!y || !z) || x) ||
+         rewrite(x || (y && (x || z)), (y && z) || x) ||
+         rewrite(x || (y && (neg(x) || z)), x || y) ||
+         rewrite(x || !((x || z) || y), !(y || z) || x) ||
+         rewrite(x || (!(x || z) && y), (!z && y) || x) ||
+         rewrite(x || (!(x || z) || y), (!z || y) || x) ||
+         rewrite(x || (!(neg(x) || z) || y), x || y) ||
+         rewrite(x || (y && !(x || z)), (!z && y) || x) ||
+         rewrite(x || (y || !(x || z)), (!z || y) || x) ||
+         rewrite(x || (y || !(neg(x) || z)), x || y) ||
+         rewrite(x || ((z || x) && y), (y && z) || x) ||
+         rewrite(x || ((z || neg(x)) && y), x || y) ||
+         rewrite(x || (y && (z || x)), (y && z) || x) ||
+         rewrite(x || (y && (z || neg(x))), x || y) ||
+         rewrite(x || (!(z || x) && y), (!z && y) || x) ||
+         rewrite(x || (!(z || x) || y), (!z || y) || x) ||
+         rewrite(x || (!(z || neg(x)) || y), x || y) ||
+         rewrite(x || (y && !(z || x)), (!z && y) || x) ||
+         rewrite(x || (y || !(z || x)), (!z || y) || x) ||
+         rewrite(x || (y || !(z || neg(x))), x || y) ||
+         rewrite((x && y) || (x && z), (y || z) && x) ||
+         rewrite((x && y) || (neg(x) && z), select(x, y, z)) ||
+         rewrite(!(x && y) || (x && z), !x || (!y || z)) ||
+         rewrite((x && y) || (z && x), (y || z) && x) ||
+         rewrite((x && y) || (z && neg(x)), select(x, y, z)) ||
+         rewrite(!(x && y) || (z && x), !x || (!y || z)) ||
+         rewrite((y && x) || (x && z), (y || z) && x) ||
+         rewrite((y && x) || (neg(x) && z), select(x, y, z)) ||
+         rewrite((y && x) || (z && x), (y || z) && x) ||
+         rewrite((y && x) || (z && neg(x)), select(x, y, z)) ||
+         rewrite((x || y) || (neg(x) && z), (y || z) || x) ||
+         rewrite(!(x || y) || (x && z), select(x, z, !y)) ||
+         rewrite((x || y) || (z && neg(x)), (y || z) || x) ||
+         rewrite(!(x || y) || (z && x), select(x, z, !y)) ||
+         rewrite((x || y) || (x || z), (y || z) || x) ||
+         rewrite(!(x || y) || (x || z), (!y || z) || x) ||
+         rewrite((x || y) || (z || x), (y || z) || x) ||
+         rewrite(!(x || y) || (z || x), (!y || z) || x) ||
+         rewrite((y || x) || (neg(x) && z), (y || z) || x) ||
+         rewrite((y || x) || (z && neg(x)), (y || z) || x) ||
+         rewrite((y || x) || (x || z), (y || z) || x) ||
+         rewrite((y || x) || (z || x), (y || z) || x) ||
+         rewrite(((x && z) && y) || neg(x), !x || (y && z)) ||
+         rewrite((y && (x && z)) || neg(x), !x || (y && z)) ||
+         rewrite(((x && z) || y) || x, x || y) ||
+         rewrite(((x && z) || y) || neg(x), !x || (y || z)) ||
+         rewrite(!((x && z) || y) || x, !y || x) ||
+         rewrite((y || (x && z)) || x, x || y) ||
+         rewrite((y || (x && z)) || neg(x), !x || (y || z)) ||
+         rewrite((!(x && z) && y) || x, x || y) ||
+         rewrite((!(x && z) && y) || neg(x), !x || (!z && y)) ||
+         rewrite((y && !(x && z)) || x, x || y) ||
+         rewrite((y && !(x && z)) || neg(x), !x || (!z && y)) ||
+         rewrite(((z && x) && y) || neg(x), !x || (y && z)) ||
+         rewrite((y && (z && x)) || neg(x), !x || (y && z)) ||
+         rewrite(((z && x) || y) || x, x || y) ||
+         rewrite(((z && x) || y) || neg(x), !x || (y || z)) ||
+         rewrite((y || (z && x)) || x, x || y) ||
+         rewrite((y || (z && x)) || neg(x), !x || (y || z)) ||
+         rewrite((!(z && x) && y) || x, x || y) ||
+         rewrite((!(z && x) && y) || neg(x), !x || (!z && y)) ||
+         rewrite((y && !(z && x)) || x, x || y) ||
+         rewrite((y && !(z && x)) || neg(x), !x || (!z && y)) ||
+         rewrite(((x || z) && y) || x, (y && z) || x) ||
+         rewrite(((x || z) && y) || neg(x), !x || y) ||
+         rewrite(!((x || z) && y) || x, (!y || !z) || x) ||
+         rewrite((y && (x || z)) || x, (y && z) || x) ||
+         rewrite((y && (x || z)) || neg(x), !x || y) ||
+         rewrite(!((x || z) || y) || x, !(y || z) || x) ||
+         rewrite((!(x || z) && y) || x, (!z && y) || x) ||
+         rewrite((!(x || z) || y) || x, (!z || y) || x) ||
+         rewrite((!(x || z) || y) || neg(x), !x || y) ||
+         rewrite((y && !(x || z)) || x, (!z && y) || x) ||
+         rewrite((y || !(x || z)) || x, (!z || y) || x) ||
+         rewrite((y || !(x || z)) || neg(x), !x || y) ||
+         rewrite(((z || x) && y) || x, (y && z) || x) ||
+         rewrite(((z || x) && y) || neg(x), !x || y) ||
+         rewrite((y && (z || x)) || x, (y && z) || x) ||
+         rewrite((y && (z || x)) || neg(x), !x || y) ||
+         rewrite((!(z || x) && y) || x, (!z && y) || x) ||
+         rewrite((!(z || x) || y) || x, (!z || y) || x) ||
+         rewrite((!(z || x) || y) || neg(x), !x || y) ||
+         rewrite((y && !(z || x)) || x, (!z && y) || x) ||
+         rewrite((y || !(z || x)) || x, (!z || y) || x) ||
+         rewrite((y || !(z || x)) || neg(x), !x || y) ||
 
          rewrite(x < y || x < z, x < max(y, z)) ||
          rewrite(y < x || z < x, min(y, z) < x) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1491,6 +1491,17 @@ void check_boolean() {
     check(x < y && x >= y, f);
     check(x <= y && x > y, f);
 
+    // Check an expression can be cancelled against a buried version of itself or its negation
+    check(x < y && (b1 && (b2 && y <= x)), f);
+    check(x < y && (b1 && (b2 && x < y)), ((x < y) && b2) && b1);
+    check(x < y && (b1 || (b2 || y <= x)), (b1 || b2) && (x < y));
+    check(x < y && (b1 || (b2 || x < y)), x < y);
+
+    check(x == y && (b1 && (b2 && y != x)), f);
+    check(x == y && (b1 && (b2 && x == y)), ((x == y) && b2) && b1);
+    check(x == y && (b1 || (b2 || x != y)), (b1 || b2) && (x == y));
+    check(x == y && (b1 || (b2 || x == y)), x == y);
+
     check(x <= max(x, y), t);
     check(x < min(x, y), f);
     check(min(x, y) <= x, t);


### PR DESCRIPTION
This PR adds more simplification rules for nested And and Or nodes, mostly centered around cancelling terms, or a term and its already-simplified negation (e.g. x < y and y <= x). The original motivating example was that I needed a rule that says that in an implication (encoded as `!a || b`), you can assume a sub-clause of the LHS on the RHS, so:

```rewrite(!(x && y) || (x && z), !(x && y) || z)```

But there are a dizzying number of these, so in the end I just enumerated all simplifier-canonical LHS trees with up to four leaves in And, Or, and Not operators where x appears on both sides of the root node, or x appears on the left and its negation appears on the right. Each of these can be uniquely characterized by their 8-entry truth table. 

I then also enumerated all non-simplifying three-leaf trees in the same variables and their truth tables. You can join these two lists to find a mapping from each four-leaf tree to an equivalent three-leaf tree. Somewhat surprisingly, if you allow selects on the RHS as well, there's a three-leaf tree (with one 'x' cancelled) for every four-leaf tree. So they all simplify.

Naively you might expect there to be 256 unique RHS expressions (for 256 possible 8-entry truth tables), but it's pointless to have a !y or a !z on the LHS, because you could just as easily write the rule to match the !y instead of the y, so that cuts down on the number of possible boolean functions quite a bit.

This subsumed a good number of existing rules. It increases the size of Simplify_And.o and Simplify_Or.o by a bit, but they're still smaller than e.g. Simplify_Sub.o and Simplify_Add.o. I could not measure any compile-time regressions or any major effect on the apps. We don't currently rely heavily on simplification of boolean expressions (except maybe when detecting if it's OK to parallelize an RVar), but there are things I'd like to do that would rely on it more heavily.

Because these were generated via enumeration and then copy-pasted from the output of that ad-hoc tool, they can be considered formally verified.

A more powerful version of this would have rules where you have things implied by x on the RHS, rather than just x or its negation. E.g. `!((x < 10) && y) || (x < 20)` could simplify to true, because x < 20 is implied by x < 10. However this seems beyond the capabilities of a peepholing TRS. At some point you need an SMT solver, but I'm trying to go as far as reasonably possible without one.