### PR TITLE
Rename CodeGen_Posix to CodeGen_CPU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,7 @@ SOURCE_FILES = \
   Closure.cpp \
   CodeGen_ARM.cpp \
   CodeGen_C.cpp \
+  CodeGen_CPU.cpp \
   CodeGen_D3D12Compute_Dev.cpp \
   CodeGen_GPU_Dev.cpp \
   CodeGen_Hexagon.cpp \
@@ -474,7 +475,6 @@ SOURCE_FILES = \
   CodeGen_LLVM.cpp \
   CodeGen_Metal_Dev.cpp \
   CodeGen_OpenCL_Dev.cpp \
-  CodeGen_Posix.cpp \
   CodeGen_PowerPC.cpp \
   CodeGen_PTX_Dev.cpp \
   CodeGen_PyTorch.cpp \
@@ -667,13 +667,13 @@ HEADER_FILES = \
   ClampUnsafeAccesses.h \
   Closure.h \
   CodeGen_C.h \
+  CodeGen_CPU.h \
   CodeGen_D3D12Compute_Dev.h \
   CodeGen_GPU_Dev.h \
   CodeGen_Internal.h \
   CodeGen_LLVM.h \
   CodeGen_Metal_Dev.h \
   CodeGen_OpenCL_Dev.h \
