### PR TITLE
bound the reallocation copy in BlockStorage and PointerTable

### DIFF
--- a/src/runtime/internal/block_storage.h
+++ b/src/runtime/internal/block_storage.h
@@ -396,9 +396,12 @@ void BlockStorage::allocate(void *user_context, size_t new_capacity) {
                             << "block_count=" << (int32_t)block_count << " "
                             << "alloc_size=" << (int32_t)alloc_size << ") ...\n";
 #endif
+        // resize() assigns the requested count before growing, so the existing
+        // allocation may hold fewer than count entries.
+        size_t copy_count = min(count, capacity);
         void *new_ptr = alloc_size ? allocator.allocate(user_context, alloc_size) : nullptr;
-        if (count != 0 && ptr != nullptr && new_ptr != nullptr) {
-            memcpy(new_ptr, ptr, count * config.entry_size);
+        if (copy_count != 0 && ptr != nullptr && new_ptr != nullptr) {
+            memcpy(new_ptr, ptr, copy_count * config.entry_size);
         }
         if (ptr != nullptr) {
             halide_abort_if_false(user_context, allocator.deallocate != nullptr);

--- a/src/runtime/internal/pointer_table.h
+++ b/src/runtime/internal/pointer_table.h
@@ -336,9 +336,12 @@ void PointerTable::allocate(void *user_context, size_t new_capacity) {
         debug(user_context) << "PointerTable: Allocating (bytes=" << (int32_t)bytes << " allocator=" << (void *)allocator.allocate << ")...\n";
 #endif
 
+        // resize() assigns the requested count before growing, so the existing
+        // allocation may hold fewer than count entries.
+        size_t copy_count = min(count, capacity);
         void *new_ptr = bytes ? allocator.allocate(user_context, bytes) : nullptr;
-        if (count != 0 && ptr != nullptr && new_ptr != nullptr) {
-            memcpy(new_ptr, ptr, count * sizeof(void *));
+        if (copy_count != 0 && ptr != nullptr && new_ptr != nullptr) {
+            memcpy(new_ptr, ptr, copy_count * sizeof(void *));
         }
         if (ptr != nullptr) {
             halide_debug_assert(user_context, allocator.deallocate != nullptr);

--- a/test/runtime/block_storage.cpp
+++ b/test/runtime/block_storage.cpp
@@ -146,6 +146,39 @@ int main(int argc, char **argv) {
         HALIDE_CHECK(user_context, e2.f32 == s2.f32);
     }
 
+    // test growing past the initial capacity
+    {
+        BlockStorage::Config config = BlockStorage::default_config();
+        config.entry_size = sizeof(int);
+
+        const size_t entry_count = 2 * BlockStorage::default_capacity;
+
+        // Appending past the default capacity reallocates, so the entries
+        // already stored have to survive the move.
+        BlockStorage bs1(user_context, config);
+        for (size_t i = 0; i < entry_count; ++i) {
+            int value = (int)i;
+            bs1.append(user_context, &value);
+        }
+        HALIDE_CHECK(user_context, bs1.size() == entry_count);
+        for (size_t i = 0; i < entry_count; ++i) {
+            HALIDE_CHECK(user_context, read_as<int>(bs1, i) == (int)i);
+        }
+
+        // fill() resizes before copying, which grows the allocation the same way.
+        int values[2 * BlockStorage::default_capacity];
+        for (size_t i = 0; i < entry_count; ++i) {
+            values[i] = (int)(entry_count - i);
+        }
+
+        BlockStorage bs2(user_context, config);
+        bs2.fill(user_context, values, entry_count);
+        HALIDE_CHECK(user_context, bs2.size() == entry_count);
+        for (size_t i = 0; i < entry_count; ++i) {
+            HALIDE_CHECK(user_context, read_as<int>(bs2, i) == values[i]);
+        }
+    }
+
     print(user_context) << "Success!\n";
     return 0;
 }

--- a/test/runtime/string_table.cpp
+++ b/test/runtime/string_table.cpp
@@ -43,6 +43,26 @@ int main(int argc, char **argv) {
         HALIDE_CHECK(user_context, st1.contains(data[3]));
     }
 
+    // test growing past the initial capacity
+    {
+        // The table is backed by PointerTable, which reallocates once the
+        // entry count passes its default capacity.
+        const size_t entry_count = 2 * PointerTable::default_capacity;
+        const char *entry = "extension_name";
+
+        // Uses the default allocator on purpose: allocate_system() pads every
+        // block, which would hide a read past the end of one.
+        StringTable st2(user_context, 0);
+        for (size_t i = 0; i < entry_count; ++i) {
+            st2.append(user_context, entry);
+        }
+        HALIDE_CHECK(user_context, st2.size() == entry_count);
+        HALIDE_CHECK(user_context, st2.contains(entry));
+        for (size_t i = 0; i < entry_count; ++i) {
+            HALIDE_CHECK(user_context, strncmp(st2[i], entry, strlen(entry)) == 0);
+        }
+    }
+
     print(user_context) << "Success!\n";
     return 0;
 }


### PR DESCRIPTION
Both resizable containers in the runtime over-read the old block when they grow:

- resize() assigns the new entry count to `count`, then allocate() copies `count` entries out of the previous allocation, which only holds the old capacity
- one append past the 32-entry default reads a single entry too far; a 64-entry fill on a 128-byte block reads 256 bytes
- PointerTable::allocate has the same shape, reached from StringTable::append when the Vulkan extension and layer tables outgrow their initial capacity

Clamping the copy to what the old allocation actually holds leaves the rest of the grow path alone. Both new tests trip ASAN before the change and pass after.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
