### PR TITLE
Fix vector_reduce simplification bug.

### DIFF
--- a/src/Simplify_Exprs.cpp
+++ b/src/Simplify_Exprs.cpp
@@ -69,7 +69,7 @@ Expr Simplify::visit(const VectorReduce *op, ExprInfo *info) {
         return value;
     }
 
-    if (info && op->type.is_int()) {
+    if (info && op->type.is_int_or_uint()) {
         switch (op->op) {
         case VectorReduce::Add:
             // Alignment of result is the alignment of the arg. Bounds
@@ -123,7 +123,8 @@ Expr Simplify::visit(const VectorReduce *op, ExprInfo *info) {
     case VectorReduce::Add: {
         auto rewrite = IRMatcher::rewriter(IRMatcher::h_add(value, lanes), op->type);
         if (rewrite(h_add(x * broadcast(y, arg_lanes), lanes), h_add(x, lanes) * broadcast(y, lanes)) ||
-            rewrite(h_add(broadcast(x, arg_lanes) * y, lanes), h_add(y, lanes) * broadcast(x, lanes))) {
+            rewrite(h_add(broadcast(x, arg_lanes) * y, lanes), h_add(y, lanes) * broadcast(x, lanes)) ||
+            rewrite(h_add(broadcast(x, arg_lanes), lanes), broadcast(x * factor, lanes))) {
             return mutate(rewrite.result, info);
         }
         break;

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -810,6 +810,24 @@ void check_vectors() {
           int_vector);
     check(VectorReduce::make(VectorReduce::Max, Broadcast::make(int_vector, 4), 8),
           VectorReduce::make(VectorReduce::Max, Broadcast::make(int_vector, 4), 8));
+
+    {
+        // h_add(broadcast(x, 8), 4) should simplify to broadcast(x * 2, 4)
+        check(VectorReduce::make(VectorReduce::Add, broadcast(x, 8), 4),
+              broadcast(x * 2, 4));
+    }
+
+    {
+        Expr const_u8 = cast(UInt(8), 3);
+        check(VectorReduce::make(VectorReduce::Add, broadcast(const_u8, 9), 3), broadcast(cast(UInt(8), 9), 3));
+    }
+
+    {
+        // Test VectorReduce::Add on a variable of unsigned type to ensure the multiplied factor
+        // keeps the correct type and avoids type-mismatch assertion failures.
+        Expr u8_x = Variable::make(UInt(8), "u8_x");
+        check(VectorReduce::make(VectorReduce::Add, broadcast(u8_x, 9), 3), broadcast(u8_x * cast(UInt(8), 3), 3));
+    }
 }
 
 void check_bounds() {


### PR DESCRIPTION
Gemini said:

An analysis of the debug prints and Halide's source code reveals that `vector_reduce_add(x9((uint8)3))` incorrectly constant-folds into `x3((uint8)3)` instead of `x3((uint8)9)`. This evaluation happens because of two closely related bugs in the simplifier for `VectorReduce`:

1. **Incorrect Integer Check for Bounds Tracking:**
   In `Simplify::visit(const VectorReduce *op, ExprInfo *info)`, bounds tracking attempts to properly scale bounds of an addition by multiplying the current bounds by the reduction factor. However, the condition checking if bounds should be tracked checks if `op->type.is_int()`. In Halide, `.is_int()` checks if the type is a **signed integer**; it evaluates to `false` for unsigned integer types like `uint8`. As a result, the reduction scaling is completely skipped, leaving the initial bounds unchanged (`[3, 3]`). The mutator spots these single-point bounds and prematurely folds the expression down to exactly `3`. We need to use `.is_int_or_uint()`.

2. **Missing `IRMatcher` Structural Rewrite Rule:**
   Currently, the `IRMatcher` structurally matches `vector_reduce_add` of an explicit multiplication with a broadcast (`h_add(x * broadcast(y, ...), ...)`). However, unlike `VectorReduce::Min` and `VectorReduce::Max` which properly flatten a bare broadcast, `VectorReduce::Add` lacks the rule to reduce `h_add(broadcast(x, arg_lanes), lanes)`. Adding `broadcast(x * factor, lanes)` structurally captures reductions of broadcasts into equivalent scaled broadcasts even when dealing with variable expressions. 

Here are the fixes for both issues:

```cpp
--- Simplify_Exprs.cpp
+++ Simplify_Exprs.cpp
@@ -73,7 +73,7 @@
         return value;
     }
 
-    if (info && op->type.is_int()) {
+    if (info && op->type.is_int_or_uint()) {
         switch (op->op) {
         case VectorReduce::Add:
             // Alignment of result is the alignment of the arg. Bounds
@@ -124,7 +124,8 @@
     case VectorReduce::Add: {
         auto rewrite = IRMatcher::rewriter(IRMatcher::h_add(value, lanes), op->type);
         if (rewrite(h_add(x * broadcast(y, arg_lanes), lanes), h_add(x, lanes) * broadcast(y, lanes)) ||
-            rewrite(h_add(broadcast(x, arg_lanes) * y, lanes), h_add(y, lanes) * broadcast(x, lanes))) {
+            rewrite(h_add(broadcast(x, arg_lanes) * y, lanes), h_add(y, lanes) * broadcast(x, lanes)) ||
+            rewrite(h_add(broadcast(x, arg_lanes), lanes), broadcast(x * factor, lanes))) {
             return mutate(rewrite.result, info);
         }
         break;
```

Fixes #9030.