### PR TITLE
Fix lossless_cast test on WASM

### DIFF
--- a/test/correctness/lossless_cast.cpp
+++ b/test/correctness/lossless_cast.cpp
@@ -437,7 +437,7 @@ int fuzz_test(uint32_t root_seed) {
     std::cout << "Fuzz testing with root seed " << root_seed << "\n";
     for (int i = 0; i < 1000; i++) {
         auto s = seed_generator();
-        std::cout << s << "\n" << std::flush;
+        std::cout << s << std::endl;
         if (test_one(s)) {
             return 1;
         }


### PR DESCRIPTION
The correctness_lossless_cast failed on WASM in #8948 during fuzzing with the following LLVM internal assertion error:

```
correctness_lossless_cast: /__w/llvm-wheel/llvm-wheel/src_cache/main/llvm/include/llvm/Support/Casting.h:560: decltype(auto) llvm::cast(const From&) [with To = LoadSDNode; From = SDValue]: Assertion `isa<To>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
```

Unfortunately, the seed was not flushed to stdout prior to the failure. This PR is intended to improve error reporting in this case and, ideally, reproduce and fix the error.