### PR TITLE
Fix Makefile dep so autoscheduler plugins re-cp into distrib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2416,7 +2416,7 @@ ifeq ($(UNAME), Darwin)
 endif
 
 
-$(DISTRIB_DIR)/lib/libautoschedule_%.$(PLUGIN_EXT): $(BIN_DIR)/libautoschedule_%.$(PLUGIN_EXT)
+$(DISTRIB_DIR)/lib/libautoschedule_%.$(PLUGIN_EXT): $(BIN_DIR)/libautoschedule_%.$(PLUGIN_EXT) $(DISTRIB_DIR)/lib/libHalide.$(SHARED_EXT)
 	@mkdir -p $(@D)
 	cp $< $(DISTRIB_DIR)/lib
 ifeq ($(UNAME), Darwin)


### PR DESCRIPTION
The libHalide.so distrib rule runs `rm -rf $(DISTRIB_DIR)` before repopulating, which deletes the previously-copied autoscheduler plugins. Make decides up-front whether the plugin distrib targets need rebuilding, so it doesn't notice the deletion. The mullapudi2016 and li2018 sub-makes treat libHalide as order-only, so their bin/ files don't refresh either, leaving distrib missing those two plugins until a second `make distrib`.

Add libHalide.so as a prereq of the plugin distrib rule so the cp re-fires whenever libHalide is rebuilt.

This fixes a makefile bug where you have to run "make distrib" twice on any change.
