### PR TITLE
Update GitHub actions steps and configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -23,7 +23,7 @@ jobs:
     name: Check clang-tidy
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # We intentionally don't use VCPKG here so that we get some
       # notification that the ecosystem is moving on without us.

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -41,13 +41,15 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 11
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - uses: ilammy/msvc-dev-cmd@v1
-      - uses: lukka/get-cmake@v3.28.4
+      - uses: lukka/get-cmake@v4.2.0
+        with:
+          cmakeVersion: "~3.28.0"
 
       ########################################################################
       # LLVM
@@ -68,7 +70,7 @@ jobs:
       #- uses: mxschmitt/action-tmate@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: "cp3*-${{ matrix.platform_tag }}"
           CIBW_SKIP: "cp3{5,6,7,8,9}* cp314t-*"
@@ -148,7 +150,7 @@ jobs:
             cmake --build build &&
             ctest --test-dir build --output-on-failure
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: wheels-${{ matrix.platform_tag }}
           path: ./wheelhouse/*.whl
@@ -160,7 +162,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: wheels-*
           merge-multiple: true

--- a/.github/workflows/pre-commit-push-fixes.yml
+++ b/.github/workflows/pre-commit-push-fixes.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Download auto-fix artifacts
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: pre-commit-fixes
           path: /tmp/pre-commit-fixes
@@ -58,7 +58,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: steps.download.outcome == 'success' && env.skip != 'true'
         with:
           repository: ${{ steps.pr.outputs.head-repo }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,13 +17,13 @@ jobs:
     name: Run pre-commit checks
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
 
-      - uses: actions/setup-python@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run pre-commit
         id: pre-commit
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload auto-fix artifacts
         if: ${{ !cancelled() && steps.diff.outputs.has-fixes == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pre-commit-fixes
           path: |

--- a/.github/workflows/testing-arm-linux.yml
+++ b/.github/workflows/testing-arm-linux.yml
@@ -46,9 +46,9 @@ jobs:
             python: linux-aarch64-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/testing-ecosystem.yml
+++ b/.github/workflows/testing-ecosystem.yml
@@ -26,7 +26,7 @@ jobs:
     name: CMake configure (Ubuntu 24.04)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -46,9 +46,9 @@ jobs:
           #   python: cpython-3.10-linux-x86_64-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/testing-make.yml
+++ b/.github/workflows/testing-make.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -50,9 +50,9 @@ jobs:
           #   python: cpython-3.10.20-windows-x86_64-none
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:

--- a/.github/workflows/upgrade-llvm.yml
+++ b/.github/workflows/upgrade-llvm.yml
@@ -30,7 +30,7 @@ jobs:
           git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config --global user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
@@ -49,7 +49,7 @@ jobs:
             git checkout -b "$BRANCH"
           fi
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
 
       - name: Upgrade halide-llvm
         run: uv lock -P halide-llvm


### PR DESCRIPTION
Several of our runners are showing warnings that will eventually become errors as GHA deprecates old versions of Node JS. This upgrades all our actions to their latest versions and configures Dependabot to keep them up to date.