### PR TITLE
Fixed signedness of loop index test

### DIFF
--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -1757,7 +1757,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const For *op) {
             SpvId loop_test_type_id = builder.declare_type(Bool());
             SpvId loop_test_id = builder.reserve_id(SpvResultId);
             builder.append(SpvFactory::load(index_type_id, loop_index_id, loop_var_id));
-            builder.append(SpvFactory::integer_less_than(loop_test_type_id, loop_test_id, loop_index_id, max_id, index_type.is_uint()));
+            builder.append(SpvFactory::integer_less_than(loop_test_type_id, loop_test_id, loop_index_id, max_id, index_type.is_int()));
             builder.append(SpvFactory::conditional_branch(loop_test_id, body_block_id, merge_block_id));
         }
         builder.leave_block();


### PR DESCRIPTION
The less than on a for loop in a vulkan kernel is unsigned, but it should be signed, because the last arg being passed to integer_less_than is flipped.

This causes a problem in the min/max for loop PR because the < becomes a <= so this loop runs forever instead of not running at all:

```
for (int x = 0; x <= -1; x++) ...
```

I couldn't construct a case where it matters on main. I think it would need a negative extent for loop. A loop with a negative min and a positive max would terminate early, but loops are rebased to zero so that doesn't happen.