### PR TITLE
Add ability to get the type of a FuncRef

### DIFF
--- a/python_bindings/src/halide/halide_/PyFuncRef.cpp
+++ b/python_bindings/src/halide/halide_/PyFuncRef.cpp
@@ -18,7 +18,9 @@ void define_func_ref(py::module &m) {
         py::class_<FuncRef>(m, "FuncRef")
             .def("__getitem__", &FuncRef::operator[])
             .def("size", &FuncRef::size)
-            .def("__len__", &FuncRef::size);
+            .def("__len__", &FuncRef::size)
+            .def("type", &FuncRef::type)
+            .def("types", &FuncRef::types);
     add_binary_operators(func_ref_class);
 }
 

--- a/python_bindings/test/correctness/basics.py
+++ b/python_bindings/test/correctness/basics.py
@@ -343,12 +343,22 @@ def test_typed_funcs():
     with assert_throws(hl.HalideError, "it is undefined"):
         assert f.dimensions() == 0
 
+    with assert_throws(hl.HalideError, "it is undefined"):
+        assert f[x, y].type() == hl.Int(32)
+
     f = hl.Func(hl.Int(32), 2, "f")
     assert not f.defined()
     assert f.type() == hl.Int(32)
     assert f.types() == [hl.Int(32)]
     assert f.outputs() == 1
     assert f.dimensions() == 2
+    assert f[x, y].type() == hl.Int(32)
+
+    with assert_throws(hl.HalideError, "has not yet been defined"):
+        # While we can ask for the type of f[x, y], because it's a
+        # typed Func, we still can't use it as an Expr
+        g = hl.Func("g")
+        g[x, y] = f[x, y]
 
     f = hl.Func([hl.Int(32), hl.Float(64)], 3, "f")
     assert not f.defined()
@@ -356,6 +366,7 @@ def test_typed_funcs():
         assert f.type() == hl.Int(32)
 
     assert f.types() == [hl.Int(32), hl.Float(64)]
+    assert f[x, y].types() == [hl.Int(32), hl.Float(64)]
     assert f.outputs() == 2
     assert f.dimensions() == 3
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -3352,6 +3352,32 @@ size_t FuncRef::size() const {
     return func.outputs();
 }
 
+const Type &FuncRef::type() const {
+    const auto &types =
+        (func.has_pure_definition() || func.has_extern_definition()) ?
+            func.output_types() :
+            func.required_types();
+    if (types.empty()) {
+        user_error << "Can't call type() on call to Func \"" << func.name()
+                   << "\" because it is undefined or has no type requirements.\n";
+    } else if (types.size() > 1) {
+        user_error << "Can't call type() on call to Func \"" << func.name()
+                   << "\" because it returns a Tuple.\n";
+    }
+    return types[0];
+}
+
+const std::vector<Type> &FuncRef::types() const {
+    const auto &types =
+        (func.has_pure_definition() || func.has_extern_definition()) ?
+            func.output_types() :
+            func.required_types();
+    user_assert(!types.empty())
+        << "Can't call types() on call to Func \"" << func.name()
+        << "\" because it is undefined or has no type requirements.\n";
+    return types;
+}
+
 bool FuncRef::equivalent_to(const FuncRef &other) const {
     if (!func.same_as(other.func) ||
         implicit_placeholder_pos != other.implicit_placeholder_pos ||

--- a/src/Func.h
+++ b/src/Func.h
@@ -586,6 +586,20 @@ public:
      * of a definition. Only works for single-output Funcs. */
     operator Expr() const;
 
+    /** Get the type(s) of the outputs of the Func to which this FuncRef refers.
+     *
+     * It is not legal to call type() unless the Func has non-Tuple elements.
+     *
+     * If the Func isn't yet defined, and was not specified with required types,
+     * a runtime error will occur.
+     *
+     * If the Func isn't yet defined, but *was* specified with required types,
+     * the requirements will be returned. */
+    // @{
+    const Type &type() const;
+    const std::vector<Type> &types() const;
+    // @}
+
     /** When a FuncRef refers to a function that provides multiple
      * outputs, you can access each output as an Expr using
      * operator[].

--- a/src/Tuple.cpp
+++ b/src/Tuple.cpp
@@ -6,6 +6,11 @@ namespace Halide {
 
 Tuple::Tuple(const FuncRef &f)
     : exprs(f.size()) {
+    user_assert(f.function().has_pure_definition() ||
+                f.function().has_extern_definition())
+        << "Can't call Func \"" << f.function().name()
+        << "\" because it has not yet been defined.\n";
+
     user_assert(f.size() > 1)
         << "Can't construct a Tuple from a call to Func \""
         << f.function().name() << "\" because it does not return a Tuple.\n";


### PR DESCRIPTION
This is mostly relevant in the python bindings, where FuncRefs might get passed around and treated as Exprs, including asking for their type. In the C++ front-end such functions would typically take an Expr, but the same problem could arise in generic code.

Also improved the error message if you try to call an undefined Func in python. It was something about it not returning a Tuple. The general fix seemed to be to add a better error message when casting a FuncRef of an undefined Func to a Tuple.