### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+registries:
+  halide:
+    type: python-index
+    url: https://pypi.halide-lang.org/simple/
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - "*.txt"
+    registries:
+      - halide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,10 @@ ci-base = [
     { include-group = "tools" },
 ]
 
-ci-llvm-main = [{ include-group = "ci-base" }, "halide-llvm==23.0.0.dev0+g80f627e6"]
-ci-llvm-22 = [{ include-group = "ci-base" }, "halide-llvm==22.1.0rc3"]
-ci-llvm-21 = [{ include-group = "ci-base" }, "halide-llvm==21.1.8"]
-ci-llvm-20 = [{ include-group = "ci-base" }, "halide-llvm==20.1.8"]
+ci-llvm-main = [{ include-group = "ci-base" }, "halide-llvm~=23.0.0.dev0"]
+ci-llvm-22 = [{ include-group = "ci-base" }, "halide-llvm~=22.1.0rc0"]
+ci-llvm-21 = [{ include-group = "ci-base" }, "halide-llvm~=21.1.0"]
+ci-llvm-20 = [{ include-group = "ci-base" }, "halide-llvm~=20.1.0"]
 
 [project.urls]
 Homepage = "https://halide-lang.org"

--- a/uv.lock
+++ b/uv.lock
@@ -188,7 +188,7 @@ ci-base = [
 ]
 ci-llvm-20 = [
     { name = "cmake", specifier = ">=3.28" },
-    { name = "halide-llvm", specifier = "==20.1.8", index = "https://pypi.halide-lang.org/simple" },
+    { name = "halide-llvm", specifier = "~=20.1.0", index = "https://pypi.halide-lang.org/simple" },
     { name = "ninja", specifier = ">=1.11,!=1.13.0" },
     { name = "onnx", specifier = "==1.18.0" },
     { name = "pybind11", specifier = ">=2.11.1" },
@@ -200,7 +200,7 @@ ci-llvm-20 = [
 ]
 ci-llvm-21 = [
     { name = "cmake", specifier = ">=3.28" },
-    { name = "halide-llvm", specifier = "==21.1.8", index = "https://pypi.halide-lang.org/simple" },
+    { name = "halide-llvm", specifier = "~=21.1.0", index = "https://pypi.halide-lang.org/simple" },
     { name = "ninja", specifier = ">=1.11,!=1.13.0" },
     { name = "onnx", specifier = "==1.18.0" },
     { name = "pybind11", specifier = ">=2.11.1" },
@@ -212,7 +212,7 @@ ci-llvm-21 = [
 ]
 ci-llvm-22 = [
     { name = "cmake", specifier = ">=3.28" },
-    { name = "halide-llvm", specifier = "==22.1.0rc3", index = "https://pypi.halide-lang.org/simple" },
+    { name = "halide-llvm", specifier = "~=22.1.0rc0", index = "https://pypi.halide-lang.org/simple" },
     { name = "ninja", specifier = ">=1.11,!=1.13.0" },
     { name = "onnx", specifier = "==1.18.0" },
     { name = "pybind11", specifier = ">=2.11.1" },
@@ -224,7 +224,7 @@ ci-llvm-22 = [
 ]
 ci-llvm-main = [
     { name = "cmake", specifier = ">=3.28" },
-    { name = "halide-llvm", specifier = "==23.0.0.dev0+g80f627e6", index = "https://pypi.halide-lang.org/simple" },
+    { name = "halide-llvm", specifier = "~=23.0.0.dev0", index = "https://pypi.halide-lang.org/simple" },
     { name = "ninja", specifier = ">=1.11,!=1.13.0" },
     { name = "onnx", specifier = "==1.18.0" },
     { name = "pybind11", specifier = ">=2.11.1" },


### PR DESCRIPTION
This should enable dependabot to update the `uv.lock` file to bump our Python-managed dependencies, including LLVM via the `halide-llvm` package.

Pinning a particular version in the `pyproject.toml` is the wrong idea -- the `uv.lock` manages the consistent set, while the `pyproject.toml` manages the constraints. Under this interpretation, the constraint is that LLVM 22 should be... a version of LLVM 22. But it's `uv.lock` that says we're on 22.1.0rc3 (for example). Similarly `ci-llvm-main` says we depend on even a pre-release version of LLVM 23 (via the `.dev0` constraint).

For reference, one can regenerate `uv.lock` after a change to `pyproject.toml` by running `uv lock`. One can upgrade a particular package via `uv lock -P halide-llvm` (for example) followed by `uv sync [--group ci-llvm-NN]`.