### PR TITLE
Repeat performance tests up to 5 times on GHA

### DIFF
--- a/.github/workflows/testing-arm-linux.yml
+++ b/.github/workflows/testing-arm-linux.yml
@@ -104,17 +104,20 @@ jobs:
         run: |
           cmake -S . -B build -DHalide_TARGET=host
           cmake --build build
-          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -LE performance -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -L performance --repeat until-pass:5
 
       - name: Test (NEON)
         if: matrix.bits == '64'
         run: |
           cmake -S . -B build -DHalide_TARGET=arm-64-linux-arm_dot_prod-arm_fp16
           cmake --build build
-          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -LE performance -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -L performance --repeat until-pass:5
 
       - name: Test (no extensions)
         run: |
           cmake -S . -B build -DHalide_TARGET=cmake
           cmake --build build
-          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -LE performance -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -L performance --repeat until-pass:5

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -96,10 +96,12 @@ jobs:
         run: |
           cmake -S . -B build -DHalide_TARGET=host
           cmake --build build
-          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -LE performance -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -L performance --repeat until-pass:5
 
       - name: Test (no extensions)
         run: |
           cmake -S . -B build -DHalide_TARGET=cmake
           cmake --build build
-          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -LE performance -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -L performance --repeat until-pass:5

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -92,6 +92,11 @@ jobs:
       - name: Initial build
         run: cmake --build build
 
+      - name: DEBUG - print cpu info and Halide host target
+        run: |
+          cat /proc/cpuinfo
+          ./build/src/autoschedulers/common/get_host_target
+
       - name: Test (host)
         run: |
           cmake -S . -B build -DHalide_TARGET=host

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -86,10 +86,12 @@ jobs:
         run: |
           cmake -S . -B build -DHalide_TARGET=host
           cmake --build build
-          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -LE performance -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -L performance --repeat until-pass:5
 
       - name: Test (no extensions)
         run: |
           cmake -S . -B build -DHalide_TARGET=cmake
           cmake --build build
-          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -LE performance -j "$(nproc)"
+          ctest --test-dir build --build-config RelWithDebInfo --output-on-failure -L performance --repeat until-pass:5


### PR DESCRIPTION
The GHA runners are very noisy and our performance tests aren't very stable anyway.

`skip_buildbots` because this is GHA workflow-only