### PR TITLE
Make the Makefile fuzz targets match the CMake fuzz run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1296,6 +1296,9 @@ ERROR_TESTS = $(shell ls $(ROOT_DIR)/test/error/*.cpp)
 WARNING_TESTS = $(shell ls $(ROOT_DIR)/test/warning/*.cpp)
 RUNTIME_TESTS = $(shell ls $(ROOT_DIR)/test/runtime/*.cpp)
 FUZZ_TESTS = $(filter-out %halide_fuzz_main.cpp %IRGraphCXXPrinter.cpp, $(shell ls $(ROOT_DIR)/test/fuzz/*.cpp))
+# Match the args used by the CMake build: 1000 runs per test, and no more than
+# five minutes of total time.
+FUZZ_TEST_ARGS ?= -runs=1000 -max_total_time=300
 GENERATOR_EXTERNAL_TESTS := $(shell ls $(ROOT_DIR)/test/generator/*test.cpp)
 GENERATOR_EXTERNAL_TEST_GENERATOR := $(shell ls $(ROOT_DIR)/test/generator/*_generator.cpp)
 TUTORIALS = $(filter-out %_generate.cpp, $(shell ls $(ROOT_DIR)/tutorial/*.cpp))
@@ -2091,7 +2094,7 @@ quiet_correctness_%: $(BIN_DIR)/correctness_%
 
 fuzz_%: $(BIN_DIR)/fuzz_%
 	@-mkdir -p $(TMP_DIR)
-	cd $(TMP_DIR) ; $(CURDIR)/$<
+	cd $(TMP_DIR) ; $(CURDIR)/$< $(FUZZ_TEST_ARGS)
 	@-echo
 
 valgrind_%: $(BIN_DIR)/correctness_%


### PR DESCRIPTION
The Makefile ran the fuzzers with the harness defaults (10000 runs, no time limit), while CMake/CI uses -runs=1000 -max_total_time=300. Use the same args from the Makefile, overridable via FUZZ_TEST_ARGS.

