### PR TITLE
Fix conform request in the Vulkan memory allocator to avoid rounding up on subsequent passes.

### DIFF
--- a/src/runtime/internal/memory_resources.h
+++ b/src/runtime/internal/memory_resources.h
@@ -161,6 +161,30 @@ ALWAYS_INLINE size_t conform_size(size_t offset, size_t size, size_t alignment, 
     }
 }
 
+// Updates request with conformed alignment, offset and size, computed from the given required size and alignment constraints,
+// rounding up to the nearest multiple if specified. The request is updated in-place.
+// -- Required alignment must be power of two!
+ALWAYS_INLINE void conform_memory_request(MemoryRequest *request, size_t required_size, size_t required_alignment, size_t nearest_multiple) {
+    size_t actual_alignment = conform_alignment(request->alignment, required_alignment);
+
+    // Ensure the request ends on an aligned address.
+    // NOTE: use the conformed alignment and not the input alignment. Otherwise, conform is not idempotent:
+    // A first pass that uses the original nearest_multiple writes a new alignment such that a subsequent pass
+    // sees a larger alignment and writes a larger nearest_multiple, which results in a larger size calculated
+    // in the second pass. The block allocator requires that conform is idempotent because it calls conform
+    // defensively several times at different layers.
+    if (actual_alignment > nearest_multiple) {
+        request->properties.nearest_multiple = actual_alignment;
+    }
+
+    size_t actual_offset = aligned_offset(request->offset, actual_alignment);
+    size_t actual_size = conform_size(actual_offset, required_size, actual_alignment, request->properties.nearest_multiple);
+
+    request->size = actual_size;
+    request->alignment = actual_alignment;
+    request->offset = actual_offset;
+}
+
 // Clamps the given value to be within the [min_value, max_value] range
 ALWAYS_INLINE size_t clamped_size(size_t value, size_t min_value, size_t max_value) {
     size_t result = (value < min_value) ? min_value : value;

--- a/src/runtime/internal/region_allocator.h
+++ b/src/runtime/internal/region_allocator.h
@@ -329,7 +329,7 @@ BlockRegion *RegionAllocator::find_block_region(void *user_context, const Memory
             debug(user_context) << "RegionAllocator: found suitable region ( "
                                 << "user_context=" << (void *)(user_context) << " "
                                 << "block_resource=" << (void *)block << " "
-                                << "block_size=" << (uint32_t)block->memory.allocation.size << " "
+                                << "block_size=" << (uint32_t)block->memory.size << " "
                                 << "block_reserved=" << (uint32_t)block->reserved << " "
                                 << "requested_size=" << (uint32_t)request.size << " "
                                 << "requested_is_dedicated=" << (request.dedicated ? "true" : "false") << " "

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -136,8 +136,6 @@ private:
 
     int lookup_requirements(void *user_context, size_t size, uint32_t usage_flags, VkMemoryRequirements *memory_requirements);
 
-    int conform_request(MemoryRequest *request, VkMemoryRequirements *memory_requirements);
-
     size_t block_byte_count = 0;
     size_t block_count = 0;
     size_t region_byte_count = 0;
@@ -578,39 +576,6 @@ int VulkanMemoryAllocator::lookup_requirements(void *user_context, size_t size, 
     vkDestroyBuffer(this->device, buffer, this->alloc_callbacks);
     return halide_error_code_success;
 }
-int VulkanMemoryAllocator::conform_request(MemoryRequest *request, VkMemoryRequirements *memory_requirements) {
-    size_t actual_alignment = conform_alignment(request->alignment, memory_requirements->alignment);
-
-    // Ensure the request ends on an aligned address.
-    // NOTE: use the conformed alignment and not the input alignment. Otherwise, conform is not idempotent:
-    // A first pass that uses the original nearest_multiple writes a new alignment such that a subsequent pass
-    // sees a larger alignment and writes a larger nearest_multiple, which results in a larger size calculated
-    // in the second pass. The block allocator requires that conform is idempotent because it calls conform
-    // defensively several times at different layers.
-    if (actual_alignment > config.nearest_multiple) {
-        request->properties.nearest_multiple = actual_alignment;
-    }
-
-    size_t actual_offset = aligned_offset(request->offset, actual_alignment);
-    size_t actual_size = conform_size(actual_offset, memory_requirements->size, actual_alignment, request->properties.nearest_multiple);
-
-#if defined(HL_VK_DEBUG_MEM)
-    if ((request->size != actual_size) || (request->alignment != actual_alignment) || (request->offset != actual_offset)) {
-        debug(nullptr) << "VulkanMemoryAllocator: Adjusting request to match requirements (\n"
-                       << "  size = " << (uint64_t)request->size << " => " << (uint64_t)actual_size << ",\n"
-                       << "  alignment = " << (uint64_t)request->alignment << " => " << (uint64_t)actual_alignment << ",\n"
-                       << "  offset = " << (uint64_t)request->offset << " => " << (uint64_t)actual_offset << ",\n"
-                       << "  required.size = " << (uint64_t)memory_requirements->size << ",\n"
-                       << "  required.alignment = " << (uint64_t)memory_requirements->alignment << "\n)\n";
-    }
-#endif
-    request->size = actual_size;
-    request->alignment = actual_alignment;
-    request->offset = actual_offset;
-
-    return halide_error_code_success;
-}
-
 
 int VulkanMemoryAllocator::conform_block_request(void *instance_ptr, MemoryRequest *request) {
 
@@ -647,11 +612,25 @@ int VulkanMemoryAllocator::conform_block_request(void *instance_ptr, MemoryReque
                    << "uniform_buffer_offset_alignment=" << (uint32_t)instance->physical_device_limits.minUniformBufferOffsetAlignment << ", "
                    << "storage_buffer_offset_alignment=" << (uint32_t)instance->physical_device_limits.minStorageBufferOffsetAlignment << ", "
                    << "dedicated=" << (request->dedicated ? "true" : "false") << ")\n";
+
+    const MemoryRequest original_request = *request;
 #endif
 
     request->properties.alignment = memory_requirements.alignment;
+    conform_memory_request(request, memory_requirements.size, memory_requirements.alignment, instance->config.nearest_multiple);
 
-    return instance->conform_request(request, &memory_requirements);
+#if defined(HL_VK_DEBUG_MEM)
+    if ((request->size != original_request.size) || (request->alignment != original_request.alignment) || (request->offset != original_request.offset)) {
+        debug(nullptr) << "VulkanMemoryAllocator: Adjusting request to match requirements (\n"
+                       << "  size = " << (uint64_t)original_request.size << " => " << (uint64_t)request->size << ",\n"
+                       << "  alignment = " << (uint64_t)original_request.alignment << " => " << (uint64_t)request->alignment << ",\n"
+                       << "  offset = " << (uint64_t)original_request.offset << " => " << (uint64_t)request->offset << ",\n"
+                       << "  required.size = " << (uint64_t)memory_requirements.size << ",\n"
+                       << "  required.alignment = " << (uint64_t)memory_requirements.alignment << "\n)\n";
+    }
+#endif
+
+    return halide_error_code_success;
 }
 
 int VulkanMemoryAllocator::allocate_block(void *instance_ptr, MemoryBlock *block) {
@@ -1041,7 +1020,24 @@ int VulkanMemoryAllocator::conform(void *user_context, MemoryRequest *request) {
         }
     }
 
-    return conform_request(request, &memory_requirements);
+#if defined(HL_VK_DEBUG_MEM)
+    const MemoryRequest original_request = *request;
+#endif
+
+    conform_memory_request(request, memory_requirements.size, memory_requirements.alignment, config.nearest_multiple);
+
+#if defined(HL_VK_DEBUG_MEM)
+    if ((request->size != original_request.size) || (request->alignment != original_request.alignment) || (request->offset != original_request.offset)) {
+        debug(nullptr) << "VulkanMemoryAllocator: Adjusting request to match requirements (\n"
+                       << "  size = " << (uint64_t)original_request.size << " => " << (uint64_t)request->size << ",\n"
+                       << "  alignment = " << (uint64_t)original_request.alignment << " => " << (uint64_t)request->alignment << ",\n"
+                       << "  offset = " << (uint64_t)original_request.offset << " => " << (uint64_t)request->offset << ",\n"
+                       << "  required.size = " << (uint64_t)memory_requirements.size << ",\n"
+                       << "  required.alignment = " << (uint64_t)memory_requirements.alignment << "\n)\n";
+    }
+#endif
+
+    return halide_error_code_success;
 }
 
 int VulkanMemoryAllocator::conform_region_request(void *instance_ptr, MemoryRequest *request) {

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -1006,12 +1006,18 @@ int VulkanMemoryAllocator::conform(void *user_context, MemoryRequest *request) {
         }
     }
 
-    // Ensure the request ends on an aligned address
-    if (request->alignment > config.nearest_multiple) {
-        request->properties.nearest_multiple = request->alignment;
+    size_t actual_alignment = conform_alignment(request->alignment, memory_requirements.alignment);
+
+    // Ensure the request ends on an aligned address.
+    // NOTE: use the conformed alignment and not the input alignment. Otherwise, conform is not idempotent:
+    // A first pass that uses the original nearest_multiple writes a new alignment such that a subsequent pass
+    // sees a larger alignment and writes a larger nearest_multiple, which results in a larger size calculated
+    // in the second pass. The block allocator requires that conform is idempotent because it calls conform
+    // defensively several times at different layers.
+    if (actual_alignment > config.nearest_multiple) {
+        request->properties.nearest_multiple = actual_alignment;
     }
 
-    size_t actual_alignment = conform_alignment(request->alignment, memory_requirements.alignment);
     size_t actual_offset = aligned_offset(request->offset, actual_alignment);
     size_t actual_size = conform_size(actual_offset, memory_requirements.size, actual_alignment, request->properties.nearest_multiple);
 

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -641,12 +641,12 @@ int VulkanMemoryAllocator::allocate_block(void *instance_ptr, MemoryBlock *block
 
     void *user_context = instance->owner_context;
     if ((instance->device == nullptr) || (instance->physical_device == nullptr)) {
-        error(user_context) << "VulkanBlockAllocator: Unable to deallocate block! Invalid device handle!\n";
+        error(user_context) << "VulkanBlockAllocator: Unable to allocate block! Invalid device handle!\n";
         return halide_error_code_internal_error;
     }
 
     if (block == nullptr) {
-        error(user_context) << "VulkanBlockAllocator: Unable to deallocate block! Invalid pointer!\n";
+        error(user_context) << "VulkanBlockAllocator: Unable to allocate block! Invalid pointer!\n";
         return halide_error_code_internal_error;
     }
 

--- a/src/runtime/vulkan_memory.h
+++ b/src/runtime/vulkan_memory.h
@@ -136,6 +136,8 @@ private:
 
     int lookup_requirements(void *user_context, size_t size, uint32_t usage_flags, VkMemoryRequirements *memory_requirements);
 
+    int conform_request(MemoryRequest *request, VkMemoryRequirements *memory_requirements);
+
     size_t block_byte_count = 0;
     size_t block_count = 0;
     size_t region_byte_count = 0;
@@ -576,6 +578,39 @@ int VulkanMemoryAllocator::lookup_requirements(void *user_context, size_t size, 
     vkDestroyBuffer(this->device, buffer, this->alloc_callbacks);
     return halide_error_code_success;
 }
+int VulkanMemoryAllocator::conform_request(MemoryRequest *request, VkMemoryRequirements *memory_requirements) {
+    size_t actual_alignment = conform_alignment(request->alignment, memory_requirements->alignment);
+
+    // Ensure the request ends on an aligned address.
+    // NOTE: use the conformed alignment and not the input alignment. Otherwise, conform is not idempotent:
+    // A first pass that uses the original nearest_multiple writes a new alignment such that a subsequent pass
+    // sees a larger alignment and writes a larger nearest_multiple, which results in a larger size calculated
+    // in the second pass. The block allocator requires that conform is idempotent because it calls conform
+    // defensively several times at different layers.
+    if (actual_alignment > config.nearest_multiple) {
+        request->properties.nearest_multiple = actual_alignment;
+    }
+
+    size_t actual_offset = aligned_offset(request->offset, actual_alignment);
+    size_t actual_size = conform_size(actual_offset, memory_requirements->size, actual_alignment, request->properties.nearest_multiple);
+
+#if defined(HL_VK_DEBUG_MEM)
+    if ((request->size != actual_size) || (request->alignment != actual_alignment) || (request->offset != actual_offset)) {
+        debug(nullptr) << "VulkanMemoryAllocator: Adjusting request to match requirements (\n"
+                       << "  size = " << (uint64_t)request->size << " => " << (uint64_t)actual_size << ",\n"
+                       << "  alignment = " << (uint64_t)request->alignment << " => " << (uint64_t)actual_alignment << ",\n"
+                       << "  offset = " << (uint64_t)request->offset << " => " << (uint64_t)actual_offset << ",\n"
+                       << "  required.size = " << (uint64_t)memory_requirements->size << ",\n"
+                       << "  required.alignment = " << (uint64_t)memory_requirements->alignment << "\n)\n";
+    }
+#endif
+    request->size = actual_size;
+    request->alignment = actual_alignment;
+    request->offset = actual_offset;
+
+    return halide_error_code_success;
+}
+
 
 int VulkanMemoryAllocator::conform_block_request(void *instance_ptr, MemoryRequest *request) {
 
@@ -614,9 +649,9 @@ int VulkanMemoryAllocator::conform_block_request(void *instance_ptr, MemoryReque
                    << "dedicated=" << (request->dedicated ? "true" : "false") << ")\n";
 #endif
 
-    request->size = memory_requirements.size;
     request->properties.alignment = memory_requirements.alignment;
-    return halide_error_code_success;
+
+    return instance->conform_request(request, &memory_requirements);
 }
 
 int VulkanMemoryAllocator::allocate_block(void *instance_ptr, MemoryBlock *block) {
@@ -1006,36 +1041,7 @@ int VulkanMemoryAllocator::conform(void *user_context, MemoryRequest *request) {
         }
     }
 
-    size_t actual_alignment = conform_alignment(request->alignment, memory_requirements.alignment);
-
-    // Ensure the request ends on an aligned address.
-    // NOTE: use the conformed alignment and not the input alignment. Otherwise, conform is not idempotent:
-    // A first pass that uses the original nearest_multiple writes a new alignment such that a subsequent pass
-    // sees a larger alignment and writes a larger nearest_multiple, which results in a larger size calculated
-    // in the second pass. The block allocator requires that conform is idempotent because it calls conform
-    // defensively several times at different layers.
-    if (actual_alignment > config.nearest_multiple) {
-        request->properties.nearest_multiple = actual_alignment;
-    }
-
-    size_t actual_offset = aligned_offset(request->offset, actual_alignment);
-    size_t actual_size = conform_size(actual_offset, memory_requirements.size, actual_alignment, request->properties.nearest_multiple);
-
-#if defined(HL_VK_DEBUG_MEM)
-    if ((request->size != actual_size) || (request->alignment != actual_alignment) || (request->offset != actual_offset)) {
-        debug(nullptr) << "VulkanMemoryAllocator: Adjusting request to match requirements (\n"
-                       << "  size = " << (uint64_t)request->size << " => " << (uint64_t)actual_size << ",\n"
-                       << "  alignment = " << (uint64_t)request->alignment << " => " << (uint64_t)actual_alignment << ",\n"
-                       << "  offset = " << (uint64_t)request->offset << " => " << (uint64_t)actual_offset << ",\n"
-                       << "  required.size = " << (uint64_t)memory_requirements.size << ",\n"
-                       << "  required.alignment = " << (uint64_t)memory_requirements.alignment << "\n)\n";
-    }
-#endif
-    request->size = actual_size;
-    request->alignment = actual_alignment;
-    request->offset = actual_offset;
-
-    return halide_error_code_success;
+    return conform_request(request, &memory_requirements);
 }
 
 int VulkanMemoryAllocator::conform_region_request(void *instance_ptr, MemoryRequest *request) {

--- a/test/runtime/block_allocator.cpp
+++ b/test/runtime/block_allocator.cpp
@@ -460,6 +460,70 @@ int main(int argc, char **argv) {
             }
         }
 
+        // test conform_memory_request
+        {
+            // conform_memory_request must be idempotent: the block allocator conforms
+            // requests defensively at several layers, feeding an already-conformed
+            // request back in. Restrict the sweep to request alignments that do not
+            // exceed the required alignment (both powers of two) so the conformed
+            // alignment stays a power of two and aligned_offset does not abort.
+            for (size_t required_alignment = 1; required_alignment <= 128; required_alignment *= 2) {
+                for (size_t nearest_multiple = 0; nearest_multiple <= 64; nearest_multiple = nearest_multiple ? nearest_multiple * 2 : 1) {
+                    for (size_t request_alignment = 0; request_alignment <= required_alignment; request_alignment = request_alignment ? request_alignment * 2 : 1) {
+                        for (size_t required_size = 1; required_size <= 100; ++required_size) {
+                            for (size_t offset = 0; offset <= 64; offset += 16) {
+                                MemoryRequest request = {0};
+                                request.offset = offset;
+                                request.alignment = request_alignment;
+
+                                conform_memory_request(&request, required_size, required_alignment, nearest_multiple);
+                                MemoryRequest conformed = request;
+
+                                conform_memory_request(&request, required_size, required_alignment, nearest_multiple);
+
+                                halide_abort_if_false(user_context, request.size == conformed.size);
+                                halide_abort_if_false(user_context, request.alignment == conformed.alignment);
+                                halide_abort_if_false(user_context, request.offset == conformed.offset);
+                                halide_abort_if_false(user_context, request.properties.nearest_multiple == conformed.properties.nearest_multiple);
+
+                                halide_abort_if_false(user_context, conformed.size >= required_size);
+                                halide_abort_if_false(user_context, conformed.size >= conformed.alignment);
+                                halide_abort_if_false(user_context, conformed.alignment == conform_alignment(request_alignment, required_alignment));
+                                halide_abort_if_false(user_context, conformed.offset == aligned_offset(offset, conformed.alignment));
+                                halide_abort_if_false(user_context, (conformed.offset % conformed.alignment) == 0);
+                                if (conformed.properties.nearest_multiple > 0) {
+                                    halide_abort_if_false(user_context, (conformed.size % conformed.properties.nearest_multiple) == 0);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Regression scenarios from the vulkan allocator fixes (Mesa lavapipe/RADV
+            // reporting 64-byte buffer alignment): a buffer whose size is a multiple of
+            // the config nearest_multiple but not of the device alignment must round up
+            // to the device alignment and stay stable across repeated conforms.
+            size_t regression_required_size[2] = {96, 9338976};
+            size_t regression_required_alignment[2] = {64, 64};
+            size_t regression_nearest_multiple[2] = {32, 32};
+            for (int i = 0; i < 2; ++i) {
+                MemoryRequest request = {0};
+
+                conform_memory_request(&request, regression_required_size[i], regression_required_alignment[i], regression_nearest_multiple[i]);
+                MemoryRequest conformed = request;
+
+                conform_memory_request(&request, regression_required_size[i], regression_required_alignment[i], regression_nearest_multiple[i]);
+
+                halide_abort_if_false(user_context, conformed.size >= regression_required_size[i]);
+                halide_abort_if_false(user_context, (conformed.size % regression_required_alignment[i]) == 0);
+                halide_abort_if_false(user_context, request.size == conformed.size);
+                halide_abort_if_false(user_context, request.alignment == conformed.alignment);
+                halide_abort_if_false(user_context, request.offset == conformed.offset);
+                halide_abort_if_false(user_context, request.properties.nearest_multiple == conformed.properties.nearest_multiple);
+            }
+        }
+
         BlockAllocator::destroy(user_context, instance);
         HALIDE_CHECK(user_context, get_allocated_system_memory() == 0);
     }


### PR DESCRIPTION
<!-- Describe your changes and the motivation behind them. -->

This PR fixes two bugs in the vulkan memory allocator, both related to conform. I ran into these issues when testing out the Vulkan backend with Mesa (llvmpipe / RADV).

I did not add any tests because I could not see any existing tests for the Vulkan-specific runtime internals, and coming up with a test strategy for this is not something I feel prepared to do at this point since I'm new to the project.

I used Claude to help root-cause the bugs and then implemented the fixes myself.

Fixes #8868 

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [X] Commits include AI attribution where applicable (see Code of Conduct)
