### PR TITLE
reject unsupported bit depths in load_png

### DIFF
--- a/test/correctness/image_io.cpp
+++ b/test/correctness/image_io.cpp
@@ -294,6 +294,48 @@ void test_read_big_endian_row_channel_offset() {
     }
 }
 
+#ifndef HALIDE_NO_PNG
+void test_png_unsupported_bit_depth() {
+    // A 1-bit grayscale PNG is a valid file, but load_png only supports 8- and
+    // 16-bit samples. Before the fix it selected the 16-bit row reader and read
+    // past the packed row buffer; now it should reject the file cleanly.
+    std::ostringstream o;
+    o << Internal::get_test_tmp_dir() << "test_1bit.png";
+    std::string filename = o.str();
+
+    const int width = 64, height = 8;
+    FILE *fp = fopen(filename.c_str(), "wb");
+    if (!fp) {
+        std::cout << "Cannot write " << filename << "\n";
+        exit(1);
+    }
+    png_structp png = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+    png_infop info = png_create_info_struct(png);
+    if (setjmp(png_jmpbuf(png))) {
+        std::cout << "Failed to write " << filename << "\n";
+        exit(1);
+    }
+    png_init_io(png, fp);
+    png_set_IHDR(png, info, width, height, 1, PNG_COLOR_TYPE_GRAY,
+                 PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_BASE, PNG_FILTER_TYPE_BASE);
+    png_write_info(png, info);
+    std::vector<uint8_t> row((width + 7) / 8, 0xaa);
+    for (int y = 0; y < height; y++) {
+        png_write_row(png, row.data());
+    }
+    png_write_end(png, nullptr);
+    png_destroy_write_struct(&png, &info);
+    fclose(fp);
+
+    Halide::Runtime::Buffer<> img;
+    bool loaded = Tools::load<Halide::Runtime::Buffer<>, Tools::Internal::CheckReturn>(filename, &img);
+    if (loaded) {
+        std::cout << "Expected loading a 1-bit PNG to fail, but it succeeded\n";
+        exit(1);
+    }
+}
+#endif
+
 int main(int argc, char **argv) {
     do_test<int8_t>();
     do_test<int16_t>();
@@ -310,6 +352,9 @@ int main(int argc, char **argv) {
     do_test<double>();
     test_mat_header();
     test_read_big_endian_row_channel_offset();
+#ifndef HALIDE_NO_PNG
+    test_png_unsupported_bit_depth();
+#endif
     printf("Success!\n");
     return 0;
 }

--- a/tools/halide_image_io.h
+++ b/tools/halide_image_io.h
@@ -905,6 +905,14 @@ bool load_png(const std::string &filename, ImageType *im) {
     const int channels = png_get_channels(png_ptr, info_ptr);
     const int bit_depth = png_get_bit_depth(png_ptr, info_ptr);
 
+    // Only 8- and 16-bit samples map to a supported buffer type. Sub-byte
+    // depths (1/2/4) keep a packed row layout, but the row reader below is
+    // selected as 16-bit for anything that isn't 8-bit, so it would read past
+    // the packed row and write past the buffer. Reject them here.
+    if (!check(bit_depth == 8 || bit_depth == 16, "Unsupported PNG bit depth")) {
+        return false;
+    }
+
     const halide_type_t im_type(halide_type_uint, bit_depth);
     std::vector<int> im_dimensions = {width, height};
     if (channels != 1) {


### PR DESCRIPTION
load_png picks the row reader from bit depth without checking it is one the loader actually supports:

- libpng reports bit_depth 1/2/4 for sub-byte grayscale and palette PNGs and keeps a packed row, so png_get_rowbytes() is only ceil(width*bit_depth/8) bytes
- anything that is not 8-bit takes the read_big_endian_row<uint16_t> path, which reads 2 bytes per pixel past the packed row buffer and stores 16-bit samples into a buffer whose element size is 1 byte for the 1-bit halide type
- reachable from any caller that loads an untrusted PNG; ASAN flags a heap-buffer-overflow read in read_big_endian on a 1-bit file

Reject bit depths other than 8 or 16 up front, which is what query_png() already advertises, so valid 8- and 16-bit files are unchanged. Added a regression test that writes a 1-bit PNG and checks the load returns false instead of running off the row.