### PR TITLE
Fix Windows pip packaging and cross-platform libHalide shadowing

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -139,6 +139,7 @@ jobs:
             CMAKE_GENERATOR=Ninja
             CMAKE_PREFIX_PATH='${{ github.workspace }}\opt'
             SETUPTOOLS_SCM_OVERRIDES_FOR_HALIDE='{local_scheme="no-local-version"}'
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --ignore-existing -w {dest_dir} {wheel}
           CIBW_BEFORE_TEST_LINUX: pip install cmake ninja
           CIBW_TEST_COMMAND: >
             cmake -G Ninja -S {project}/python_bindings/apps -B build -DCMAKE_BUILD_TYPE=Release &&

--- a/python_bindings/src/halide/__init__.py
+++ b/python_bindings/src/halide/__init__.py
@@ -16,7 +16,12 @@ def _preload_bundled_halide_library():
     if hasattr(os, "add_dll_directory") and bin_dir.is_dir():
         os.add_dll_directory(str(bin_dir))
 
-    for relpath in ("bin/Halide.dll", "lib/libHalide.dylib", "lib64/libHalide.so", "lib/libHalide.so"):
+    for relpath in (
+        "bin/Halide.dll",
+        "lib/libHalide.dylib",
+        "lib64/libHalide.so",
+        "lib/libHalide.so",
+    ):
         lib_path = root / relpath
         if lib_path.exists():
             ctypes.CDLL(str(lib_path))

--- a/python_bindings/src/halide/__init__.py
+++ b/python_bindings/src/halide/__init__.py
@@ -1,16 +1,30 @@
-def patch_dll_dirs():
+def _preload_bundled_halide_library():
+    # Force-load our own copy of the Halide runtime library by absolute path before
+    # importing halide_, so that halide_'s implicit load of the same library (by
+    # soname/module name) resolves to this already-loaded instance instead of
+    # searching LD_LIBRARY_PATH / PATH / the default dynamic linker paths, where a
+    # foreign, incompatible libHalide could shadow ours.
+    # See: https://github.com/halide/Halide/issues/8866
+    import ctypes
     import os
 
-    if hasattr(os, "add_dll_directory"):
-        from pathlib import Path
+    from pathlib import Path
 
-        bin_dir = Path(__file__).parent / "bin"
-        if bin_dir.exists():
-            os.add_dll_directory(str(bin_dir))
+    root = Path(__file__).parent
+
+    bin_dir = root / "bin"
+    if hasattr(os, "add_dll_directory") and bin_dir.is_dir():
+        os.add_dll_directory(str(bin_dir))
+
+    for relpath in ("bin/Halide.dll", "lib/libHalide.dylib", "lib64/libHalide.so", "lib/libHalide.so"):
+        lib_path = root / relpath
+        if lib_path.exists():
+            ctypes.CDLL(str(lib_path))
+            return
 
 
-patch_dll_dirs()
-del patch_dll_dirs
+_preload_bundled_halide_library()
+del _preload_bundled_halide_library
 
 from .halide_ import *  # noqa: E402, F403
 


### PR DESCRIPTION
## Summary

- Fixes #8866: the Python bindings could load a foreign `libHalide.so`/`Halide.dll` that shadows the one bundled in the wheel. `halide_` depends on it by soname/module name alone, and the dynamic linker's search order (RUNPATH < `LD_LIBRARY_PATH` on Linux; PATH/default dirs on Windows) lets a same-named library elsewhere on the system take precedence over the bundled copy. Confirmed via `readelf` that `halide_.so` has RUNPATH (not RPATH), and reproduced the failure end-to-end in WSL: a garbage `libHalide.so` on `LD_LIBRARY_PATH` broke `import halide` before this fix, and no longer does after it.
- The fix explicitly loads our own copy via `ctypes` with an absolute path before importing `halide_`. Both Linux's and Windows's loaders recognize a module already mapped into the process by its soname/module name and reuse it instead of searching again, so `halide_`'s implicit dependency resolves to our copy regardless of what else is on the search path.
- Separately, cibuildwheel 4.0 made `delvewheel repair` the Windows default, and it was erroring out trying to locate `Halide.dll` itself (it doesn't search inside the not-yet-repaired wheel), breaking the Windows pip packaging workflow. Re-enabled with `--ignore-existing`, which tells delvewheel to treat DLLs already bundled in the wheel as satisfying their own dependencies rather than erroring out. Verified against the current published `win_amd64` wheel: with this flag, delvewheel leaves `Halide.dll` alone but still correctly vendors `msvcp140.dll`, a genuine external MSVC runtime dependency that isn't currently bundled at all -- so this isn't just a no-op safety net, it closes a real gap in the Windows wheel's self-containedness.

## Test plan

- [x] Reproduced #8866 in WSL against the published `halide==21.0.0` manylinux wheel (garbage `libHalide.so` on `LD_LIBRARY_PATH` breaks import)
- [x] Verified the ctypes-preload fix flips that repro from fail to pass, and that basic Halide functionality (`Func`/`realize`) still works
- [x] Verified `delvewheel repair --ignore-existing` against the published `win_amd64` wheel: no error, `Halide.dll` untouched, `msvcp140.dll` correctly vendored
- [ ] CI: Build PyPI package workflow green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)