### PR TITLE
check serialized vector lengths before indexing in deserializer

### DIFF
--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -942,6 +942,9 @@ std::vector<Expr> Deserializer::deserialize_expr_vector(const flatbuffers::Vecto
                                                         const flatbuffers::Vector<flatbuffers::Offset<void>> *exprs_serialized) {
     user_assert(exprs_types != nullptr);
     user_assert(exprs_serialized != nullptr);
+    user_assert(exprs_types->size() == exprs_serialized->size())
+        << "deserialized expr vector carries " << exprs_serialized->size()
+        << " exprs, but " << exprs_types->size() << " type codes\n";
     std::vector<Expr> result;
     result.reserve(exprs_serialized->size());
     for (size_t i = 0; i < exprs_serialized->size(); ++i) {
@@ -1163,6 +1166,9 @@ FuseLoopLevel Deserializer::deserialize_fuse_loop_level(const Serialize::FuseLoo
     for (const auto &align_strategy : *fuse_loop_level->align_strategies()) {
         align_strategies.push_back(deserialize_loop_align_strategy((Serialize::LoopAlignStrategy)align_strategy));
     }
+    user_assert(align_dimension_names.size() == align_strategies.size())
+        << "deserialized fuse loop level carries " << align_dimension_names.size()
+        << " align dimension names, but " << align_strategies.size() << " align strategies\n";
     std::map<std::string, LoopAlignStrategy> align;
     for (size_t i = 0; i < align_dimension_names.size(); ++i) {
         align[align_dimension_names[i]] = align_strategies[i];
@@ -1311,6 +1317,10 @@ Buffer<> Deserializer::deserialize_buffer(const Serialize::Buffer *buffer) {
     const std::string name = deserialize_string(buffer->name());
     const auto type = deserialize_type(buffer->type());
     const int32_t dimensions = buffer->dimensions();
+    user_assert(buffer->dims() != nullptr) << "deserialized buffer " << name << " has no dims\n";
+    user_assert(dimensions >= 0 && (size_t)dimensions == buffer->dims()->size())
+        << "deserialized buffer " << name << " declares " << dimensions
+        << " dimensions, but carries " << buffer->dims()->size() << " of them\n";
     std::vector<halide_dimension_t> hl_buffer_dimensions;
     std::vector<halide_dimension_t> dense_buffer_dimensions;
     hl_buffer_dimensions.reserve(dimensions);
@@ -1473,6 +1483,10 @@ Pipeline Deserializer::deserialize(const std::vector<uint8_t> &data) {
     }
 
     std::vector<Func> funcs;
+    user_assert(pipeline_obj->funcs() != nullptr) << "deserialized pipeline has no funcs\n";
+    user_assert(pipeline_obj->funcs()->size() == functions.size())
+        << "deserialized pipeline carries " << pipeline_obj->funcs()->size()
+        << " funcs, but " << functions.size() << " func names\n";
     for (size_t i = 0; i < pipeline_obj->funcs()->size(); ++i) {
         deserialize_function(pipeline_obj->funcs()->Get(i), functions[i]);
         funcs.emplace_back(functions[i]);


### PR DESCRIPTION
the deserializer takes a length from one field of the .hlpipe flatbuffer and applies it as an index into a different, independently sized one, and nothing runs a flatbuffers verifier over the input first. deserialize_expr_vector walks exprs_serialized while indexing exprs_types, deserialize_fuse_loop_level walks align_dimension_names while indexing align_strategies, deserialize_buffer loops to the scalar dimensions field while indexing dims, and deserialize walks funcs while indexing functions, which is sized from func_names_in_order. flatbuffers::Vector::Get only guards with FLATBUFFERS_ASSERT, which is plain assert() and compiles out under NDEBUG, so a file that disagrees with itself reads past the vector and treats the bytes that follow as a relative table offset; a buffer declaring dimensions=3 while carrying a single dim faults inside BufferDimension::min() under asan, and the align_strategies case is a straight heap overread. the serializer writes each of these pairs in lockstep, so requiring them to agree only rejects input that was already malformed.

the generated schema header is private to the Halide target and serialization is behind an optional flag, so there's no natural home for a malformed-file test in test/error; #9208 landed the same shape of check in the same file without one.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
