### PR TITLE
reject non-positive extents in load_npy and load_mat

### DIFF
--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -294,6 +294,76 @@ void test_read_big_endian_row_channel_offset() {
     }
 }
 
+// A negative extent in the header makes size_in_bytes() exceed the
+// allocation, so the payload read runs off the end of the buffer.
+void test_negative_extents() {
+    const auto write_file = [](const std::string &filename, const std::vector<uint8_t> &bytes) {
+        std::ofstream fs(filename.c_str(), std::ofstream::binary);
+        fs.write((const char *)bytes.data(), bytes.size());
+        fs.close();
+    };
+    const auto append32 = [](std::vector<uint8_t> &bytes, uint32_t value) {
+        for (int i = 0; i < 4; i++) {
+            bytes.push_back((uint8_t)(value >> (8 * i)));
+        }
+    };
+
+    {
+        // .npy with a shape of (2, -3)
+        std::string dict = "{'descr': '<i4', 'fortran_order': False, 'shape': (2, -3), }";
+        while ((6 + 2 + 2 + dict.size()) % 64 != 0) {
+            dict += ' ';
+        }
+        std::vector<uint8_t> bytes = {0x93, 'N', 'U', 'M', 'P', 'Y', 1, 0};
+        bytes.push_back((uint8_t)(dict.size() & 0xff));
+        bytes.push_back((uint8_t)((dict.size() >> 8) & 0xff));
+        bytes.insert(bytes.end(), dict.begin(), dict.end());
+        bytes.resize(bytes.size() + 16, 0);
+
+        std::ostringstream o;
+        o << Internal::get_test_tmp_dir() << "test_negative_extents.npy";
+        std::string filename = o.str();
+        write_file(filename, bytes);
+
+        Buffer<> buf;
+        if (Tools::load<Buffer<>, Tools::Internal::CheckReturn>(filename, &buf)) {
+            std::cout << "Loaded " << filename << " despite a negative extent\n";
+            exit(1);
+        }
+    }
+
+    {
+        // .mat with extents of (4, -4)
+        std::vector<uint8_t> bytes(128, 0);
+        append32(bytes, Tools::Internal::miMATRIX);
+        append32(bytes, 64);
+        append32(bytes, Tools::Internal::miUINT32);
+        append32(bytes, 8);
+        append32(bytes, Tools::Internal::miUINT8);
+        append32(bytes, 1);
+        append32(bytes, Tools::Internal::miINT32);
+        append32(bytes, 8);
+        append32(bytes, 4);
+        append32(bytes, (uint32_t)-4);
+        append32(bytes, Tools::Internal::miINT8);
+        append32(bytes, 0);
+        append32(bytes, Tools::Internal::miUINT8);
+        append32(bytes, 16);
+        bytes.resize(bytes.size() + 16, 0);
+
+        std::ostringstream o;
+        o << Internal::get_test_tmp_dir() << "test_negative_extents.mat";
+        std::string filename = o.str();
+        write_file(filename, bytes);
+
+        Buffer<> buf;
+        if (Tools::load<Buffer<>, Tools::Internal::CheckReturn>(filename, &buf)) {
+            std::cout << "Loaded " << filename << " despite a negative extent\n";
+            exit(1);
+        }
+    }
+}
+
 #ifndef HALIDE_NO_PNG
 void test_png_unsupported_bit_depth() {
     // A 1-bit grayscale PNG is a valid file, but load_png only supports 8- and
@@ -355,6 +425,7 @@ int main(int argc, char **argv) {
 #ifndef HALIDE_NO_PNG
     test_png_unsupported_bit_depth();
 #endif
+    test_negative_extents();
     printf("Success!\n");
     return 0;
 }

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -1347,6 +1347,12 @@ bool load_npy(const std::string &filename, ImageType *im) {
         return false;
     }
 
+    for (const int extent : h.extents) {
+        if (!check(extent > 0, "Bad extent in .npy file")) {
+            return false;
+        }
+    }
+
     halide_type_t im_type((halide_type_code_t)0, 0);
     for (const auto &d : npy_dtypes) {
         if (h.type_code == d.second.type_code && h.type_bytes == d.second.type_bytes) {
@@ -1787,6 +1793,12 @@ bool load_mat(const std::string &filename, ImageType *im) {
     if (dims & 1) {
         uint32_t padding;
         if (!check(f.read_bytes(&padding, 4), "Could not read .mat header\n")) {
+            return false;
+        }
+    }
+
+    for (const int extent : extents) {
+        if (!check(extent > 0, "Bad extent in .mat file\n")) {
             return false;
         }
     }


### PR DESCRIPTION
`load_npy` and `load_mat` build the output buffer straight from the extents in the file header without checking their sign, then read the payload with `f.read_bytes(im->begin(), im->size_in_bytes())`. A negative extent makes the computed `end()` fall short of the real end of the allocation, so `size_in_bytes()` reports more than was allocated and the payload read writes past the heap block; `Buffer::check_overflow` only catches this under `assert`, which is gone in a release build. `load_tmp` already validates `header[0..3] > 0` for the same reason, so this applies that check in the two loaders that were missing it.

Reproducer: a `.npy` with `'shape': (2, -3)` and a `.mat` with extents `(4, -4)`, both built in the new test. On the unpatched tree, compiled `-O2 -DNDEBUG -fsanitize=address`, each gives a heap-buffer-overflow write at `halide_image_io.h:1367` (npy) and `:1861` (mat); the test aborts. With the fix both are rejected and the existing round-trip tests are unaffected.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)
