### PR TITLE
Add RuntimeLibraryInfo to pass pipeline for LLVM >= 22

### DIFF
--- a/src/LLVM_Headers.h
+++ b/src/LLVM_Headers.h
@@ -92,6 +92,9 @@
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 #include <llvm/Transforms/Utils/RelLookupTableConverter.h>
 #include <llvm/Transforms/Utils/SymbolRewriter.h>
+#if LLVM_VERSION >= 220
+#include "llvm/Analysis/RuntimeLibcallInfo.h"
+#endif
 
 // IWYU pragma: end_exports
 

--- a/src/LLVM_Output.cpp
+++ b/src/LLVM_Output.cpp
@@ -390,6 +390,14 @@ void emit_file(const llvm::Module &module_in, Internal::LLVMOStream &out,
 
     const auto &triple = llvm::Triple(module->getTargetTriple());
     pass_manager.add(new llvm::TargetLibraryInfoWrapperPass(triple));
+#if LLVM_VERSION >= 220
+    pass_manager.add(new llvm::RuntimeLibraryInfoWrapper(
+        module->getTargetTriple(), target_machine->Options.ExceptionModel,
+        target_machine->Options.FloatABIType,
+        target_machine->Options.EABIVersion,
+        target_machine->Options.MCOptions.ABIName,
+        target_machine->Options.VecLib));
+#endif
 
     // Make sure things marked as always-inline get inlined
     pass_manager.add(llvm::createAlwaysInlinerLegacyPass());


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/168622 adds a new analysis for determining what libcalls are supported by a target. We need to add it to the Halide pass pipeline, otherwise all libcalls are marked unsupported. This results in some memory libcalls being lowered to loops instead, which can increase runtime. This manifested for us as timeouts for the web assembly tests due to the WABT interpreter taking significantly longer to interpret memset loops versus the libcall.