### PR TITLE
Move Makefile testing to GitHub Actions

### DIFF
--- a/.github/workflows/testing-make.yml
+++ b/.github/workflows/testing-make.yml
@@ -43,13 +43,13 @@ jobs:
       - name: Set up environment
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            echo "LLVM_CONFIG=llvm-config-$LLVM_VERSION" >> "$GITHUB_ENV"
+            echo "LLVM_CONFIG=llvm-config-$LLVM_VERSION" | tee -a "$GITHUB_ENV"
           elif [ "$RUNNER_OS" = "macOS" ]; then
-            echo "LLVM_CONFIG=$(brew --prefix llvm@$LLVM_VERSION)/bin/llvm-config" >> "$GITHUB_ENV"
+            echo "LLVM_CONFIG=$(brew --prefix llvm@$LLVM_VERSION)/bin/llvm-config" | tee -a "$GITHUB_ENV"
           fi
+          echo "MAKEFLAGS=-j $(getconf _NPROCESSORS_ONLN)" | tee -a "$GITHUB_ENV"
 
-      - name: Build tests
-        run: make -j$(getconf _NPROCESSORS_ONLN) build_tests
+      - run: make build_tests
 
       - run: make test_internal
         continue-on-error: true


### PR DESCRIPTION
We only have four workflows left for Makefiles on the buildbots, so the complexity they add to the buildbot master configuration code is no longer justified. This PR aims to replace the buildbot testing for Make with GitHub Actions.

This is in service of a larger project of pinning the LLVM main version inside the repository.

Corresponding build_bot PR: halide/build_bot#315