### PR TITLE
Delete some apparent dead code for inlining

### DIFF
--- a/src/BoundsInference.cpp
+++ b/src/BoundsInference.cpp
@@ -849,11 +849,15 @@ public:
         // Compute the intrinsic relationships between the stages of
         // the functions.
 
-        // Figure out which functions will be inlined away
+        // Figure out which functions will be inlined away. First sanity check
+        // that none of the outputs are inlined, or the code below would do the
+        // wrong thing with them.
+        for (const Function &o : outputs) {
+            internal_assert(!o.schedule().compute_level().is_inlined());
+        }
         vector<bool> inlined(f.size());
         for (size_t i = 0; i < inlined.size(); i++) {
-            if (i < f.size() - 1 &&
-                f[i].schedule().compute_level().is_inlined() &&
+            if (f[i].schedule().compute_level().is_inlined() &&
                 f[i].can_be_inlined()) {
                 inlined[i] = true;
                 inliner.to_inline.insert(f[i]);
@@ -896,16 +900,6 @@ public:
                 cond_val.value = inliner.do_inlining(cond_val.value);
             }
         }
-
-        // Remove the inlined stages
-        vector<Stage> new_stages;
-        for (const auto &stage : stages) {
-            if (!stage.func.schedule().compute_level().is_inlined() ||
-                !stage.func.can_be_inlined()) {
-                new_stages.push_back(stage);
-            }
-        }
-        new_stages.swap(stages);
 
         // Dump the stages post-inlining for debugging
         /*


### PR DESCRIPTION
Bounds inference has code to explicitly delete inlined stages from the vector of stages, but inlined stages were never added to it in the loop that constructs it, so this appears to be dead.

There was also a suspicious i < f.size() - 1 condition when deciding what is going to be inlined. I believe this is to skip the output Func, but if there are multiple outputs Funcs this just skips one of them, so this is either wrong or misleading. Alternatively this might be an optimization: the Funcs are in topological order, so what would the last Func even be inlined into? If it's last it has no callers. Still, I thought it was simpler to explicitly verify the assumption that the outputs aren't inlined, and then touch every Func.