### PR TITLE
Don't wrap lambdas pointlessly

### DIFF
--- a/src/BoundaryConditions.h
+++ b/src/BoundaryConditions.h
@@ -64,7 +64,7 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_region(Region &collected_args,
 
 template<typename T>
 Func func_like_to_func(T &&func_like) {
-    if constexpr (std::is_same_v<std::decay_t<T>, Func>) {
+    if constexpr (std::is_convertible_v<T, Func>) {
         return std::forward<T>(func_like);
     } else {
         return lambda(_, func_like(_));


### PR DESCRIPTION
repeat_edge(imageparam) has *two* wrapper Funcs around it, not even counting the repeat_edge Func. The imageparam comes with one (accessible via its implicit cast to Func operator), and then because it's not exactly a Func, the boundary condition helper func_like_to_func adds another one. This commit changes the boundary condition helper to use a class's existing implicit conversion to a Func if there is one, avoiding the pointless extra Func.

The else case is still necessary because a Halide::Buffer can be accessed like a Func, but not implicitly cast to a Func.
