### PR TITLE
Disable peep-hole scalar op in SVE2 code-gen

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1211,7 +1211,9 @@ void CodeGen_ARM::visit(const Cast *op) {
     }
 
     // LLVM fptoui generates fcvtzs or fcvtzu in inconsistent way
-    if (op->value.type().is_float() && op->type.is_int_or_uint()) {
+    if (op->value.type().is_float() &&
+        op->type.is_int_or_uint() &&
+        !target.has_feature(Target::SVE2)) {
         if (Value *v = call_overloaded_intrin(op->type, "fp_to_int", {op->value})) {
             value = v;
             return;
@@ -1337,51 +1339,22 @@ void CodeGen_ARM::visit(const Sub *op) {
     }
 
     // Peep-hole (0 - b) pattern to generate "negate" instruction
-    if (is_const_zero(op->a)) {
-        if (target_vscale() != 0) {
-            if ((op->type.bits() >= 8 && op->type.is_int())) {
-                if (Value *v = call_overloaded_intrin(op->type, "negate", {op->b})) {
-                    value = v;
-                    return;
-                }
-            } else if (op->type.bits() >= 16 && op->type.is_float()) {
-                ScopedFastMath guard(this);
-                value = builder->CreateFNeg(codegen(op->b));
-                return;
-            }
-        } else {
-            // llvm.neon.neg/fneg intrinsic doesn't seem to exist. Instead,
-            // llvm will generate floating point negate instructions if we ask for (-0.0f)-x
-            if (op->type.is_float() &&
-                (op->type.bits() >= 32 || is_float16_and_has_feature(op->type))) {
-                Constant *a;
-                if (op->type.bits() == 16) {
-                    a = ConstantFP::getNegativeZero(f16_t);
-                } else if (op->type.bits() == 32) {
-                    a = ConstantFP::getNegativeZero(f32_t);
-                } else if (op->type.bits() == 64) {
-                    a = ConstantFP::getNegativeZero(f64_t);
-                } else {
-                    a = nullptr;
-                    internal_error << "Unknown bit width for floating point type: " << op->type << "\n";
-                }
-
-                Value *b = codegen(op->b);
-
-                if (op->type.lanes() > 1) {
-                    a = get_splat(op->type.lanes(), a);
-                }
-                ScopedFastMath guard(this);
-                value = builder->CreateFSub(a, b);
-                return;
-            }
+    if (is_const_zero(op->a) &&
+        (target_vscale() != 0 && op->type.is_vector()) &&
+        (op->type.bits() >= 8 && op->type.is_int())) {
+        if (Value *v = call_overloaded_intrin(op->type, "negate", {op->b})) {
+            value = v;
+            return;
         }
     }
 
+    // llvm.neon.neg/fneg intrinsic doesn't seem to exist. Instead,
     // llvm will generate floating point negate instructions if we ask for (-0.0f)-x
-    if (op->type.is_float() &&
+    if (is_const_zero(op->a) &&
+        op->type.is_float() &&
         (op->type.bits() >= 32 || is_float16_and_has_feature(op->type)) &&
-        is_const_zero(op->a)) {
+        (op->type.is_vector() || !target.has_feature(Target::Feature::SVE2))) {
+
         Constant *a;
         if (op->type.bits() == 16) {
             a = ConstantFP::getNegativeZero(f16_t);
@@ -1409,7 +1382,9 @@ void CodeGen_ARM::visit(const Sub *op) {
 
 void CodeGen_ARM::visit(const Min *op) {
     // Use a 2-wide vector for scalar floats.
-    if (!simd_intrinsics_disabled() && (op->type.is_float() || op->type.is_vector())) {
+    if (!simd_intrinsics_disabled() &&
+        ((op->type.is_float() && !target.has_feature(Target::SVE2)) ||
+         op->type.is_vector())) {
         value = call_overloaded_intrin(op->type, "min", {op->a, op->b});
         if (value) {
             return;
@@ -1421,7 +1396,9 @@ void CodeGen_ARM::visit(const Min *op) {
 
 void CodeGen_ARM::visit(const Max *op) {
     // Use a 2-wide vector for scalar floats.
-    if (!simd_intrinsics_disabled() && (op->type.is_float() || op->type.is_vector())) {
+    if (!simd_intrinsics_disabled() &&
+        ((op->type.is_float() && !target.has_feature(Target::SVE2)) ||
+         op->type.is_vector())) {
         value = call_overloaded_intrin(op->type, "max", {op->a, op->b});
         if (value) {
             return;

--- a/test/correctness/simd_op_check_sve2.cpp
+++ b/test/correctness/simd_op_check_sve2.cpp
@@ -602,8 +602,10 @@ private:
                 Expr float_max = Float(bits).max();
                 add_arm64("ucvtf", cast_f(min(float_max, u_1)));
                 add_arm64("scvtf", cast_f(i_1));
-                add_arm64({{"fcvtzu", bits, force_vectorized_lanes}}, vf, cast(UInt(bits), f_1));
-                add_arm64({{"fcvtzs", bits, force_vectorized_lanes}}, vf, cast(Int(bits), f_1));
+                if (is_vector) {
+                    add_arm64("fcvtzu", cast(UInt(bits), max(f_1, 0.f)));
+                    add_arm64("fcvtzs", cast(Int(bits), f_1));
+                }
                 add_arm64({{"frintn", bits, force_vectorized_lanes}}, vf, round(f_1));
                 add_arm64({{"frintm", bits, force_vectorized_lanes}}, vf, floor(f_1));
                 add_arm64({{"frintp", bits, force_vectorized_lanes}}, vf, ceil(f_1));
@@ -612,8 +614,8 @@ private:
                 add_arm32_f32({{"vmax.f", bits, force_vectorized_lanes}}, vf, max(f_1, f_2));
                 add_arm32_f32({{"vmin.f", bits, force_vectorized_lanes}}, vf, min(f_1, f_2));
 
-                add_arm64({{"fmax", bits, force_vectorized_lanes}}, vf, max(f_1, f_2));
-                add_arm64({{"fmin", bits, force_vectorized_lanes}}, vf, min(f_1, f_2));
+                add_arm64("fmax", is_vector ? "fmax" : "fmaxnm", max(f_1, f_2));
+                add_arm64("fmin", is_vector ? "fmin" : "fminnm", min(f_1, f_2));
                 if (bits != 64 && total_bits != 192) {
                     // Halide relies on LLVM optimization for this pattern, and in some case it doesn't work
                     add_arm64("fmla", is_vector ? (has_sve() ? "(fmla|fmad)" : "fmla") : "fmadd", f_1 + f_2 * f_3);


### PR DESCRIPTION
In SVE2 codegen, we stop generating vector instructions for scalar op as LLVM can generate simpler one.

Omit fcvtzu/s scalar type in simd_op_check_sve2 test as LLVM lowers fptoui inconsistently between half and float types.