### PR TITLE
Remove missing Errors.h from Halide_Plugin file list

### DIFF
--- a/src/autoschedulers/common/CMakeLists.txt
+++ b/src/autoschedulers/common/CMakeLists.txt
@@ -5,7 +5,6 @@ target_sources(
     INTERFACE
     FILE_SET HEADERS
     FILES
-    Errors.h
     HalidePlugin.h
     ParamParser.h
     cmdline.h


### PR DESCRIPTION
When I upgraded CMake from 4.2 to 4.3 locally, it started erroring on a missing `Errors.h` file in the autoscheduler common sources. I'm not updating the pip pin to 4.3 though because the CMake package is having issues on PyPI right now:

https://github.com/scikit-build/cmake-python-distributions/issues/692
https://github.com/pypi/support/issues/10002

There's nothing in the release notes about the new behavior, but there's no harm in removing this since, after all, it doesn't exist.