### PR TITLE
Fix simd_op_check_arm failure in LLVM trunk

### DIFF
--- a/test/correctness/simd_op_check_arm.cpp
+++ b/test/correctness/simd_op_check_arm.cpp
@@ -508,7 +508,11 @@ public:
             check(arm32 ? "vneg.s16" : "neg", 4 * w, -i16_1);
             check(arm32 ? "vneg.s32" : "neg", 2 * w, -i32_1);
             check(arm32 ? "vneg.f32" : "fneg", 4 * w, -f32_1);
-            check(arm32 ? "vneg.f64" : "fneg", 2 * w, -f64_1);
+            if (Internal::get_llvm_version() < 230) {
+                check(arm32 ? "vneg.f64" : "fneg", 2 * w, -f64_1);
+            } else {
+                check(arm32 ? "veor" : "fneg", 2 * w, -f64_1);
+            }
 
             // VNMLA    -       F, D    Negative Multiply Accumulate
             // VNMLS    -       F, D    Negative Multiply Subtract


### PR DESCRIPTION
<!-- Describe your changes and the motivation behind them. -->

Fix the test failure which was found while verifying #9132 with the latest LLVM.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
