### PR TITLE
Update macOS platform tags in pip.yml

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -37,9 +37,9 @@ jobs:
             platform_tag: manylinux_x86_64
           - os: windows-latest
             platform_tag: win_amd64
-          - os: macos-13
+          - os: macos-15-intel
             platform_tag: macosx_x86_64
-          - os: macos-14
+          - os: macos-15
             platform_tag: macosx_arm64
 
     env:


### PR DESCRIPTION
`macos-13`, which had been Intel-only, is being deprecated.

The deprecation announcement cautions that `macos-15-intel` will be the _last_ Intel macOS GHA image. We should think about when we can deprecate Intel macs, too.