### PR TITLE
Add contribution guidelines and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -6,7 +6,10 @@ body:
     id: description
     attributes:
       label: Description
-      description: A clear and concise description of the bug.
+      description: >-
+        A clear and concise description of the bug. What happened and how
+        did it differ from what you expected? Include error messages or
+        incorrect output.
     validations:
       required: true
   - type: textarea
@@ -15,22 +18,9 @@ body:
       label: Reproducing case
       description: >-
         A minimal, self-contained code example that demonstrates the problem. The
-        smaller and more self-contained, the better.
+        smaller and more self-contained, the better. Ideally, it should look like
+        one of the tests in `test/correctness`.
       render: cpp
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-      description: What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual behavior
-      description: What actually happened? Include error messages or incorrect output.
     validations:
       required: true
   - type: dropdown
@@ -45,7 +35,7 @@ body:
         - GitHub release binary
         - Other (describe below)
     validations:
-      required: true
+      required: false
   - type: input
     id: halide-version
     attributes:
@@ -55,7 +45,7 @@ body:
         if you downloaded a binary.
       placeholder: "e.g. 19.0.0"
     validations:
-      required: true
+      required: false
   - type: input
     id: halide-commit
     attributes:
@@ -72,14 +62,14 @@ body:
       description: The Halide target string used when the bug occurs.
       placeholder: "e.g. x86-64-linux-avx2, arm-64-osx"
     validations:
