### PR TITLE
[runtime] Only enable _Float16 when the compiler supports it

### DIFF
--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -108,7 +108,7 @@ extern "C" {
 // Ideally there would be a better way to detect if the type
 // is supported, even in a compiler independent fashion, but
 // coming up with one has proven elusive.
-#if defined(__clang__) && (__clang_major__ >= 15) && !defined(__EMSCRIPTEN__) && !defined(__i386__) && !defined(__wasm__)
+#if defined(__clang__) && (__clang_major__ >= 15) && !defined(__EMSCRIPTEN__) && !defined(__i386__) && !defined(__wasm__) && defined(__FLT16_MANT_DIG__)
 #if defined(__is_identifier)
 #if !__is_identifier(_Float16)
 #undef HALIDE_CPP_COMPILER_HAS_FLOAT16


### PR DESCRIPTION
The clang branch of the HALIDE_CPP_COMPILER_HAS_FLOAT16 detection enables _Float16 whenever `_Float16` is a reserved keyword (detected via __is_identifier). However, clang reserves the keyword on *all* targets since clang 8 while only actually *supporting* the type on some. On a target where clang reserves but does not support _Float16 (e.g. PowerPC) the check is a false positive and the build fails with "error: _Float16 is not supported on this target".

clang (and gcc) only predefine the __FLT16_* limit macros when the target actually supports _Float16, so additionally require defined(__FLT16_MANT_DIG__). This is the compiler-independent "better way to detect if the type is supported" the adjacent comment asks for, and it is a no-op on every target where _Float16 already worked.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
