### PR TITLE
Add saturating add/sub intrinsics to RISC-V vector backend

### DIFF
--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -62,6 +62,8 @@ struct RISCVIntrinsic {
 const RISCVIntrinsic signed_intrinsic_defs[] = {
     {"vaadd", Type::Int, "halving_add", {Type::Int, Type::Int}, AddVLArg | RoundDown | Commutes},
     {"vaadd", Type::Int, "rounding_halving_add", {Type::Int, Type::Int}, AddVLArg | RoundUp | Commutes},
+    {"vsadd", Type::Int, "saturating_add", {Type::Int, Type::Int}, AddVLArg | Commutes},
+    {"vssub", Type::Int, "saturating_sub", {Type::Int, Type::Int}, AddVLArg},
     {"vwadd", {Type::Int, 2}, "widening_add", {Type::Int, Type::Int}, AddVLArg | MangleReturnType | Commutes},
     {"vwsub", {Type::Int, 2}, "widening_sub", {Type::Int, Type::Int}, AddVLArg | MangleReturnType},
     {"vwmul", {Type::Int, 2}, "widening_mul", {Type::Int, Type::Int}, AddVLArg | MangleReturnType | Commutes},
@@ -70,6 +72,8 @@ const RISCVIntrinsic signed_intrinsic_defs[] = {
 const RISCVIntrinsic unsigned_intrinsic_defs[] = {
     {"vaaddu", {Type::UInt}, "halving_add", {Type::UInt, Type::UInt}, AddVLArg | RoundDown | Commutes},
     {"vaaddu", {Type::UInt}, "rounding_halving_add", {Type::UInt, Type::UInt}, AddVLArg | RoundUp | Commutes},
+    {"vsaddu", {Type::UInt}, "saturating_add", {Type::UInt, Type::UInt}, AddVLArg | Commutes},
+    {"vssubu", {Type::UInt}, "saturating_sub", {Type::UInt, Type::UInt}, AddVLArg},
     {"vwaddu", {Type::UInt, 2}, "widening_add", {Type::UInt, Type::UInt}, AddVLArg | MangleReturnType | Commutes},
     {"vwsubu", {Type::UInt, 2}, "widening_sub", {Type::UInt, Type::UInt}, AddVLArg | MangleReturnType},
     {"vwmulu", {Type::UInt, 2}, "widening_mul", {Type::UInt, Type::UInt}, AddVLArg | MangleReturnType | Commutes},

--- a/test/correctness/simd_op_check_riscv.cpp
+++ b/test/correctness/simd_op_check_riscv.cpp
@@ -96,6 +96,10 @@ public:
         check("vaaddu.vv", lanes, halving_add(u_1, u_2));
         check("vaadd.vv", lanes, rounding_halving_add(i_1, i_2));
         check("vaaddu.vv", lanes, rounding_halving_add(u_1, u_2));
+        check("vsadd.vv", lanes, saturating_add(i_1, i_2));
+        check("vsaddu.vv", lanes, saturating_add(u_1, u_2));
+        check("vssub.vv", lanes, saturating_sub(i_1, i_2));
+        check("vssubu.vv", lanes, saturating_sub(u_1, u_2));
 
         // Widening intrinsics
         if (base_bit_width < 64) {


### PR DESCRIPTION
## Summary

- Map `saturating_add` to RVV `vsadd.vv` / `vsaddu.vv` instructions
- Map `saturating_sub` to RVV `vssub.vv` / `vssubu.vv` instructions
- Add corresponding `simd_op_check_riscv` test cases

These are the most commonly used missing operations for image processing workloads (clamped arithmetic). They fit the existing `RISCVIntrinsic` table pattern with zero infrastructure changes — just 4 new table entries per signedness.

Fixes #9184

## Test plan

- [ ] `simd_op_check_riscv` checks for `vsadd.vv`, `vsaddu.vv`, `vssub.vv`, `vssubu.vv` instruction patterns in generated assembly
- [ ] Existing halving_add, rounding_halving_add, widening_* tests continue to pass
- [ ] CI passes