-      required: true
+      required: false
   - type: input
     id: os
     attributes:
       label: Operating system
       placeholder: "e.g. Ubuntu 24.04, macOS 15.3, Windows 11"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: extra
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a functional correctness problem (wrong output, crash, compilation failure, etc.)
+labels: [ "bug" ]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Reproducing case
+      description: >-
+        A minimal, self-contained code example that demonstrates the problem. The
+        smaller and more self-contained, the better.
+      render: cpp
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages or incorrect output.
+    validations:
+      required: true
+  - type: dropdown
+    id: halide-source
+    attributes:
+      label: How did you get Halide?
+      options:
+        - Built from source
+        - pip (halide)
+        - vcpkg
+        - Homebrew
+        - GitHub release binary
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: halide-version
+    attributes:
+      label: Halide version
+      description: >-
+        The version number reported by your package manager, or the release tag
+        if you downloaded a binary.
+      placeholder: "e.g. 19.0.0"
+    validations:
+      required: true
+  - type: input
+    id: halide-commit
+    attributes:
+      label: Halide commit (if known)
+      description: >-
+        If you built from source, the commit hash you built from.
+      placeholder: "e.g. abc1234"
+    validations:
+      required: false
+  - type: input
+    id: target
+    attributes:
+      label: Target
+      description: The Halide target string used when the bug occurs.
+      placeholder: "e.g. x86-64-linux-avx2, arm-64-osx"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Ubuntu 24.04, macOS 15.3, Windows 11"
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Anything else that might be relevant (build flags, environment, workarounds found, etc.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,3 +8,8 @@ contact_links:
     about: >-
       Share early-stage ideas or brainstorm in Discussions. Polished proposals
       can be promoted to a feature specification issue.
+  - name: Contributor guidelines
+    url: https://github.com/halide/Halide/blob/main/CONTRIBUTING.md
+    about: >-
+      Guidelines for contributing to Halide development. Read these before
+      making a pull request or filing an issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions
+    url: https://github.com/halide/Halide/discussions/categories/q-a
+    about: Ask questions about using Halide in GitHub Discussions.
+  - name: Ideas and brainstorming
+    url: https://github.com/halide/Halide/discussions/categories/ideas
+    about: >-
+      Share early-stage ideas or brainstorm in Discussions. Polished proposals
+      can be promoted to a feature specification issue.

--- a/.github/ISSUE_TEMPLATE/enhancement-request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.yml
@@ -1,14 +1,16 @@
-name: Missed optimization
-description: Report a case where Halide produces correct but unexpectedly slow code.
-labels: ["performance"]
+name: Enhancement request
+description: Report a case where Halide produces a correct output in a suboptimal way
+labels: [ "enhancement" ]
 body:
   - type: textarea
     id: description
     attributes:
       label: Description
       description: >-
-        A clear description of the missed optimization. What performance do you
-        expect, and what are you observing?
+        Describe the problem: could an error message could be made clearer?
+        Is documentation is missing or misleading?
+        Was an optimization was missed?
+        Did a pipeline take unexpectedly long to compile?
     validations:
       required: true
   - type: textarea
@@ -16,19 +18,10 @@ body:
     attributes:
       label: Reproducing case
       description: >-
-        A minimal Halide pipeline that demonstrates the issue. Include the
-        schedule if relevant.
+        A minimal, self-contained code example that demonstrates the problem. The
+        smaller and more self-contained, the better. Ideally, it should look like
+        one of the tests in `test/correctness`.
       render: cpp
-    validations:
-      required: true
-  - type: textarea
-    id: performance
-    attributes:
-      label: Performance details
-      description: >-
-        Include relevant measurements: execution time, generated assembly
-        snippets, loop nest structure (Func::print_loop_nest()), or
-        HL_DEBUG_CODEGEN output.
     validations:
       required: true
   - type: dropdown
@@ -43,7 +36,7 @@ body:
         - GitHub release binary
         - Other (describe below)
     validations:
-      required: true
+      required: false
   - type: input
     id: halide-version
     attributes:
@@ -53,7 +46,7 @@ body:
         if you downloaded a binary.
       placeholder: "e.g. 19.0.0"
     validations:
-      required: true
+      required: false
   - type: input
     id: halide-commit
     attributes:
@@ -67,16 +60,21 @@ body:
     id: target
     attributes:
       label: Target
-      description: The Halide target string used.
+      description: The Halide target string used when the bug occurs.
       placeholder: "e.g. x86-64-linux-avx2, arm-64-osx"
     validations:
-      required: true
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Ubuntu 24.04, macOS 15.3, Windows 11"
+    validations:
+      required: false
   - type: textarea
     id: extra
     attributes:
       label: Additional context
-      description: >-
-        Any other relevant information (comparison with hand-written code,
-        alternative schedules tried, etc.)
+      description: Anything else that might be relevant (build flags, environment, workarounds found, etc.)
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature-spec.yml
+++ b/.github/ISSUE_TEMPLATE/feature-spec.yml
@@ -1,0 +1,45 @@
+name: Feature specification
+description: >-
+  Propose a well-specified new feature. For early-stage ideas, please start a
+  Discussion instead.
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Note:** This template is for polished feature proposals. If your idea is
+        still in the brainstorming stage, please
+        [start a Discussion](https://github.com/halide/Halide/discussions/categories/ideas)
+        instead. It can be promoted to an issue once the design solidifies.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this feature solve? Who is affected?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >-
+        Describe the feature in detail. Include proposed API surfaces, semantics,
+        and behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider, and why is this one preferred?
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: >-
+        References, related issues, prior art in other projects, or anything
+        else that supports the proposal.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-spec.yml
+++ b/.github/ISSUE_TEMPLATE/feature-spec.yml
@@ -2,7 +2,7 @@ name: Feature specification
 description: >-
   Propose a well-specified new feature. For early-stage ideas, please start a
   Discussion instead.
-labels: ["feature"]
+labels: [ "feature" ]
 body:
   - type: markdown
     attributes:
@@ -24,14 +24,8 @@ body:
       label: Proposed solution
       description: >-
         Describe the feature in detail. Include proposed API surfaces, semantics,
-        and behavior.
-    validations:
-      required: true
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Alternatives considered
-      description: What other approaches did you consider, and why is this one preferred?
+        and behavior. Compare this solution to other approaches you considered.
+        Why is this one preferred?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/missed-optimization.yml
+++ b/.github/ISSUE_TEMPLATE/missed-optimization.yml
@@ -1,0 +1,82 @@
+name: Missed optimization
+description: Report a case where Halide produces correct but unexpectedly slow code.
+labels: ["performance"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: >-
+        A clear description of the missed optimization. What performance do you
+        expect, and what are you observing?
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Reproducing case
+      description: >-
+        A minimal Halide pipeline that demonstrates the issue. Include the
+        schedule if relevant.
+      render: cpp
+    validations:
+      required: true
+  - type: textarea
+    id: performance
+    attributes:
+      label: Performance details
+      description: >-
+        Include relevant measurements: execution time, generated assembly
+        snippets, loop nest structure (Func::print_loop_nest()), or
+        HL_DEBUG_CODEGEN output.
+    validations:
+      required: true
+  - type: dropdown
+    id: halide-source
+    attributes:
+      label: How did you get Halide?
+      options:
+        - Built from source
+        - pip (halide)
+        - vcpkg
+        - Homebrew
+        - GitHub release binary
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: halide-version
+    attributes:
+      label: Halide version
+      description: >-
+        The version number reported by your package manager, or the release tag
+        if you downloaded a binary.
+      placeholder: "e.g. 19.0.0"
+    validations:
+      required: true
+  - type: input
+    id: halide-commit
+    attributes:
+      label: Halide commit (if known)
+      description: >-
+        If you built from source, the commit hash you built from.
+      placeholder: "e.g. abc1234"
+    validations:
+      required: false
+  - type: input
+    id: target
+    attributes:
+      label: Target
+      description: The Halide target string used.
+      placeholder: "e.g. x86-64-linux-avx2, arm-64-osx"
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: >-
+        Any other relevant information (comparison with hand-written code,
+        alternative schedules tried, etc.)
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Description
+
+<!-- Describe your changes and the motivation behind them. -->
+
+Fixes #<!-- issue number, if applicable -->
+
+## Performance impact
+
+<!--
+  Describe any expected impact on code generation quality or runtime performance.
+  Include benchmark results where practical. Write "N/A" if this change does not
+  affect performance.
+-->
+
+## Checklist
+
+- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
+- [ ] Commits include AI attribution where applicable (see [Code of Conduct](../CODE_OF_CONDUCT.md))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,25 @@
-## Description
-
 <!-- Describe your changes and the motivation behind them. -->
 
 Fixes #<!-- issue number, if applicable -->
 
-## Performance impact
+## Breaking changes
 
-<!--
-  Describe any expected impact on code generation quality or runtime performance.
-  Include benchmark results where practical. Write "N/A" if this change does not
-  affect performance.
--->
+List any breaking changes here. If there are none, you can remove this section.
+Common breaking changes include:
+
+- Changes to any existing APIs in the `Halide::` namespace, but not the
+  `Halide::Internal::` namespace.
+- Anything else that may cause existing Halide code to fail to compile or change
+  output.
+
+These do not necessarily disqualify a PR from being merged, but they should at
+least be tagged with the `release_notes` label.
 
 ## Checklist
 
 - [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
 - [ ] Documentation updated (if public API changed)
-- [ ] Python bindings updated (if `Halide::` namespace API changed)
-- [ ] Commits include AI attribution where applicable (see
-  [Code of Conduct](../CODE_OF_CONDUCT.md))
+- [ ] Python bindings updated (if public API changed)
+- [ ] Benchmarks are included here if the change is intended to affect
+  performance.
+- [ ] Commits include AI attribution where applicable (see Code of Conduct)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,6 @@ Fixes #<!-- issue number, if applicable -->
 ## Checklist
 
 - [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
+- [ ] Documentation updated (if public API changed)
+- [ ] Python bindings updated (if `Halide::` namespace API changed)
 - [ ] Commits include AI attribution where applicable (see [Code of Conduct](../CODE_OF_CONDUCT.md))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,5 @@ Fixes #<!-- issue number, if applicable -->
 - [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
 - [ ] Documentation updated (if public API changed)
 - [ ] Python bindings updated (if `Halide::` namespace API changed)
-- [ ] Commits include AI attribution where applicable (see [Code of Conduct](../CODE_OF_CONDUCT.md))
+- [ ] Commits include AI attribution where applicable (see
+  [Code of Conduct](../CODE_OF_CONDUCT.md))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to Halide
+
+Thank you for your interest in contributing to Halide! This document explains
+how to participate in the project, whether you're reporting a bug, proposing a
+feature, or submitting code.
+
+## Code of Conduct
+
+All participants in the Halide community are expected to follow our
+[Code of Conduct](CODE_OF_CONDUCT.md). Please read it before contributing.
+
+## Getting started
+
+### Before opening a pull request
+
+If you are new to the project, please open an issue or start a Discussion before
+submitting a pull request. This helps us align on the approach before you invest
+significant effort, and avoids situations where a contribution gets rejected
+after the work is already done.
+
+Even for established contributors, opening an issue or Discussion first is
+encouraged for any non-trivial change.
+
+### Questions and brainstorming
+
+For questions about using Halide, brainstorming ideas, or early-stage feature
+discussions, please use
+[GitHub Discussions](https://github.com/halide/Halide/discussions). Issues are
+reserved for actionable items: confirmed bugs, missed optimizations with
+reproducing cases, and polished feature specifications.
+
+## Reporting bugs
+
+We have two issue templates for different kinds of problems:
+
+- **Bug report** — for functional correctness issues (wrong output, crashes,
+  compilation failures, etc.)
+- **Missed optimization** — for cases where Halide produces correct but
+  unexpectedly slow code.
+
+Both templates will ask you to provide a minimal reproducing case. The more
+self-contained your example, the faster we can investigate.
+
+## Proposing features
+
+Feature proposals should be well-specified: describe the problem, the proposed
+solution, and any alternatives you considered. If your idea is still in the
+brainstorming stage, start a Discussion instead; it can be promoted to an issue
+once the design solidifies.
+
+## Pull requests
+
+### Requirements
+
+- **Tests are expected** for all code changes. Bug fixes should include a
+  regression test. New features should include tests that exercise the new
+  functionality. Documentation-only changes, CI configuration updates, and
+  trivial fixes (typos, formatting) are exempt.
+
+- **CI must be green.** We merge on green. Our CI runs a number of automated
+  checks, including (but not limited to) `clang-format` for C++ and `ruff` for
+  Python. If CI fails, please update your PR to fix the issue. The set of checks
+  may grow over time.
+
+- **AI attribution.** If any part of your contribution was generated or
+  substantially assisted by an AI tool, you must note this in the commit message
+  using a `Co-authored-by` trailer, as described in the
+  [Code of Conduct](CODE_OF_CONDUCT.md). For example:
+
+    ```
+    Co-authored-by: Claude <noreply@anthropic.com>
+    ```
+
+- **Performance impact.** If your change could affect code generation quality or
+  runtime performance, please describe the expected impact in the PR description
+  and include benchmark results where practical.
+
+### Review and merging
+
+Every pull request requires approval from at least one project maintainer. Once
+a PR is approved and CI is green, any maintainer may merge it.
+
+## Building Halide
+
+See the [README](README.md#building-halide) for build instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,12 @@ All participants in the Halide community are expected to follow our
 
 ### Before opening a pull request
 
-If you are new to the project, please open an issue or start a Discussion before
+If you are new to the project, please open an Issue or start a Discussion before
 submitting a pull request. This helps us align on the approach before you invest
 significant effort, and avoids situations where a contribution gets rejected
 after the work is already done.
 
-Even for established contributors, opening an issue or Discussion first is
+Even for established contributors, opening an Issue or Discussion first is
 encouraged for any non-trivial change.
 
 ### Questions and brainstorming
@@ -35,8 +35,10 @@ We have two issue templates for different kinds of problems:
 
 - **Bug report** — for functional correctness issues (wrong output, crashes,
   compilation failures, etc.)
-- **Missed optimization** — for cases where Halide produces correct but
-  unexpectedly slow code.
+- **Enhancement requests** — for cases where Halide produces a correct output,
+  but something could be better: an error message could be made clearer,
+  documentation is missing or misleading, an optimization was missed, or a
+  pipeline took unexpectedly long to compile.
 
 Both templates will ask you to provide a minimal reproducing case. The more
 self-contained your example, the faster we can investigate.
@@ -52,23 +54,34 @@ once the design solidifies.
 
 ### Requirements
 
+_Note: the following list of requirements is still in an aspirational state. You
+may see contributors make ad-hoc, but justified, exceptions to these rules. When
+this happens, the justification should be noted in writing in the PR comments._
+
 - **Tests are expected** for all code changes. Bug fixes should include a
   regression test. New features should include tests that exercise the new
-  functionality. Documentation-only changes, CI configuration updates, and
+  functionality. We will always ask that new features come with a fuzz test,
+  where applicable. Documentation-only changes, CI configuration updates, and
   trivial fixes (typos, formatting) are exempt.
 
 - **CI must be green.** We merge on green. Our CI runs a number of automated
   checks, including (but not limited to) `clang-format` for C++ and `ruff` for
   Python. If CI fails, please update your PR to fix the issue. The set of checks
-  may grow over time.
+  may grow over time. We use `pre-commit` to enforce these checks in CI; it is a
+  good idea to run it locally, too.
 
-- **AI attribution.** If any part of your contribution was generated or
-  substantially assisted by an AI tool, you must note this in the commit message
-  using a `Co-authored-by` trailer, as described in the
-  [Code of Conduct](CODE_OF_CONDUCT.md). For example:
+- **AI attribution.** If a significant part of your contribution was generated
+  by an AI tool, you must note this in the commit message using a
+  `Co-authored-by` trailer, as described in the
+  [Code of Conduct](CODE_OF_CONDUCT.md). For example (this list is not
+  exhaustive):
 
   ```
-  Co-authored-by: Claude <noreply@anthropic.com>
+  Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>
+  Co-authored-by: Cursor <cursoragent@cursor.com>
+  Co-authored-by: Gemini 3 <gemini-code-assist@google.com>
+  Co-authored-by: copilot-swe-agent[bot] <198982749+copilot@users.noreply.github.com>
+  Co-authored-by: chatgpt-codex-connector[bot] <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com>
   ```
 
 - **Documentation.** New or changed public APIs (those in the `Halide::`
@@ -85,7 +98,40 @@ once the design solidifies.
 ### Review and merging
 
 Every pull request requires approval from at least one project maintainer. Once
-a PR is approved and CI is green, any maintainer may merge it.
+a PR is approved and CI is green, any maintainer may merge it. While we don't
+have a formal code ownership process, it is a good idea to use git-blame to
+determine who the relevant maintainer is.
+
+Normally, we are able to review PRs within a (business) week. If a PR has not
+been reviewed in that time, please add a comment to the PR tagging the relevant
+maintainer. We appreciate reminders, but no more than once per week, please. Do
+not ping maintainers over email or other side channels.
+
+If your PR has stalled in review, it may be helpful to break it up into smaller
+PRs that are easier to review. A good rule of thumb is that PRs larger than 500
+lines take significantly longer to review.
+
+## Common PR anti-patterns
+
+In the past, we have seen PRs fail to be merged for a number of (often
+frustrating) reasons. We list a few here to help you avoid them.
+
+1. **Working on something large before broader consensus is reached.** If you're
+   working on something that you expect to take multiple days of work or
+   hundreds of lines of code to complete, please start a Discussion to make sure
+   the design is sound and that the maintainers understand your problem and
+   agree with your proposed solution. It's frustrating to do a lot of work just
+   to hear the maintainers think the problem doesn't need to be solved in Halide
+   (e.g. should be done at the application level or in LLVM). These are
+   sometimes known as "XY problems."
+2. **Communication deadlock between author and reviewer.** We sometimes see PRs
+   stall because the author and the reviewer believe they are waiting on the
+   other person to do something. This is why we encourage you to ping PRs when
+   you're waiting for a response.
+3. **Bundling unrelated changes, especially bug-fixes, into a single PR.** When
+   CI is red due to a pre-existing bug, it is tempting to roll the fix into your
+   PR. However, this makes the PR larger and makes it take longer to review.
+   This can snowball.
 
 ## Building Halide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,13 @@ once the design solidifies.
     Co-authored-by: Claude <noreply@anthropic.com>
     ```
 
+- **Documentation.** New or changed public APIs (those in the `Halide::`
+  namespace) should be accompanied by updated documentation.
+
+- **Python bindings.** Halide provides a Python binding for its public C++ API.
+  If your change adds or modifies an API in the `Halide::` namespace, please
+  update the corresponding Python bindings as well.
+
 - **Performance impact.** If your change could affect code generation quality or
   runtime performance, please describe the expected impact in the PR description
   and include benchmark results where practical.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,9 @@ once the design solidifies.
   using a `Co-authored-by` trailer, as described in the
   [Code of Conduct](CODE_OF_CONDUCT.md). For example:
 
-    ```
-    Co-authored-by: Claude <noreply@anthropic.com>
-    ```
+  ```
+  Co-authored-by: Claude <noreply@anthropic.com>
+  ```
 
 - **Documentation.** New or changed public APIs (those in the `Halide::`
   namespace) should be accompanied by updated documentation.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` covering the issue-first workflow, testing expectations, CI requirements, AI attribution policy, and review/merge process.
- Add GitHub issue form templates for bug reports, missed optimizations, and feature specifications.
- Add issue template config that redirects Q&A and brainstorming to Discussions.
- Add a PR template with a performance impact section and checklist for tests and AI attribution.

## Test plan

These can only be verified after merging, since GitHub renders issue/PR templates from the default branch:

- [ ] Verify issue templates render correctly: go to Issues > New Issue and check all three templates plus the Discussion links.
- [ ] Verify PR template renders correctly: open a draft PR and check the pre-filled body.
- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub and links resolve.
- [ ] Review wording with other maintainers.

This is the result of a back-and-forth drafting process with [Claude Code](https://claude.com/claude-code).