### PR TITLE
Add a SKIP-WITH-ISSUE-####

### DIFF
--- a/cmake/HalideTestHelpers.cmake
+++ b/cmake/HalideTestHelpers.cmake
@@ -77,7 +77,7 @@ function(add_halide_test TARGET)
         PROPERTIES
         LABELS "${args_GROUPS}"
         ENVIRONMENT "HL_TARGET=${_resolved_target};HL_JIT_TARGET=${_resolved_target}"
-        SKIP_REGULAR_EXPRESSION "\\[SKIP\\]"
+        SKIP_REGULAR_EXPRESSION "\\[SKIP(-WITH-ISSUE(-[0-9]+)?)?\\]"
         WILL_FAIL ${args_EXPECT_FAILURE}
     )
     if ("multithreaded" IN_LIST args_GROUPS)

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -314,7 +314,7 @@ private:
 
 int main(int argc, char **argv) {
     // FIXME
-    printf("[SKIP] Test is currently broken. See https://github.com/halide/Halide/issues/8083");
+    printf("[SKIP-WITH-ISSUE-8083] Test is currently broken. See https://github.com/halide/Halide/issues/8083");
     return 0;
 
     return SimdOpCheckTest::main<SimdOpCheck>(

--- a/test/correctness/gpu_allocation_cache.cpp
+++ b/test/correctness/gpu_allocation_cache.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
     }
     if (target.has_feature(Target::D3D12Compute)) {
         // https://github.com/halide/Halide/issues/5000
-        printf("[SKIP] Allocation cache not yet implemented for D3D12Compute.\n");
+        printf("[SKIP-WITH-ISSUE-5000] Allocation cache not yet implemented for D3D12Compute.\n");
         return 0;
     }
     if (target.has_feature(Target::Vulkan) && ((target.os == Target::IOS) || target.os == Target::OSX)) {

--- a/test/correctness/interpreter.cpp
+++ b/test/correctness/interpreter.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
     if (target.os == Target::Windows &&
         (target.has_feature(Target::OpenCL) ||
          target.has_feature(Target::D3D12Compute))) {
-        printf("[SKIP] workaround for issue #5738\n");
+        printf("[SKIP-WITH-ISSUE-5738] workaround for issue #5738\n");
         return 0;
     }
 
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
 
     // Workaround for https://github.com/halide/Halide/issues/7420
     if (target.has_feature(Target::WebGPU)) {
-        printf("[SKIP] workaround for issue #7420\n");
+        printf("[SKIP-WITH-ISSUE-7420] workaround for issue #7420\n");
         return 0;
     }
 

--- a/test/correctness/multi_way_select.cpp
+++ b/test/correctness/multi_way_select.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
 #if defined(__APPLE__) && defined(__x86_64__)
     if (get_jit_target_from_environment().has_feature(Target::WebGPU)) {
-        printf("[SKIP] This fails on x86 Macs (pre-Ventura) due to a bug in Apple's Metal Shading Language compiler. See https://github.com/halide/Halide/issues/7389.\n");
+        printf("[SKIP-WITH-ISSUE-7389] This fails on x86 Macs (pre-Ventura) due to a bug in Apple's Metal Shading Language compiler. See https://github.com/halide/Halide/issues/7389.\n");
         return 0;
     }
 #endif

--- a/test/correctness/simd_op_check_wasm.cpp
+++ b/test/correctness/simd_op_check_wasm.cpp
@@ -538,7 +538,7 @@ private:
 
 int main(int argc, char **argv) {
 #ifdef HALIDE_INTERNAL_USING_ASAN
-    printf("[SKIP] This test causes an ASAN crash relating to ASAN's use of sigaltstack. It doesn't seem to be due to a bug in the test itself (see https://github.com/halide/Halide/pull/8078#issuecomment-1935407878)");
+    printf("[SKIP-WITH-ISSUE-8078] This test causes an ASAN crash relating to ASAN's use of sigaltstack. It doesn't seem to be due to a bug in the test itself (see https://github.com/halide/Halide/pull/8078#issuecomment-1935407878)");
     return 0;
 #endif
 

--- a/test/performance/boundary_conditions.cpp
+++ b/test/performance/boundary_conditions.cpp
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
 
     // Workaround for https://github.com/halide/Halide/issues/7420
     if (target.has_feature(Target::WebGPU)) {
-        printf("[SKIP] workaround for issue #7420 (performance 2x as slow as expected)\n");
+        printf("[SKIP-WITH-ISSUE-7420] workaround for issue #7420 (performance 2x as slow as expected)\n");
         return 0;
     }
 


### PR DESCRIPTION
New regex to allow marking tests to be skipped because of an unresolved issue.

First step to facilitate #9018.