### PR TITLE
validate trace packet payload layout before using its accessors

### DIFF
--- a/util/HalideTraceUtils.cpp
+++ b/util/HalideTraceUtils.cpp
@@ -16,6 +16,10 @@ bool Packet::read_from_filedesc(FILE *fdesc) {
     if (!Packet::read(this, header_size, fdesc)) {
         return false;
     }
+    if (size < header_size) {
+        fprintf(stderr, "Packet smaller than the header in trace stream (%d)\n", (int)size);
+        return false;
+    }
     size_t payload_size = size - header_size;
     if (payload_size > sizeof(payload)) {
         fprintf(stderr, "Payload larger than %d bytes in trace stream (%d)\n", (int)sizeof(payload), (int)payload_size);
@@ -25,6 +29,37 @@ bool Packet::read_from_filedesc(FILE *fdesc) {
     if (!Packet::read(payload, payload_size, fdesc)) {
         fprintf(stderr, "Unexpected EOF mid-packet");
         return false;
+    }
+    if (!validate_payload(payload_size)) {
+        fprintf(stderr, "Malformed packet in trace stream\n");
+        return false;
+    }
+    return true;
+}
+
+bool Packet::validate_payload(size_t payload_size) const {
+    // dimensions, lanes and the type all come from the stream, and together
+    // they say where the coordinates, the value, the func name and the trace
+    // tag live in the payload. Check that layout fits in the bytes we read
+    // before any of the accessors hand out a pointer into it.
+    if (dimensions < 0) {
+        return false;
+    }
+    size_t used = (size_t)dimensions * sizeof(int32_t) + value_bytes();
+    if (used > payload_size) {
+        return false;
+    }
+    // The func name and the trace tag follow the value, and both must be
+    // nul-terminated within the payload.
+    const uint8_t *p = payload + used;
+    size_t remaining = payload_size - used;
+    for (int i = 0; i < 2; i++) {
+        const uint8_t *nul = (const uint8_t *)memchr(p, 0, remaining);
+        if (!nul) {
+            return false;
+        }
+        remaining -= nul + 1 - p;
+        p = nul + 1;
     }
     return true;
 }

--- a/util/HalideTraceUtils.h
+++ b/util/HalideTraceUtils.h
@@ -92,6 +92,10 @@ struct Packet : public halide_trace_packet_t {
 private:
     // Do a blocking read of some number of bytes from a unistd file descriptor.
     bool read(void *d, size_t size, FILE *fdesc);
+
+    // Check that the layout described by the header fits in the payload bytes
+    // that were actually read.
+    bool validate_payload(size_t payload_size) const;
 };
 
 }  // namespace Internal

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -174,10 +174,38 @@ struct PacketAndPayload : public halide_trace_packet_t {
             return false;  // EOF
         }
 
+        if (this->size < header_size) {
+            fail() << "Packet smaller than the header, of size " << this->size;
+        }
+
         const size_t payload_size = this->size - header_size;
         if (payload_size > sizeof(this->payload) || !read_or_die(this->payload, payload_size)) {
             // Shouldn't ever get EOF here
             fail() << "Unable to read packet payload of size " << payload_size;
+        }
+
+        // dimensions, lanes and the type all come from the stream, and together
+        // they say where the coordinates, the value, the func name and the
+        // trace tag live in the payload. Check that layout fits in the bytes we
+        // read before any of the accessors hand out a pointer into it.
+        if (this->dimensions < 0) {
+            fail() << "Packet with negative dimensions " << this->dimensions;
+        }
+        const size_t used = (size_t)this->dimensions * sizeof(int32_t) + this->value_bytes();
+        if (used > payload_size) {
+            fail() << "Packet payload of size " << payload_size << " too small for its contents";
+        }
+        // The func name and the trace tag follow the value, and both must be
+        // nul-terminated within the payload.
+        const uint8_t *p = this->payload + used;
+        size_t remaining = payload_size - used;
+        for (int i = 0; i < 2; i++) {
+            const uint8_t *nul = (const uint8_t *)memchr(p, 0, remaining);
+            if (!nul) {
+                fail() << "Packet with unterminated name in its payload";
+            }
+            remaining -= nul + 1 - p;
+            p = nul + 1;
         }
         return true;
     }


### PR DESCRIPTION
Both trace-packet readers take `size`, `dimensions`, `lanes` and the element type straight from the stream and then hand out pointers computed from them: `value()` is `coordinates() + dimensions` and `func()` is `value() + lanes * type().bytes()`, so a packet declaring 2000 dimensions with a four-byte payload puts `func()` 8001 bytes into a 4096-byte payload array. `HalideTraceDump` runs `string(p.func())` on that (ASAN reports a heap-buffer-overflow READ in `strlen`; without ASAN it prints whatever memory follows the packet as a Func name) and `HalideTraceViz` indexes `coordinates()` the same way; `size` is also used unchecked in `size - header_size`, so a size below the header underflows the payload length. Both readers now reject an undersized `size` and check, once the payload is in, that the coordinates and value fit in the bytes actually read and that the func name and trace tag are terminated inside them, which every packet written by `src/runtime/tracing.cpp` already satisfies since it derives `size` from exactly those parts.

The trace tools aren't built or exercised by the test suite, so there's no natural home for a regression test; I checked this with crafted trace files against a standalone harness around the reader, and with a well-formed packet to confirm valid input still parses identically.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
