### PR TITLE
Make the GHA workflows respect "skip_buildbots"

### DIFF
--- a/.github/workflows/presubmit-clang-tidy.yml
+++ b/.github/workflows/presubmit-clang-tidy.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   check_clang_tidy:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_buildbots') }}
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip_buildbots')"
     name: Check clang-tidy
     runs-on: macos-latest
     steps:

--- a/.github/workflows/testing-arm-linux.yml
+++ b/.github/workflows/testing-arm-linux.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   arm-linux:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_buildbots') }}
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip_buildbots')"
     name: arm-${{ matrix.bits }} / ${{ matrix.uv_group }}
     runs-on: ubuntu-24.04-arm
     strategy:

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   linux:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_buildbots') }}
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip_buildbots')"
     name: linux-${{ matrix.bits }} / ${{ matrix.uv_group }}
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/testing-make.yml
+++ b/.github/workflows/testing-make.yml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   build_make:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_buildbots') }}
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip_buildbots')"
     name: build on ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -31,7 +31,7 @@ defaults:
 
 jobs:
   windows:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip_buildbots') }}
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip_buildbots')"
     name: windows-${{ matrix.bits }} / ${{ matrix.uv_group }}
     runs-on: windows-2022
     strategy:


### PR DESCRIPTION
As it says in the title.

The presubmit workflow always runs by design.