### PR TITLE
Bounds propagation during sliding window optimization

### DIFF
--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -761,7 +761,6 @@ class SlidingWindow : public IRMutator {
     // Keep track of realizations we want to slide, from innermost to
     // outermost.
     list<Function> sliding;
-
     Scope<Interval> bounds_scope;
 
     using IRMutator::visit;
@@ -822,7 +821,6 @@ class SlidingWindow : public IRMutator {
 
         list<pair<string, Expr>> prev_loop_mins;
         list<pair<string, Expr>> new_lets;
-
         for (const Function &func : sliding) {
             debug(3) << "Doing sliding window analysis on function " << func.name() << "\n";
 

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -1,6 +1,7 @@
 #include "SlidingWindow.h"
 
 #include "Bounds.h"
+#include "CSE.h"
 #include "CompilerLogger.h"
 #include "Debug.h"
 #include "ExprUsesVar.h"
@@ -86,7 +87,7 @@ public:
 // Perform all the substitutions in a scope
 Expr expand_expr(const Expr &e, const Scope<Expr> &scope) {
     ExpandExpr ee(scope);
-    Expr result = ee(e);
+    Expr result = common_subexpression_elimination(ee(e));
     debug(4) << "Expanded " << e << " into " << result << "\n";
     return result;
 }

--- a/src/SlidingWindow.cpp
+++ b/src/SlidingWindow.cpp
@@ -223,6 +223,7 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
     Expr loop_min;
     set<int> &slid_dimensions;
     Scope<Expr> scope;
+    Scope<Interval> &bounds_scope;
 
     // For loops strictly between the loop being slid over and the current
     // node (not including the loop being slid over itself).
@@ -282,8 +283,8 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
                 internal_assert(min_val && max_val);
                 Expr min_req = *min_val;
                 Expr max_req = *max_val;
-                min_req = expand_expr(min_req, scope);
-                max_req = expand_expr(max_req, scope);
+                min_req = simplify(expand_expr(min_req, scope), bounds_scope);
+                max_req = simplify(expand_expr(max_req, scope), bounds_scope);
 
                 debug(3) << func_args[i] << ":" << min_req << ", " << max_req << "\n";
                 if (expr_depends_on_var(min_req, loop_var) ||
@@ -594,7 +595,10 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
     }
 
     Stmt visit(const LetStmt *op) override {
-        ScopedBinding<Expr> bind(scope, op->name, simplify(expand_expr(op->value, scope)));
+        ScopedBinding<Interval> bind_bounds(bounds_scope, op->name,
+                                            bounds_of_expr_in_scope(op->value, bounds_scope));
+        ScopedBinding<Expr> bind(scope, op->name, simplify(expand_expr(op->value, scope), bounds_scope));
+
         Stmt new_body = mutate(op->body);
 
         Expr value = op->value;
@@ -613,8 +617,10 @@ class SlidingWindowOnFunctionAndLoop : public IRMutator {
     }
 
 public:
-    SlidingWindowOnFunctionAndLoop(Function f, string v, Expr v_min, set<int> &slid_dimensions)
-        : func(std::move(f)), loop_var(std::move(v)), loop_min(std::move(v_min)), slid_dimensions(slid_dimensions) {
+    SlidingWindowOnFunctionAndLoop(Function f, string v, Expr v_min, set<int> &slid_dimensions,
+                                   Scope<Interval> &bounds_scope)
+        : func(std::move(f)), loop_var(std::move(v)), loop_min(std::move(v_min)),
+          slid_dimensions(slid_dimensions), bounds_scope(bounds_scope) {
     }
 
     Expr new_loop_min;
@@ -756,7 +762,15 @@ class SlidingWindow : public IRMutator {
     // outermost.
     list<Function> sliding;
 
+    Scope<Interval> bounds_scope;
+
     using IRMutator::visit;
+
+    Stmt visit(const LetStmt *op) override {
+        ScopedBinding<Interval> bind(bounds_scope, op->name,
+                                     bounds_of_expr_in_scope(op->value, bounds_scope));
+        return IRMutator::visit(op);
+    }
 
     Stmt visit(const Realize *op) override {
         // Find the args for this function
@@ -808,6 +822,7 @@ class SlidingWindow : public IRMutator {
 
         list<pair<string, Expr>> prev_loop_mins;
         list<pair<string, Expr>> new_lets;
+
         for (const Function &func : sliding) {
             debug(3) << "Doing sliding window analysis on function " << func.name() << "\n";
 
@@ -827,7 +842,14 @@ class SlidingWindow : public IRMutator {
 
             set<int> &slid_dims = slid_dimensions[func.name()];
             size_t old_slid_dims_size = slid_dims.size();
-            SlidingWindowOnFunctionAndLoop slider(func, name, prev_loop_min, slid_dims);
+
+            Interval min_bounds = bounds_of_expr_in_scope(loop_min, bounds_scope);
+            Interval max_bounds = bounds_of_expr_in_scope(loop_max, bounds_scope);
+            ScopedBinding<Interval> bind_bounds(bounds_scope, op->name,
+                                                Interval(min_bounds.min, max_bounds.max));
+
+            SlidingWindowOnFunctionAndLoop slider(func, name, prev_loop_min, slid_dims, bounds_scope);
+
             body = slider(body);
 
             if (func.schedule().memory_type() == MemoryType::Register &&

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -299,6 +299,7 @@ tests(
     sliding_over_guard_with_if.cpp
     sliding_reduction.cpp
     sliding_window.cpp
+    sliding_window_cascade.cpp
     solve.cpp
     sort_exprs.cpp
     specialize.cpp

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -415,6 +415,30 @@ int main(int argc, char **argv) {
         }
     }
 
+    {
+        // Sliding a cascade of filters. Halide needs bounds propagation
+        // to prove that the innermost filters have monotonic bounds.
+        count = 0;
+        Func f1, f2, f3, f4, g;
+        f1(x) = call_counter(x, 0);
+        f2(x) = f1(0) + f1(x);
+        f3(x) = f2(0) + f2(x);
+        f4(x) = f3(0) + f3(x);
+        g(x) = f4(0) + f4(x);
+        f1.store_root().compute_at(g, x);
+        f2.store_root().compute_at(g, x);
+        f3.store_root().compute_at(g, x);
+        f4.store_root().compute_at(g, x);
+        g.bound(x, 0, 10);
+
+        g.realize({10});
+        // f1 spans x in [0, 9], so 10 calls when slid.
+        if (count != 10) {
+            printf("f1 was called %d times instead of %d times\n", count, 10);
+            return 1;
+        }
+    }
+
     printf("Success!\n");
     return 0;
 }

--- a/test/correctness/sliding_window_cascade.cpp
+++ b/test/correctness/sliding_window_cascade.cpp
@@ -1,0 +1,40 @@
+#include "Halide.h"
+#include <cstdio>
+
+// Stress test the sliding window pass on a pipeline with a long
+// dependency chain of Funcs, each of which is computed in the
+// same loop over the output.
+// The partially compiled schedule has a long chain of let statements
+// that represent the inferred bounds of each function. When
+// analyzing the innermost functions during the
+// sliding window pass, Halide used to expand the chain of let
+// statements through direct substitution without CSE, which
+// caused exponential blow-up. With CSE added, the blow-up is
+// reduced to quadratic. The function call indices are chosen
+// to make it difficult for the simplifier to eliminate the blow-up.
+//
+// We do not necessarily expect Halide to prove that the sliding window pass
+// can be applied to every func in the chain, since the bounds
+// expressions have large numbers of nodes even with CSE.
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    int count = 0;
+    const int N = 100;
+    Var x("x");
+    Func f[N];
+    Func out;
+    f[0](x) = x % 2;
+    f[0].store_root().compute_at(out, x);
+    for (int i = 1; i < N; i++) {
+        f[i](x) = f[i - 1](x - 1) + f[i - 1](min(x + 1, 20));
+        f[i].store_root().compute_at(out, x);
+    }
+    out(x) = f[N - 1](x);
+    out.bound(x, 0, 10);
+    out.realize({10});
+    out.compile_jit(get_jit_target_from_environment());
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/sliding_window_cascade.cpp
+++ b/test/correctness/sliding_window_cascade.cpp
@@ -20,7 +20,6 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    int count = 0;
     const int N = 100;
     Var x("x");
     Func f[N];


### PR DESCRIPTION
This PR makes it easier for Halide to prove that loop bounds are monotonically increasing/decreasing during the sliding window optimization by tracking overall bounds information for variables used in the loop bound expressions. It tracks bounds rather than attempting more aggressive simplification in order to avoid longer compile times. I found this issue when I tried to write a cascade of filters where the loop bound expressions got more complex after applying the sliding window optimization to each successive filter.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Commits include AI attribution where applicable (see Code of Conduct)
