### PR TITLE
validate paired array lengths in pipeline deserializer

### DIFF
--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -942,6 +942,7 @@ std::vector<Expr> Deserializer::deserialize_expr_vector(const flatbuffers::Vecto
                                                         const flatbuffers::Vector<flatbuffers::Offset<void>> *exprs_serialized) {
     user_assert(exprs_types != nullptr);
     user_assert(exprs_serialized != nullptr);
+    user_assert(exprs_types->size() == exprs_serialized->size()) << "malformed pipeline: expression type and value counts do not match\n";
     std::vector<Expr> result;
     result.reserve(exprs_serialized->size());
     for (size_t i = 0; i < exprs_serialized->size(); ++i) {
@@ -1163,6 +1164,7 @@ FuseLoopLevel Deserializer::deserialize_fuse_loop_level(const Serialize::FuseLoo
     for (const auto &align_strategy : *fuse_loop_level->align_strategies()) {
         align_strategies.push_back(deserialize_loop_align_strategy((Serialize::LoopAlignStrategy)align_strategy));
     }
+    user_assert(align_dimension_names.size() == align_strategies.size()) << "malformed pipeline: fused loop level dimension and strategy counts do not match\n";
     std::map<std::string, LoopAlignStrategy> align;
     for (size_t i = 0; i < align_dimension_names.size(); ++i) {
         align[align_dimension_names[i]] = align_strategies[i];
@@ -1311,6 +1313,7 @@ Buffer<> Deserializer::deserialize_buffer(const Serialize::Buffer *buffer) {
     const std::string name = deserialize_string(buffer->name());
     const auto type = deserialize_type(buffer->type());
     const int32_t dimensions = buffer->dimensions();
+    user_assert(dimensions >= 0 && (size_t)dimensions <= buffer->dims()->size()) << "malformed pipeline: buffer dimension count does not match the serialized dimensions\n";
     std::vector<halide_dimension_t> hl_buffer_dimensions;
     std::vector<halide_dimension_t> dense_buffer_dimensions;
     hl_buffer_dimensions.reserve(dimensions);
@@ -1468,6 +1471,7 @@ Pipeline Deserializer::deserialize(const std::vector<uint8_t> &data) {
     }
 
     std::vector<Func> funcs;
+    user_assert(pipeline_obj->funcs()->size() == functions.size()) << "malformed pipeline: serialized function count does not match the number of function names\n";
     for (size_t i = 0; i < pipeline_obj->funcs()->size(); ++i) {
         deserialize_function(pipeline_obj->funcs()->Get(i), functions[i]);
         funcs.emplace_back(functions[i]);
@@ -1487,6 +1491,7 @@ Pipeline Deserializer::deserialize(const std::vector<uint8_t> &data) {
 
     const auto *requirements_objs = pipeline_obj->requirements();
     const auto *requirement_type_objs = pipeline_obj->requirements_type();
+    user_assert(requirements_objs->size() == requirement_type_objs->size()) << "malformed pipeline: requirement type and value counts do not match\n";
 
     std::vector<Stmt> requirements;
     requirements.reserve(requirements_objs->size());


### PR DESCRIPTION
Malformed pipeline input can drive an out-of-bounds access in the deserializer, which runs no verifier on the incoming buffer (GetPipeline just casts the bytes).

- Several loops index one serialized array by another array's length without checking they match; the serializer writes each pair in lockstep, so valid `.hlpipe` files are fine, but a crafted file can declare mismatched counts
- The funcs loop is the worst case: `functions[]` is sized from `func_names_in_order`, while the loop bound is the independent `funcs()` vector length, so a larger func count hands `deserialize_function` an out-of-bounds `Function` reference that `update_with_deserialization` then writes into
- `deserialize_expr_vector` (expr types vs values), the requirements loop (type vs value), `deserialize_fuse_loop_level` (dimension names vs strategies), and `deserialize_buffer` (dimensions scalar vs `dims()` length) share the same shape
- Each site now checks the lengths agree, so a mismatch is rejected with a clear error instead of indexing past the end

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
