### PR TITLE
Fix Func/Parameter name collision when Func is the pipeline output

### DIFF
--- a/src/FindCalls.cpp
+++ b/src/FindCalls.cpp
@@ -103,9 +103,12 @@ std::map<std::string, Function> build_environment(const std::vector<Function> &f
     // Validate the environment: no Parameter (ImageParam, Generator
     // Input<Buffer>, or scalar Param) may share a name with a Func in the
     // pipeline. Such a collision otherwise causes confusing internal errors
-    // later in lowering. Output Funcs intentionally share names with their
-    // output buffer Parameters, so exclude buffer params whose name matches
-    // an output Func.
+    // later in lowering (or, worse, silently aliases the two buffers). A
+    // Func is allowed to reference its own output buffer Parameter (e.g.
+    // via Func::output_buffer()), since that Parameter is created by the
+    // Func itself and necessarily shares its name; we detect that case by
+    // identity (same_as), not by name, so a distinct buffer Parameter that
+    // merely happens to share a Func's name is still caught.
     class FindParamNames : public IRVisitor {
         using IRVisitor::visit;
         void record(const Parameter &p) {
@@ -113,7 +116,7 @@ std::map<std::string, Function> build_environment(const std::vector<Function> &f
                 return;
             }
             if (p.is_buffer()) {
-                buffer_names.insert(p.name());
+                buffer_params[p.name()].push_back(p);
             } else {
                 scalar_names.insert(p.name());
             }
@@ -127,21 +130,34 @@ std::map<std::string, Function> build_environment(const std::vector<Function> &f
         }
 
     public:
-        std::set<std::string> buffer_names;
+        std::map<std::string, std::vector<Parameter>> buffer_params;
         std::set<std::string> scalar_names;
     } finder;
     for (const auto &p : env) {
         p.second.accept(&finder);
     }
-    std::set<std::string> output_names;
-    for (const Function &f : funcs) {
-        output_names.insert(f.name());
-    }
-    for (const std::string &name : finder.buffer_names) {
-        if (output_names.count(name)) {
+    for (const auto &entry : finder.buffer_params) {
+        const std::string &name = entry.first;
+        auto func_it = env.find(name);
+        if (func_it == env.end()) {
             continue;
         }
-        if (env.count(name)) {
+        const Function &f = func_it->second;
+        bool all_are_own_output_buffer = true;
+        for (const Parameter &p : entry.second) {
+            bool matches_own_output = false;
+            for (const Parameter &out_p : f.output_buffers()) {
+                if (p.same_as(out_p)) {
+                    matches_own_output = true;
+                    break;
+                }
+            }
+            if (!matches_own_output) {
+                all_are_own_output_buffer = false;
+                break;
+            }
+        }
+        if (!all_are_own_output_buffer) {
             user_error << "The name \"" << name << "\" is used for both "
                        << "an input buffer (ImageParam or Generator Input<Buffer>) "
                        << "and a Func in the same pipeline. "

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -93,6 +93,7 @@ tests(
     no_default_device.cpp
     nonexistent_update_stage.cpp
     null_host_field.cpp
+    output_func_input_buffer_name_collision.cpp
     overflow_during_constant_folding.cpp
     pointer_arithmetic.cpp
     predicate_loads_used_in_inner_splits.cpp

--- a/test/error/output_func_input_buffer_name_collision.cpp
+++ b/test/error/output_func_input_buffer_name_collision.cpp
@@ -1,0 +1,22 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // The pipeline's own output Func is declared before an ImageParam of
+    // the same name, and the ImageParam is used as an input to that same
+    // Func. Because the Func is the pipeline output, its own auto-created
+    // output buffer Parameter also shares this name -- but the ImageParam
+    // is a distinct Parameter object, so this must still be flagged as a
+    // collision rather than silently aliasing the two buffers.
+    Var x;
+    Func foo("foo");
+    ImageParam foo_param(Int(32), 1, "foo");
+    foo(x) = foo_param(x) + 1;
+
+    foo.compile_jit();
+
+    printf("Should not get here\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

#9145 detected/prevented Func/Parameter name collisions, but exempted any buffer Parameter whose *name* matched an output Func's name (assuming it must be that Func's own auto-created output buffer). A distinct, separately-constructed `ImageParam` with the same name slipped through the check:

```cpp
Func foo("foo");
ImageParam foo_param(Int(32), 1, "foo");
foo(x) = foo_param(x) + 1;
```

Lowering silently merged the input and output into a single buffer symbol, discarding the real input data with no error.

`FindCalls.cpp` now checks identity (`Parameter::same_as` against `Function::output_buffers()`) instead of name equality, so only the Func's actual own output buffer is exempted; any other same-named Parameter is correctly flagged with a `user_error`, matching the existing collision-error convention from #9145.

## Test plan

- [x] Added `test/error/output_func_input_buffer_name_collision.cpp` covering the previously-uncovered ordering (output Func declared before same-named ImageParam)
- [x] Existing collision tests (`input_{buffer,param,generator_buffer}_func_name_collision`, `input_func_name_unique`) still pass
- [x] Full `ctest -L correctness` suite passes (remaining failures are pre-existing, unrelated `numpy`-missing errors in Python binding tests)