### PR TITLE
Unsupport SVE explicitly

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -978,6 +978,15 @@ llvm::Function *CodeGen_ARM::define_intrin_wrapper(const std::string &inner_name
 void CodeGen_ARM::init_module() {
     CodeGen_Posix::init_module();
 
+    // TODO: https://github.com/halide/Halide/issues/8872
+    // if (target.features_any_of({Target::SVE, Target::SVE2})) {
+    if (target.has_feature(Target::SVE2)) {
+        user_assert(target.vector_bits != 0) << "For SVE/SVE2 support, target_vector_bits=<size> must be set in target.\n";
+        user_assert((target.vector_bits % 128) == 0) << "For SVE/SVE2 support, target_vector_bits must be a multiple of 128.\n";
+    } else if (target.has_feature(Target::SVE)) {
+        user_warning << "Halide does not support SVE for now. Use SVE2 if your target device supports it.\n";
+    }
+
     const bool has_neon = !target.has_feature(Target::NoNEON);
     const bool has_sve = target.has_feature(Target::SVE2);
     if (!(has_neon || has_sve)) {
@@ -1453,7 +1462,7 @@ void CodeGen_ARM::visit(const Store *op) {
             // TODO(zvookin): Handle vector_bits_*.
             if (vec_bits % 128 == 0) {
                 type_ok_for_vst = true;
-                int target_vector_bits = target.vector_bits;
+                int target_vector_bits = native_vector_bits();
                 if (target_vector_bits == 0) {
                     target_vector_bits = 128;
                 }
@@ -2546,7 +2555,8 @@ string CodeGen_ARM::mattrs() const {
         if (target.has_feature(Target::SVE2)) {
             attrs.emplace_back("+sve2");
         } else if (target.has_feature(Target::SVE)) {
-            attrs.emplace_back("+sve");
+            // TODO: https://github.com/halide/Halide/issues/8872
+            // attrs.emplace_back("+sve");
         }
         if (target.os == Target::IOS || target.os == Target::OSX) {
             attrs.emplace_back("+reserve-x18");
@@ -2565,17 +2575,13 @@ bool CodeGen_ARM::use_soft_float_abi() const {
 }
 
 int CodeGen_ARM::native_vector_bits() const {
-    if (target.has_feature(Target::SVE) || target.has_feature(Target::SVE2)) {
-        return std::max(target.vector_bits, 128);
-    } else {
-        return 128;
-    }
+    return std::max(target_vscale(), 1) * 128;
 }
 
 int CodeGen_ARM::target_vscale() const {
-    if (target.features_any_of({Target::SVE, Target::SVE2})) {
-        user_assert(target.vector_bits != 0) << "For SVE/SVE2 support, target_vector_bits=<size> must be set in target.\n";
-        user_assert((target.vector_bits % 128) == 0) << "For SVE/SVE2 support, target_vector_bits must be a multiple of 128.\n";
+    // TODO: https://github.com/halide/Halide/issues/8872
+    // if (target.features_any_of({Target::SVE, Target::SVE2})) {
+    if (target.has_feature(Target::SVE2)) {
         return target.vector_bits / 128;
     }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -268,10 +268,11 @@ Target calculate_host_target() {
         initial_features.push_back(Target::ARMFp16);
     }
 
-    if (hwcaps & HWCAP_SVE) {
-        initial_features.push_back(Target::SVE);
-        has_scalable_vector = true;
-    }
+    // TODO: https://github.com/halide/Halide/issues/8872
+    // if (hwcaps & HWCAP_SVE) {
+    //     initial_features.push_back(Target::SVE);
+    //     has_scalable_vector = true;
+    // }
 
     if (hwcaps2 & HWCAP2_SVE2) {
         initial_features.push_back(Target::SVE2);
@@ -295,10 +296,11 @@ Target calculate_host_target() {
         initial_features.push_back(Target::ARMDotProd);
     }
 
-    if (IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE)) {
-        initial_features.push_back(Target::SVE);
-        has_scalable_vector = true;
-    }
+    // TODO: https://github.com/halide/Halide/issues/8872
+    // if (IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE)) {
+    //     initial_features.push_back(Target::SVE);
+    //     has_scalable_vector = true;
+    // }
 
 #endif
 


### PR DESCRIPTION
Because scalable vector support in CodeGen_ARM is only for SVE'2' at the moment.