### PR TITLE
Rewrite sliding window bounds let at the correct loop level

### DIFF
--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -230,13 +230,11 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
 
     map<string, Expr> replacements;
 
-    // Loop-nest depth (size of enclosing_loops) at the moment we visited the
-    // target producer. Bounds inference places the lets that drive the
-    // producer at this same loop level, so replacements must only be applied
-    // to LetStmts at that same level — same-named lets at deeper for-loop
-    // nesting (e.g. inside the consume side of the func) serve other
-    // purposes and must not be rewritten.
-    size_t producer_loop_depth = 0;
+    // The immediately-enclosing For node, and the one enclosing the target
+    // producer. Replacements are only applied to LetStmts directly inside
+    // producer_for.
+    const For *current_for = nullptr;
+    Stmt producer_for;
 
     using IRMutator::visit;
 
@@ -509,7 +507,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
                 replacements[n + ".min"] = Variable::make(Int(32), prefix + dim + ".min");
                 replacements[n + ".max"] = Variable::make(Int(32), prefix + dim + ".max");
             }
-            producer_loop_depth = enclosing_loops.size();
+            producer_for = Stmt(current_for);
 
             // Ok, we have a new min/max required and we're going to
             // rewrite all the lets that define bounds required. Now
@@ -575,6 +573,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
         Expr min = expand_expr(op->min, scope);
         Expr max = expand_expr(op->max, scope);
         ScopedBinding<> bind(enclosing_loops, op->name);
+        ScopedValue<const For *> bind_for(current_for, op);
         if (equal(min, max)) {
             // Just treat it like a let
             Stmt s = LetStmt::make(op->name, min, op->body);
@@ -601,7 +600,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
         Expr value = op->value;
 
         map<string, Expr>::iterator iter = replacements.find(op->name);
-        if (iter != replacements.end() && enclosing_loops.size() == producer_loop_depth) {
+        if (iter != replacements.end() && current_for == producer_for.get()) {
             value = iter->second;
             replacements.erase(iter);
         }

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -224,10 +224,19 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
     set<int> &slid_dimensions;
     Scope<Expr> scope;
 
-    // Loops between the loop being slid over and the produce node
+    // For loops strictly between the loop being slid over and the current
+    // node (not including the loop being slid over itself).
     Scope<> enclosing_loops;
 
     map<string, Expr> replacements;
+
+    // Loop-nest depth (size of enclosing_loops) at the moment we visited the
+    // target producer. Bounds inference places the lets that drive the
+    // producer at this same loop level, so replacements must only be applied
+    // to LetStmts at that same level — same-named lets at deeper for-loop
+    // nesting (e.g. inside the consume side of the func) serve other
+    // purposes and must not be rewritten.
+    size_t producer_loop_depth = 0;
 
     using IRMutator::visit;
 
@@ -500,6 +509,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
                 replacements[n + ".min"] = Variable::make(Int(32), prefix + dim + ".min");
                 replacements[n + ".max"] = Variable::make(Int(32), prefix + dim + ".max");
             }
+            producer_loop_depth = enclosing_loops.size();
 
             // Ok, we have a new min/max required and we're going to
             // rewrite all the lets that define bounds required. Now
@@ -591,7 +601,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
         Expr value = op->value;
 
         map<string, Expr>::iterator iter = replacements.find(op->name);
-        if (iter != replacements.end()) {
+        if (iter != replacements.end() && enclosing_loops.size() == producer_loop_depth) {
             value = iter->second;
             replacements.erase(iter);
         }


### PR DESCRIPTION
Sliding window populates a replacements map keyed by .min/.max let names and rewrites the first matching LetStmt encountered on the way out from the producer. That happens to hit the right let today because we don't inject bounds for that Func anywhere else that we might hit first (e.g. inside a loop on the consumer side, which is visited after the producer). That's a shaky assumption though. It caused a bug in another branch where I added more .min/.max declaration sites for other purposes. This PR explicitly only rewrites the ones immediately inside the Produce node's loop. No test changes because there's no bug to trigger on main. This just makes the code more robust to future changes.
