### PR TITLE
Use value initialization to clear halide_buffer_t in unpack_buffer

### DIFF
--- a/src/PythonExtensionGen.cpp
+++ b/src/PythonExtensionGen.cpp
@@ -214,7 +214,7 @@ bool unpack_buffer(PyObject *py_obj,
         return false;
     }
 
-    memset(&halide_buf, 0, sizeof(halide_buf));
+    halide_buf = {};
     needs_device_free = true;
     if (!py_buf.format) {
         halide_buf.type.code = halide_type_uint;


### PR DESCRIPTION
GCC >= 8 (and presumbly Clang, according to Google) thinks `halide_buffer_t` is a non-trivial type and triggers `-Werror=class-memaccess`.

Since this is in a generated `.cpp` file, we should use the C++ idiom.