### PR TITLE
Fix internal error sliding through a compute_with-fused loop

### DIFF
--- a/apps/harris/Makefile
+++ b/apps/harris/Makefile
@@ -10,11 +10,11 @@ $(GENERATOR_BIN)/harris.generator: harris_generator.cpp $(GENERATOR_DEPS)
 
 $(BIN)/%/harris.a: $(GENERATOR_BIN)/harris.generator
 	@mkdir -p $(@D)
-	$< -g harris -f harris -o $(BIN)/$* target=$*-no_runtime
+	$< -g harris -f harris -e $(GENERATOR_OUTPUTS) -o $(BIN)/$* target=$*-no_runtime
 
 $(BIN)/%/harris_auto_schedule.a: $(GENERATOR_BIN)/harris.generator
 	@mkdir -p $(@D)
-	$< -g harris -f harris_auto_schedule -o $(BIN)/$* target=$*-no_runtime autoscheduler=Mullapudi2016
+	$< -g harris -f harris_auto_schedule  -e $(GENERATOR_OUTPUTS) -o $(BIN)/$* target=$*-no_runtime autoscheduler=Mullapudi2016
 
 $(BIN)/%/runtime.a: $(GENERATOR_BIN)/harris.generator
 	@mkdir -p $(@D)

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -901,7 +901,7 @@ public:
 };
 
 // It is convenient to be able to assume that loops have a .loop_min.orig
-// let in addition to .loop_min. Most of these will get simplified away.
+// let giving the original loop min. Most of these will get simplified away.
 class AddLoopMinOrig : public IRMutator {
     using IRMutator::visit;
 
@@ -916,7 +916,7 @@ class AddLoopMinOrig : public IRMutator {
         } else {
             result = For::make(op->name, min, max, op->for_type, op->partition_policy, op->device_api, body);
         }
-        return LetStmt::make(op->name + ".loop_min.orig", Variable::make(Int(32), op->name + ".loop_min"), result);
+        return LetStmt::make(op->name + ".loop_min.orig", op->min, result);
     }
 };
 

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -393,6 +393,28 @@ int main(int argc, char **argv) {
         }
     }
 
+    {
+        // Sliding a producer along the outer loop of a pair of outputs fused
+        // together with compute_with. Previously triggered an internal compiler
+        // error referencing a missing .loop_min symbol on the fused loop.
+        count = 0;
+        Func f, g1, g2;
+        f(x, y) = call_counter(x, y);
+        g1(x, y) = f(x, y - 1) + f(x, y + 1);
+        g2(x, y) = f(x, y - 1) - f(x, y + 1);
+
+        f.store_root().compute_at(g1, y);
+        g2.compute_with(g1, x);
+
+        Pipeline({g1, g2}).realize({10, 10});
+
+        // f spans y in [-1, 10], so 12 rows of 10 = 120 calls when slid.
+        if (count != 120) {
+            printf("f was called %d times instead of %d times\n", count, 120);
+            return 1;
+        }
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
While messing with alternative harris schedules, I encountered an internal compiler error about a missing symbol. Claude says:

AddLoopMinOrig referred to a Variable("<loop>.loop_min") for the value of its .loop_min.orig let. For loops renamed by compute_with's substitute_fused_bounds, no .loop_min let exists under the fused name, so sliding window emitted references to a non-existent symbol and codegen failed with "Symbol not found: ...fused...loop_min". Use the loop's min expression directly instead.

Also fix a pre-existing oversight in apps/harris/Makefile where \$(GENERATOR_OUTPUTS) was not passed to the generator.

