### PR TITLE
Report clang-tidy errors as GitHub annotations

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -7,6 +7,7 @@ on:
       - '**.c'
       - '**.cpp'
       - 'run-clang-tidy.sh'
+      - 'tools/clang-tidy-filter.sh'
       - '**.clang-tidy'
       - '.github/workflows/clang-tidy.yml'
 

--- a/run-clang-tidy.sh
+++ b/run-clang-tidy.sh
@@ -128,32 +128,18 @@ jq -s 'add' "${CLANG_TIDY_BUILD_DIR}/compile_commands.json" \
     >"${CLANG_TIDY_BUILD_DIR}/compile_commands_merged.json"
 mv "${CLANG_TIDY_BUILD_DIR}/compile_commands_merged.json" "${CLANG_TIDY_BUILD_DIR}/compile_commands.json"
 
-# Wrapper filters noisy "N warnings generated." from each clang-tidy invocation.
-CLANG_TIDY_FILTER="${CLANG_TIDY_BUILD_DIR}/clang-tidy-filter.sh"
-cat >"${CLANG_TIDY_FILTER}" <<WRAPPER
-#!/usr/bin/env bash
-"${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-tidy" "\$@" 2>&1 | grep -v '^[[:digit:]]\+ warnings\? generated\.\$'
-exit "\${PIPESTATUS[0]}"
-WRAPPER
-chmod +x "${CLANG_TIDY_FILTER}"
+echo "Running clang-tidy..."
 
-echo Running clang-tidy...
 export PYTHONUNBUFFERED=1
+export CLANG_TIDY_REAL_BINARY="${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-tidy"
+export CLANG_TIDY_ROOT_DIR="${ROOT_DIR}"
 "${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/run-clang-tidy" \
     ${FIX} \
     -j "${J}" \
     -quiet \
     -p "${CLANG_TIDY_BUILD_DIR}" \
-    -clang-tidy-binary "${CLANG_TIDY_FILTER}" \
+    -clang-tidy-binary "${ROOT_DIR}/tools/clang-tidy-filter.sh" \
     -clang-apply-replacements-binary "${CLANG_TIDY_LLVM_INSTALL_DIR}/bin/clang-apply-replacements" \
     "$@"
 
-CLANG_TIDY_EXIT_CODE=$?
-
-if [ "$CLANG_TIDY_EXIT_CODE" -eq 0 ]; then
-    echo "Success!"
-else
-    echo "clang-tidy failed with exit code $CLANG_TIDY_EXIT_CODE"
-fi
-
-exit "$CLANG_TIDY_EXIT_CODE"
+echo "Success!"

--- a/tools/clang-tidy-filter.sh
+++ b/tools/clang-tidy-filter.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+if [[ -z ${CLANG_TIDY_REAL_BINARY:-} ]]; then
+    echo "CLANG_TIDY_REAL_BINARY must be set" 1>&2
+    exit 1
+fi
+
+if [[ -z ${CLANG_TIDY_ROOT_DIR:-} ]]; then
+    echo "CLANG_TIDY_ROOT_DIR must be set" 1>&2
+    exit 1
+fi
+
+escape_github_annotation_value() {
+    local value="$1"
+    value="${value//'%'/%25}"
+    value="${value//$'\r'/%0D}"
+    value="${value//$'\n'/%0A}"
+    value="${value//','/%2C}"
+    value="${value//':'/%3A}"
+    printf '%s' "${value}"
+}
+
+OUTPUT_FILE=$(mktemp)
+"${CLANG_TIDY_REAL_BINARY}" "$@" >"${OUTPUT_FILE}" 2>&1
+CLANG_TIDY_STATUS=$?
+
+grep -v '^[[:digit:]]\+ warnings\? generated\.$' "${OUTPUT_FILE}"
+
+if [[ ${GITHUB_ACTIONS} == "true" ]]; then
+    while IFS= read -r line; do
+        if [[ ${line} =~ ^(.+):([0-9]+):([0-9]+):[[:space:]](warning|error|note):[[:space:]](.*)\ \[([^][]+)\]$ ]]; then
+            file="${BASH_REMATCH[1]}"
+            line_no="${BASH_REMATCH[2]}"
+            col_no="${BASH_REMATCH[3]}"
+            severity="${BASH_REMATCH[4]}"
+            message="${BASH_REMATCH[5]}"
+            check_name="${BASH_REMATCH[6]}"
+        elif [[ ${line} =~ ^(.+):([0-9]+):([0-9]+):[[:space:]](warning|error|note):[[:space:]](.*)$ ]]; then
+            file="${BASH_REMATCH[1]}"
+            line_no="${BASH_REMATCH[2]}"
+            col_no="${BASH_REMATCH[3]}"
+            severity="${BASH_REMATCH[4]}"
+            message="${BASH_REMATCH[5]}"
+            check_name="clang-tidy"
+        else
+            continue
+        fi
+
+        if [[ ${file} == "${CLANG_TIDY_ROOT_DIR}/"* ]]; then
+            file="${file#"${CLANG_TIDY_ROOT_DIR}/"}"
+        fi
+
+        file="$(escape_github_annotation_value "${file}")"
+        title="$(escape_github_annotation_value "${check_name}")"
+        message="$(escape_github_annotation_value "${message}")"
+
+        echo "::${severity} file=${file},line=${line_no},col=${col_no},title=${title}::${message}"
+    done <"${OUTPUT_FILE}"
+fi
+
+rm -f "${OUTPUT_FILE}"
+exit "${CLANG_TIDY_STATUS}"


### PR DESCRIPTION
PR #9077 had some clang-tidy failures, but digging through the logs to see what's wrong isn't fun. This PR turns the `clang-tidy` error messages into commit/PR annotations.