### PR TITLE
cast<t>(immediate) should be make_const(t, immediate)

### DIFF
--- a/src/AddAtomicMutex.cpp
+++ b/src/AddAtomicMutex.cpp
@@ -326,7 +326,7 @@ protected:
         }
 
         if (const std::string *mutex_name = needs_mutex_allocation.find(producer_name)) {
-            Expr extent = cast<uint64_t>(1);  // uint64_t to handle LargeBuffers
+            Expr extent = make_one(UInt(64));  // uint64_t to handle LargeBuffers
             for (const Expr &e : op->extents) {
                 extent = extent * e;
             }
@@ -378,7 +378,7 @@ protected:
         if (const std::string *mutex_name = needs_mutex_allocation.find(it->first)) {
             // All output buffers in a Tuple have the same extent.
             OutputImageParam output_buffer = Func(f).output_buffers()[0];
-            Expr extent = cast<uint64_t>(1);  // uint64_t to handle LargeBuffers
+            Expr extent = make_one(UInt(64));  // uint64_t to handle LargeBuffers
             for (int i = 0; i < output_buffer.dimensions(); i++) {
                 extent *= output_buffer.dim(i).extent();
             }

--- a/src/Associativity.cpp
+++ b/src/Associativity.cpp
@@ -537,8 +537,8 @@ void associativity_test() {
         Expr f_call_0 = Call::make(t, "f", {x_idx}, Call::CallType::Halide, FunctionPtr(), 0);
 
         for (const Expr &e : {cast<uint8_t>(min(cast<uint16_t>(x) + y, 255)),
-                              select(x > 255 - y, cast<uint8_t>(255), y),
-                              select(x < -y, y, cast<uint8_t>(255)),
+                              select(x > 255 - y, make_const(UInt(8), 255), y),
+                              select(x < -y, y, make_const(UInt(8), 255)),
                               saturating_add(x, y),
                               saturating_add(y, x),
                               saturating_cast<uint8_t>(widening_add(x, y))}) {

--- a/src/BoundaryConditions.cpp
+++ b/src/BoundaryConditions.cpp
@@ -45,7 +45,7 @@ Func constant_exterior(const Func &source, const Tuple &value,
         << ") than dimensions (" << args.size()
         << ") Func " << source.name() << " has.\n";
 
-    Expr out_of_bounds = cast<bool>(false);
+    Expr out_of_bounds = Halide::Internal::make_zero(Bool());
     for (size_t i = 0; i < bounds.size(); i++) {
         const Var &arg_var = args[i];
         Expr min = bounds[i].min;

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -3623,22 +3623,22 @@ void bounds_test() {
     scope.pop("x");
 
     // Check some bitwise ops.
-    check(scope, (cast<uint8_t>(x) & cast<uint8_t>(7)), u8(0), u8(7));
-    check(scope, (cast<uint8_t>(3) & cast<uint8_t>(2)), u8(2), u8(2));
-    check(scope, (cast<uint8_t>(1) | cast<uint8_t>(2)), u8(3), u8(3));
-    check(scope, (cast<uint8_t>(3) ^ cast<uint8_t>(2)), u8(1), u8(1));
-    check(scope, (~cast<uint8_t>(3)), u8(0xfc), u8(0xfc));
+    check(scope, (cast<uint8_t>(x) & make_const(UInt(8), 7)), u8(0), u8(7));
+    check(scope, (make_const(UInt(8), 3) & make_const(UInt(8), 2)), u8(2), u8(2));
+    check(scope, (make_one(UInt(8)) | make_const(UInt(8), 2)), u8(3), u8(3));
+    check(scope, (make_const(UInt(8), 3) ^ make_const(UInt(8), 2)), u8(1), u8(1));
+    check(scope, (~make_const(UInt(8), 3)), u8(0xfc), u8(0xfc));
     check(scope, cast<uint8_t>(x + 5) & cast<uint8_t>(x + 3), u8(0), u8(13));
     check(scope, cast<int8_t>(x - 5) & cast<int8_t>(x + 3), i8(0), i8(13));
     check(scope, cast<int8_t>(2 * x - 5) & cast<int8_t>(x - 3), i8(-128), i8(15));
     check(scope, cast<uint8_t>(x + 5) | cast<uint8_t>(x + 3), u8(5), u8(255));
     check(scope, cast<int8_t>(x + 5) | cast<int8_t>(x + 3), i8(3), i8(127));
     check(scope, ~cast<uint8_t>(x), u8(-11), u8(-1));
-    check(scope, (cast<uint8_t>(x) >> cast<uint8_t>(1)), u8(0), u8(5));
-    check(scope, (cast<uint8_t>(10) >> cast<uint8_t>(1)), u8(5), u8(5));
-    check(scope, (cast<uint8_t>(x + 3) << cast<uint8_t>(1)), u8(6), u8(26));
-    check(scope, (cast<uint8_t>(x + 3) << cast<uint8_t>(7)), u8(0), u8(255));  // Overflows
-    check(scope, (cast<uint8_t>(5) << cast<uint8_t>(1)), u8(10), u8(10));
+    check(scope, (cast<uint8_t>(x) >> make_one(UInt(8))), u8(0), u8(5));
+    check(scope, (make_const(UInt(8), 10) >> make_one(UInt(8))), u8(5), u8(5));
+    check(scope, (cast<uint8_t>(x + 3) << make_one(UInt(8))), u8(6), u8(26));
+    check(scope, (cast<uint8_t>(x + 3) << make_const(UInt(8), 7)), u8(0), u8(255));  // Overflows
+    check(scope, (make_const(UInt(8), 5) << make_one(UInt(8))), u8(10), u8(10));
     check(scope, (x << 12), 0, 10 << 12);
     check(scope, x & 4095, 0, 10);          // LHS known to be positive
     check(scope, x & 123, 0, 10);           // Doesn't have to be a precise bitmask
@@ -3712,7 +3712,7 @@ void bounds_test() {
           u16(0), u16(4095));
 
     check(scope,
-          cast<uint8_t>(clamp(cast<uint16_t>(x ^ y), cast<uint16_t>(0), cast<uint16_t>(128))),
+          cast<uint8_t>(clamp(cast<uint16_t>(x ^ y), make_zero(UInt(16)), make_const(UInt(16), 128))),
           u8(0), u8(128));
 
     Expr u8_1 = cast<uint8_t>(Load::make(Int(8), "buf", x, Buffer<>(), Parameter(), const_true(), ModulusRemainder()));
@@ -3720,19 +3720,19 @@ void bounds_test() {
     check(scope, cast<uint16_t>(u8_1) + cast<uint16_t>(u8_2),
           u16(0), u16(255 * 2));
 
-    check(scope, saturating_cast<uint8_t>(clamp(x, 5, 10)), cast<uint8_t>(5), cast<uint8_t>(10));
+    check(scope, saturating_cast<uint8_t>(clamp(x, 5, 10)), make_const(UInt(8), 5), make_const(UInt(8), 10));
     {
         scope.push("x", Interval(UInt(32).min(), UInt(32).max()));
-        check(scope, saturating_cast<int32_t>(max(cast<uint32_t>(x), cast<uint32_t>(5))), cast<int32_t>(5), Int(32).max());
+        check(scope, saturating_cast<int32_t>(max(cast<uint32_t>(x), make_const(UInt(32), 5))), make_const(Int(32), 5), Int(32).max());
         scope.pop("x");
     }
     {
         Expr z = Variable::make(Float(32), "z");
-        scope.push("z", Interval(cast<float>(-1), cast<float>(1)));
-        check(scope, saturating_cast<int32_t>(z), cast<int32_t>(-1), cast<int32_t>(1));
-        check(scope, saturating_cast<double>(z), cast<double>(-1), cast<double>(1));
-        check(scope, saturating_cast<float16_t>(z), cast<float16_t>(-1), cast<float16_t>(1));
-        check(scope, saturating_cast<uint8_t>(z), cast<uint8_t>(0), cast<uint8_t>(1));
+        scope.push("z", Interval(make_const(Float(32), -1), make_one(Float(32))));
+        check(scope, saturating_cast<int32_t>(z), make_const(Int(32), -1), make_one(Int(32)));
+        check(scope, saturating_cast<double>(z), make_const(Float(64), -1), make_one(Float(64)));
+        check(scope, saturating_cast<float16_t>(z), make_const(Float(16), -1), make_one(Float(16)));
+        check(scope, saturating_cast<uint8_t>(z), make_zero(UInt(8)), make_one(UInt(8)));
         scope.pop("z");
     }
     {

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -170,7 +170,7 @@ Stmt acquire_hvx_context(Stmt stmt, const Target &target) {
     // Modify the stmt to add a call to halide_qurt_hvx_lock, and
     // register a destructor to call halide_qurt_hvx_unlock.
     Stmt check_hvx_lock = call_halide_qurt_hvx_lock(target);
-    Expr dummy_obj = reinterpret(Handle(), cast<uint64_t>(1));
+    Expr dummy_obj = reinterpret(Handle(), make_one(UInt(64)));
     Expr hvx_unlock =
         Call::make(Handle(), Call::register_destructor,
                    {Expr("halide_qurt_hvx_unlock_as_destructor"), dummy_obj},

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3989,7 +3989,7 @@ void CodeGen_LLVM::codegen_asserts(const vector<const AssertStmt *> &asserts) {
 
     // Mix all the conditions together into a bitmask
 
-    Expr bitmask = cast<uint64_t>(1) << 63;
+    Expr bitmask = make_const(UInt(64), ((uint64_t)1) << 63);
     for (size_t i = 0; i < asserts.size(); i++) {
         bitmask = bitmask | (cast<uint64_t>(!asserts[i]->condition) << i);
     }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -2167,7 +2167,7 @@ void generator_test() {
         const std::vector<uint64_t> a = {1, 2, 3, 4};
         Var x;
         Func fn_typed, fn_untyped;
-        fn_typed(x) = cast<int16_t>(38);
+        fn_typed(x) = make_const(Int(16), 38);
         fn_untyped(x) = 32.f;
         const std::vector<Func> fn_array = {fn_untyped, fn_untyped};
 

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2065,7 +2065,7 @@ public:
     void set_estimate(const TBase &value) {
         this->check_gio_access();
         user_assert(value == nullptr) << "nullptr is the only valid estimate for Input<PointerType>";
-        Expr e = reinterpret(type_of<T2>(), cast<uint64_t>(0));
+        Expr e = reinterpret(type_of<T2>(), make_zero(UInt(64)));
         for (Parameter &p : this->parameters_) {
             p.set_estimate(e);
         }

--- a/src/OffloadGPULoops.cpp
+++ b/src/OffloadGPULoops.cpp
@@ -200,18 +200,18 @@ class InjectGpuOffload : public IRMutator {
                 arg_types_or_sizes.emplace_back(cast(target_size_t_type, i.is_buffer ? 8 : i.type.bytes()));
             }
 
-            arg_is_buffer.emplace_back(cast<uint8_t>(i.is_buffer));
+            arg_is_buffer.emplace_back(make_const(UInt(8), (int)i.is_buffer));
         }
 
         // nullptr-terminate the lists
-        args.emplace_back(reinterpret(Handle(), cast<uint64_t>(0)));
+        args.emplace_back(reinterpret(Handle(), make_zero(UInt(64))));
         if (runtime_run_takes_types) {
             internal_assert(sizeof(halide_type_t) == sizeof(uint32_t));
-            arg_types_or_sizes.emplace_back(cast<uint32_t>(0));
+            arg_types_or_sizes.emplace_back(make_zero(UInt(32)));
         } else {
             arg_types_or_sizes.emplace_back(cast(target_size_t_type, 0));
         }
-        arg_is_buffer.emplace_back(cast<uint8_t>(0));
+        arg_is_buffer.emplace_back(make_zero(UInt(8)));
 
         debug(3) << "bounds.num_blocks[0] = " << bounds.num_blocks[0] << "\n";
         debug(3) << "bounds.num_blocks[1] = " << bounds.num_blocks[1] << "\n";

--- a/src/Profiling.cpp
+++ b/src/Profiling.cpp
@@ -201,7 +201,7 @@ private:
 
     Stmt unconditionally_set_current_func(int id) {
         Stmt s = Evaluate::make(Call::make(Int(32), "halide_profiler_set_current_func",
-                                           {profiler_instance, id, reinterpret(Handle(), cast<uint64_t>(0))}, Call::Extern));
+                                           {profiler_instance, id, reinterpret(Handle(), make_zero(UInt(64)))}, Call::Extern));
         return s;
     }
 
@@ -210,7 +210,7 @@ private:
             return Evaluate::make(0);
         }
         most_recently_set_func = id;
-        Expr last_arg = in_leaf_task ? profiler_local_sampling_token : reinterpret(Handle(), cast<uint64_t>(0));
+        Expr last_arg = in_leaf_task ? profiler_local_sampling_token : reinterpret(Handle(), make_zero(UInt(64)));
         // This call gets inlined and becomes a single store instruction.
         Stmt s = Evaluate::make(Call::make(Int(32), "halide_profiler_set_current_func",
                                            {profiler_instance, id, last_arg}, Call::Extern));


### PR DESCRIPTION
Doing a Halide cast of a c++ int constructs an immediate Expr (e.g. IntImm) and then eagerly folds it to a different type of immediate in the Cast constructor. It's better to just construct the immediate using the desired type to begin with.
