### PR TITLE
Add __iter__ to RDom bindings

### DIFF
--- a/python_bindings/cmake/AddPythonTest.cmake
+++ b/python_bindings/cmake/AddPythonTest.cmake
@@ -13,6 +13,8 @@ function(add_python_test)
     cmake_path(GET ARG_FILE STEM test_name)
     set(test_name "${ARG_LABEL}_${test_name}")
 
+    set(test_labels python ${ARG_LABEL})
+
     add_test(
         NAME "${test_name}"
         COMMAND ${Halide_PYTHON_LAUNCHER} "$<TARGET_FILE:Python::Interpreter>" "$<SHELL_PATH:${CMAKE_CURRENT_SOURCE_DIR}/${ARG_FILE}>" ${ARG_TEST_ARGS}
@@ -20,7 +22,7 @@ function(add_python_test)
     set_tests_properties(
         "${test_name}"
         PROPERTIES
-        LABELS "python"
+        LABELS "${test_labels}"
         ENVIRONMENT "${ARG_ENVIRONMENT}"
         ENVIRONMENT_MODIFICATION "${ARG_PYTHONPATH}"
         SKIP_REGULAR_EXPRESSION "\\[SKIP\\]"

--- a/python_bindings/src/halide/halide_/PyRDom.cpp
+++ b/python_bindings/src/halide/halide_/PyRDom.cpp
@@ -37,14 +37,17 @@ void define_rdom(py::module &m) {
         RDom rd;
         int idx = 0;
         RDomIterator() = default;
-        RDomIterator(const RDom &r) : rd(r), idx(0) {}
+        RDomIterator(const RDom &r) : rd(r) {
+        }
         RVar next() {
             if (idx >= rd.dimensions()) {
                 throw py::stop_iteration();
             }
             return rd[idx++];
         }
-        RDomIterator &iter() { return *this; }
+        RDomIterator &iter() {
+            return *this;
+        }
     };
 
     // Expose the iterator type to Python so we can return it from __iter__.
@@ -71,7 +74,7 @@ void define_rdom(py::module &m) {
                 if (i < 0 || i >= r.dimensions()) {
                     throw pybind11::key_error();
                 }
-                return r[i];
+                return r[i];  //
             })
             .def_readonly("x", &RDom::x)
             .def_readonly("y", &RDom::y)
@@ -80,7 +83,7 @@ void define_rdom(py::module &m) {
             .def("__repr__", [](const RDom &r) -> std::string {
                 std::ostringstream o;
                 o << "<halide.RDom " << r << ">";
-                return o.str();
+                return o.str();  //
             });
 
     add_binary_operators(rdom_class);

--- a/python_bindings/test/correctness/rdom.py
+++ b/python_bindings/test/correctness/rdom.py
@@ -46,6 +46,16 @@ def test_rdom():
     return 0
 
 
+def test_rdom_iter():
+    # Verify that RDom is iterable and yields RVars matching index access
+    r = hl.RDom([(0, 10), (0, 20)], "r")
+    it = list(r)
+    assert len(it) == len(r)
+    assert all(hasattr(v, "min") and hasattr(v, "extent") for v in it)
+    for i in range(len(r)):
+        assert str(it[i]) == str(r[i])
+
+
 def test_implicit_pure_definition():
     a = np.random.ranf((2, 3)).astype(np.float32)
     expected = a.sum(axis=1)
@@ -67,3 +77,4 @@ def test_implicit_pure_definition():
 if __name__ == "__main__":
     test_rdom()
     test_implicit_pure_definition()
+    test_rdom_iter()


### PR DESCRIPTION
This was coded with some supervision by GitHub Copilot using a mix of GPT-5 and Claude Sonnet 4.5 models.

The fix in `AddPythonTest.cmake` was written by me after Copilot struggled to figure out how to run the Python correctness tests.

Fixes #8855 