### PR TITLE
cap trace value memcpy at scalar value size

### DIFF
--- a/util/HalideTraceUtils.h
+++ b/util/HalideTraceUtils.h
@@ -2,6 +2,7 @@
 #define HALIDE_TRACE_UTILS_H
 
 #include "HalideRuntime.h"
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 
@@ -78,8 +79,9 @@ struct Packet : public halide_trace_packet_t {
         // so that value_as<>() won't complain under sanitizers.
         halide_scalar_value_t aligned_value;
         // Only copy the number of bytes in the type: the stream isn't guaranteed
-        // to be padded to sizeof(halide_scalar_value_t).
-        memcpy(&aligned_value, val, type().bits / 8);
+        // to be padded to sizeof(halide_scalar_value_t). type().bits comes from
+        // the stream, so cap the copy so a bogus type can't overrun aligned_value.
+        memcpy(&aligned_value, val, std::min<size_t>(type().bits / 8, sizeof(aligned_value)));
         return value_as<T>(type(), aligned_value);
     }
 

--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -144,8 +144,9 @@ T get_value_as(const halide_trace_packet_t &p, int idx) {
     // so that value_as<>() won't complain under sanitizers.
     halide_scalar_value_t aligned_value;
     // Only copy the number of bytes in the type: the stream isn't guaranteed
-    // to be padded to sizeof(halide_scalar_value_t).
-    memcpy(&aligned_value, val, type.bits / 8);
+    // to be padded to sizeof(halide_scalar_value_t). type.bits comes from the
+    // stream, so cap the copy so a bogus type can't overrun aligned_value.
+    memcpy(&aligned_value, val, std::min<size_t>(type.bits / 8, sizeof(aligned_value)));
     return value_as<double>(type, aligned_value);
 }
 


### PR DESCRIPTION
`get_value_as` in `HalideTraceViz.cpp` and `Packet::get_value_as` in `HalideTraceUtils.h` copy `type.bits / 8` bytes of a trace value into a fixed 8-byte `halide_scalar_value_t`, but `type.bits` comes straight from the packet header in the trace stream. A crafted load/store packet declaring a scalar type wider than 64 bits makes the memcpy write up to 31 bytes into the 8-byte local, overflowing the stack before `value_as` ever checks the type. Cap the copy at `sizeof(halide_scalar_value_t)` at both sites; valid types (bits <= 64) copy exactly as before.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
