### PR TITLE
check serialized buffer data size before memcpy in deserialize_buffer

### DIFF
--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -1337,7 +1337,12 @@ Buffer<> Deserializer::deserialize_buffer(const Serialize::Buffer *buffer) {
     // then create a (potential sparse) buffer with original dimension infos and copy from the dense buffer
     auto fake_dense_buffer = Buffer<>(type, nullptr, dimensions, dense_buffer_dimensions.data(), name + "_dense_fake");
     auto dense_buffer = Buffer<>::make_with_shape_of(fake_dense_buffer, nullptr, nullptr, name + "_dense_tmp");
-    memcpy(dense_buffer.data(), buffer->data()->data(), buffer->data()->size());
+    const auto *buffer_data = buffer->data();
+    user_assert(buffer_data != nullptr) << "deserialized buffer " << name << " has no data\n";
+    user_assert(buffer_data->size() == dense_buffer.size_in_bytes())
+        << "deserialized buffer " << name << " carries " << buffer_data->size()
+        << " bytes of data, but its dimensions require " << dense_buffer.size_in_bytes() << "\n";
+    memcpy(dense_buffer.data(), buffer_data->data(), buffer_data->size());
     auto fake_buffer = Buffer<>(type, nullptr, dimensions, hl_buffer_dimensions.data(), name + "_fake");
     auto hl_buffer = Buffer<>::make_with_shape_of(fake_buffer, nullptr, nullptr, name);
     hl_buffer.copy_from(dense_buffer);


### PR DESCRIPTION
Malformed input to the pipeline deserializer can overflow the heap in `deserialize_buffer`.

- The dense buffer is sized from the serialized dims/type, but the payload is memcpy'd using the data vector's own length
- That length is a separate field in the `.hlpipe` file, so a buffer declaring small dimensions with a large data blob writes past the allocation
- Validate the blob length against the destination `size_in_bytes()` (and reject a null data vector) before the copy, which is exactly the invariant the serializer always writes

Confirmed on an ASAN build: a 4x4 uint8 buffer (16 dense bytes) carrying a 4 KB data blob reports a heap-buffer-overflow WRITE at the memcpy; with the size check the file is rejected cleanly.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)