### PR TITLE
Improve solve_for_outer_interval for max/min comparisons

### DIFF
--- a/src/Solve.cpp
+++ b/src/Solve.cpp
@@ -312,6 +312,12 @@ protected:
             } else if (mul_a && mul_b && equal(mul_a->b, mul_b->b)) {
                 // f(x)*a - g(x)*a -> (f(x) - g(x))*a;
                 expr = mutate((mul_a->a - mul_b->a) * mul_a->b);
+            } else if (mul_a && equal(mul_a->a, b)) {
+                // f(x)*a - f(x) -> f(x) * (a - 1)
+                expr = mutate(b * (mul_a->b - 1));
+            } else if (mul_b && equal(mul_b->a, a)) {
+                // f(x) - f(x)*a -> f(x) * (1 - a)
+                expr = mutate(a * (make_one(a.type()) - mul_b->b));
             } else if (div_a && !a_failed && no_overflow_int(op->type) && can_prove(div_a->b != 0)) {
                 // f(x)/a - g(x) -> (f(x) - g(x) * a) / a
                 // Same overflow and div-by-zero concerns as the Add case above.
@@ -1053,7 +1059,35 @@ class SolveForInterval : public IRVisitor {
         if (!already_solved) {
             SolverResult solved = solve_expression(le, var, scope);
             if (!solved.fully_solved) {
-                fail();
+                // solve_expression failed; try direct max/min decomposition on the LHS.
+                if (const Max *max_fallback = le->a.as<Max>()) {
+                    // max(a, b) <= c <==> a <= c && b <= c
+                    (max_fallback->a <= le->b && max_fallback->b <= le->b).accept(this);
+                } else if (const Min *min_fallback = le->a.as<Min>()) {
+                    // min(a, b) <= c <==> a <= c || b <= c
+                    (min_fallback->a <= le->b || min_fallback->b <= le->b).accept(this);
+                } else if (const Mul *mul_fallback = le->a.as<Mul>()) {
+                    // max/min(a, b) * pos_c <= rhs <==> a*pos_c <= rhs [&&/||] b*pos_c <= rhs
+                    const Max *mxf = mul_fallback->a.as<Max>();
+                    const Min *mnf = mul_fallback->a.as<Min>();
+                    Expr factor = mul_fallback->b;
+                    if (!mxf && !mnf) {
+                        mxf = mul_fallback->b.as<Max>();
+                        mnf = mul_fallback->b.as<Min>();
+                        factor = mul_fallback->a;
+                    }
+                    if (mxf && is_positive_const(factor)) {
+                        // max(a, b) * pos_c <= rhs <==> a*pos_c <= rhs && b*pos_c <= rhs
+                        (mxf->a * factor <= le->b && mxf->b * factor <= le->b).accept(this);
+                    } else if (mnf && is_positive_const(factor)) {
+                        // min(a, b) * pos_c <= rhs <==> a*pos_c <= rhs || b*pos_c <= rhs
+                        (mnf->a * factor <= le->b || mnf->b * factor <= le->b).accept(this);
+                    } else {
+                        fail();
+                    }
+                } else {
+                    fail();
+                }
             } else {
                 already_solved = true;
                 solved.result.accept(this);
@@ -1110,7 +1144,35 @@ class SolveForInterval : public IRVisitor {
         if (!already_solved) {
             SolverResult solved = solve_expression(ge, var, scope);
             if (!solved.fully_solved) {
-                fail();
+                // solve_expression failed; try direct max/min decomposition on the LHS.
+                if (const Max *max_fallback = ge->a.as<Max>()) {
+                    // max(a, b) >= c <==> a >= c || b >= c
+                    (max_fallback->a >= ge->b || max_fallback->b >= ge->b).accept(this);
+                } else if (const Min *min_fallback = ge->a.as<Min>()) {
+                    // min(a, b) >= c <==> a >= c && b >= c
+                    (min_fallback->a >= ge->b && min_fallback->b >= ge->b).accept(this);
+                } else if (const Mul *mul_fallback = ge->a.as<Mul>()) {
+                    // max/min(a, b) * pos_c >= rhs <==> a*pos_c >= rhs [||/&&] b*pos_c >= rhs
+                    const Max *mxf = mul_fallback->a.as<Max>();
+                    const Min *mnf = mul_fallback->a.as<Min>();
+                    Expr factor = mul_fallback->b;
+                    if (!mxf && !mnf) {
+                        mxf = mul_fallback->b.as<Max>();
+                        mnf = mul_fallback->b.as<Min>();
+                        factor = mul_fallback->a;
+                    }
+                    if (mxf && is_positive_const(factor)) {
+                        // max(a, b) * pos_c >= rhs <==> a*pos_c >= rhs || b*pos_c >= rhs
+                        (mxf->a * factor >= ge->b || mxf->b * factor >= ge->b).accept(this);
+                    } else if (mnf && is_positive_const(factor)) {
+                        // min(a, b) * pos_c >= rhs <==> a*pos_c >= rhs && b*pos_c >= rhs
+                        (mnf->a * factor >= ge->b && mnf->b * factor >= ge->b).accept(this);
+                    } else {
+                        fail();
+                    }
+                } else {
+                    fail();
+                }
             } else {
                 already_solved = true;
                 solved.result.accept(this);

--- a/test/correctness/solve.cpp
+++ b/test/correctness/solve.cpp
@@ -568,6 +568,22 @@ void test_float_select_condition_not_simplified() {
          {"z", make_const(Float(32), 1.5e9f)}});
 }
 
+void test_outer_interval_max_min() {
+    // max(x, 1) * 2 <= x is always false: the max branch gives 2*x <= x (so
+    // x <= 0) while the constant branch gives 2 <= x (so x >= 2); these
+    // constraints are disjoint, so the outer interval is empty.
+    check_outer_interval(max(x, 1) * 2 <= x, Interval::pos_inf(), Interval::neg_inf());
+
+    // max(abs(select(x < 0, f(x-1), 5)), 2) <= x: the constant branch requires
+    // 2 <= x (i.e. x >= 2), so x < 2 is always false regardless of f.
+    // abs(Int(32)) returns UInt(32) in Halide, so cast back to Int(32) first to
+    // keep max(...) as the outermost node (otherwise an implicit Cast wraps it).
+    Expr fx1 = Call::make(Int(32), "f", {x - 1}, Call::PureExtern);
+    Expr abs_val = cast<int32_t>(Halide::abs(select(x < 0, fx1, Expr(5))));
+    Expr expr2 = max(abs_val, 2) <= x;
+    check_outer_interval(expr2, 2, Interval::pos_inf());
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {
@@ -599,6 +615,7 @@ int main(int argc, char **argv) {
     test_simplify_preserves_float_to_uint_cast_chain();
     test_float_mul_eq_zero_divisor_not_rewritten();
     test_float_select_condition_not_simplified();
+    test_outer_interval_max_min();
     std::printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
Two related improvements to SolveForInterval:

1. SolveExpression::visit(Sub): add `f(x)*a - f(x) → f(x)*(a-1)` and the symmetric `f(x) - f(x)*a → f(x)*(1-a)` reduction rules. Without these, expressions like `2*x - x` couldn't be simplified, blocking the solver from rearranging comparisons such as `2*x <= x` into `x <= 0`.

2. SolveForInterval::visit(LE/GE): when solve_expression fails to fully isolate the variable, try a direct max/min decomposition on the LHS before falling back to fail(). The rules applied are: `max(a, b) <= c  ⟺  a <= c && b <= c min(a, b) <= c  ⟺  a <= c || b <= c max(a, b) * pos_c <= rhs  ⟺  a*pos_c <= rhs && b*pos_c <= rhs min(a, b) * pos_c <= rhs  ⟺  a*pos_c <= rhs || b*pos_c <= rhs` (and symmetric >= variants)

Together these enable two previously unhandled cases:
  - `max(x, 1) * 2 <= x`  →  `Interval::nothing()`  (always false)
  - `max(abs(select(x < 0, f(x-1), 5)), 2) <= x`  →  `[2, +∞)` (the constant branch forces x >= 2 even when f is opaque)

These limitations were found by @stevenraphael 

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Commits include AI attribution where applicable (see Code of Conduct)
