### PR TITLE
Prefer @llvm.ceil.* intrinsics

### DIFF
--- a/src/runtime/posix_math.ll
+++ b/src/runtime/posix_math.ll
@@ -101,20 +101,17 @@ define weak_odr half @floor_f16(half %x) nounwind uwtable readnone alwaysinline 
        ret half %y
 }
 
-; These are llvm 3.3 only
-; declare float @llvm.ceil.f32(float) nounwind readnone
-; declare double @llvm.ceil.f64(double) nounwind readnone
-declare float @ceilf(float) nounwind readnone
-declare double @ceil(double) nounwind readnone
+declare float @llvm.ceil.f32(float) nounwind readnone
+declare double @llvm.ceil.f64(double) nounwind readnone
 declare half @llvm.ceil.f16(half) nounwind readnone
 
 define weak_odr float @ceil_f32(float %x) nounwind uwtable readnone alwaysinline {
-       %y = tail call float @ceilf(float %x) nounwind readnone
+       %y = tail call float @llvm.ceil.f32(float %x) nounwind readnone
        ret float %y
 }
 
 define weak_odr double @ceil_f64(double %x) nounwind uwtable readnone alwaysinline {
-       %y = tail call double @ceil(double %x) nounwind readnone
+       %y = tail call double @llvm.ceil.f64(double %x) nounwind readnone
        ret double %y
 }
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/171288 removed the SDAG lowering for ceil/ceilf calls. This was causing some errors for us when using webassembly:

Internal Error at third_party/halide/halide/src/WasmExecutor.cpp:2368 Condition failed: instance: Error initializing module: invalid import "env.ceilf"

Explicitly using the intrinsics is still covered by webassembly and given the commenting out of these intrinsics mentions that they were not used due to needing to support LLVM <3.3, I think we can safely enable these now.