### PR TITLE
Fix exponential blow-up in skip_stages on chains of let-bound selects

### DIFF
--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -488,41 +488,41 @@ protected:
         mutate(op->false_value);
         // func_info now holds the false-branch info.
 
-        // Combine the two branches with select(cond, t, f). A missing
-        // entry on a side means used=false / loaded=false for that branch.
-        auto combine = [&](const Expr &t, const Expr &f) {
-            Expr tt = t.defined() ? t : const_false();
-            Expr ff = f.defined() ? f : const_false();
-            return make_select(op->condition, tt, ff);
+        // Ids touched on both branches: combine with select(cond, t, f),
+        // so make_select can collapse `select(c, X, X) -> X` when the
+        // two branches contributed the same Expr.
+        // Ids touched on only one branch: AND the predicate with the
+        // appropriate side of the condition.
+        auto merge_into_old = [&](size_t id, const Expr &u, const Expr &l) {
+            auto [q, inserted] = old.try_emplace(id, FuncInfo{u, l});
+            if (!inserted) {
+                q->second.used = make_or(q->second.used, u);
+                q->second.loaded = make_or(q->second.loaded, l);
+            }
         };
 
-        // Walk every id present in either branch.
         for (auto &p : func_info) {
             size_t id = p.first;
             auto it_t = true_info.find(id);
-            Expr t_u, t_l;
+            Expr u, l;
             if (it_t != true_info.end()) {
-                t_u = it_t->second.used;
-                t_l = it_t->second.loaded;
+                u = make_select(op->condition, it_t->second.used, p.second.used);
+                l = make_select(op->condition, it_t->second.loaded, p.second.loaded);
                 true_info.erase(it_t);
+            } else {
+                u = make_and(p.second.used, !op->condition);
+                l = make_and(p.second.loaded, !op->condition);
             }
-            FuncInfo merged{combine(t_u, p.second.used),
-                             combine(t_l, p.second.loaded)};
-            auto [q, inserted] = old.try_emplace(id, merged);
-            if (!inserted) {
-                q->second.used = make_or(q->second.used, merged.used);
-                q->second.loaded = make_or(q->second.loaded, merged.loaded);
-            }
+            merge_into_old(id, u, l);
         }
+        // The ids left in true_info are the ones that were only touched
+        // on the true branch (the ones present in both branches were
+        // combined and erased in the loop above).
         for (auto &p : true_info) {
             size_t id = p.first;
-            FuncInfo merged{combine(p.second.used, Expr()),
-                             combine(p.second.loaded, Expr())};
-            auto [q, inserted] = old.try_emplace(id, merged);
-            if (!inserted) {
-                q->second.used = make_or(q->second.used, merged.used);
-                q->second.loaded = make_or(q->second.loaded, merged.loaded);
-            }
+            Expr u = make_and(p.second.used, op->condition);
+            Expr l = make_and(p.second.loaded, op->condition);
+            merge_into_old(id, u, l);
         }
         func_info.clear();
         old.swap(func_info);

--- a/src/SkipStages.cpp
+++ b/src/SkipStages.cpp
@@ -397,6 +397,21 @@ protected:
         }
     }
 
