### PR TITLE
Use Overload of lookupTarget Accepting Triple

### DIFF
--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -609,7 +609,13 @@ vector<char> CodeGen_PTX_Dev::compile_to_src() {
     // Allocate target machine
 
     std::string err_str;
-    const llvm::Target *llvm_target = TargetRegistry::lookupTarget(triple.str(), err_str);
+    const llvm::Target *llvm_target = TargetRegistry::lookupTarget(
+#if LLVM_VERSION >= 220
+        triple,
+#else
+        triple.str(),
+#endif
+        err_str);
     internal_assert(llvm_target) << err_str << "\n";
 
     TargetOptions options;


### PR DESCRIPTION
The overload accepting a llvm::StringRef is deprecated and will be removed once LLVM 22 branches. This also removes some needless llvm::Triple->std::string->llvm::triple roundtripping.