### PR TITLE
simd op check: Do not include the scalar version and error checking code in the code that will be used to scan for the instruction.

### DIFF
--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -350,22 +350,22 @@ public:
                 .vectorize(xi);
         }
 
-        // We'll check over H rows, but we won't let the pipeline know H
-        // statically, as that can trigger some simplifications that change
-        // instruction selection.
-        Param<int> rows;
-        rows.set(H);
-        arg_types.push_back(rows);
-
-        // The output to the pipeline is the maximum absolute difference as a double.
-        RDom r_check(0, W, 0, rows);
-        Halide::Func error("error_" + name);
-        error() = Halide::cast<double>(maximum(absd(f(r_check.x, r_check.y), f_scalar(r_check.x, r_check.y))));
-
-        compile_and_check(error, op, name, vector_width, arg_types, error_msg);
+        compile_and_check(f, op, name, vector_width, arg_types, error_msg);
 
         bool can_run_the_code = can_run_code();
         if (can_run_the_code) {
+            // We'll check over H rows, but we won't let the pipeline know H
+            // statically, as that can trigger some simplifications that change
+            // instruction selection.
+            Param<int> rows;
+            rows.set(H);
+            arg_types.push_back(rows);
+
+            // The output to the pipeline is the maximum absolute difference as a double.
+            RDom r_check(0, W, 0, rows);
+            Halide::Func error("error_" + name);
+            error() = Halide::cast<double>(maximum(absd(f(r_check.x, r_check.y), f_scalar(r_check.x, r_check.y))));
+
             Target run_target = get_run_target();
 
             // Make some unallocated input buffers

--- a/test/correctness/simd_op_check_x86.cpp
+++ b/test/correctness/simd_op_check_x86.cpp
@@ -414,8 +414,8 @@ public:
             // Some llvm's don't use kandw, but instead predicate the computation of bool_2
             // using the result of bool_1
             // check(use_avx512 ? "kandw" : "vandps", 8, bool_1 & bool_2);
-            check(use_avx512 ? "korw" : "vorps", 8, bool_1 | bool_2);
-            check(use_avx512 ? "kxorw" : "vxorps", 8, bool_1 ^ bool_2);
+            check(use_avx512 ? "korb" : "vorps", 8, bool_1 | bool_2);
+            check(use_avx512 ? "kxorb" : "vxorps", 8, bool_1 ^ bool_2);
 
             check("vaddps*ymm", 8, f32_1 + f32_2);
             check("vaddpd*ymm", 4, f64_1 + f64_2);


### PR DESCRIPTION
Sometimes, we get false positive test result when the scalar version or error checking code is generating the instruction we're after.

Found one such case on x86 (`korw`). I'll let the buildbots figure out if there is more instances.