### PR TITLE
Upgrade wabt to version 1.0.39

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -14,7 +14,7 @@ env:
   # TODO: detect this from repo somehow: https://github.com/halide/Halide/issues/8406
   LLVM_VERSION: 21.1.1
   FLATBUFFERS_VERSION: 23.5.26
-  WABT_VERSION: 1.0.36
+  WABT_VERSION: 1.0.39
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -19,7 +19,7 @@ FetchContent_Declare(
 FetchContent_Declare(
     wabt
     GIT_REPOSITORY https://github.com/WebAssembly/wabt.git
-    GIT_TAG 3e826ecde1adfba5f88d10d361131405637e65a3 # 1.0.36
+    GIT_TAG ad75c5edcdff96d73c245b57fbc07607aaca9f95 # 1.0.39
     GIT_SHALLOW TRUE
     SYSTEM
 )

--- a/doc/BuildingHalideWithCMake.md
+++ b/doc/BuildingHalideWithCMake.md
@@ -146,7 +146,7 @@ building the core pieces of Halide.
 | [Clang]       | `==LLVM`           | _always_                   |                                                     |
 | [LLD]         | `==LLVM`           | _always_                   |                                                     |
 | [flatbuffers] | `~=23.5.26`        | `WITH_SERIALIZATION=ON`    |                                                     |
-| [wabt]        | `==1.0.36`         | `Halide_WASM_BACKEND=wabt` | Does not have a stable API; exact version required. |
+| [wabt]        | `==1.0.39`         | `Halide_WASM_BACKEND=wabt` | Does not have a stable API; exact version required. |
 | [V8]          | trunk              | `Halide_WASM_BACKEND=V8`   | Difficult to build. See [WebAssembly.md]            |
 | [Python]      | `>=3.10`           | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
 | [pybind11]    | `~=2.11.1`         | `WITH_PYTHON_BINDINGS=ON`  |                                                     |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -598,7 +598,7 @@ if (MSVC AND Halide_WASM_BACKEND STREQUAL "wabt")
 endif ()
 
 if (Halide_WASM_BACKEND STREQUAL "wabt")
-    find_package(wabt 1.0.36 REQUIRED)
+    find_package(wabt 1.0.39 REQUIRED)
     _Halide_pkgdep(wabt)
 
     if (Halide_BUNDLE_STATIC)


### PR DESCRIPTION
This PR updates the wabt to version 1.0.39, ensuring compatibility with Homebrew and vcpkg (both of which have upgraded).

The docker images have been updated to support this change.