-  CodeGen_Posix.h \
   CodeGen_PTX_Dev.h \
   CodeGen_PyTorch.h \
   CodeGen_Targets.h \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,13 +74,13 @@ target_sources(
     ClampUnsafeAccesses.h
     Closure.h
     CodeGen_C.h
+    CodeGen_CPU.h
     CodeGen_D3D12Compute_Dev.h
     CodeGen_GPU_Dev.h
     CodeGen_Internal.h
     CodeGen_LLVM.h
     CodeGen_Metal_Dev.h
     CodeGen_OpenCL_Dev.h
-    CodeGen_Posix.h
     CodeGen_PTX_Dev.h
     CodeGen_PyTorch.h
     CodeGen_Targets.h
@@ -256,6 +256,7 @@ target_sources(
     Closure.cpp
     CodeGen_ARM.cpp
     CodeGen_C.cpp
+    CodeGen_CPU.cpp
     CodeGen_D3D12Compute_Dev.cpp
     CodeGen_GPU_Dev.cpp
     CodeGen_Hexagon.cpp
@@ -263,7 +264,6 @@ target_sources(
     CodeGen_LLVM.cpp
     CodeGen_Metal_Dev.cpp
     CodeGen_OpenCL_Dev.cpp
-    CodeGen_Posix.cpp
     CodeGen_PowerPC.cpp
     CodeGen_PTX_Dev.cpp
     CodeGen_PyTorch.cpp

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -3,7 +3,7 @@
 
 #include "CSE.h"
 #include "CodeGen_Internal.h"
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "ConciseCasts.h"
 #include "Debug.h"
 #include "DecomposeVectorShuffle.h"
@@ -171,13 +171,13 @@ class SubstituteInStridedLoads : public IRMutator {
 };
 
 /** A code generator that emits ARM code from a given Halide stmt. */
-class CodeGen_ARM : public CodeGen_Posix {
+class CodeGen_ARM : public CodeGen_CPU {
 public:
     /** Create an ARM code generator for the given arm target. */
     CodeGen_ARM(const Target &);
 
 protected:
-    using CodeGen_Posix::visit;
+    using CodeGen_CPU::visit;
 
     /** Similar to llvm_type_of, but allows providing a VectorTypeConstraint to
      * force Fixed or VScale vector results. */
@@ -285,7 +285,7 @@ protected:
 };
 
 CodeGen_ARM::CodeGen_ARM(const Target &target)
-    : CodeGen_Posix(complete_arm_target(target)) {
+    : CodeGen_CPU(complete_arm_target(target)) {
 
     // TODO(https://github.com/halide/Halide/issues/8088): See if
     // use_llvm_vp_intrinsics can replace architecture specific code in this
@@ -1024,7 +1024,7 @@ llvm::Function *CodeGen_ARM::define_intrin_wrapper(const std::string &inner_name
 }
 
 void CodeGen_ARM::init_module() {
-    CodeGen_Posix::init_module();
+    CodeGen_CPU::init_module();
 
     // TODO: https://github.com/halide/Halide/issues/8872
     // if (target.features_any_of({Target::SVE, Target::SVE2})) {
@@ -1223,7 +1223,7 @@ void CodeGen_ARM::compile_func(const LoweredFunc &f,
     // and a - (b << c) into umlsl/smlsl.
     func.body = distribute_shifts(func.body, /* multiply_adds */ true);
 
-    CodeGen_Posix::compile_func(func, simple_name, extern_name);
+    CodeGen_CPU::compile_func(func, simple_name, extern_name);
 }
 
 void CodeGen_ARM::visit(const Cast *op) {
@@ -1272,7 +1272,7 @@ void CodeGen_ARM::visit(const Cast *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Add *op) {
@@ -1282,7 +1282,7 @@ void CodeGen_ARM::visit(const Add *op) {
     };
 
     if (simd_intrinsics_disabled()) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1371,12 +1371,12 @@ void CodeGen_ARM::visit(const Add *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Sub *op) {
     if (simd_intrinsics_disabled()) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1429,7 +1429,7 @@ void CodeGen_ARM::visit(const Sub *op) {
         return;
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Min *op) {
@@ -1443,7 +1443,7 @@ void CodeGen_ARM::visit(const Min *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Max *op) {
@@ -1457,19 +1457,19 @@ void CodeGen_ARM::visit(const Max *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Store *op) {
     // Predicated store
     const bool is_predicated_store = !is_const_one(op->predicate);
     if (is_predicated_store && !target.has_feature(Target::SVE2)) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
     if (simd_intrinsics_disabled()) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1478,7 +1478,7 @@ void CodeGen_ARM::visit(const Store *op) {
 
     // We only deal with ramps here except for SVE2
     if (!ramp && !target.has_feature(Target::SVE2)) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1625,7 +1625,7 @@ void CodeGen_ARM::visit(const Store *op) {
                 }
                 vpred_predicated_store_val = codegen(vpred_predicated_store);
             } else {
-                CodeGen_Posix::visit(op);
+                CodeGen_CPU::visit(op);
                 return;
             }
         }
@@ -1786,7 +1786,7 @@ void CodeGen_ARM::visit(const Store *op) {
     // If the stride is one or minus one, we can deal with that using vanilla codegen
     const IntImm *stride = ramp ? ramp->stride.as<IntImm>() : nullptr;
     if (stride && (stride->value == 1 || stride->value == -1)) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1812,19 +1812,19 @@ void CodeGen_ARM::visit(const Store *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Load *op) {
     // Predicated load
     const bool is_predicated_load = !is_const_one(op->predicate);
     if (is_predicated_load && !target.has_feature(Target::SVE2)) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
     if (simd_intrinsics_disabled()) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1832,7 +1832,7 @@ void CodeGen_ARM::visit(const Load *op) {
 
     // We only deal with ramps here
     if (!ramp && !target.has_feature(Target::SVE2)) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1840,7 +1840,7 @@ void CodeGen_ARM::visit(const Load *op) {
     const IntImm *stride = ramp ? ramp->stride.as<IntImm>() : nullptr;
     if (stride && (-1 <= stride->value && stride->value <= 1) &&
         !target.has_feature(Target::SVE2)) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -1867,7 +1867,7 @@ void CodeGen_ARM::visit(const Load *op) {
 
     if (target.has_feature(Target::SVE2)) {
         if (stride && stride->value < 1) {
-            CodeGen_Posix::visit(op);
+            CodeGen_CPU::visit(op);
             return;
         } else if (stride && stride->value == 1) {
             const int natural_lanes = target.natural_vector_size(op->type);
@@ -1887,7 +1887,7 @@ void CodeGen_ARM::visit(const Load *op) {
                 value = slice_vector(value, 0, ramp->lanes);
                 return;
             } else {
-                CodeGen_Posix::visit(op);
+                CodeGen_CPU::visit(op);
                 return;
             }
         } else if (op->index.type().is_vector()) {
@@ -1963,7 +1963,7 @@ void CodeGen_ARM::visit(const Load *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Shuffle *op) {
@@ -1983,12 +1983,12 @@ void CodeGen_ARM::visit(const Shuffle *op) {
         load->type.lanes() == stride * op->type.lanes()) {
 
         value = codegen_dense_vector_load(load, nullptr, /* slice_to_native */ false);
-        value = CodeGen_Posix::shuffle_vectors(value, op->indices);
+        value = CodeGen_CPU::shuffle_vectors(value, op->indices);
         return;
     }
 
     if (target_vscale() == 0) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -2035,13 +2035,13 @@ void CodeGen_ARM::visit(const Shuffle *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 llvm::Type *CodeGen_ARM::get_vector_type_from_value(Value *vec_or_scalar, int n) {
     llvm::Type *t = vec_or_scalar->getType();
     llvm::Type *elt = t->isVectorTy() ? get_vector_element_type(t) : t;
-    return CodeGen_Posix::get_vector_type(elt, n);
+    return CodeGen_CPU::get_vector_type(elt, n);
 }
 
 Value *CodeGen_ARM::concat_vectors(const vector<Value *> &vecs) {
@@ -2050,7 +2050,7 @@ Value *CodeGen_ARM::concat_vectors(const vector<Value *> &vecs) {
     if (target_vscale() == 0 ||
         vecs.size() <= 1 ||
         isa<FixedVectorType>(vecs[0]->getType())) {
-        return CodeGen_Posix::concat_vectors(vecs);
+        return CodeGen_CPU::concat_vectors(vecs);
     }
 
     int total_lanes = 0;
@@ -2072,7 +2072,7 @@ Value *CodeGen_ARM::slice_vector(llvm::Value *vec, int start, int slice_size) {
     // Override only for scalable vector
     if (target_vscale() == 0 ||
         !is_scalable_vector(vec)) {
-        return CodeGen_Posix::slice_vector(vec, start, slice_size);
+        return CodeGen_CPU::slice_vector(vec, start, slice_size);
     }
 
     const int vec_lanes = get_vector_num_elements(vec->getType());
@@ -2206,7 +2206,7 @@ Value *CodeGen_ARM::interleave_vectors(const std::vector<Value *> &vecs) {
     if (simd_intrinsics_disabled() || target_vscale() == 0 ||
         vecs.size() < 2 ||
         !is_scalable_vector(vecs[0])) {
-        return CodeGen_Posix::interleave_vectors(vecs);
+        return CodeGen_CPU::interleave_vectors(vecs);
     }
 
     // Lower into llvm.vector.interleave intrinsic.
@@ -2238,13 +2238,13 @@ Value *CodeGen_ARM::interleave_vectors(const std::vector<Value *> &vecs) {
         return interleave;
     }
 
-    return CodeGen_Posix::interleave_vectors(vecs);
+    return CodeGen_CPU::interleave_vectors(vecs);
 };
 
 Value *CodeGen_ARM::shuffle_vectors(Value *a, Value *b, const std::vector<int> &indices) {
     if (simd_intrinsics_disabled() || target_vscale() == 0 ||
         !is_scalable_vector(a)) {
-        return CodeGen_Posix::shuffle_vectors(a, b, indices);
+        return CodeGen_CPU::shuffle_vectors(a, b, indices);
     }
 
     internal_assert(a->getType() == b->getType());
@@ -2411,7 +2411,7 @@ void CodeGen_ARM::visit(const Ramp *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const Call *op) {
@@ -2519,7 +2519,7 @@ void CodeGen_ARM::visit(const Call *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const LT *op) {
@@ -2529,11 +2529,11 @@ void CodeGen_ARM::visit(const LT *op) {
         // See https://bugs.llvm.org/show_bug.cgi?id=45036
         llvm::IRBuilderBase::FastMathFlagGuard guard(*builder);
         builder->clearFastMathFlags();
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::visit(const LE *op) {
@@ -2543,16 +2543,16 @@ void CodeGen_ARM::visit(const LE *op) {
         // See https://bugs.llvm.org/show_bug.cgi?id=45036
         llvm::IRBuilderBase::FastMathFlagGuard guard(*builder);
         builder->clearFastMathFlags();
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_ARM::codegen_vector_reduce(const VectorReduce *op, const Expr &init) {
     if (simd_intrinsics_disabled()) {
-        CodeGen_Posix::codegen_vector_reduce(op, init);
+        CodeGen_CPU::codegen_vector_reduce(op, init);
         return;
     }
 
@@ -2565,7 +2565,7 @@ void CodeGen_ARM::codegen_vector_reduce(const VectorReduce *op, const Expr &init
     if (codegen_across_vector_reduce(op, init)) {
         return;
     }
-    CodeGen_Posix::codegen_vector_reduce(op, init);
+    CodeGen_CPU::codegen_vector_reduce(op, init);
 }
 
 bool CodeGen_ARM::codegen_dot_product_vector_reduce(const VectorReduce *op, const Expr &init) {
@@ -2801,21 +2801,21 @@ Type CodeGen_ARM::upgrade_type_for_arithmetic(const Type &t) const {
     if (is_float16_and_has_feature(t)) {
         return t;
     }
-    return CodeGen_Posix::upgrade_type_for_arithmetic(t);
+    return CodeGen_CPU::upgrade_type_for_arithmetic(t);
 }
 
 Type CodeGen_ARM::upgrade_type_for_argument_passing(const Type &t) const {
     if (is_float16_and_has_feature(t)) {
         return t;
     }
-    return CodeGen_Posix::upgrade_type_for_argument_passing(t);
+    return CodeGen_CPU::upgrade_type_for_argument_passing(t);
 }
 
 Type CodeGen_ARM::upgrade_type_for_storage(const Type &t) const {
     if (is_float16_and_has_feature(t)) {
         return t;
     }
-    return CodeGen_Posix::upgrade_type_for_storage(t);
+    return CodeGen_CPU::upgrade_type_for_storage(t);
 }
 
 int CodeGen_ARM::natural_vector_size(const Halide::Type &t) const {
@@ -2951,13 +2951,13 @@ bool CodeGen_ARM::supports_call_as_float16(const Call *op) const {
 
 }  // namespace
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_ARM(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_ARM(const Target &target) {
     return std::make_unique<CodeGen_ARM>(target);
 }
 
 #else  // WITH_ARM || WITH_AARCH64
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_ARM(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_ARM(const Target &target) {
     user_error << "ARM not enabled for this build of Halide.\n";
     return nullptr;
 }

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -2,8 +2,8 @@
 #include <sstream>
 
 #include "CSE.h"
-#include "CodeGen_Internal.h"
 #include "CodeGen_CPU.h"
+#include "CodeGen_Internal.h"
 #include "ConciseCasts.h"
 #include "Debug.h"
 #include "DecomposeVectorShuffle.h"

--- a/src/CodeGen_CPU.cpp
+++ b/src/CodeGen_CPU.cpp
@@ -2,7 +2,7 @@
 
 #include "CSE.h"
 #include "CodeGen_Internal.h"
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "Debug.h"
 #include "IR.h"
 #include "IROperator.h"
@@ -18,11 +18,11 @@ using std::vector;
 
 using namespace llvm;
 
-CodeGen_Posix::CodeGen_Posix(const Target &t)
+CodeGen_CPU::CodeGen_CPU(const Target &t)
     : CodeGen_LLVM(t) {
 }
 
-Value *CodeGen_Posix::codegen_allocation_size(const std::string &name, Type type, const std::vector<Expr> &extents, const Expr &condition) {
+Value *CodeGen_CPU::codegen_allocation_size(const std::string &name, Type type, const std::vector<Expr> &extents, const Expr &condition) {
     // Compute size from list of extents checking for overflow.
 
     Expr overflow = make_zero(UInt(64));
@@ -74,7 +74,7 @@ Value *CodeGen_Posix::codegen_allocation_size(const std::string &name, Type type
     return codegen(total_size);
 }
 
-CodeGen_Posix::Allocation CodeGen_Posix::create_allocation(const std::string &name, Type type, MemoryType memory_type,
+CodeGen_CPU::Allocation CodeGen_CPU::create_allocation(const std::string &name, Type type, MemoryType memory_type,
                                                            const std::vector<Expr> &extents, const Expr &condition,
                                                            const Expr &new_expr, std::string free_function, int padding) {
     Value *llvm_size = nullptr;
@@ -313,7 +313,7 @@ CodeGen_Posix::Allocation CodeGen_Posix::create_allocation(const std::string &na
     return allocation;
 }
 
-void CodeGen_Posix::free_allocation(const std::string &name) {
+void CodeGen_CPU::free_allocation(const std::string &name) {
     Allocation alloc = allocations.get(name);
 
     if (alloc.stack_bytes) {
@@ -333,7 +333,7 @@ void CodeGen_Posix::free_allocation(const std::string &name) {
     sym_pop(name);
 }
 
-string CodeGen_Posix::get_allocation_name(const std::string &n) {
+string CodeGen_CPU::get_allocation_name(const std::string &n) {
     if (const auto *alloc = allocations.find(n)) {
         return alloc->name;
     } else {
@@ -341,7 +341,7 @@ string CodeGen_Posix::get_allocation_name(const std::string &n) {
     }
 }
 
-void CodeGen_Posix::visit(const Allocate *alloc) {
+void CodeGen_CPU::visit(const Allocate *alloc) {
     if (sym_exists(alloc->name)) {
         user_error << "Can't have two different buffers with the same name: "
                    << alloc->name << "\n";
@@ -360,7 +360,7 @@ void CodeGen_Posix::visit(const Allocate *alloc) {
     }
 }
 
-void CodeGen_Posix::visit(const Free *stmt) {
+void CodeGen_CPU::visit(const Free *stmt) {
     free_allocation(stmt->name);
 }
 

--- a/src/CodeGen_CPU.cpp
+++ b/src/CodeGen_CPU.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
 #include "CSE.h"
-#include "CodeGen_Internal.h"
 #include "CodeGen_CPU.h"
+#include "CodeGen_Internal.h"
 #include "Debug.h"
 #include "IR.h"
 #include "IROperator.h"
@@ -75,8 +75,8 @@ Value *CodeGen_CPU::codegen_allocation_size(const std::string &name, Type type, 
 }
 
 CodeGen_CPU::Allocation CodeGen_CPU::create_allocation(const std::string &name, Type type, MemoryType memory_type,
-                                                           const std::vector<Expr> &extents, const Expr &condition,
-                                                           const Expr &new_expr, std::string free_function, int padding) {
+                                                       const std::vector<Expr> &extents, const Expr &condition,
+                                                       const Expr &new_expr, std::string free_function, int padding) {
     Value *llvm_size = nullptr;
     int64_t stack_bytes = 0;
     int32_t constant_bytes = Allocate::constant_allocation_size(extents, name);

--- a/src/CodeGen_CPU.h
+++ b/src/CodeGen_CPU.h
@@ -1,5 +1,5 @@
-#ifndef HALIDE_CODEGEN_POSIX_H
-#define HALIDE_CODEGEN_POSIX_H
+#ifndef HALIDE_CODEGEN_CPU_H
+#define HALIDE_CODEGEN_CPU_H
 
 /** \file
  * Defines a base-class for code-generators on posixy cpu platforms
@@ -10,19 +10,21 @@
 namespace Halide {
 namespace Internal {
 
-/** A code generator that emits posix code from a given Halide stmt. */
-class CodeGen_Posix : public CodeGen_LLVM {
+/** A base class for LLVM-based CPU code generators. This means targets that
+ * have a stack and a heap and halide_malloc, as opposed to targets like CUDA
+ * which expose memory differently. */
+class CodeGen_CPU : public CodeGen_LLVM {
 public:
-    /** Create an posix code generator. Processor features can be
-     * enabled using the appropriate arguments */
-    CodeGen_Posix(const Target &t);
+    /** Create a CPU code generator. Processor features can be enabled using the
+     * appropriate arguments */
+    CodeGen_CPU(const Target &t);
 
 protected:
     using CodeGen_LLVM::visit;
 
-    /** Posix implementation of Allocate. Small constant-sized allocations go
-     * on the stack. The rest go on the heap by calling "halide_malloc"
-     * and "halide_free" in the standard library. */
+    /** Implementation of Allocate. Small constant-sized allocations go on the
+     * stack. The rest go on the heap by calling "halide_malloc" and
+     * "halide_free" in the standard library. */
     // @{
     void visit(const Allocate *) override;
     void visit(const Free *) override;

--- a/src/CodeGen_CPU.h
+++ b/src/CodeGen_CPU.h
@@ -2,7 +2,7 @@
 #define HALIDE_CODEGEN_CPU_H
 
 /** \file
- * Defines a base-class for code-generators on posixy cpu platforms
+ * Defines a base-class for LLVM-based code-generators for CPU-like architectures.
  */
 
 #include "CodeGen_LLVM.h"
@@ -10,9 +10,12 @@
 namespace Halide {
 namespace Internal {
 
-/** A base class for LLVM-based CPU code generators. This means targets that
- * have a stack and a heap and halide_malloc, as opposed to targets like CUDA
- * which expose memory differently. */
+/** A base class for LLVM-based CPU code generators. Currently this mostly
+ * concerns the memory model. This is a base class for targets that have a stack
+ * and a heap and halide_malloc, as opposed to targets like CUDA which expose
+ * memory differently. This is not intended to be restricted to *just* the
+ * memory model though - anything shared across CPU-like architectures
+ * (e.g. support for common syscalls) can be placed here too. */
 class CodeGen_CPU : public CodeGen_LLVM {
 public:
     /** Create a CPU code generator. Processor features can be enabled using the

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -4,7 +4,7 @@
 #include "AlignLoads.h"
 #include "CSE.h"
 #include "CodeGen_Internal.h"
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "Debug.h"
 #include "HexagonOptimize.h"
 #include "IREquality.h"
@@ -31,7 +31,7 @@ using namespace llvm;
 namespace {
 
 /** A code generator that emits Hexagon code from a given Halide stmt. */
-class CodeGen_Hexagon : public CodeGen_Posix {
+class CodeGen_Hexagon : public CodeGen_CPU {
 public:
     /** Create a Hexagon code generator for the given Hexagon target. */
     CodeGen_Hexagon(const Target &);
@@ -58,7 +58,7 @@ protected:
         return (isa_version >= 65);
     }
 
-    using CodeGen_Posix::visit;
+    using CodeGen_CPU::visit;
 
     /** Nodes for which we want to emit specific hexagon intrinsics */
     ///@{
@@ -95,7 +95,7 @@ protected:
     llvm::Value *interleave_vectors(const std::vector<llvm::Value *> &v) override;
     llvm::Value *shuffle_vectors(llvm::Value *a, llvm::Value *b,
                                  const std::vector<int> &indices) override;
-    using CodeGen_Posix::shuffle_vectors;
+    using CodeGen_CPU::shuffle_vectors;
     ///@}
 
     /** Generate a LUT lookup using vlut instructions. */
@@ -127,7 +127,7 @@ private:
 };
 
 CodeGen_Hexagon::CodeGen_Hexagon(const Target &t)
-    : CodeGen_Posix(t) {
+    : CodeGen_CPU(t) {
     if (target.has_feature(Halide::Target::HVX_v68)) {
         isa_version = 68;
     } else if (target.has_feature(Halide::Target::HVX_v66)) {
@@ -475,7 +475,7 @@ Stmt inject_hvx_lock_unlock(Stmt body, const Target &target) {
 void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
                                    const string &simple_name,
                                    const string &extern_name) {
-    CodeGen_Posix::begin_func(f.linkage, simple_name, extern_name, f.args);
+    CodeGen_CPU::begin_func(f.linkage, simple_name, extern_name, f.args);
 
     Stmt body = f.body;
 
@@ -532,7 +532,7 @@ void CodeGen_Hexagon::compile_func(const LoweredFunc &f,
 
     body.accept(this);
 
-    CodeGen_Posix::end_func(f.args);
+    CodeGen_CPU::end_func(f.args);
 }
 
 struct HvxIntrinsic {
@@ -846,7 +846,7 @@ const HvxIntrinsic intrinsic_wrappers[] = {
 // fall-through to CodeGen_LLVM.
 
 void CodeGen_Hexagon::init_module() {
-    CodeGen_Posix::init_module();
+    CodeGen_CPU::init_module();
 
     // LLVM's HVX vector intrinsics don't include the type of the
     // operands, they all operate on vectors of 32 bit integers. To make
@@ -1073,7 +1073,7 @@ Value *CodeGen_Hexagon::interleave_vectors(const vector<llvm::Value *> &v) {
 
         return vdelta(lut, indices);
     }
-    return CodeGen_Posix::interleave_vectors(v);
+    return CodeGen_CPU::interleave_vectors(v);
 }
 
 // Check if indices form a strided ramp, allowing undef elements to
@@ -1208,7 +1208,7 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
     if (!is_strided_ramp(indices, start, stride)) {
         if (is_concat_or_slice(indices)) {
             // Let LLVM handle concat or slices.
-            return CodeGen_Posix::shuffle_vectors(a, b, indices);
+            return CodeGen_CPU::shuffle_vectors(a, b, indices);
         }
         return vdelta(concat_vectors({a, b}), indices);
     }
@@ -1254,7 +1254,7 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
             }
             return call_intrin_cast(native_ty, intrin_id, {b, a, codegen(bytes_off)});
         }
-        return CodeGen_Posix::shuffle_vectors(a, b, indices);
+        return CodeGen_CPU::shuffle_vectors(a, b, indices);
     } else if (stride == 2 && (start == 0 || start == 1)) {
         // For stride 2 shuffles, we can use vpack or vdeal.
         // It's hard to use call_intrin here. We'll just slice and
@@ -1285,7 +1285,7 @@ Value *CodeGen_Hexagon::shuffle_vectors(Value *a, Value *b,
                 llvm::Intrinsic::ID intrin = start == 0 ? INTRINSIC_128B(lo) : INTRINSIC_128B(hi);
                 ret_i = call_intrin_cast(native_ty, intrin, {packed});
             } else {
-                return CodeGen_Posix::shuffle_vectors(a, b, indices);
+                return CodeGen_CPU::shuffle_vectors(a, b, indices);
             }
             if (i + native_elements > result_elements) {
                 // This is the last vector, and it has a few extra
@@ -1769,7 +1769,7 @@ Value *CodeGen_Hexagon::call_intrin(Type result_type, const string &name,
     }
     function_does_not_access_memory(fn);
     fn->addFnAttr(llvm::Attribute::NoUnwind);
-    return CodeGen_Posix::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
+    return CodeGen_CPU::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
                                       fn, std::move(args));
 }
 
@@ -1792,7 +1792,7 @@ Value *CodeGen_Hexagon::call_intrin(llvm::Type *result_type, const string &name,
     }
     function_does_not_access_memory(fn);
     fn->addFnAttr(llvm::Attribute::NoUnwind);
-    return CodeGen_Posix::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
+    return CodeGen_CPU::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
                                       fn, std::move(args));
 }
 
@@ -1871,14 +1871,14 @@ void CodeGen_Hexagon::visit(const Mul *op) {
         // v68 has vector support for single-precision float.
         if (target.has_feature(Halide::Target::HVX_v68) &&
             op->type.is_float() && op->type.bits() == 32) {
-            CodeGen_Posix::visit(op);
+            CodeGen_CPU::visit(op);
             return;
         }
         internal_error << "Unhandled HVX multiply " << op->a.type() << "*"
                        << op->b.type() << "\n"
                        << Expr(op) << "\n";
     } else {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -2069,7 +2069,7 @@ void CodeGen_Hexagon::visit(const Call *op) {
         return;
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_Hexagon::visit(const Max *op) {
@@ -2083,7 +2083,7 @@ void CodeGen_Hexagon::visit(const Max *op) {
             value = codegen(equiv);
         }
     } else {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -2098,7 +2098,7 @@ void CodeGen_Hexagon::visit(const Min *op) {
             value = codegen(equiv);
         }
     } else {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -2117,7 +2117,7 @@ void CodeGen_Hexagon::visit(const Select *op) {
                                (op->true_value & cond) | (op->false_value & ~cond));
         value = codegen(equiv);
     } else {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -2294,19 +2294,19 @@ void CodeGen_Hexagon::visit(const Allocate *alloc) {
         new_alloc.accept(this);
     } else {
         // For all other memory types
-        CodeGen_Posix::visit(alloc);
+        CodeGen_CPU::visit(alloc);
     }
 }
 
 }  // namespace
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_Hexagon(const Target &target) {
     return std::make_unique<CodeGen_Hexagon>(target);
 }
 
 #else  // WITH_HEXAGON
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_Hexagon(const Target &target) {
     user_error << "hexagon not enabled for this build of Halide.\n";
     return nullptr;
 }

--- a/src/CodeGen_Hexagon.cpp
+++ b/src/CodeGen_Hexagon.cpp
@@ -3,8 +3,8 @@
 
 #include "AlignLoads.h"
 #include "CSE.h"
-#include "CodeGen_Internal.h"
 #include "CodeGen_CPU.h"
+#include "CodeGen_Internal.h"
 #include "Debug.h"
 #include "HexagonOptimize.h"
 #include "IREquality.h"
@@ -1770,7 +1770,7 @@ Value *CodeGen_Hexagon::call_intrin(Type result_type, const string &name,
     function_does_not_access_memory(fn);
     fn->addFnAttr(llvm::Attribute::NoUnwind);
     return CodeGen_CPU::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
-                                      fn, std::move(args));
+                                    fn, std::move(args));
 }
 
 Value *CodeGen_Hexagon::call_intrin(llvm::Type *result_type, const string &name,
@@ -1793,7 +1793,7 @@ Value *CodeGen_Hexagon::call_intrin(llvm::Type *result_type, const string &name,
     function_does_not_access_memory(fn);
     fn->addFnAttr(llvm::Attribute::NoUnwind);
     return CodeGen_CPU::call_intrin(result_type, get_vector_num_elements(fn->getReturnType()),
-                                      fn, std::move(args));
+                                    fn, std::move(args));
 }
 
 string CodeGen_Hexagon::mcpu_target() const {

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -6,7 +6,7 @@
 #include "CSE.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_LLVM.h"
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "CodeGen_Targets.h"
 #include "CompilerLogger.h"
 #include "Debug.h"

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4,9 +4,9 @@
 
 #include "CPlusPlusMangle.h"
 #include "CSE.h"
+#include "CodeGen_CPU.h"
 #include "CodeGen_Internal.h"
 #include "CodeGen_LLVM.h"
-#include "CodeGen_CPU.h"
 #include "CodeGen_Targets.h"
 #include "CompilerLogger.h"
 #include "Debug.h"

--- a/src/CodeGen_PowerPC.cpp
+++ b/src/CodeGen_PowerPC.cpp
@@ -1,4 +1,4 @@
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 
 #include "LLVM_Headers.h"
 
@@ -13,7 +13,7 @@ using std::vector;
 namespace {
 
 /** A code generator that emits PowerPC code from a given Halide stmt. */
-class CodeGen_PowerPC : public CodeGen_Posix {
+class CodeGen_PowerPC : public CodeGen_CPU {
 public:
     /** Create a powerpc code generator. Processor features can be
      * enabled using the appropriate flags in the target struct. */
@@ -28,7 +28,7 @@ protected:
     bool use_soft_float_abi() const override;
     int native_vector_bits() const override;
 
-    using CodeGen_Posix::visit;
+    using CodeGen_CPU::visit;
 
     /** Nodes for which we want to emit specific PowerPC intrinsics */
     // @{
@@ -38,7 +38,7 @@ protected:
 };
 
 CodeGen_PowerPC::CodeGen_PowerPC(const Target &t)
-    : CodeGen_Posix(t) {
+    : CodeGen_CPU(t) {
 }
 
 const int max_intrinsic_args = 4;
@@ -97,7 +97,7 @@ const PowerPCIntrinsic intrinsic_defs[] = {
 };
 
 void CodeGen_PowerPC::init_module() {
-    CodeGen_Posix::init_module();
+    CodeGen_CPU::init_module();
 
     for (const PowerPCIntrinsic &i : intrinsic_defs) {
         if (i.feature != Target::FeatureEnd && !target.has_feature(i.feature)) {
@@ -127,7 +127,7 @@ void CodeGen_PowerPC::visit(const Min *op) {
             return;
         }
     }
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_PowerPC::visit(const Max *op) {
@@ -137,7 +137,7 @@ void CodeGen_PowerPC::visit(const Max *op) {
             return;
         }
     }
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 string CodeGen_PowerPC::mcpu_target() const {
@@ -181,13 +181,13 @@ int CodeGen_PowerPC::native_vector_bits() const {
 
 }  // namespace
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_PowerPC(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_PowerPC(const Target &target) {
     return std::make_unique<CodeGen_PowerPC>(target);
 }
 
 #else  // WITH_POWERPC
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_PowerPC(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_PowerPC(const Target &target) {
     user_error << "PowerPC not enabled for this build of Halide.\n";
     return nullptr;
 }

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -1,6 +1,6 @@
 #include "CSE.h"
 #include "CodeGen_Internal.h"
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "Debug.h"
 #include "IREquality.h"
 #include "IRMatch.h"
@@ -113,14 +113,14 @@ const RISCVIntrinsic *MatchRISCVIntrisic(const Call *op) {
 }
 
 /** A code generator that emits RISC-V code from a given Halide stmt. */
-class CodeGen_RISCV : public CodeGen_Posix {
+class CodeGen_RISCV : public CodeGen_CPU {
 public:
     /** Create a RISC-V code generator. Processor features can be
      * enabled using the appropriate flags in the target struct. */
     CodeGen_RISCV(const Target &);
 
 protected:
-    using CodeGen_Posix::visit;
+    using CodeGen_CPU::visit;
 
     string mcpu_target() const override;
     string mcpu_tune() const override;
@@ -138,7 +138,7 @@ private:
 };
 
 CodeGen_RISCV::CodeGen_RISCV(const Target &t)
-    : CodeGen_Posix(t) {
+    : CodeGen_CPU(t) {
     use_llvm_vp_intrinsics = true;
     user_assert(native_vector_bits() > 0) << "No vector_bits was specified for RISCV codegen; "
                                           << "this is almost certainly a mistake. You should add -rvv-vector_bits_N "
@@ -223,7 +223,7 @@ void CodeGen_RISCV::visit(const Call *op) {
     bool handled = (intrinsic_def != nullptr) &&
                    call_riscv_vector_intrinsic(*intrinsic_def, op);
     if (!handled) {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -402,13 +402,13 @@ bool CodeGen_RISCV::call_riscv_vector_intrinsic(const RISCVIntrinsic &intrin, co
 
 }  // anonymous namespace
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_RISCV(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_RISCV(const Target &target) {
     return std::make_unique<CodeGen_RISCV>(target);
 }
 
 #else  // WITH_RISCV
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_RISCV(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_RISCV(const Target &target) {
     user_error << "RISCV not enabled for this build of Halide.\n";
     return nullptr;
 }

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -1,6 +1,6 @@
 #include "CSE.h"
-#include "CodeGen_Internal.h"
 #include "CodeGen_CPU.h"
+#include "CodeGen_Internal.h"
 #include "Debug.h"
 #include "IREquality.h"
 #include "IRMatch.h"

--- a/src/CodeGen_Targets.h
+++ b/src/CodeGen_Targets.h
@@ -13,15 +13,15 @@ struct Target;
 
 namespace Internal {
 
-class CodeGen_Posix;
+class CodeGen_CPU;
 
 /** Construct CodeGen object for a variety of targets. */
-std::unique_ptr<CodeGen_Posix> new_CodeGen_ARM(const Target &target);
-std::unique_ptr<CodeGen_Posix> new_CodeGen_Hexagon(const Target &target);
-std::unique_ptr<CodeGen_Posix> new_CodeGen_PowerPC(const Target &target);
-std::unique_ptr<CodeGen_Posix> new_CodeGen_RISCV(const Target &target);
-std::unique_ptr<CodeGen_Posix> new_CodeGen_X86(const Target &target);
-std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target);
+std::unique_ptr<CodeGen_CPU> new_CodeGen_ARM(const Target &target);
+std::unique_ptr<CodeGen_CPU> new_CodeGen_Hexagon(const Target &target);
+std::unique_ptr<CodeGen_CPU> new_CodeGen_PowerPC(const Target &target);
+std::unique_ptr<CodeGen_CPU> new_CodeGen_RISCV(const Target &target);
+std::unique_ptr<CodeGen_CPU> new_CodeGen_X86(const Target &target);
+std::unique_ptr<CodeGen_CPU> new_CodeGen_WebAssembly(const Target &target);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -1,7 +1,7 @@
 #include <functional>
 #include <sstream>
 
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "ConciseCasts.h"
 #include "ConstantBounds.h"
 #include "IRMatch.h"
@@ -23,12 +23,12 @@ using namespace Halide::ConciseCasts;
 namespace {
 
 /** A code generator that emits WebAssembly code from a given Halide stmt. */
-class CodeGen_WebAssembly : public CodeGen_Posix {
+class CodeGen_WebAssembly : public CodeGen_CPU {
 public:
     CodeGen_WebAssembly(const Target &);
 
 protected:
-    using CodeGen_Posix::visit;
+    using CodeGen_CPU::visit;
 
     void init_module() override;
 
@@ -45,7 +45,7 @@ protected:
 };
 
 CodeGen_WebAssembly::CodeGen_WebAssembly(const Target &t)
-    : CodeGen_Posix(t) {
+    : CodeGen_CPU(t) {
 }
 
 constexpr int max_intrinsic_args = 4;
@@ -112,7 +112,7 @@ const WasmIntrinsic intrinsic_defs[] = {
 };
 
 void CodeGen_WebAssembly::init_module() {
-    CodeGen_Posix::init_module();
+    CodeGen_CPU::init_module();
 
     for (const WasmIntrinsic &i : intrinsic_defs) {
         if (i.feature != Target::FeatureEnd && !target.has_feature(i.feature)) {
@@ -206,7 +206,7 @@ void CodeGen_WebAssembly::visit(const Cast *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_WebAssembly::visit(const Call *op) {
@@ -297,7 +297,7 @@ void CodeGen_WebAssembly::visit(const Call *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_WebAssembly::codegen_vector_reduce(const VectorReduce *op, const Expr &init) {
@@ -369,7 +369,7 @@ void CodeGen_WebAssembly::codegen_vector_reduce(const VectorReduce *op, const Ex
         }
     }
 
-    CodeGen_Posix::codegen_vector_reduce(op, init);
+    CodeGen_CPU::codegen_vector_reduce(op, init);
 }
 
 string CodeGen_WebAssembly::mcpu_target() const {
@@ -434,14 +434,14 @@ int CodeGen_WebAssembly::native_vector_bits() const {
 
 }  // namespace
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_WebAssembly(const Target &target) {
     user_assert(target.bits == 32) << "Only wasm32 is supported.";
     return std::make_unique<CodeGen_WebAssembly>(target);
 }
 
 #else  // WITH_WEBASSEMBLY
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_WebAssembly(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_WebAssembly(const Target &target) {
     user_error << "WebAssembly not enabled for this build of Halide.\n";
     return nullptr;
 }

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -1,5 +1,5 @@
-#include "CodeGen_Internal.h"
 #include "CodeGen_CPU.h"
+#include "CodeGen_Internal.h"
 #include "ConciseCasts.h"
 #include "ConstantBounds.h"
 #include "Debug.h"

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -1,5 +1,5 @@
 #include "CodeGen_Internal.h"
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "ConciseCasts.h"
 #include "ConstantBounds.h"
 #include "Debug.h"
@@ -73,7 +73,7 @@ Target complete_x86_target(Target t) {
 }
 
 /** A code generator that emits x86 code from a given Halide stmt. */
-class CodeGen_X86 : public CodeGen_Posix {
+class CodeGen_X86 : public CodeGen_CPU {
 public:
     /** Create an x86 code generator. Processor features can be
      * enabled using the appropriate flags in the target struct. */
@@ -88,7 +88,7 @@ protected:
 
     int vector_lanes_for_slice(const Type &t) const;
 
-    using CodeGen_Posix::visit;
+    using CodeGen_CPU::visit;
 
     void init_module() override;
 
@@ -116,7 +116,7 @@ private:
 };
 
 CodeGen_X86::CodeGen_X86(Target t)
-    : CodeGen_Posix(complete_x86_target(t)) {
+    : CodeGen_CPU(complete_x86_target(t)) {
 }
 
 const int max_intrinsic_args = 6;
@@ -306,7 +306,7 @@ const x86Intrinsic intrinsic_defs[] = {
 };
 
 void CodeGen_X86::init_module() {
-    CodeGen_Posix::init_module();
+    CodeGen_CPU::init_module();
 
     for (const x86Intrinsic &i : intrinsic_defs) {
         if (i.feature != Target::FeatureEnd && !target.has_feature(i.feature)) {
@@ -384,7 +384,7 @@ void CodeGen_X86::visit(const Add *op) {
             return;
         }
     }
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_X86::visit(const Sub *op) {
@@ -407,7 +407,7 @@ void CodeGen_X86::visit(const Sub *op) {
             }
         }
     }
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_X86::visit(const GT *op) {
@@ -440,7 +440,7 @@ void CodeGen_X86::visit(const GT *op) {
         value = concat_vectors(result);
         value = slice_vector(value, 0, t.lanes());
     } else {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -472,7 +472,7 @@ void CodeGen_X86::visit(const EQ *op) {
         value = concat_vectors(result);
         value = slice_vector(value, 0, t.lanes());
     } else {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -513,7 +513,7 @@ void CodeGen_X86::visit(const Select *op) {
         value = concat_vectors(result);
         value = slice_vector(value, 0, t.lanes());
     } else {
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
     }
 }
 
@@ -539,7 +539,7 @@ void CodeGen_X86::visit(const Cast *op) {
 
     if (!dst.is_vector()) {
         // We only have peephole optimizations for vectors after this point.
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -600,13 +600,13 @@ void CodeGen_X86::visit(const Cast *op) {
         }
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_X86::visit(const Call *op) {
     if (!op->type.is_vector()) {
         // We only have peephole optimizations for vectors beyond this point.
-        CodeGen_Posix::visit(op);
+        CodeGen_CPU::visit(op);
         return;
     }
 
@@ -773,12 +773,12 @@ void CodeGen_X86::visit(const Call *op) {
         return;
     }
 
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_X86::codegen_vector_reduce(const VectorReduce *op, const Expr &init) {
     if (op->op != VectorReduce::Add && op->op != VectorReduce::SaturatingAdd) {
-        CodeGen_Posix::codegen_vector_reduce(op, init);
+        CodeGen_CPU::codegen_vector_reduce(op, init);
         return;
     }
     const int factor = op->value.type().lanes() / op->type.lanes();
@@ -926,12 +926,12 @@ void CodeGen_X86::codegen_vector_reduce(const VectorReduce *op, const Expr &init
         }
     }
 
-    CodeGen_Posix::codegen_vector_reduce(op, init);
+    CodeGen_CPU::codegen_vector_reduce(op, init);
 }
 
 void CodeGen_X86::visit(const Allocate *op) {
     ScopedBinding<MemoryType> bind(mem_type, op->name, op->memory_type);
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_X86::visit(const Load *op) {
@@ -946,7 +946,7 @@ void CodeGen_X86::visit(const Load *op) {
             return;
         }
     }
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 void CodeGen_X86::visit(const Store *op) {
@@ -962,7 +962,7 @@ void CodeGen_X86::visit(const Store *op) {
             return;
         }
     }
-    CodeGen_Posix::visit(op);
+    CodeGen_CPU::visit(op);
 }
 
 string CodeGen_X86::mcpu_target() const {
@@ -1173,13 +1173,13 @@ int CodeGen_X86::vector_lanes_for_slice(const Type &t) const {
 
 }  // namespace
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_X86(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_X86(const Target &target) {
     return std::make_unique<CodeGen_X86>(target);
 }
 
 #else  // WITH_X86
 
-std::unique_ptr<CodeGen_Posix> new_CodeGen_X86(const Target &target) {
+std::unique_ptr<CodeGen_CPU> new_CodeGen_X86(const Target &target) {
     user_error << "x86 not enabled for this build of Halide.\n";
     return nullptr;
 }

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -8,7 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "CodeGen_Posix.h"
+#include "CodeGen_CPU.h"
 #include "CodeGen_Targets.h"
 #include "Debug.h"
 #include "Error.h"
@@ -288,7 +288,7 @@ std::vector<char> compile_to_wasm(const Module &module, const std::string &fn_na
     // for the alloca usage.
     size_t stack_size = 65536;
     {
-        std::unique_ptr<CodeGen_Posix> cg(new_CodeGen_WebAssembly(module.target()));
+        std::unique_ptr<CodeGen_CPU> cg(new_CodeGen_WebAssembly(module.target()));
         cg->set_context(context);
         fn_module = cg->compile(module);
         stack_size += cg->get_requested_alloca_total();


### PR DESCRIPTION
This base class was misnamed. It's intended for all llvm-based backends that use a CPU-like memory architecture. I.e. there's a stack and a heap and halide_malloc and halide_free exist. This covers our existing CPU architectures, but also Hexagon and WebAssembly, which use CPU-like memory models. If we add more things that are shared across CPU-like architectures in future, they would go here. Runtime modules with "posix" in the name weren't renamed because that's more correct. Those are modules that implement our runtime by calling posix functions.

No functional changes intended.