+    // select on bools that collapses select(c, X, X) -> X and the
+    // constant-cond cases.
+    Expr make_select(const Expr &c, const Expr &t, const Expr &f) {
+        if (is_const_one(c)) {
+            return t;
+        }
+        if (is_const_zero(c)) {
+            return f;
+        }
+        if (t.same_as(f)) {
+            return t;
+        }
+        return select(c, t, f);
+    }
+
     void merge_func_info(std::map<size_t, FuncInfo> *old,
                          const std::map<size_t, FuncInfo> &new_info,
                          const Expr &used = Expr{},
@@ -468,10 +483,48 @@ protected:
         std::map<size_t, FuncInfo> old;
         old.swap(func_info);
         mutate(op->true_value);
-        merge_func_info(&old, func_info, op->condition);
-        func_info.clear();
+        std::map<size_t, FuncInfo> true_info;
+        true_info.swap(func_info);
         mutate(op->false_value);
-        merge_func_info(&old, func_info, !op->condition);
+        // func_info now holds the false-branch info.
+
+        // Combine the two branches with select(cond, t, f). A missing
+        // entry on a side means used=false / loaded=false for that branch.
+        auto combine = [&](const Expr &t, const Expr &f) {
+            Expr tt = t.defined() ? t : const_false();
+            Expr ff = f.defined() ? f : const_false();
+            return make_select(op->condition, tt, ff);
+        };
+
+        // Walk every id present in either branch.
+        for (auto &p : func_info) {
+            size_t id = p.first;
+            auto it_t = true_info.find(id);
+            Expr t_u, t_l;
+            if (it_t != true_info.end()) {
+                t_u = it_t->second.used;
+                t_l = it_t->second.loaded;
+                true_info.erase(it_t);
+            }
+            FuncInfo merged{combine(t_u, p.second.used),
+                             combine(t_l, p.second.loaded)};
+            auto [q, inserted] = old.try_emplace(id, merged);
+            if (!inserted) {
+                q->second.used = make_or(q->second.used, merged.used);
+                q->second.loaded = make_or(q->second.loaded, merged.loaded);
+            }
+        }
+        for (auto &p : true_info) {
+            size_t id = p.first;
+            FuncInfo merged{combine(p.second.used, Expr()),
+                             combine(p.second.loaded, Expr())};
+            auto [q, inserted] = old.try_emplace(id, merged);
+            if (!inserted) {
+                q->second.used = make_or(q->second.used, merged.used);
+                q->second.loaded = make_or(q->second.loaded, merged.loaded);
+            }
+        }
+        func_info.clear();
         old.swap(func_info);
         mutate(op->condition);  // Check for any calls in the condition
 

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -219,6 +219,7 @@ tests(GROUPS correctness
       low_bit_depth_noise.cpp
       make_struct.cpp
       many_dimensions.cpp
+      many_inlined_selects.cpp
       many_small_extern_stages.cpp
       many_updates.cpp
       math.cpp

--- a/test/correctness/many_inlined_selects.cpp
+++ b/test/correctness/many_inlined_selects.cpp
@@ -5,20 +5,19 @@
 // Stress test for skip_stages on a Func whose value is read via a long chain
 // of CSE'd let bindings, each carrying a Select gated on an independent
 // scalar Param. The setup:
-//   - F has a self-referencing update definition (so it gets
+//   - f has a self-referencing update definition (so it gets
 //     compute_at(innermost) and shows up in conditionally_used_funcs).
-//   - A chain of derived Exprs over F is built, each referenced multiple
+//   - A chain of derived Exprs over f is built, each referenced multiple
 //     times downstream so CSE materialises them as a let chain.
 //   - Each chain value contains a Select gated on a Param<bool>.
-//   - A final Select feeds the whole chain into the output.
 //
 // This pattern used to scale exponentially in skip_stages: every nested
 // Select roughly doubled the size of the .used / .loaded predicate that
-// the mutator built up for F, because the boolean form
+// the mutator built up for f, because the boolean form
 // `(t && cond) || (f && !cond)` couldn't recognise that the t and f
 // sub-predicates were the same Expr coming from a let-stashed FuncInfo
 // above. At this chain length the predicate would contain ~2^500 IR
-// nodes — i.e. skip_stages would crash trying to allocate it long
+// nodes -- i.e. skip_stages would crash trying to allocate it long
 // before any wall-clock timeout fired. Post-fix it lowers in a fraction
 // of a second.
 
@@ -28,7 +27,6 @@ int main(int argc, char **argv) {
     Var x("x"), y("y"), c("c");
 
     ImageParam src(Float(32), 3, "src");
-    Param<bool> gate("gate");
 
     constexpr int num_params = 8;
     std::vector<Param<bool>> conds;
@@ -37,50 +35,38 @@ int main(int argc, char **argv) {
         conds.emplace_back("cond" + std::to_string(i));
     }
 
-    // F: self-referencing update -> can't be inlined, becomes a separate
+    // f: self-referencing update -> can't be inlined, becomes a separate
     // compute_at(innermost) Func, so it shows up in skip_stages's analysis.
-    Func F("F");
-    F(x, y, c) = src(x, y, c) * 1.5f + 0.5f;
-    F(x, y, c) = clamp(F(x, y, c), 0.0f, 1.0f);
+    Func f("f");
+    f(x, y, c) = src(x, y, c) * 1.5f + 0.5f;
+    f(x, y, c) = clamp(f(x, y, c), 0.0f, 1.0f);
 
-    // -- Build a long chain of derived expressions. Each Expr is held in a
-    // C++ variable and referenced multiple times by subsequent Exprs, so
-    // CSE will materialise each as a let in the lowered IR.
+    // Build a long chain of derived expressions. Each entry references
+    // the immediately preceding one (chain.back()) plus two pseudo-random
+    // earlier ones. The dependency on chain.back() guarantees that every
+    // entry is reachable from the final one, so nothing gets dropped as
+    // dead. CSE will materialise each entry as a let in the lowered IR.
+    // Each chain entry's value contains a Select gated on one of the
+    // Param<bool>s.
     constexpr int chain_len = 500;
     std::vector<Expr> chain;
     chain.reserve(chain_len + 3);
-    chain.push_back(F(x, y, 0));
-    chain.push_back(F(x, y, 1));
-    chain.push_back(F(x, y, 2));
+    chain.push_back(f(x, y, 0));
+    chain.push_back(f(x, y, 1));
+    chain.push_back(f(x, y, 2));
     for (int i = 0; i < chain_len; i++) {
-        Expr a = chain[(i * 3) % chain.size()];
+        Expr a = chain.back();
         Expr b = chain[(i * 5 + 1) % chain.size()];
         Expr d = chain[(i * 7 + 2) % chain.size()];
-        // Each chain entry's value contains a select gated on one of the
-        // Param<bool>s. The let cascade in skip_stages's analysis marks
-        // the whole chain as interesting and the mutator builds a
-        // predicate for each let in turn.
         Expr cond = conds[i % num_params];
         Expr e = select(cond, a * b + d, (a - d) * b) +
                  cast<float>(i) * 0.0001f;
         chain.push_back(e);
     }
 
-    // -- Final expression is a single select gated on a runtime param.
-    // The branches reference the *last* (and therefore transitively every)
-    // chain entry, so the in-condition cascade marks every let interesting.
-    Expr branch_t = chain.back() + chain[chain.size() / 2];
-    Expr branch_f = chain.back() - chain[chain.size() / 2];
     Func out("out");
-    out(x, y) = select(gate, branch_t, branch_f);
-
-    Target target = get_jit_target_from_environment();
-    int vec = target.natural_vector_size<float>();
-    Var tx("tx"), yo("yo"), yi("yi");
-    out.split(x, x, tx, vec, TailStrategy::GuardWithIf).vectorize(tx)
-       .split(y, yo, yi, 64, TailStrategy::GuardWithIf).parallel(yo);
-
-    out.compile_jit(target);
+    out(x, y) = chain.back();
+    out.compile_jit(get_jit_target_from_environment());
     printf("Success!\n");
     return 0;
 }

--- a/test/correctness/many_inlined_selects.cpp
+++ b/test/correctness/many_inlined_selects.cpp
@@ -1,0 +1,86 @@
+#include "Halide.h"
+#include <cstdio>
+#include <vector>
+
+// Stress test for skip_stages on a Func whose value is read via a long chain
+// of CSE'd let bindings, each carrying a Select gated on an independent
+// scalar Param. The setup:
+//   - F has a self-referencing update definition (so it gets
+//     compute_at(innermost) and shows up in conditionally_used_funcs).
+//   - A chain of derived Exprs over F is built, each referenced multiple
+//     times downstream so CSE materialises them as a let chain.
+//   - Each chain value contains a Select gated on a Param<bool>.
+//   - A final Select feeds the whole chain into the output.
+//
+// This pattern used to scale exponentially in skip_stages: every nested
+// Select roughly doubled the size of the .used / .loaded predicate that
+// the mutator built up for F, because the boolean form
+// `(t && cond) || (f && !cond)` couldn't recognise that the t and f
+// sub-predicates were the same Expr coming from a let-stashed FuncInfo
+// above. At this chain length the predicate would contain ~2^500 IR
+// nodes — i.e. skip_stages would crash trying to allocate it long
+// before any wall-clock timeout fired. Post-fix it lowers in a fraction
+// of a second.
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Var x("x"), y("y"), c("c");
+
+    ImageParam src(Float(32), 3, "src");
+    Param<bool> gate("gate");
+
+    constexpr int num_params = 8;
+    std::vector<Param<bool>> conds;
+    conds.reserve(num_params);
+    for (int i = 0; i < num_params; i++) {
+        conds.emplace_back("cond" + std::to_string(i));
+    }
+
+    // F: self-referencing update -> can't be inlined, becomes a separate
+    // compute_at(innermost) Func, so it shows up in skip_stages's analysis.
+    Func F("F");
+    F(x, y, c) = src(x, y, c) * 1.5f + 0.5f;
+    F(x, y, c) = clamp(F(x, y, c), 0.0f, 1.0f);
+
+    // -- Build a long chain of derived expressions. Each Expr is held in a
+    // C++ variable and referenced multiple times by subsequent Exprs, so
+    // CSE will materialise each as a let in the lowered IR.
+    constexpr int chain_len = 500;
+    std::vector<Expr> chain;
+    chain.reserve(chain_len + 3);
+    chain.push_back(F(x, y, 0));
+    chain.push_back(F(x, y, 1));
+    chain.push_back(F(x, y, 2));
+    for (int i = 0; i < chain_len; i++) {
+        Expr a = chain[(i * 3) % chain.size()];
+        Expr b = chain[(i * 5 + 1) % chain.size()];
+        Expr d = chain[(i * 7 + 2) % chain.size()];
+        // Each chain entry's value contains a select gated on one of the
+        // Param<bool>s. The let cascade in skip_stages's analysis marks
+        // the whole chain as interesting and the mutator builds a
+        // predicate for each let in turn.
+        Expr cond = conds[i % num_params];
+        Expr e = select(cond, a * b + d, (a - d) * b) +
+                 cast<float>(i) * 0.0001f;
+        chain.push_back(e);
+    }
+
+    // -- Final expression is a single select gated on a runtime param.
+    // The branches reference the *last* (and therefore transitively every)
+    // chain entry, so the in-condition cascade marks every let interesting.
+    Expr branch_t = chain.back() + chain[chain.size() / 2];
+    Expr branch_f = chain.back() - chain[chain.size() / 2];
+    Func out("out");
+    out(x, y) = select(gate, branch_t, branch_f);
+
+    Target target = get_jit_target_from_environment();
+    int vec = target.natural_vector_size<float>();
+    Var tx("tx"), yo("yo"), yi("yi");
+    out.split(x, x, tx, vec, TailStrategy::GuardWithIf).vectorize(tx)
+       .split(y, yo, yi, 64, TailStrategy::GuardWithIf).parallel(yo);
+
+    out.compile_jit(target);
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
In SkipStages::visit(Select), the two branches' per-Func .used / .loaded predicates were combined as `(t_used && cond) || (f_used && !cond)`. When both branches contributed the same Expr -- which is exactly what happens when both branches read the same let-stashed FuncInfo from an outer let -- make_or could not recognise the And nodes as equivalent (they aren't same_as even when their operands are), so the predicate roughly doubled in size at every nested Select. A long chain of CSE'd lets where each let value contains a Select then drove the predicate size to 2^N, well past the point where allocating the IR is feasible.

Combine the two branches with `select(cond, t, f)` instead, and add a make_select helper that collapses `select(c, X, X) -> X` and the constant-cond cases. When both branches contributed the same Expr, make_select drops the condition immediately and the chain stays linear.

The new correctness test (many_inlined_selects.cpp) constructs a 500- element CSE'd let chain whose values each carry a Param<bool>-gated Select, then feeds the chain into a final Select. With the bug present this test would not terminate -- skip_stages would crash allocating ~2^500 IR nodes long before any reasonable timeout fired.

