### PR TITLE
[Target] Replace public fields with getters/setters

### DIFF
--- a/apps/conv_layer/conv_layer_generator.cpp
+++ b/apps/conv_layer/conv_layer_generator.cpp
@@ -137,8 +137,8 @@ public:
             const int vec = natural_vector_size<float>();
 
             if (get_target().has_feature(Target::AVX512_Skylake) ||
-                (get_target().arch == Target::ARM &&
-                 get_target().bits == 64)) {
+                (get_target().arch() == Target::ARM &&
+                 get_target().bits() == 64)) {
                 // On Skylake we have one load per fma and 32
                 // registers available, so there's considerable
                 // flexibility in the schedule. We'll use 20 accumulator
@@ -146,7 +146,7 @@ public:
                 // choice for ARMv8, which also has 32 registers.
                 tile_w = 4;
                 tile_h = 5;
-            } else if (get_target().arch == Target::X86) {
+            } else if (get_target().arch() == Target::X86) {
                 // With 16-register ISAs like x86 with AVX2, we can
                 // only do one load per two fmas, which constrains the
                 // schedule to have to be a squarish 12-register tile

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -190,8 +190,8 @@ public:
             // file on this target.
             int num_regs = 16;
             if (get_target().has_feature(Target::AVX512_Skylake) ||
-                (get_target().arch == Target::ARM &&
-                 get_target().bits == 64)) {
+                (get_target().arch() == Target::ARM &&
+                 get_target().bits() == 64)) {
                 num_regs = 32;
             }
 

--- a/apps/fft/fft.cpp
+++ b/apps/fft/fft.cpp
@@ -439,7 +439,7 @@ std::pair<FuncType, FuncType> tiled_transpose(FuncType f, int max_tile_size,
     // efficient transpose. The strategy is to break the transpose into 4x4 tiles,
     // transpose the tiles themselves (dense vector load/stores), then transpose
     // the data within each tile (stride 4 loads).
-    if (target.arch != Target::ARM && !always_tile) {
+    if (target.arch() != Target::ARM && !always_tile) {
         return {transpose(f), FuncType()};
     }
 

--- a/apps/hannk/halide/common_halide.cpp
+++ b/apps/hannk/halide/common_halide.cpp
@@ -6,11 +6,11 @@ using namespace Halide::ConciseCasts;
 namespace hannk {
 
 int get_register_count(const Target &target) {
-    switch (target.arch) {
+    switch (target.arch()) {
     case Target::X86:
         return target.features_any_of({Target::AVX512_Skylake, Target::AVX512_Cannonlake, Target::AVX512_SapphireRapids}) ? 32 : 16;
     case Target::ARM:
-        return target.bits == 64 ? 32 : 16;
+        return target.bits() == 64 ? 32 : 16;
     case Target::Hexagon:
         return 32;
     default:
@@ -19,7 +19,7 @@ int get_register_count(const Target &target) {
 }
 
 int get_vector_reduction_factor(const Target &target, Type t) {
-    if (target.arch == Target::Hexagon ||
+    if (target.arch() == Target::Hexagon ||
         target.has_feature(Target::ARMDotProd) ||
         target.has_feature(Target::AVX512_SapphireRapids)) {
         return 32 / t.bits();
@@ -233,7 +233,7 @@ Expr quantize_i16(const Expr &x, const Expr &multiplier, const Expr &shift, cons
 Expr quantize_and_relu_u8(const Expr &x, const Expr &multiplier, const Expr &shift, const Expr &zero,
                           const Expr &min, const Expr &max, const Target &target) {
     Expr result = quantize_i16(x, multiplier, shift, target);
-    if (target.arch == Target::ARM || target.arch == Target::Hexagon || target.arch == Target::X86) {
+    if (target.arch() == Target::ARM || target.arch() == Target::Hexagon || target.arch() == Target::X86) {
         // These targets have saturating narrow instructions, so it's best to clamp
         // after narrowing for more vector throughput.
         result = u8_sat(saturating_add(result, zero));

--- a/apps/hannk/halide/conv_generator.cpp
+++ b/apps/hannk/halide/conv_generator.cpp
@@ -16,7 +16,7 @@ Var ci("ci"), co("co");
 // without widening 8-bit multiplication, it's faster to just subtract the
 // offsets and use 16-bit multiplications.
 bool use_8bit_multiply(const Target &target) {
-    return target.arch != Target::X86 || target.has_feature(Target::AVX512_SapphireRapids);
+    return target.arch() != Target::X86 || target.has_feature(Target::AVX512_SapphireRapids);
 }
 
 // How many registers to use as accumulators, as a function of the target.
@@ -254,7 +254,7 @@ public:
             convolved.update().specialize(filter_depth == vector_reduction);
         }
 
-        if (!use_8bit_multiply(target) && get_target().arch == Target::X86) {
+        if (!use_8bit_multiply(target) && get_target().arch() == Target::X86) {
             // On x86, widening subtracts eat up a lot of the already scarce
             // registers, so precomputing this outside the inner loop helps
             // a lot.

--- a/python_bindings/src/halide/halide_/PyTarget.cpp
+++ b/python_bindings/src/halide/halide_/PyTarget.cpp
@@ -31,10 +31,11 @@ void define_target(py::module &m) {
             .def("__eq__", [](const Target &value, Target *value2) { return value2 && value == *value2; })
             .def("__ne__", [](const Target &value, Target *value2) { return !value2 || value != *value2; })
 
-            .def_readwrite("os", &Target::os)
-            .def_readwrite("arch", &Target::arch)
-            .def_readwrite("bits", &Target::bits)
-            .def_readwrite("processor_tune", &Target::processor_tune)
+            .def_property("os", &Target::os, &Target::set_os)
+            .def_property("arch", &Target::arch, &Target::set_arch)
+            .def_property("bits", &Target::bits, &Target::set_bits)
+            .def_property("vector_bits", &Target::vector_bits, &Target::set_vector_bits)
+            .def_property("processor_tune", &Target::processor_tune, &Target::set_processor_tune)
 
             .def("__repr__", &target_repr)
             .def("__str__", &Target::to_string)

--- a/src/Bounds.cpp
+++ b/src/Bounds.cpp
@@ -1460,7 +1460,7 @@ protected:
                             interval.max = a_interval.max >> abs(b_interval.max);
                         }
                     } else if (op->is_intrinsic(Call::shift_right)) {
-                        // Only try to improve on bounds-of-type if we can prove 0 <= b < t.bits,
+                        // Only try to improve on bounds-of-type if we can prove 0 <= b < t.bits(),
                         // as shift_right(a, b) is UB for b outside that range.
                         if (b_interval.is_bounded()) {
                             bool b_min_ok_positive = can_prove(b_interval.min >= 0 &&

--- a/src/CPlusPlusMangle.cpp
+++ b/src/CPlusPlusMangle.cpp
@@ -187,7 +187,7 @@ struct QualsState {
 };
 
 std::string mangle_indirection_and_cvr_quals(const Type &type, const Target &target) {
-    QualsState state(type, (target.bits == 64) ? "E" : "");
+    QualsState state(type, (target.bits() == 64) ? "E" : "");
     for (uint8_t modifier : type.handle_type()->cpp_type_modifiers) {
         state.handle_modifier(modifier);
     }
@@ -346,17 +346,17 @@ std::string simple_type_to_mangle_char(const std::string &type_name, const Targe
     } else if (type_name == "uint32_t") {
         return "j";
     } else if (type_name == "int64_t") {
-        if (target.os == Target::OSX ||
-            target.os == Target::IOS ||
-            target.bits == 32) {
+        if (target.os() == Target::OSX ||
+            target.os() == Target::IOS ||
+            target.bits() == 32) {
             return "x";
         } else {
             return "l";
         }
     } else if (type_name == "uint64_t") {
-        if (target.os == Target::OSX ||
-            target.os == Target::IOS ||
-            target.bits == 32) {
+        if (target.os() == Target::OSX ||
+            target.os() == Target::IOS ||
+            target.bits() == 32) {
             return "y";
         } else {
             return "m";
@@ -533,15 +533,15 @@ std::string mangle_type(const Type &type, const Target &target, PrevPrefixes &pr
         case 16:
             return "s";
         case 32:
-            if (target.arch == Target::Hexagon) {
+            if (target.arch() == Target::Hexagon) {
                 return "l";
             } else {
                 return "i";
             }
         case 64:
-            if (target.os == Target::OSX ||
-                target.os == Target::IOS ||
-                target.bits == 32) {
+            if (target.os() == Target::OSX ||
+                target.os() == Target::IOS ||
+                target.bits() == 32) {
                 return "x";
             } else {
                 return "l";
@@ -559,15 +559,15 @@ std::string mangle_type(const Type &type, const Target &target, PrevPrefixes &pr
         case 16:
             return "t";
         case 32:
-            if (target.arch == Target::Hexagon) {
+            if (target.arch() == Target::Hexagon) {
                 return "m";
             } else {
                 return "j";
             }
         case 64:
-            if (target.os == Target::OSX ||
-                target.os == Target::IOS ||
-                target.bits == 32) {
+            if (target.os() == Target::OSX ||
+                target.os() == Target::IOS ||
+                target.bits() == 32) {
                 return "y";
             } else {
                 return "m";
@@ -618,7 +618,7 @@ std::string cplusplus_function_mangled_name(const std::string &name, const std::
 std::string cplusplus_function_mangled_name(const std::string &name, const std::vector<std::string> &namespaces,
                                             Type return_type, const std::vector<ExternFuncArgument> &args,
                                             const Target &target) {
-    if (target.os == Target::Windows) {
+    if (target.os() == Target::Windows) {
         return WindowsMangling::cplusplus_function_mangled_name(name, namespaces, return_type, args, target);
     } else {
         return ItaniumABIMangling::cplusplus_function_mangled_name(name, namespaces, return_type, args, target);
@@ -1084,7 +1084,7 @@ void cplusplus_mangle_test() {
                 args.emplace_back(make_zero(Handle(&t2)));
                 args.emplace_back(make_zero(Handle(&t3)));
 
-                MangleResult *expecteds = (target.os == Target::Windows) ? (target.bits == 64 ? all_mods_win64 : all_mods_win32) : all_mods_itanium;
+                MangleResult *expecteds = (target.os() == Target::Windows) ? (target.bits() == 64 ? all_mods_win64 : all_mods_win32) : all_mods_itanium;
                 check_result(expecteds, expecteds_index, target,
                              cplusplus_function_mangled_name("test_function", {}, Int(32), args, target));
             }
@@ -1100,7 +1100,7 @@ void cplusplus_mangle_test() {
             args.emplace_back(make_zero(Handle(nullptr)));
             args.emplace_back(make_zero(Handle(nullptr)));
 
-            MangleResult *expecteds = (target.os == Target::Windows) ? (target.bits == 64 ? two_void_stars_win64 : two_void_stars_win32) : two_void_stars_itanium;
+            MangleResult *expecteds = (target.os() == Target::Windows) ? (target.bits() == 64 ? two_void_stars_win64 : two_void_stars_win32) : two_void_stars_itanium;
             check_result(expecteds, expecteds_index, target,
                          cplusplus_function_mangled_name("test_function", {}, Int(32), args, target));
         }

--- a/src/Callable.h
+++ b/src/Callable.h
@@ -101,8 +101,8 @@ private:
         return (((uint16_t)code) << 8) | (uint16_t)bits;
     }
 
-    static constexpr QuickCallCheckInfo make_scalar_qcci(halide_type_t t) {
-        return _make_qcci(t.code, t.bits);
+    static constexpr QuickCallCheckInfo make_scalar_qcci(halide_type_t type) {
+        return _make_qcci(type.code, type.bits);
     }
 
     static constexpr QuickCallCheckInfo make_buffer_qcci() {

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -991,8 +991,8 @@ void CodeGen_ARM::init_module() {
     // TODO: https://github.com/halide/Halide/issues/8872
     // if (target.features_any_of({Target::SVE, Target::SVE2})) {
     if (target.has_feature(Target::SVE2)) {
-        user_assert(target.vector_bits != 0) << "For SVE/SVE2 support, Target::vector_bits must be set. For generator target strings, add \"vector_bits_<bits>\".\n";
-        user_assert((target.vector_bits % 128) == 0) << "For SVE/SVE2 support, Target::vector_bits must be a multiple of 128.\n";
+        user_assert(target.vector_bits() != 0) << "For SVE/SVE2 support, Target::vector_bits must be set. For generator target strings, add \"vector_bits_<bits>\".\n";
+        user_assert((target.vector_bits() % 128) == 0) << "For SVE/SVE2 support, Target::vector_bits must be a multiple of 128.\n";
     } else if (target.has_feature(Target::SVE)) {
         user_warning << "Halide does not support SVE for now. Use SVE2 if your target device supports it.\n";
     }
@@ -1034,7 +1034,7 @@ void CodeGen_ARM::init_module() {
 
         // Get the name of the intrinsic with the appropriate prefix.
         const char *intrin_name = nullptr;
-        if (target.bits == 32) {
+        if (target.bits() == 32) {
             intrin_name = intrin.arm32;
         } else {
             intrin_name = intrin.arm64;
@@ -1064,7 +1064,7 @@ void CodeGen_ARM::init_module() {
                 intrinsics_map = &intrinsics_neon;
                 break;
             case SIMDFlavors::SVE:
-                vscale = target.vector_bits / 128;
+                vscale = target.vector_bits() / 128;
                 intrinsics_map = &intrinsics_sve2;
                 break;
             case SIMDFlavors::Streaming:
@@ -1086,7 +1086,7 @@ void CodeGen_ARM::init_module() {
                     continue;
                 }
             }
-            if ((target.bits == 64) &&
+            if ((target.bits() == 64) &&
                 (intrin.flags & ArmIntrinsic::Neon64Unavailable) &&
                 !is_sve_or_streaming) {
                 continue;
@@ -1101,7 +1101,7 @@ void CodeGen_ARM::init_module() {
                 const bool is_vanilla_intrinsic = starts_with(intrin_name, "llvm.");
                 if (!is_vanilla_intrinsic && (intrin.flags & ArmIntrinsic::NoPrefix) == 0) {
                     const char *prefix =
-                        target.bits == 32   ? "llvm.arm.neon." :
+                        target.bits() == 32 ? "llvm.arm.neon." :
                         is_sve_or_streaming ? "llvm.aarch64.sve." :
                                               "llvm.aarch64.neon.";
                     return concat_strings(prefix, intrin_name);
@@ -1199,7 +1199,7 @@ void CodeGen_ARM::compile_func(const LoweredFunc &f,
     internal_assert(llvm_func);
     bool is_streaming_task = (f.attributes & LoweredFunc::Attribute::SME_STREAMING_TASK) && target.has_feature(Target::SME2);
 
-    if (target.os != Target::IOS && target.os != Target::OSX) {
+    if (target.os() != Target::IOS && target.os() != Target::OSX) {
         // Substitute in strided loads to get vld2/3/4 emission. We don't do it
         // on Apple silicon, because doing a dense load and then shuffling is
         // actually faster.
@@ -1228,7 +1228,7 @@ void CodeGen_ARM::compile_func(const LoweredFunc &f,
         in_streaming = (feasible_vscale > 0) && is_streaming_task;
 
         if (!in_streaming && target.has_feature(Target::SVE2)) {
-            feasible_vscale = check_feasible_vscale(target.vector_bits,  // VL
+            feasible_vscale = check_feasible_vscale(target.vector_bits(),  // VL
                                                     lanes_used, "", simple_name);
         }
     }
@@ -1332,7 +1332,7 @@ void CodeGen_ARM::visit(const Cast *op) {
                         continue;
                     }
                 }
-                if (target.bits == 32 && pattern.intrin.find("shift_right") != string::npos) {
+                if (target.bits() == 32 && pattern.intrin.find("shift_right") != string::npos) {
                     // The 32-bit ARM backend wants right shifts as negative values.
                     matches[1] = simplify(-cast(matches[1].type().with_code(halide_type_int), matches[1]));
                 }
@@ -1593,7 +1593,7 @@ void CodeGen_ARM::visit(const Store *op) {
         intrin_type = t;
         Type elt = t.element_of();
         int vec_bits = t.bits() * t.lanes();
-        if (t.bits() <= target.bits &&
+        if (t.bits() <= target.bits() &&
             (elt == Float(32) || elt == Float(64) ||
              is_float16_and_has_feature(elt) ||
              elt == Int(8) || elt == Int(16) || elt == Int(32) || elt == Int(64) ||
@@ -1637,7 +1637,7 @@ void CodeGen_ARM::visit(const Store *op) {
         std::ostringstream instr;
         vector<llvm::Type *> arg_types;
         llvm::Type *intrin_llvm_type = llvm_type_with_constraint(intrin_type, false, is_sve ? VectorTypeConstraint::VScale : VectorTypeConstraint::Fixed);
-        if (target.bits == 32) {
+        if (target.bits() == 32) {
             instr << "llvm.arm.neon.vst"
                   << num_vecs
                   << ".p0"
@@ -1735,7 +1735,7 @@ void CodeGen_ARM::visit(const Store *op) {
                 slice_args[j] = convert_fixed_or_scalable_vector_type(slice_args[j], get_vector_type(slice_args[j]->getType()->getScalarType(), intrin_type.lanes()));
             }
 
-            if (target.bits == 32) {
+            if (target.bits() == 32) {
                 // Set the pointer argument
                 slice_args.insert(slice_args.begin(), ptr);
                 // Set the alignment argument
@@ -1873,7 +1873,7 @@ void CodeGen_ARM::visit(const Store *op) {
     }
 
     // We have builtins for strided stores with fixed but unknown stride, but they use inline assembly
-    if (target.bits != 64 /* Not yet implemented for aarch64 */) {
+    if (target.bits() != 64 /* Not yet implemented for aarch64 */) {
         ostringstream builtin;
         builtin << "strided_store_"
                 << (op->value.type().is_float() ? "f" : "i")
@@ -1927,7 +1927,7 @@ void CodeGen_ARM::visit(const Load *op) {
     }
 
     // We have builtins for strided loads with fixed but unknown stride, but they use inline assembly.
-    if (target.bits != 64 /* Not yet implemented for aarch64 */) {
+    if (target.bits() != 64 /* Not yet implemented for aarch64 */) {
         ostringstream builtin;
         builtin << "strided_load_"
                 << (op->type.is_float() ? "f" : "i")
@@ -2040,7 +2040,7 @@ void CodeGen_ARM::visit(const Shuffle *op) {
     // load.
     int stride = op->slice_stride();
     const Load *load = op->vectors[0].as<Load>();
-    if (target.os != Target::IOS && target.os != Target::OSX &&
+    if (target.os() != Target::IOS && target.os() != Target::OSX &&
         load &&
         op->vectors.size() == 1 &&
         op->is_slice() &&
@@ -2506,7 +2506,7 @@ void CodeGen_ARM::visit(const Call *op) {
         // llvm's roundeven intrinsic reliably lowers to the correct
         // instructions on aarch64, but despite having the same instruction
         // available, it doesn't seem to work for arm-32.
-        if (target.bits == 32) {
+        if (target.bits() == 32) {
             // So let's call the fallback to make sure it's vectorizable.
             value = codegen(lower_round_to_nearest_ties_to_even(op->args[0]));
             return;
@@ -2524,7 +2524,7 @@ void CodeGen_ARM::visit(const Call *op) {
                         continue;
                     }
                 }
-                if (target.bits == 32 && pattern.intrin.find("shift_right") != string::npos) {
+                if (target.bits() == 32 && pattern.intrin.find("shift_right") != string::npos) {
                     // The 32-bit ARM backend wants right shifts as negative values.
                     matches[1] = simplify(-cast(matches[1].type().with_code(halide_type_int), matches[1]));
                 }
@@ -2775,7 +2775,7 @@ bool CodeGen_ARM::codegen_pairwise_vector_reduce(const VectorReduce *op, const E
             narrow = lossless_cast(narrow_type.with_code(Type::UInt), op->value);
         }
         if (narrow.defined()) {
-            if (init.defined() && (target.bits == 32 || (target_vscale() > 0))) {
+            if (init.defined() && (target.bits() == 32 || (target_vscale() > 0))) {
                 // On 32-bit or SVE2, we have an intrinsic for widening add-accumulate.
                 // TODO: this could be written as a pattern with widen_right_add (#6951).
                 intrin = "pairwise_widening_add_accumulate";
@@ -2927,7 +2927,7 @@ int CodeGen_ARM::natural_vector_size(const Halide::Type &t) const {
 }
 
 string CodeGen_ARM::mcpu_target() const {
-    if (target.bits == 32) {
+    if (target.bits() == 32) {
         if (target.has_feature(Target::ARMv7s)) {
             return "swift";
         } else if (target.has_feature(Target::ARMv82a)) {
@@ -2938,9 +2938,9 @@ string CodeGen_ARM::mcpu_target() const {
             return "cortex-a9";
         }
     } else {
-        if (target.os == Target::IOS) {
+        if (target.os() == Target::IOS) {
             return "apple-a7";
-        } else if (target.os == Target::OSX) {
+        } else if (target.os() == Target::OSX) {
             return "apple-m1";
         } else if (target.has_feature(Target::SVE2)) {
             return "cortex-x1";
@@ -2963,7 +2963,7 @@ string CodeGen_ARM::mattrs() const {
         // The ARM (32-bit) backend calls this feature "v8"; the AArch64
         // backend calls it "v8a". The dotted sub-versions (v8.1a, v8.2a,
         // etc.) use the same names in both backends.
-        attrs.emplace_back(target.bits == 32 ? "+v8" : "+v8a");
+        attrs.emplace_back(target.bits() == 32 ? "+v8" : "+v8a");
     }
     if (target.has_feature(Target::ARMv81a)) {
         attrs.emplace_back("+v8.1a");
@@ -2998,7 +2998,7 @@ string CodeGen_ARM::mattrs() const {
     if (target.has_feature(Target::ARMDotProd)) {
         attrs.emplace_back("+dotprod");
     }
-    if (target.bits == 32) {
+    if (target.bits() == 32) {
         if (target.has_feature(Target::ARMv7s)) {
             attrs.emplace_back("+neon");
         }
@@ -3019,7 +3019,7 @@ string CodeGen_ARM::mattrs() const {
         if (target.has_feature(Target::SME2)) {
             attrs.emplace_back("+sme2");
         }
-        if (target.os == Target::IOS || target.os == Target::OSX) {
+        if (target.os() == Target::IOS || target.os() == Target::OSX) {
             attrs.emplace_back("+reserve-x18");
         }
     }
@@ -3030,9 +3030,9 @@ bool CodeGen_ARM::use_soft_float_abi() const {
     // One expects the flag is irrelevant on 64-bit, but we'll make the logic
     // exhaustive anyway. It is not clear the armv7s case is necessary either.
     return target.has_feature(Target::SoftFloatABI) ||
-           (target.bits == 32 &&
-            ((target.os == Target::Android) ||
-             (target.os == Target::IOS && !target.has_feature(Target::ARMv7s))));
+           (target.bits() == 32 &&
+            ((target.os() == Target::Android) ||
+             (target.os() == Target::IOS && !target.has_feature(Target::ARMv7s))));
 }
 
 int CodeGen_ARM::native_vector_bits() const {

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -291,7 +291,7 @@ CodeGen_C::~CodeGen_C() {
                    << "// includes a full copy of the Halide runtime so that it\n"
                    << "// can be used standalone. Declarations for the functions\n"
                    << "// in the Halide runtime are below.\n";
-            if (target.os == Target::Windows) {
+            if (target.os() == Target::Windows) {
                 stream
                     << "//\n"
                     << "// The inclusion of this runtime means that it is not legal\n"

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -217,17 +217,17 @@ std::unique_ptr<CodeGen_LLVM> CodeGen_LLVM::new_for_target(const Target &target,
     // guaranteed for the module produced by lower(), and for the host target
     // used to compile JIT trampolines.
     std::unique_ptr<CodeGen_LLVM> result;
-    if (target.arch == Target::X86) {
+    if (target.arch() == Target::X86) {
         result = new_CodeGen_X86(target);
-    } else if (target.arch == Target::ARM) {
+    } else if (target.arch() == Target::ARM) {
         result = new_CodeGen_ARM(target);
-    } else if (target.arch == Target::POWERPC) {
+    } else if (target.arch() == Target::POWERPC) {
         result = new_CodeGen_PowerPC(target);
-    } else if (target.arch == Target::Hexagon) {
+    } else if (target.arch() == Target::Hexagon) {
         result = new_CodeGen_Hexagon(target);
-    } else if (target.arch == Target::WebAssembly) {
+    } else if (target.arch() == Target::WebAssembly) {
         result = new_CodeGen_WebAssembly(target);
-    } else if (target.arch == Target::RISCV) {
+    } else if (target.arch() == Target::RISCV) {
         result = new_CodeGen_RISCV(target);
     }
     user_assert(result) << "Unknown target architecture: " << target.to_string() << "\n";
@@ -1217,7 +1217,7 @@ void CodeGen_LLVM::optimize_module() {
                 sanitizercoverage_options.Inline8bitCounters = true;
                 sanitizercoverage_options.PCTable = true;
                 // Due to TLS differences, stack depth tracking is only enabled on Linux
-                if (get_target().os == Target::OS::Linux) {
+                if (get_target().os() == Target::OS::Linux) {
                     sanitizercoverage_options.StackDepth = true;
                 }
                 mpm.addPass(SanitizerCoveragePass(sanitizercoverage_options));
@@ -2689,7 +2689,7 @@ llvm::Value *CodeGen_LLVM::codegen_vector_load(const Type &type, const std::stri
         // LLVM should codegen the same thing for a constant 1 strided load as
         // for a non-strided load.
         if (stride) {
-            if (get_target().bits == 64 && !stride->getType()->isIntegerTy(64)) {
+            if (get_target().bits() == 64 && !stride->getType()->isIntegerTy(64)) {
                 stride = builder->CreateIntCast(stride, i64_t, true);
             }
             if (try_vector_predication_intrinsic("llvm.experimental.vp.strided.load", VPResultType(slice_type, 0),
@@ -4176,7 +4176,7 @@ void CodeGen_LLVM::visit(const Store *op) {
                         annotate_store(store, slice_index);
                     }
                 } else if (ramp) {
-                    if (get_target().bits == 64 && !stride_val->getType()->isIntegerTy(64)) {
+                    if (get_target().bits() == 64 && !stride_val->getType()->isIntegerTy(64)) {
                         stride_val = builder->CreateIntCast(stride_val, i64_t, true);
                     }
                     bool generated = try_vector_predication_intrinsic("llvm.experimental.vp.strided.store", void_t, slice_lanes, AllEnabledMask(),
@@ -5448,7 +5448,7 @@ bool CodeGen_LLVM::use_pic() const {
     // addressing which avoids ADDR32 relocations that are incompatible
     // with /LARGEADDRESSAWARE.
     // See: https://github.com/llvm/llvm-project/pull/137643
-    if (target.os == Target::Windows && target.bits == 32) {
+    if (target.os() == Target::Windows && target.bits() == 32) {
         return false;
     }
     return true;

--- a/src/CodeGen_PowerPC.cpp
+++ b/src/CodeGen_PowerPC.cpp
@@ -141,7 +141,7 @@ void CodeGen_PowerPC::visit(const Max *op) {
 }
 
 string CodeGen_PowerPC::mcpu_target() const {
-    if (target.bits == 32) {
+    if (target.bits() == 32) {
         return "ppc32";
     } else {
         if (target.has_feature(Target::POWER_ARCH_2_07)) {

--- a/src/CodeGen_RISCV.cpp
+++ b/src/CodeGen_RISCV.cpp
@@ -175,8 +175,8 @@ string CodeGen_RISCV::mattrs() const {
 
     if (target.has_feature(Target::RVV)) {
         attrs.emplace_back("+v");
-        if (target.vector_bits != 0) {
-            attrs.push_back("+zvl" + std::to_string(target.vector_bits) + "b");
+        if (target.vector_bits() != 0) {
+            attrs.push_back("+zvl" + std::to_string(target.vector_bits()) + "b");
         }
     }
     return join_strings(attrs, ",");
@@ -184,7 +184,7 @@ string CodeGen_RISCV::mattrs() const {
 
 string CodeGen_RISCV::mabi() const {
     string abi;
-    if (target.bits == 32) {
+    if (target.bits() == 32) {
         abi = "ilp32";
     } else {
         abi = "lp64";
@@ -200,9 +200,9 @@ bool CodeGen_RISCV::use_soft_float_abi() const {
 }
 
 int CodeGen_RISCV::native_vector_bits() const {
-    if (target.vector_bits != 0 &&
+    if (target.vector_bits() != 0 &&
         target.has_feature(Target::RVV)) {
-        return target.vector_bits;
+        return target.vector_bits();
     }
     return 0;
 }
@@ -212,10 +212,10 @@ int CodeGen_RISCV::maximum_vector_bits() const {
 }
 
 int CodeGen_RISCV::target_vscale() const {
-    if (target.vector_bits != 0 &&
+    if (target.vector_bits() != 0 &&
         target.has_feature(Target::RVV)) {
-        internal_assert((target.vector_bits % 64) == 0);
-        return target.vector_bits / 64;
+        internal_assert((target.vector_bits() % 64) == 0);
+        return target.vector_bits() / 64;
     }
 
     return 0;
@@ -281,7 +281,7 @@ bool CodeGen_RISCV::call_riscv_vector_intrinsic(const RISCVIntrinsic &intrin, co
 
     Type ret_type = op->type.with_lanes(op_max_lanes);
 
-    llvm::Type *xlen_type = target.bits == 32 ? i32_t : i64_t;
+    llvm::Type *xlen_type = target.bits() == 32 ? i32_t : i64_t;
 
     // Produce intrinsic name and type mangling.
     llvm::Type *llvm_ret_type;
@@ -366,7 +366,7 @@ bool CodeGen_RISCV::call_riscv_vector_intrinsic(const RISCVIntrinsic &intrin, co
     mangled_name += mangle_llvm_type(llvm_arg_types[1]);
     mangled_name += mangle_llvm_type(llvm_arg_types[2]);
     if (intrin.flags & AddVLArg) {
-        mangled_name += (target.bits == 64) ? ".i64" : ".i32";
+        mangled_name += (target.bits() == 64) ? ".i64" : ".i32";
     }
 
     llvm::Function *llvm_intrinsic = get_llvm_intrin(llvm_ret_type, mangled_name, llvm_arg_types);

--- a/src/CodeGen_WebAssembly.cpp
+++ b/src/CodeGen_WebAssembly.cpp
@@ -393,7 +393,7 @@ string CodeGen_WebAssembly::mcpu_tune() const {
 }
 
 string CodeGen_WebAssembly::mattrs() const {
-    user_assert(target.os == Target::WebAssemblyRuntime)
+    user_assert(target.os() == Target::WebAssemblyRuntime)
         << "wasmrt is the only supported 'os' for WebAssembly at this time.";
 
     std::vector<std::string_view> attrs;
@@ -447,7 +447,7 @@ int CodeGen_WebAssembly::native_vector_bits() const {
 }  // namespace
 
 std::unique_ptr<CodeGen_CPU> new_CodeGen_WebAssembly(const Target &target) {
-    user_assert(target.bits == 32) << "Only wasm32 is supported.";
+    user_assert(target.bits() == 32) << "Only wasm32 is supported.";
     return std::make_unique<CodeGen_WebAssembly>(target);
 }
 

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -1716,7 +1716,7 @@ bool gather_might_be_slow(Target target) {
     // an AMD processor, gather is safe to use. If we have the AVX512 extensions
     // present in Zen4 (or above), we also know we're not on an affected
     // processor.
-    switch (target.processor_tune) {
+    switch (target.processor_tune()) {
     case Target::Processor::AMDFam10:
     case Target::Processor::BdVer1:
     case Target::Processor::BdVer2:
@@ -1740,7 +1740,7 @@ bool gather_might_be_slow(Target target) {
 
 string CodeGen_X86::mcpu_tune() const {
     // Check if any explicit request for tuning exists.
-    switch (target.processor_tune) {  // Please keep sorted.
+    switch (target.processor_tune()) {  // Please keep sorted.
     case Target::Processor::AMDFam10:
         return "amdfam10";
     case Target::Processor::BdVer1:
@@ -1773,7 +1773,7 @@ string CodeGen_X86::mcpu_tune() const {
     case Target::Processor::ProcessorGeneric:
         break;
     }
-    internal_assert(target.processor_tune == Target::Processor::ProcessorGeneric && "The switch should be exhaustive.");
+    internal_assert(target.processor_tune() == Target::Processor::ProcessorGeneric && "The switch should be exhaustive.");
     return mcpu_target();  // Detect "best" CPU from the enabled ISA's.
 }
 
@@ -1857,7 +1857,7 @@ string CodeGen_X86::mattrs() const {
     }
 
     if (target.has_feature(Target::AVX10_1)) {
-        switch (target.vector_bits) {
+        switch (target.vector_bits()) {
         case 256:
             attrs.emplace_back("+avx10.1-256");
             break;
@@ -1886,7 +1886,7 @@ bool CodeGen_X86::use_soft_float_abi() const {
 
 int CodeGen_X86::native_vector_bits() const {
     if (target.has_feature(Target::AVX10_1)) {
-        return target.vector_bits;
+        return target.vector_bits();
     } else if (target.has_feature(Target::AVX512)) {
         return 512;
     } else if (target.has_feature(Target::AVX)) {

--- a/src/DeviceInterface.cpp
+++ b/src/DeviceInterface.cpp
@@ -152,7 +152,7 @@ DeviceAPI get_default_device_api_for_target(const Target &target) {
         return DeviceAPI::OpenCL;
     } else if (target.has_feature(Target::CUDA)) {
         return DeviceAPI::CUDA;
-    } else if (target.arch != Target::Hexagon && target.has_feature(Target::HVX)) {
+    } else if (target.arch() != Target::Hexagon && target.has_feature(Target::HVX)) {
         return DeviceAPI::Hexagon;
     } else if (target.has_feature(Target::HexagonDma)) {
         return DeviceAPI::HexagonDma;

--- a/src/HexagonOffload.cpp
+++ b/src/HexagonOffload.cpp
@@ -972,8 +972,8 @@ Stmt inject_hexagon_rpc(Stmt s, const Target &host_target,
     // In the former we have true QuRT available, while on the
     // latter we simulate the Hexagon side code with a barebones
     // Shim layer, ie. NO QURT!
-    if (host_target.arch == Target::ARM) {
-        target.os = Target::QuRT;
+    if (host_target.arch() == Target::ARM) {
+        target.set_os(Target::QuRT);
     }
 
     // These feature flags are propagated from the host target to the

--- a/src/IRMatch.h
+++ b/src/IRMatch.h
@@ -92,14 +92,14 @@ struct BoundConstType {
     uint16_t lanes = 0;
 
     HALIDE_ALWAYS_INLINE BoundConstType() noexcept = default;
-    HALIDE_ALWAYS_INLINE BoundConstType(Type t) noexcept
-        : code(t.code()), bits((uint8_t)t.bits()), lanes((uint16_t)t.lanes()) {
+    HALIDE_ALWAYS_INLINE BoundConstType(Type type) noexcept
+        : code(type.code()), bits((uint8_t)type.bits()), lanes((uint16_t)type.lanes()) {
     }
     HALIDE_ALWAYS_INLINE operator Type() const noexcept {
         return Type(code, bits, lanes);
     }
-    HALIDE_ALWAYS_INLINE bool operator==(const BoundConstType &other) const noexcept {
-        return code == other.code && bits == other.bits && lanes == other.lanes;
+    HALIDE_ALWAYS_INLINE bool operator==(const BoundConstType &other_type) const noexcept {
+        return code == other_type.code && bits == other_type.bits && lanes == other_type.lanes;
     }
 };
 static_assert(sizeof(BoundConstType) == 4, "BoundConstType should be a compact 4-byte numeric type");

--- a/src/InjectHostDevBufferCopies.cpp
+++ b/src/InjectHostDevBufferCopies.cpp
@@ -789,7 +789,7 @@ Stmt inject_host_dev_buffer_copies(Stmt s, const Target &t) {
     // here, as this implementation assumes we start from the host (which
     // isn't true for Hexagon), and that it's safe to inject calls to copy
     // and/or mark things dirty (which also isn't true for Hexagon).
-    if (t.arch == Target::Hexagon) {
+    if (t.arch() == Target::Hexagon) {
         return s;
     }
 

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -379,7 +379,7 @@ void compile_module_impl(
     llvm::orc::JITTargetMachineBuilder tm_builder(llvm::Triple(m->getTargetTriple()));
     tm_builder.setOptions(options);
     tm_builder.setCodeGenOptLevel(CodeGenOptLevel::Aggressive);
-    if (target.arch == Target::Arch::RISCV) {
+    if (target.arch() == Target::Arch::RISCV) {
         tm_builder.setCodeModel(llvm::CodeModel::Medium);
     }
 
@@ -401,9 +401,9 @@ void compile_module_impl(
     };
 
     llvm::orc::LLJITBuilderState::ObjectLinkingLayerCreator linkerBuilder;
-    if ((target.arch == Target::Arch::X86 && target.bits == 32) ||
-        (target.arch == Target::Arch::ARM && target.bits == 32) ||
-        target.os == Target::Windows) {
+    if ((target.arch() == Target::Arch::X86 && target.bits() == 32) ||
+        (target.arch() == Target::Arch::ARM && target.bits() == 32) ||
+        target.os() == Target::Windows) {
         // Fallback to RTDyld-based linking to workaround errors:
         // i386: "JIT session error: Unsupported i386 relocation:4" (R_386_PLT32)
         // ARM 32bit: Unsupported target machine architecture in ELF object shared runtime-jitted-objectbuffer
@@ -1279,7 +1279,7 @@ Target JITCache::get_compiled_jit_target() const {
     // match what we expect.
     const bool has_wasm = wasm_module.contents.defined();
     const bool has_native = jit_module.compiled();
-    if (jit_target.arch == Target::WebAssembly) {
+    if (jit_target.arch() == Target::WebAssembly) {
         internal_assert(has_wasm && !has_native);
     } else if (!jit_target.has_unknowns()) {
         internal_assert(!has_wasm && has_native);
@@ -1298,7 +1298,7 @@ int JITCache::call_jit_code(const void *const *args) {
                     "compilation for Halide code.";
 #endif
 #endif
-    if (get_compiled_jit_target().arch == Target::WebAssembly) {
+    if (get_compiled_jit_target().arch() == Target::WebAssembly) {
         internal_assert(wasm_module.contents.defined());
         return wasm_module.run(args);
     } else {

--- a/src/LLVM_Runtime_Linker.cpp
+++ b/src/LLVM_Runtime_Linker.cpp
@@ -353,13 +353,13 @@ namespace Halide {
 namespace {
 
 llvm::DataLayout get_data_layout_for_target(Target target) {
-    if (target.arch == Target::X86) {
-        if (target.bits == 32) {
-            if (target.os == Target::OSX) {
+    if (target.arch() == Target::X86) {
+        if (target.bits() == 32) {
+            if (target.os() == Target::OSX) {
                 return llvm::DataLayout("e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:128-n8:16:32-S128");
-            } else if (target.os == Target::IOS) {
+            } else if (target.os() == Target::IOS) {
                 return llvm::DataLayout("e-m:o-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:128-n8:16:32-S128");
-            } else if (target.os == Target::Windows) {
+            } else if (target.os() == Target::Windows) {
                 // For 32-bit MSVC targets, alignment of f80 values is 16 bytes (see https://reviews.llvm.org/D115942)
                 if (!target.has_feature(Target::JIT)) {
                     return llvm::DataLayout("e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32-a:0:32-S32");
@@ -371,54 +371,54 @@ llvm::DataLayout get_data_layout_for_target(Target target) {
                 return llvm::DataLayout("e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128");
             }
         } else {  // 64-bit
-            if (target.os == Target::OSX) {
+            if (target.os() == Target::OSX) {
                 return llvm::DataLayout("e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128");
-            } else if (target.os == Target::IOS) {
+            } else if (target.os() == Target::IOS) {
                 return llvm::DataLayout("e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128");
-            } else if (target.os == Target::Windows && !target.has_feature(Target::JIT)) {
+            } else if (target.os() == Target::Windows && !target.has_feature(Target::JIT)) {
                 return llvm::DataLayout("e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128");
-            } else if (target.os == Target::Windows) {
+            } else if (target.os() == Target::Windows) {
                 return llvm::DataLayout("e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128");
             } else {
                 return llvm::DataLayout("e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128");
             }
         }
-    } else if (target.arch == Target::ARM) {
-        if (target.bits == 32) {
-            if (target.os == Target::IOS) {
+    } else if (target.arch() == Target::ARM) {
+        if (target.bits() == 32) {
+            if (target.os() == Target::IOS) {
                 return llvm::DataLayout("e-m:o-p:32:32-Fi8-f64:32:64-v64:32:64-v128:32:128-a:0:32-n32-S32");
             } else {
                 return llvm::DataLayout("e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64");
             }
         } else {  // 64-bit
-            if (target.os == Target::IOS) {
+            if (target.os() == Target::IOS) {
                 return llvm::DataLayout("e-m:o-i64:64-i128:128-n32:64-S128-Fn32");
-            } else if (target.os == Target::OSX) {
+            } else if (target.os() == Target::OSX) {
                 return llvm::DataLayout("e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32");
-            } else if (target.os == Target::Windows) {
+            } else if (target.os() == Target::Windows) {
                 return llvm::DataLayout("e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128-Fn32");
             } else {
                 return llvm::DataLayout("e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32");
             }
         }
-    } else if (target.arch == Target::POWERPC) {
-        if (target.bits == 32) {
+    } else if (target.arch() == Target::POWERPC) {
+        if (target.bits() == 32) {
             return llvm::DataLayout("E-m:e-p:32:32-Fn32-i64:64-n32");
         } else {
             return llvm::DataLayout("e-m:e-Fn32-i64:64-n32:64-S128-v256:256:256-v512:512:512");
         }
-    } else if (target.arch == Target::Hexagon) {
+    } else if (target.arch() == Target::Hexagon) {
         return llvm::DataLayout(
             "e-m:e-p:32:32:32-a:0-n16:32-i64:64:64-i32:32:32-i16:16:16-i1:8:8"
             "-f32:32:32-f64:64:64-v32:32:32-v64:64:64-v512:512:512-v1024:1024:1024-v2048:2048:2048");
-    } else if (target.arch == Target::WebAssembly) {
-        if (target.bits == 32) {
+    } else if (target.arch() == Target::WebAssembly) {
+        if (target.bits() == 32) {
             return llvm::DataLayout("e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20");
         } else {
             return llvm::DataLayout("e-m:e-p:64:64-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20");
         }
-    } else if (target.arch == Target::RISCV) {
-        if (target.bits == 32) {
+    } else if (target.arch() == Target::RISCV) {
+        if (target.bits() == 32) {
             return llvm::DataLayout("e-m:e-p:32:32-i64:64-n32-S128");
         } else {
             return llvm::DataLayout("e-m:e-p:64:64-i64:64-i128:128-n32:64-S128");
@@ -460,21 +460,21 @@ std::optional<llvm::VersionTuple> get_os_version_constraint(const llvm::Triple &
 llvm::Triple get_triple_for_target(const Target &target) {
     llvm::Triple triple;
 
-    if (target.arch == Target::X86) {
-        if (target.bits == 32) {
+    if (target.arch() == Target::X86) {
+        if (target.bits() == 32) {
             triple.setArch(llvm::Triple::x86);
         } else {
-            user_assert(target.bits == 64) << "Target must be 32- or 64-bit.\n";
+            user_assert(target.bits() == 64) << "Target must be 32- or 64-bit.\n";
             triple.setArch(llvm::Triple::x86_64);
         }
 
-        if (target.os == Target::Linux) {
+        if (target.os() == Target::Linux) {
             triple.setOS(llvm::Triple::Linux);
             triple.setEnvironment(llvm::Triple::GNU);
-        } else if (target.os == Target::OSX) {
+        } else if (target.os() == Target::OSX) {
             triple.setVendor(llvm::Triple::Apple);
             triple.setOS(llvm::Triple::MacOSX);
-        } else if (target.os == Target::Windows) {
+        } else if (target.os() == Target::Windows) {
             triple.setVendor(llvm::Triple::PC);
             triple.setOS(llvm::Triple::Win32);
             triple.setEnvironment(llvm::Triple::MSVC);
@@ -482,25 +482,25 @@ llvm::Triple get_triple_for_target(const Target &target) {
                 // Use ELF for jitting
                 triple.setObjectFormat(llvm::Triple::ELF);
             }
-        } else if (target.os == Target::Android) {
+        } else if (target.os() == Target::Android) {
             triple.setOS(llvm::Triple::Linux);
             triple.setEnvironment(llvm::Triple::Android);
-        } else if (target.os == Target::IOS) {
+        } else if (target.os() == Target::IOS) {
             // X86 on iOS for the simulator
             triple.setVendor(llvm::Triple::Apple);
             triple.setOS(llvm::Triple::IOS);
-        } else if (target.os == Target::Fuchsia) {
+        } else if (target.os() == Target::Fuchsia) {
             triple.setOS(llvm::Triple::Fuchsia);
         }
-    } else if (target.arch == Target::ARM) {
-        if (target.bits == 32) {
+    } else if (target.arch() == Target::ARM) {
+        if (target.bits() == 32) {
             if (target.has_feature(Target::ARMv7s)) {
                 triple.setArchName("armv7s");
             } else {
                 triple.setArch(llvm::Triple::arm);
             }
         } else {
-            user_assert(target.bits == 64) << "Target bits must be 32 or 64\n";
+            user_assert(target.bits() == 64) << "Target bits must be 32 or 64\n";
 #ifdef WITH_AARCH64
             triple.setArch(llvm::Triple::aarch64);
 #else
@@ -508,17 +508,17 @@ llvm::Triple get_triple_for_target(const Target &target) {
 #endif
         }
 
-        if (target.os == Target::Android) {
+        if (target.os() == Target::Android) {
             triple.setOS(llvm::Triple::Linux);
             triple.setEnvironment(llvm::Triple::EABI);
-        } else if (target.os == Target::IOS) {
+        } else if (target.os() == Target::IOS) {
             triple.setOS(llvm::Triple::IOS);
             triple.setVendor(llvm::Triple::Apple);
-        } else if (target.os == Target::Linux) {
+        } else if (target.os() == Target::Linux) {
             triple.setOS(llvm::Triple::Linux);
             triple.setEnvironment(llvm::Triple::GNUEABIHF);
-        } else if (target.os == Target::Windows) {
-            user_assert(target.bits == 64) << "Windows ARM targets must be 64-bit.\n";
+        } else if (target.os() == Target::Windows) {
+            user_assert(target.bits() == 64) << "Windows ARM targets must be 64-bit.\n";
             triple.setVendor(llvm::Triple::PC);
             triple.setOS(llvm::Triple::Win32);
             triple.setEnvironment(llvm::Triple::MSVC);
@@ -527,61 +527,61 @@ llvm::Triple get_triple_for_target(const Target &target) {
                 // Currently blocked by https://github.com/halide/Halide/issues/5040
                 user_error << "No JIT support for this OS/CPU combination yet.\n";
             }
-        } else if (target.os == Target::Fuchsia) {
+        } else if (target.os() == Target::Fuchsia) {
             triple.setOS(llvm::Triple::Fuchsia);
-        } else if (target.os == Target::OSX) {
+        } else if (target.os() == Target::OSX) {
             triple.setVendor(llvm::Triple::Apple);
             triple.setOS(llvm::Triple::MacOSX);
             triple.setArchName("arm64");
-        } else if (target.os == Target::NoOS) {
+        } else if (target.os() == Target::NoOS) {
             // For bare-metal environments
 
         } else {
             user_error << "No arm support for this OS\n";
         }
-    } else if (target.arch == Target::POWERPC) {
+    } else if (target.arch() == Target::POWERPC) {
 #ifdef WITH_POWERPC
         // Only ppc*-unknown-linux-gnu are supported for the time being.
-        user_assert(target.os == Target::Linux) << "PowerPC target is Linux-only.\n";
+        user_assert(target.os() == Target::Linux) << "PowerPC target is Linux-only.\n";
         triple.setVendor(llvm::Triple::UnknownVendor);
         triple.setOS(llvm::Triple::Linux);
         triple.setEnvironment(llvm::Triple::GNU);
-        if (target.bits == 32) {
+        if (target.bits() == 32) {
             triple.setArch(llvm::Triple::ppc);
         } else {
             // Currently POWERPC64 support is only little-endian.
-            user_assert(target.bits == 64) << "Target must be 32- or 64-bit.\n";
+            user_assert(target.bits() == 64) << "Target must be 32- or 64-bit.\n";
             triple.setArch(llvm::Triple::ppc64le);
         }
 #else
         user_error << "PowerPC llvm target not enabled in this build of Halide\n";
 #endif
-    } else if (target.arch == Target::Hexagon) {
+    } else if (target.arch() == Target::Hexagon) {
         triple.setVendor(llvm::Triple::UnknownVendor);
         triple.setArch(llvm::Triple::hexagon);
         triple.setObjectFormat(llvm::Triple::ELF);
-    } else if (target.arch == Target::WebAssembly) {
+    } else if (target.arch() == Target::WebAssembly) {
         triple.setVendor(llvm::Triple::UnknownVendor);
-        if (target.bits == 32) {
+        if (target.bits() == 32) {
             triple.setArch(llvm::Triple::wasm32);
         } else {
             triple.setArch(llvm::Triple::wasm64);
         }
         triple.setObjectFormat(llvm::Triple::Wasm);
-    } else if (target.arch == Target::RISCV) {
-        if (target.bits == 32) {
+    } else if (target.arch() == Target::RISCV) {
+        if (target.bits() == 32) {
             triple.setArch(llvm::Triple::riscv32);
         } else {
-            user_assert(target.bits == 64) << "Target must be 32- or 64-bit.\n";
+            user_assert(target.bits() == 64) << "Target must be 32- or 64-bit.\n";
             triple.setArch(llvm::Triple::riscv64);
         }
 
-        if (target.os == Target::Linux) {
+        if (target.os() == Target::Linux) {
             triple.setOS(llvm::Triple::Linux);
-        } else if (target.os == Target::Android) {
+        } else if (target.os() == Target::Android) {
             triple.setOS(llvm::Triple::Linux);
             triple.setEnvironment(llvm::Triple::Android);
-        } else if (target.os == Target::NoOS) {
+        } else if (target.os() == Target::NoOS) {
             // for baremetal environment
         } else {
             user_error << "No RISCV support for this OS\n";
@@ -591,7 +591,7 @@ llvm::Triple get_triple_for_target(const Target &target) {
     }
 
     if (target.has_feature(Target::Simulator)) {
-        user_assert(target.os == Target::IOS) << "Simulator only supported for iOS\n";
+        user_assert(target.os() == Target::IOS) << "Simulator only supported for iOS\n";
         triple.setEnvironment(llvm::Triple::Simulator);
     }
 
@@ -632,7 +632,7 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
     // Set the layout and triple on the modules before linking, so
     // llvm doesn't complain while combining them.
     for (auto &module : modules) {
-        if (t.os == Target::Windows &&
+        if (t.os() == Target::Windows &&
             !Internal::starts_with(module->getName().str(), "windows_")) {
             // When compiling for windows, all wchars are
             // 16-bit. Generic modules may have it set to 32-bit. Drop
@@ -678,7 +678,7 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
     // Comdats are left in for other platforms as they are required
     // for certain things on Windows and they are useful in general in
     // ELF based formats.
-    if (t.os == Target::IOS || t.os == Target::OSX) {
+    if (t.os() == Target::IOS || t.os() == Target::OSX) {
         for (auto &global_obj : modules[0]->global_objects()) {
             global_obj.setComdat(nullptr);
         }
@@ -737,7 +737,7 @@ void link_modules(std::vector<std::unique_ptr<llvm::Module>> &modules, Target t,
         // Windows requires every symbol that's going to get merged
         // has a comdat that specifies how. The linkage type alone
         // isn't enough.
-        if (t.os == Target::Windows && f.isWeakForLinker()) {
+        if (t.os() == Target::Windows && f.isWeakForLinker()) {
             llvm::Comdat *comdat = modules[0]->getOrInsertComdat(f_name);
             comdat->setSelectionKind(llvm::Comdat::Any);
             f.setComdat(comdat);
@@ -854,7 +854,7 @@ namespace Internal {
 
 std::unique_ptr<llvm::Module> link_with_wasm_jit_runtime(llvm::LLVMContext *c, const Target &t,
                                                          std::unique_ptr<llvm::Module> extra_module) {
-    bool bits_64 = (t.bits == 64);
+    bool bits_64 = (t.bits() == 64);
     bool debug = t.has_feature(Target::Debug);
 
     // We only need to include things that must be linked in as callable entrypoints;
@@ -921,9 +921,9 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
 
     //    Halide::Internal::debug(0) << "Getting initial module type " << (int)module_type << "\n";
 
-    internal_assert(t.bits == 32 || t.bits == 64)
+    internal_assert(t.bits() == 32 || t.bits() == 64)
         << "Bad target: " << t.to_string();
-    bool bits_64 = (t.bits == 64);
+    bool bits_64 = (t.bits() == 64);
     bool debug = t.has_feature(Target::Debug);
     bool tsan = t.has_feature(Target::TSAN);
 
@@ -954,13 +954,13 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
     };
 
     const auto add_linux_thread_id = [&] {
-        if (t.arch == Target::X86) {
+        if (t.arch() == Target::X86) {
             modules.push_back(get_initmod_linux_x86_thread_id(c, bits_64, debug));
-        } else if (t.arch == Target::ARM) {
+        } else if (t.arch() == Target::ARM) {
             modules.push_back(get_initmod_linux_arm_thread_id(c, bits_64, debug));
-        } else if (t.arch == Target::RISCV) {
+        } else if (t.arch() == Target::RISCV) {
             modules.push_back(get_initmod_linux_riscv_thread_id(c, bits_64, debug));
-        } else if (t.arch == Target::POWERPC) {
+        } else if (t.arch() == Target::POWERPC) {
             modules.push_back(get_initmod_linux_powerpc_thread_id(c, bits_64, debug));
         }
     };
@@ -988,12 +988,12 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
     if (module_type != ModuleGPU) {
         if (module_type != ModuleJITInlined && module_type != ModuleAOTNoRuntime) {
             // OS-dependent modules
-            if (t.os == Target::Linux) {
+            if (t.os() == Target::Linux) {
                 add_allocator();
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
-                if (t.arch == Target::X86) {
+                if (t.arch() == Target::X86) {
                     modules.push_back(get_initmod_linux_clock(c, bits_64, debug));
                 } else {
                     modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -1003,7 +1003,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_linux_yield(c, bits_64, debug));
                 add_linux_posix_threads();
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
-            } else if (t.os == Target::WebAssemblyRuntime) {
+            } else if (t.os() == Target::WebAssemblyRuntime) {
                 add_allocator();
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
@@ -1018,7 +1018,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                     modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));
                 }
                 modules.push_back(get_initmod_fake_get_symbol(c, bits_64, debug));
-            } else if (t.os == Target::OSX) {
+            } else if (t.os() == Target::OSX) {
                 add_allocator();
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
@@ -1029,11 +1029,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 add_darwin_posix_threads();
                 modules.push_back(get_initmod_osx_get_symbol(c, bits_64, debug));
                 modules.push_back(get_initmod_osx_host_cpu_count(c, bits_64, debug));
-            } else if (t.os == Target::Android) {
+            } else if (t.os() == Target::Android) {
                 add_allocator();
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
-                if (t.arch == Target::ARM || t.arch == Target::RISCV) {
+                if (t.arch() == Target::ARM || t.arch() == Target::RISCV) {
                     modules.push_back(get_initmod_android_clock(c, bits_64, debug));
                 } else {
                     modules.push_back(get_initmod_posix_clock(c, bits_64, debug));
@@ -1043,7 +1043,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_linux_yield(c, bits_64, debug));  // TODO: verify
                 add_linux_posix_threads();
                 modules.push_back(get_initmod_posix_get_symbol(c, bits_64, debug));
-            } else if (t.os == Target::Windows) {
+            } else if (t.os() == Target::Windows) {
                 modules.push_back(get_initmod_posix_aligned_alloc(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
@@ -1057,7 +1057,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                     modules.push_back(get_initmod_windows_threads(c, bits_64, debug));
                 }
                 modules.push_back(get_initmod_windows_get_symbol(c, bits_64, debug));
-            } else if (t.os == Target::IOS) {
+            } else if (t.os() == Target::IOS) {
                 add_allocator();
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
@@ -1066,7 +1066,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_osx_host_cpu_count(c, bits_64, debug));
                 modules.push_back(get_initmod_osx_yield(c, bits_64, debug));
                 add_darwin_posix_threads();
-            } else if (t.os == Target::QuRT) {
+            } else if (t.os() == Target::QuRT) {
                 modules.push_back(get_initmod_posix_aligned_alloc(c, bits_64, debug));
                 modules.push_back(get_initmod_qurt_allocator(c, bits_64, debug));
                 modules.push_back(get_initmod_qurt_yield(c, bits_64, debug));
@@ -1075,16 +1075,16 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 } else {
                     modules.push_back(get_initmod_qurt_threads(c, bits_64, debug));
                 }
-            } else if (t.os == Target::NoOS) {
+            } else if (t.os() == Target::NoOS) {
                 // The OS-specific symbols provided by the modules
                 // above are expected to be provided by the containing
                 // process instead at link time. Less aggressive than
                 // NoRuntime, as OS-agnostic modules like tracing are
                 // still included below.
-                if (t.arch == Target::Hexagon) {
+                if (t.arch() == Target::Hexagon) {
                     modules.push_back(get_initmod_posix_aligned_alloc(c, bits_64, debug));
                     modules.push_back(get_initmod_qurt_allocator(c, bits_64, debug));
-                } else if (t.arch == Target::ARM && t.has_feature(Target::Semihosting)) {
+                } else if (t.arch() == Target::ARM && t.has_feature(Target::Semihosting)) {
                     add_allocator();
                     modules.push_back(get_initmod_alignment_32(c, bits_64, debug));
                     modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
@@ -1092,7 +1092,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                     modules.push_back(get_initmod_posix_io(c, bits_64, debug));
                 }
                 modules.push_back(get_initmod_fake_thread_pool(c, bits_64, debug));
-            } else if (t.os == Target::Fuchsia) {
+            } else if (t.os() == Target::Fuchsia) {
                 add_allocator();
                 modules.push_back(get_initmod_posix_error_handler(c, bits_64, debug));
                 modules.push_back(get_initmod_posix_print(c, bits_64, debug));
@@ -1112,8 +1112,8 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             modules.push_back(get_initmod_destructors(c, bits_64, debug));
             modules.push_back(get_initmod_pseudostack(c, bits_64, debug));
             // Math intrinsics vary slightly across platforms
-            if (t.os == Target::Windows) {
-                if (t.bits == 32) {
+            if (t.os() == Target::Windows) {
+                if (t.bits() == 32) {
                     modules.push_back(get_initmod_win32_math_ll(c));
                 } else {
                     modules.push_back(get_initmod_posix_math_ll(c));
@@ -1126,7 +1126,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
         if (module_type != ModuleJITInlined && module_type != ModuleAOTNoRuntime) {
             // These modules are always used and shared
             modules.push_back(get_initmod_gpu_device_selection(c, bits_64, debug));
-            if (t.arch != Target::Hexagon) {
+            if (t.arch() != Target::Hexagon) {
                 // These modules don't behave correctly on a real
                 // Hexagon device (they do work in the simulator
                 // though...).
@@ -1140,10 +1140,10 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             }
             modules.push_back(get_initmod_to_string(c, bits_64, debug));
 
-            if (t.arch == Target::Hexagon ||
+            if (t.arch() == Target::Hexagon ||
                 t.has_feature(Target::HVX)) {
                 modules.push_back(get_initmod_alignment_128(c, bits_64, debug));
-            } else if (t.arch == Target::X86) {
+            } else if (t.arch() == Target::X86) {
                 // AVX-512 requires 64-byte alignment. Could only increase alignment
                 // if AVX-512 is in the target, but that falls afoul of linking
                 // multiple versions of a filter for different levels of x86 -- weak
@@ -1158,7 +1158,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             }
 
             // Prefer using fopen_lfs on Linux systems, which calls fopen64() to ensure LFS support.
-            if (t.os == Target::Linux) {
+            if (t.os() == Target::Linux) {
                 modules.push_back(get_initmod_fopen_lfs(c, bits_64, debug));
             } else {
                 modules.push_back(get_initmod_fopen(c, bits_64, debug));
@@ -1170,16 +1170,16 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             modules.push_back(get_initmod_errors(c, bits_64, debug));
 
             // Some environments don't support the atomics the profiler requires.
-            if (t.os != Target::NoOS && t.os != Target::QuRT) {
+            if (t.os() != Target::NoOS && t.os() != Target::QuRT) {
                 if (t.has_feature(Target::ProfileByTimer)) {
                     user_assert(!t.has_feature(Target::Profile)) << "Can only use one of Target::Profile and Target::ProfileByTimer.";
                     // TODO(zvookin): This should work on all Posix like systems, but needs to be tested.
-                    user_assert(t.os == Target::Linux) << "The timer based profiler currently can only be used on Linux.";
+                    user_assert(t.os() == Target::Linux) << "The timer based profiler currently can only be used on Linux.";
                     modules.push_back(get_initmod_profiler_inlined(c, bits_64, debug));
                     modules.push_back(get_initmod_timer_profiler(c, bits_64, debug));
                     modules.push_back(get_initmod_posix_timer_profiler(c, bits_64, debug));
                 } else {
-                    if (t.os == Target::Windows) {
+                    if (t.os() == Target::Windows) {
                         modules.push_back(get_initmod_windows_profiler(c, bits_64, debug));
                     } else {
                         modules.push_back(get_initmod_profiler(c, bits_64, debug));
@@ -1207,11 +1207,11 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
 
         if (module_type != ModuleJITShared) {
             // These modules are optional
-            if (t.arch == Target::X86) {
+            if (t.arch() == Target::X86) {
                 modules.push_back(get_initmod_x86_ll(c));
             }
-            if (t.arch == Target::ARM) {
-                if (t.bits == 64) {
+            if (t.arch() == Target::ARM) {
+                if (t.bits() == 64) {
                     modules.push_back(get_initmod_aarch64_ll(c));
                 } else if (t.has_feature(Target::ARMv7s)) {
                     modules.push_back(get_initmod_arm_ll(c));
@@ -1221,10 +1221,10 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                     modules.push_back(get_initmod_arm_no_neon_ll(c));
                 }
             }
-            if (t.arch == Target::POWERPC) {
+            if (t.arch() == Target::POWERPC) {
                 modules.push_back(get_initmod_powerpc_ll(c));
             }
-            if (t.arch == Target::Hexagon) {
+            if (t.arch() == Target::Hexagon) {
                 modules.push_back(get_initmod_qurt_hvx(c, bits_64, debug));
                 modules.push_back(get_initmod_hvx_128_ll(c));
                 if (t.features_any_of({Target::HVX_v65, Target::HVX_v66,
@@ -1252,7 +1252,7 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
                 modules.push_back(get_initmod_x86_amx_ll(c));
             }
             if (t.has_feature(Target::Profile)) {
-                if (t.os == Target::WebAssemblyRuntime) {
+                if (t.os() == Target::WebAssemblyRuntime) {
                     user_assert(t.has_feature(Target::WasmThreads))
                         << "The profiler requires threads to operate; enable wasm_threads to use this under WebAssembly.";
                 }
@@ -1261,10 +1261,10 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
             if (t.has_feature(Target::ProfileByTimer)) {
                 user_assert(!t.has_feature(Target::Profile)) << "Can only use one of Target::Profile and Target::ProfileByTimer.";
                 // TODO(zvookin): This should work on all Posix like systems, but needs to be tested.
-                user_assert(t.os == Target::Linux) << "The timer based profiler currently can only be used on Linux.";
+                user_assert(t.os() == Target::Linux) << "The timer based profiler currently can only be used on Linux.";
                 modules.push_back(get_initmod_profiler_inlined(c, bits_64, debug));
             }
-            if (t.arch == Target::WebAssembly) {
+            if (t.arch() == Target::WebAssembly) {
                 modules.push_back(get_initmod_wasm_math_ll(c));
             }
         }
@@ -1272,44 +1272,44 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
         if (module_type == ModuleAOT) {
             // These modules are only used for AOT compilation
             modules.push_back(get_initmod_can_use_target(c, bits_64, debug));
-            if (t.arch == Target::X86) {
-                if (t.os == Target::Android || t.os == Target::Linux) {
+            if (t.arch() == Target::X86) {
+                if (t.os() == Target::Android || t.os() == Target::Linux) {
                     modules.push_back(get_initmod_linux_x86_cpu_features(c, bits_64, debug));
                 } else {
                     modules.push_back(get_initmod_x86_cpu_features(c, bits_64, debug));
                 }
             }
-            if (t.arch == Target::ARM) {
-                if (t.bits == 64) {
-                    if (t.os == Target::Android || t.os == Target::Linux) {
+            if (t.arch() == Target::ARM) {
+                if (t.bits() == 64) {
+                    if (t.os() == Target::Android || t.os() == Target::Linux) {
                         modules.push_back(get_initmod_linux_aarch64_cpu_features(c, bits_64, debug));
-                    } else if (t.os == Target::OSX || t.os == Target::IOS) {
+                    } else if (t.os() == Target::OSX || t.os() == Target::IOS) {
                         modules.push_back(get_initmod_osx_aarch64_cpu_features(c, bits_64, debug));
-                    } else if (t.os == Target::Windows) {
+                    } else if (t.os() == Target::Windows) {
                         modules.push_back(get_initmod_windows_aarch64_cpu_features_arm(c, bits_64, debug));
                     } else {
                         modules.push_back(get_initmod_aarch64_cpu_features(c, bits_64, debug));
                     }
                 } else {
-                    if (t.os == Target::Android || t.os == Target::Linux) {
+                    if (t.os() == Target::Android || t.os() == Target::Linux) {
                         modules.push_back(get_initmod_linux_arm_cpu_features(c, bits_64, debug));
-                    } else if (t.os == Target::OSX || t.os == Target::IOS) {
+                    } else if (t.os() == Target::OSX || t.os() == Target::IOS) {
                         modules.push_back(get_initmod_osx_arm_cpu_features(c, bits_64, debug));
                     } else {
                         modules.push_back(get_initmod_arm_cpu_features(c, bits_64, debug));
                     }
                 }
             }
-            if (t.arch == Target::POWERPC) {
+            if (t.arch() == Target::POWERPC) {
                 modules.push_back(get_initmod_powerpc_cpu_features(c, bits_64, debug));
             }
-            if (t.arch == Target::Hexagon) {
+            if (t.arch() == Target::Hexagon) {
                 modules.push_back(get_initmod_hexagon_cpu_features(c, bits_64, debug));
             }
-            if (t.arch == Target::RISCV) {
+            if (t.arch() == Target::RISCV) {
                 modules.push_back(get_initmod_riscv_cpu_features(c, bits_64, debug));
             }
-            if (t.arch == Target::WebAssembly) {
+            if (t.arch() == Target::WebAssembly) {
                 modules.push_back(get_initmod_wasm_cpu_features(c, bits_64, debug));
             }
         }
@@ -1323,14 +1323,14 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
 
     if (module_type == ModuleAOT || module_type == ModuleGPU) {
         if (t.has_feature(Target::CUDA)) {
-            if (t.os == Target::Windows) {
+            if (t.os() == Target::Windows) {
                 modules.push_back(get_initmod_windows_cuda(c, bits_64, debug));
             } else {
                 modules.push_back(get_initmod_cuda(c, bits_64, debug));
             }
         }
         if (t.has_feature(Target::OpenCL)) {
-            if (t.os == Target::Windows) {
+            if (t.os() == Target::Windows) {
                 modules.push_back(get_initmod_windows_opencl(c, bits_64, debug));
             } else {
                 modules.push_back(get_initmod_opencl(c, bits_64, debug));
@@ -1338,9 +1338,9 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
         }
         if (t.has_feature(Target::Metal)) {
             modules.push_back(get_initmod_metal(c, bits_64, debug));
-            if (t.arch == Target::ARM) {
+            if (t.arch() == Target::ARM) {
                 modules.push_back(get_initmod_metal_objc_arm(c, bits_64, debug));
-            } else if (t.arch == Target::X86) {
+            } else if (t.arch() == Target::X86) {
                 modules.push_back(get_initmod_metal_objc_x86(c, bits_64, debug));
             } else {
                 user_error << "Metal can only be used on ARM or X86 architectures.\n";
@@ -1348,38 +1348,38 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
         }
         if (t.has_feature(Target::D3D12Compute)) {
             user_assert(bits_64) << "D3D12Compute target only available on 64-bit targets for now.\n";
-            user_assert(t.os == Target::Windows) << "D3D12Compute target only available on Windows targets.\n";
-            if (t.arch == Target::X86) {
+            user_assert(t.os() == Target::Windows) << "D3D12Compute target only available on Windows targets.\n";
+            if (t.arch() == Target::X86) {
                 modules.push_back(get_initmod_windows_d3d12compute_x86(c, bits_64, debug));
-            } else if (t.arch == Target::ARM) {
+            } else if (t.arch() == Target::ARM) {
                 modules.push_back(get_initmod_windows_d3d12compute_arm(c, bits_64, debug));
             } else {
                 user_error << "Direct3D 12 can only be used on ARM or X86 architectures.\n";
             }
         }
         if (t.has_feature(Target::Vulkan)) {
-            if (t.os == Target::Windows) {
+            if (t.os() == Target::Windows) {
                 modules.push_back(get_initmod_windows_vulkan(c, bits_64, debug));
             } else {
                 modules.push_back(get_initmod_vulkan(c, bits_64, debug));
             }
         }
         if (t.has_feature(Target::WebGPU)) {
-            if (t.os == Target::Windows) {
+            if (t.os() == Target::Windows) {
                 // TODO: Test on Windows and enable this.
                 // See https://github.com/halide/Halide/issues/7249
                 user_error << "WebGPU runtime not yet supported on Windows.\n";
             } else {
                 // Select the right WebGPU runtime variant based on the Target's OS:
                 // if we are targeting wasm, use the Emscripten variant; in all other cases, use Dawn variant.
-                if (t.os == Target::WebAssemblyRuntime) {
+                if (t.os() == Target::WebAssemblyRuntime) {
                     modules.push_back(get_initmod_webgpu_emscripten(c, bits_64, debug));
                 } else {
                     modules.push_back(get_initmod_webgpu_dawn(c, bits_64, debug));
                 }
             }
         }
-        if (t.arch != Target::Hexagon && t.has_feature(Target::HVX)) {
+        if (t.arch() != Target::Hexagon && t.has_feature(Target::HVX)) {
             modules.push_back(get_initmod_module_jit_ref_count(c, bits_64, debug));
             modules.push_back(get_initmod_hexagon_host(c, bits_64, debug));
         }
@@ -1392,19 +1392,19 @@ std::unique_ptr<llvm::Module> get_initial_module_for_target(Target t, llvm::LLVM
 
     if (module_type == ModuleAOTNoRuntime ||
         module_type == ModuleJITInlined ||
-        t.os == Target::NoOS) {
+        t.os() == Target::NoOS) {
         modules.push_back(get_initmod_runtime_api(c, bits_64, debug));
     }
 
     link_modules(modules, t);
 
-    if (t.os == Target::Windows &&
-        t.bits == 32 &&
+    if (t.os() == Target::Windows &&
+        t.bits() == 32 &&
         (t.has_feature(Target::JIT))) {
         undo_win32_name_mangling(modules[0].get());
     }
 
-    if (t.os == Target::Windows) {
+    if (t.os() == Target::Windows) {
         add_underscores_to_posix_calls_on_windows(modules[0].get());
     }
 

--- a/src/Lerp.cpp
+++ b/src/Lerp.cpp
@@ -143,7 +143,7 @@ Expr lower_lerp(Type final_type, Expr zero_val, Expr one_val, const Expr &weight
                 // ((x + 128) / 256 + x + 128) / 256. Note that
                 // overflow is impossible here because the most our
                 // prod_sum can be is 255^2.
-                if (target.arch == Target::X86) {
+                if (target.arch() == Target::X86) {
                     // On x86 we have no rounding shifts but we do
                     // have a multiply-keep-high-half. So it's
                     // actually one instruction cheaper to do the

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -246,7 +246,7 @@ void lower_impl(const vector<Function> &output_funcs,
     bool will_inject_host_copies =
         (t.has_gpu_feature() ||
          t.has_feature(Target::HexagonDma) ||
-         (t.arch != Target::Hexagon && (t.has_feature(Target::HVX))));
+         (t.arch() != Target::Hexagon && (t.has_feature(Target::HVX))));
 
     debug(1) << "Adding checks for images\n";
     s = add_image_checks(s, outputs, t, order, env, func_bounds, will_inject_host_copies);
@@ -474,7 +474,7 @@ void lower_impl(const vector<Function> &output_funcs,
     // Make a copy of the Stmt code, before we lower anything to less human-readable code.
     result_module.set_conceptual_code_stmt(s);
 
-    if (t.arch != Target::Hexagon && t.has_feature(Target::HVX)) {
+    if (t.arch() != Target::Hexagon && t.has_feature(Target::HVX)) {
         debug(1) << "Splitting off Hexagon offload...\n";
         s = inject_hexagon_rpc(s, t, result_module);
         debug(2) << "Lowering after splitting off Hexagon offload:\n"

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -30,7 +30,7 @@ namespace Internal {
 std::map<OutputFileType, const OutputInfo> get_output_info(const Target &target) {
     constexpr bool IsMulti = true;
     constexpr bool IsSingle = false;
-    const bool is_windows_coff = target.os == Target::Windows;
+    const bool is_windows_coff = target.os() == Target::Windows;
     // Keep in sync with cmake/HalideGeneratorHelpers.cmake
     std::map<OutputFileType, const OutputInfo> ext = {
         {OutputFileType::assembly, {"assembly", ".s", IsMulti}},
@@ -104,7 +104,7 @@ public:
                                      const std::string &suffix,
                                      const Target &target,
                                      bool in_front = false) {
-        const char *ext = (target.os == Target::Windows) ? ".obj" : ".o";
+        const char *ext = (target.os() == Target::Windows) ? ".obj" : ".o";
         return add_temp_file(base_path_name, suffix + ext, target, in_front);
     }
 
@@ -491,7 +491,7 @@ Buffer<uint8_t> Module::compile_to_buffer() const {
     // TODO: This Hexagon specific code should be removed as soon as possible.
     // This may involve adding more general support for post-processing and
     // a way of specifying to use it.
-    if (target().arch == Target::Hexagon) {
+    if (target().arch() == Target::Hexagon) {
         return compile_module_to_hexagon_shared_object(*this);
     }
 
@@ -647,7 +647,7 @@ void Module::compile(const std::map<OutputFileType, std::string> &output_files) 
                 }
             }
             debug(1) << "Module.compile(): static_library " << output_files.at(OutputFileType::static_library) << "\n";
-            Target base_target(target().os, target().arch, target().bits, target().processor_tune);
+            Target base_target(target().os(), target().arch(), target().bits(), target().processor_tune());
             create_static_library(temp_object_dir.files(), base_target, output_files.at(OutputFileType::static_library));
         }
         // Don't use contains() here, we might need assembly output for stmt_html
@@ -922,9 +922,9 @@ void compile_multitarget(const std::string &fn_name,
         const Target &target = targets[i];
 
         // arch-bits-os must be identical across all targets.
-        if (target.os != base_target.os ||
-            target.arch != base_target.arch ||
-            target.bits != base_target.bits) {
+        if (target.os() != base_target.os() ||
+            target.arch() != base_target.arch() ||
+            target.bits() != base_target.bits()) {
             user_error << "All Targets must have matching arch-bits-os for compile_multitarget.\n";
         }
         // Some features must match across all targets.
@@ -1015,7 +1015,7 @@ void compile_multitarget(const std::string &fn_name,
     // and add that to the result.
     if (!base_target.has_feature(Target::NoRuntime)) {
         // Start with a bare Target, set only the features we know are common to all.
-        Target runtime_target(base_target.os, base_target.arch, base_target.bits, base_target.processor_tune);
+        Target runtime_target(base_target.os(), base_target.arch(), base_target.bits(), base_target.processor_tune());
         for (int i = 0; i < Target::FeatureEnd; ++i) {
             // We never want NoRuntime set here.
             if (i == Target::NoRuntime) {
@@ -1118,7 +1118,7 @@ void compile_multitarget(const std::string &fn_name,
         // if code tries to somehow only autoschedule some subtargets,
         // this code may break, and that's ok.
         std::ostringstream body;
-        if (baseline_target.os == Target::OSUnknown && baseline_target.arch == Target::ArchUnknown) {
+        if (baseline_target.os() == Target::OSUnknown && baseline_target.arch() == Target::ArchUnknown) {
             body << "// No autoscheduler has been run for this Generator.";
         } else {
             for (size_t i = 0; i < auto_scheduler_results.size(); i++) {

--- a/src/OffloadGPULoops.cpp
+++ b/src/OffloadGPULoops.cpp
@@ -184,7 +184,7 @@ protected:
         debug(2) << "Compiled launch to kernel \"" << kernel_name << "\"\n";
 
         bool runtime_run_takes_types = gpu_codegen->kernel_run_takes_types();
-        Type target_size_t_type = target.bits == 32 ? Int(32) : Int(64);
+        Type target_size_t_type = target.bits() == 32 ? Int(32) : Int(64);
 
         vector<Expr> args, arg_types_or_sizes, arg_is_buffer;
         for (const DeviceArgument &i : closure_args) {
@@ -254,8 +254,8 @@ public:
         // For the GPU target we just want to pass the flags, to avoid the
         // generated kernel code unintentionally having any dependence on the
         // host arch or os.
-        device_target.os = Target::OSUnknown;
-        device_target.arch = Target::ArchUnknown;
+        device_target.set_os(Target::OSUnknown);
+        device_target.set_arch(Target::ArchUnknown);
         if (target.has_feature(Target::CUDA)) {
             cgdev[DeviceAPI::CUDA] = new_CodeGen_PTX_Dev(device_target);
         }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -703,7 +703,7 @@ Callable Pipeline::compile_to_callable(const std::vector<Argument> &args_in, con
     // TODO: it fills in the value side with JITExtern values, but does anything actually use those?
     auto jit_externs = jit_externs_in;
     std::vector<JITModule> externs_jit_module = Pipeline::make_externs_jit_module(jit_target, jit_externs);
-    if (jit_target.arch == Target::WebAssembly) {
+    if (jit_target.arch() == Target::WebAssembly) {
         FindExterns find_externs(jit_externs);
         for (const LoweredFunc &f : module.functions()) {
             f.body.accept(&find_externs);

--- a/src/Prefetch.cpp
+++ b/src/Prefetch.cpp
@@ -453,7 +453,7 @@ Stmt reduce_prefetch_dimension(Stmt stmt, const Target &t) {
     // two dimension. Other architectures generate one prefetch per cache line.
     if (t.has_feature(Target::HVX)) {
         max_dim = 2;
-    } else if (t.arch == Target::ARM) {
+    } else if (t.arch() == Target::ARM) {
         // ARM's cache line size can be 32 or 64 bytes and it can switch the
         // size at runtime. To be safe, we just use 32 bytes.
         max_dim = 1;

--- a/src/StageStridedLoads.cpp
+++ b/src/StageStridedLoads.cpp
@@ -375,7 +375,7 @@ Stmt stage_strided_loads(const Stmt &stmt, const Target &target) {
                 // horizontal add pattern matching. On ARM it also interferes
                 // with LLVM's pattern matching for vld3 and vld4.
                 bool transpose_shared_load = k.stride > 2;
-                if (target.arch == Target::ARM || target.arch == Target::Hexagon) {
+                if (target.arch() == Target::ARM || target.arch() == Target::Hexagon) {
                     transpose_shared_load = k.stride > 4;
                 }
                 std::string name = unique_name('t');

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -636,7 +636,7 @@ bool is_using_hexagon(const Target &t) {
             t.has_feature(Target::HVX_v66) ||
             t.has_feature(Target::HVX_v68) ||
             t.has_feature(Target::HexagonDma) ||
-            t.arch == Target::Hexagon);
+            t.arch() == Target::Hexagon);
 }
 
 int get_hvx_lower_bound(const Target &t) {
@@ -998,7 +998,7 @@ Target get_jit_target_from_environment() {
     } else {
         Target t(target);
         t.set_feature(Target::JIT);
-        user_assert((t.os == host.os && t.arch == host.arch && t.bits == host.bits) || Internal::WasmModule::can_jit_target(t))
+        user_assert((t.os() == host.os() && t.arch() == host.arch() && t.bits() == host.bits()) || Internal::WasmModule::can_jit_target(t))
             << "HL_JIT_TARGET must match the host OS, architecture, and bit width.\n"
             << "HL_JIT_TARGET was " << target << ". "
             << "Host is " << host.to_string() << ".\n";
@@ -1041,22 +1041,25 @@ bool merge_string(Target &t, const std::string &target) {
                 return false;
             }
             bits_specified = true;
-            t.bits = std::stoi(tok);
-        } else if (lookup_arch(tok, t.arch)) {
+            t.set_bits(std::stoi(tok));
+        } else if (Target::Arch arch; lookup_arch(tok, arch)) {
             if (arch_specified) {
                 return false;
             }
             arch_specified = true;
-        } else if (lookup_os(tok, t.os)) {
+            t.set_arch(arch);
+        } else if (Target::OS os; lookup_os(tok, os)) {
             if (os_specified) {
                 return false;
             }
             os_specified = true;
-        } else if (lookup_processor(tok, t.processor_tune)) {
+            t.set_os(os);
+        } else if (Target::Processor processor_tune; lookup_processor(tok, processor_tune)) {
             if (processor_specified) {
                 return false;
             }
             processor_specified = true;
+            t.set_processor_tune(processor_tune);
         } else if (lookup_feature(tok, feature)) {
             t.set_feature(feature);
             features_specified = true;
@@ -1064,7 +1067,7 @@ bool merge_string(Target &t, const std::string &target) {
             t.set_features({Target::TraceLoads, Target::TraceStores, Target::TraceRealizations});
             features_specified = true;
         } else if ((vector_bits = parse_vector_bits(tok)) >= 0) {
-            t.vector_bits = vector_bits;
+            t.set_vector_bits(vector_bits);
         } else {
             return false;
         }
@@ -1102,11 +1105,11 @@ bool merge_string(Target &t, const std::string &target) {
         return false;
     }
 
-    if (bits_specified && t.bits == 0) {
+    if (bits_specified && t.bits() == 0) {
         // bits == 0 is allowed iff arch and os are "unknown" and no features are set,
         // to allow for roundtripping the string for default Target() ctor.
-        if (!(arch_specified && t.arch == Target::ArchUnknown) ||
-            !(os_specified && t.os == Target::OSUnknown) ||
+        if (!(arch_specified && t.arch() == Target::ArchUnknown) ||
+            !(os_specified && t.os() == Target::OSUnknown) ||
             features_specified) {
             return false;
         }
@@ -1180,7 +1183,7 @@ void do_check_bad(const Target &t, const std::initializer_list<Target::Feature> 
 
 void Target::validate_features() const {
     // Note that the features don't have to be exhaustive, but enough to avoid obvious mistakes is good.
-    if (arch == X86) {
+    if (arch_ == X86) {
         do_check_bad(*this, {
                                 ARMDotProd,
                                 ARMFp16,
@@ -1203,7 +1206,7 @@ void Target::validate_features() const {
                                 WasmSimd128,
                                 WasmThreads,
                             });
-    } else if (arch == ARM) {
+    } else if (arch_ == ARM) {
         do_check_bad(*this, {
                                 AVX,
                                 AVX2,
@@ -1227,7 +1230,7 @@ void Target::validate_features() const {
                                 WasmSimd128,
                                 WasmThreads,
                             });
-    } else if (arch == WebAssembly) {
+    } else if (arch_ == WebAssembly) {
         do_check_bad(*this, {
                                 ARMDotProd,
                                 ARMFp16,
@@ -1360,21 +1363,21 @@ Target::Feature Target::sme_svl_feature_from_bits(int bits) {
 std::string Target::to_string() const {
     string result;
     for (const auto &arch_entry : arch_name_map) {
-        if (arch_entry.second == arch) {
+        if (arch_entry.second == arch_) {
             result += arch_entry.first;
             break;
         }
     }
-    result += "-" + std::to_string(bits);
+    result += "-" + std::to_string(bits_);
     for (const auto &os_entry : os_name_map) {
-        if (os_entry.second == os) {
+        if (os_entry.second == os_) {
             result += "-" + os_entry.first;
             break;
         }
     }
-    if (processor_tune != ProcessorGeneric) {
+    if (processor_tune_ != ProcessorGeneric) {
         for (const auto &processor_entry : processor_name_map) {
-            if (processor_entry.second == processor_tune) {
+            if (processor_entry.second == processor_tune_) {
                 result += "-" + processor_entry.first;
                 break;
             }
@@ -1390,8 +1393,8 @@ std::string Target::to_string() const {
     if (has_feature(Target::TraceLoads) && has_feature(Target::TraceStores) && has_feature(Target::TraceRealizations)) {
         result = Internal::replace_all(std::move(result), "trace_loads-trace_realizations-trace_stores", "trace_all");
     }
-    if (vector_bits != 0) {
-        result += "-vector_bits_" + std::to_string(vector_bits);
+    if (vector_bits_ != 0) {
+        result += "-vector_bits_" + std::to_string(vector_bits_);
     }
 
     return result;
@@ -1401,25 +1404,25 @@ std::string Target::to_string() const {
 bool Target::supported() const {
     bool bad = false;
 #if !defined(WITH_ARM)
-    bad |= arch == Target::ARM && bits == 32;
+    bad |= arch_ == Target::ARM && bits_ == 32;
 #endif
 #if !defined(WITH_AARCH64)
-    bad |= arch == Target::ARM && bits == 64;
+    bad |= arch_ == Target::ARM && bits_ == 64;
 #endif
 #if !defined(WITH_X86)
-    bad |= arch == Target::X86;
+    bad |= arch_ == Target::X86;
 #endif
 #if !defined(WITH_POWERPC)
-    bad |= arch == Target::POWERPC;
+    bad |= arch_ == Target::POWERPC;
 #endif
 #if !defined(WITH_HEXAGON)
-    bad |= arch == Target::Hexagon;
+    bad |= arch_ == Target::Hexagon;
 #endif
 #if !defined(WITH_WEBASSEMBLY)
-    bad |= arch == Target::WebAssembly;
+    bad |= arch_ == Target::WebAssembly;
 #endif
 #if !defined(WITH_RISCV)
-    bad |= arch == Target::RISCV;
+    bad |= arch_ == Target::RISCV;
 #endif
 #if !defined(WITH_NVPTX)
     bad |= has_feature(Target::CUDA);
@@ -1443,7 +1446,7 @@ bool Target::supported() const {
 }
 
 bool Target::has_unknowns() const {
-    return os == OSUnknown || arch == ArchUnknown || bits == 0;
+    return os_ == OSUnknown || arch_ == ArchUnknown || bits_ == 0;
 }
 
 void Target::set_feature(Feature f, bool value) {
@@ -1524,17 +1527,17 @@ const std::vector<std::pair<Target::Feature, Target::Feature>> &implied_feature_
 
 void Target::set_implied_features() {
     // Implications that depend on more than just the feature set.
-    if (arch == X86 && has_feature(AVX10_1)) {
+    if (arch_ == X86 && has_feature(AVX10_1)) {
         // AVX10.1 at a given vector width supports the corresponding legacy
         // AVX feature set. The pairs below then cascade further.
-        if (vector_bits >= 256) {
+        if (vector_bits_ >= 256) {
             set_feature(AVX2);
         }
-        if (vector_bits >= 512) {
+        if (vector_bits_ >= 512) {
             set_feature(AVX512_SapphireRapids);
         }
     }
-    if (arch == ARM && os == OSX) {
+    if (arch_ == ARM && os_ == OSX) {
         // Apple silicon implements at least the ARM v8.4-A spec.
         set_feature(ARMv84a);
     }
@@ -1563,15 +1566,15 @@ void Target::unset_implied_features() {
 
     // Undo the conditional implications from set_implied_features(). These run
     // after the pair loop, mirroring how their seeds run before it there.
-    if (arch == X86 && has_feature(AVX10_1)) {
-        if (vector_bits >= 512) {
+    if (arch_ == X86 && has_feature(AVX10_1)) {
+        if (vector_bits_ >= 512) {
             set_feature(AVX512_SapphireRapids, false);
         }
-        if (vector_bits >= 256) {
+        if (vector_bits_ >= 256) {
             set_feature(AVX2, false);
         }
     }
-    if (arch == ARM && os == OSX) {
+    if (arch_ == ARM && os_ == OSX) {
         set_feature(ARMv84a, false);
     }
 }
@@ -1937,15 +1940,15 @@ int Target::natural_vector_size(const Halide::Type &t) const {
     const bool is_integer = t.is_int() || t.is_uint();
     const int data_size = t.bytes();
 
-    if (arch == Target::ARM) {
-        if (vector_bits != 0 &&
+    if (arch_ == Target::ARM) {
+        if (vector_bits_ != 0 &&
             (has_feature(Halide::Target::SVE2) ||
              (t.is_float() && has_feature(Halide::Target::SVE)))) {
-            return vector_bits / (data_size * 8);
+            return vector_bits_ / (data_size * 8);
         } else {
             return 16 / data_size;
         }
-    } else if (arch == Target::Hexagon) {
+    } else if (arch_ == Target::Hexagon) {
         if (is_integer) {
             if (has_feature(Halide::Target::HVX)) {
                 return 128 / data_size;
@@ -1957,7 +1960,7 @@ int Target::natural_vector_size(const Halide::Type &t) const {
             // HVX does not have vector float instructions.
             return 1;
         }
-    } else if (arch == Target::X86) {
+    } else if (arch_ == Target::X86) {
         if (is_integer && (has_feature(Halide::Target::AVX512_Skylake) ||
                            has_feature(Halide::Target::AVX512_Cannonlake) ||
                            has_feature(Halide::Target::AVX512_Zen4) ||
@@ -1987,7 +1990,7 @@ int Target::natural_vector_size(const Halide::Type &t) const {
             // SSE was all 128-bit. We ignore MMX.
             return 16 / data_size;
         }
-    } else if (arch == Target::WebAssembly) {
+    } else if (arch_ == Target::WebAssembly) {
         if (has_feature(Halide::Target::WasmSimd128)) {
             // 128-bit vectors for other types.
             return 16 / data_size;
@@ -1995,10 +1998,10 @@ int Target::natural_vector_size(const Halide::Type &t) const {
             // No vectors, sorry.
             return 1;
         }
-    } else if (arch == Target::RISCV) {
-        if (vector_bits != 0 &&
+    } else if (arch_ == Target::RISCV) {
+        if (vector_bits_ != 0 &&
             has_feature(Halide::Target::RVV)) {
-            return vector_bits / (data_size * 8);
+            return vector_bits_ / (data_size * 8);
         } else {
             return 1;
         }
@@ -2122,7 +2125,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
         matching_mask.set(feature);
     }
 
-    if (arch != other.arch || bits != other.bits || os != other.os) {
+    if (arch_ != other.arch_ || bits_ != other.bits_ || os_ != other.os_) {
         debug(1) << "runtime targets must agree on platform (arch-bits-os)\n"
                  << "  this:  " << *this << "\n"
                  << "  other: " << other << "\n";
@@ -2139,7 +2142,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // Union of features is computed through bitwise-or, and masked away by the features we care about
     // Intersection of features is computed through bitwise-and and masked away, too.
     // We merge the bits via bitwise or.
-    Target output = Target{os, arch, bits, processor_tune};
+    Target output = Target{os_, arch_, bits_, processor_tune_};
     output.features = ((features | other.features) & union_mask) | ((features | other.features) & matching_mask) | ((features & other.features) & intersection_mask);
 
     // Pick tight lower bound for CUDA capability. Use fall-through to clear redundant features

--- a/src/Target.h
+++ b/src/Target.h
@@ -30,8 +30,8 @@ struct Target {
         QuRT,
         NoOS,
         Fuchsia,
-        WebAssemblyRuntime
-    } os = OSUnknown;
+        WebAssemblyRuntime,
+    };
 
     /** The architecture used by the target. Determines the
      * instruction set to use.
@@ -43,16 +43,8 @@ struct Target {
         Hexagon,
         POWERPC,
         WebAssembly,
-        RISCV
-    } arch = ArchUnknown;
-
-    /** The bit-width of the target machine. Must be 0 for unknown, or 32 or 64. */
-    int bits = 0;
-
-    /** The bit-width of a vector register for targets where this is configurable and
-     * targeting a fixed size is desired. The default of 0 indicates no assumption of
-     * fixed size is allowed. */
-    int vector_bits = 0;
+        RISCV,
+    };
 
     /** The specific processor to be targeted, tuned for.
      * Corresponds to processor_name_map in Target.cpp.
@@ -75,7 +67,7 @@ struct Target {
         ZnVer3,    /// Tune for AMD Zen 3 CPU (AMD Family 19h, launched 2020).
         ZnVer4,    /// Tune for AMD Zen 4 CPU (AMD Family 19h, launched 2022).
         ZnVer5,    /// Tune for AMD Zen 5 CPU (AMD Family 1Ah, launched 2024).
-    } processor_tune = ProcessorGeneric;
+    };
 
     /** Optional features a target can have.
      * Corresponds to feature_name_map in Target.cpp.
@@ -204,12 +196,12 @@ struct Target {
         HLSL_SM67 = halide_target_feature_hlsl_sm67,
         HLSL_SM68 = halide_target_feature_hlsl_sm68,
         HLSL_SM69 = halide_target_feature_hlsl_sm69,
-        FeatureEnd = halide_target_feature_end
+        FeatureEnd = halide_target_feature_end,
     };
     Target() = default;
     Target(OS o, Arch a, int b, Processor pt, const std::vector<Feature> &initial_features = std::vector<Feature>(),
            int vb = 0)
-        : os(o), arch(a), bits(b), vector_bits(vb), processor_tune(pt) {
+        : os_(o), arch_(a), bits_(b), vector_bits_(vb), processor_tune_(pt) {
         for (const auto &f : initial_features) {
             set_feature(f);
         }
@@ -319,13 +311,49 @@ struct Target {
      * will be an arbitrary DeviceAPI. */
     DeviceAPI get_required_device_api() const;
 
+    /** Getters and setters for target properties. */
+    OS os() const {
+        return os_;
+    }
+    void set_os(OS o) {
+        os_ = o;
+    }
+
+    Arch arch() const {
+        return arch_;
+    }
+    void set_arch(Arch a) {
+        arch_ = a;
+    }
+
+    int bits() const {
+        return bits_;
+    }
+    void set_bits(int b) {
+        bits_ = b;
+    }
+
+    int vector_bits() const {
+        return vector_bits_;
+    }
+    void set_vector_bits(int vb) {
+        vector_bits_ = vb;
+    }
+
+    Processor processor_tune() const {
+        return processor_tune_;
+    }
+    void set_processor_tune(Processor pt) {
+        processor_tune_ = pt;
+    }
+
     bool operator==(const Target &other) const {
-        return os == other.os &&
-               arch == other.arch &&
-               bits == other.bits &&
-               processor_tune == other.processor_tune &&
+        return os_ == other.os_ &&
+               arch_ == other.arch_ &&
+               bits_ == other.bits_ &&
+               processor_tune_ == other.processor_tune_ &&
                features == other.features &&
-               vector_bits == other.vector_bits;
+               vector_bits_ == other.vector_bits_;
     }
 
     bool operator!=(const Target &other) const {
@@ -373,7 +401,7 @@ struct Target {
 
     /** Return true iff 64 bits and has_feature(LargeBuffers). */
     bool has_large_buffers() const {
-        return bits == 64 && has_feature(LargeBuffers);
+        return bits_ == 64 && has_feature(LargeBuffers);
     }
 
     /** Return the maximum buffer size in bytes supported on this
@@ -430,6 +458,12 @@ struct Target {
     static Target::Feature sme_svl_feature_from_bits(int bits);
 
 private:
+    OS os_ = OSUnknown;
+    Arch arch_ = ArchUnknown;
+    int bits_ = 0;
+    int vector_bits_ = 0;
+    Processor processor_tune_ = ProcessorGeneric;
+
     /** A bitmask that stores the active features. */
     std::bitset<FeatureEnd> features;
 

--- a/src/Target.h
+++ b/src/Target.h
@@ -405,14 +405,11 @@ struct Target {
     }
 
     /** Return the maximum buffer size in bytes supported on this
-     * Target. This is 2^31 - 1 except on 64-bit targets when the LargeBuffers
-     * feature is enabled, which expands the maximum to 2^63 - 1. */
+     * Target. This is (signed) INT32_MAX except on 64-bit targets
+     * when the LargeBuffers feature is enabled, which expands the
+     * maximum to (signed) INT64_MAX. */
     int64_t maximum_buffer_size() const {
-        if (has_large_buffers()) {
-            return (((uint64_t)1) << 63) - 1;
-        } else {
-            return (((uint64_t)1) << 31) - 1;
-        }
+        return has_large_buffers() ? INT64_MAX : INT32_MAX;
     }
 
     /** Get the minimum cuda capability found as an integer. Returns

--- a/src/TargetQueryOps.cpp
+++ b/src/TargetQueryOps.cpp
@@ -17,7 +17,7 @@ class LowerTargetQueryOps : public IRMutator {
     Expr visit(const Call *call) override {
         if (call->is_intrinsic(Call::target_arch_is)) {
             Target::Arch arch = (Target::Arch)as_const_int(call->args[0]).value();
-            return make_bool(t.arch == arch);
+            return make_bool(t.arch() == arch);
         } else if (call->is_intrinsic(Call::target_has_feature)) {
             Target::Feature feat = (Target::Feature)as_const_int(call->args[0]).value();
             return make_bool(t.has_feature(feat));
@@ -26,9 +26,9 @@ class LowerTargetQueryOps : public IRMutator {
             return Expr(t.natural_vector_size(zero.type()));
         } else if (call->is_intrinsic(Call::target_os_is)) {
             Target::OS os = (Target::OS)as_const_int(call->args[0]).value();
-            return make_bool(t.os == os);
+            return make_bool(t.os() == os);
         } else if (call->is_intrinsic(Call::target_bits)) {
-            return Expr(t.bits);
+            return Expr(t.bits());
         }
 
         return IRMutator::visit(call);

--- a/src/Type.h
+++ b/src/Type.h
@@ -348,8 +348,8 @@ public:
 
     /** Construct a (scalar) language Type from an ABI element type. */
     HALIDE_ALWAYS_INLINE
-    Type(halide_type_t that, const halide_handle_cplusplus_type *handle_type = nullptr)
-        : Type(that.code, that.bits, 1, handle_type) {
+    Type(halide_type_t type, const halide_handle_cplusplus_type *handle_type = nullptr)
+        : Type(type.code, type.bits, 1, handle_type) {
     }
 
     /** Erase this language Type to the ABI/runtime halide_type_t for use in
@@ -532,8 +532,8 @@ public:
 
     /** Compare a language type to an ABI element type. Equal iff this type is a
      * single element (not a vector) with the same code and bits. */
-    bool operator==(const halide_type_t &other) const {
-        return type_lanes < 2 && (uint8_t)type_code == (uint8_t)other.code && type_bits == other.bits;
+    bool operator==(const halide_type_t &abi_type) const {
+        return type_lanes < 2 && type_code == abi_type.code && type_bits == abi_type.bits;
     }
 
     /** Compare two types for inequality */

--- a/src/WasmExecutor.cpp
+++ b/src/WasmExecutor.cpp
@@ -2720,7 +2720,7 @@ void destroy<WasmModuleContents>(const WasmModuleContents *p) {
 /*static*/
 bool WasmModule::can_jit_target(const Target &target) {
 #if WITH_WABT || WITH_V8
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         return true;
     }
 #endif

--- a/src/autoschedulers/li2018/GradientAutoscheduler.cpp
+++ b/src/autoschedulers/li2018/GradientAutoscheduler.cpp
@@ -82,7 +82,7 @@ void reorder_storage(const Stage &stage,
 
 int natural_vector_size(const Target &target, const Type &t) {
     const int data_size = t.bytes();
-    if (target.os == Target::OSUnknown || target.arch == Target::ArchUnknown || target.bits != 0) {
+    if (target.os() == Target::OSUnknown || target.arch() == Target::ArchUnknown || target.bits() != 0) {
         return 32 / data_size;
     } else {
         return target.natural_vector_size(t);

--- a/test/autoschedulers/mullapudi2016/cost_function.cpp
+++ b/test/autoschedulers/mullapudi2016/cost_function.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/data_dependent.cpp
+++ b/test/autoschedulers/mullapudi2016/data_dependent.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/extern.cpp
+++ b/test/autoschedulers/mullapudi2016/extern.cpp
@@ -122,7 +122,7 @@ void test_case_3() {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/fibonacci.cpp
+++ b/test/autoschedulers/mullapudi2016/fibonacci.cpp
@@ -39,7 +39,7 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/histogram.cpp
+++ b/test/autoschedulers/mullapudi2016/histogram.cpp
@@ -121,7 +121,7 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/large_window.cpp
+++ b/test/autoschedulers/mullapudi2016/large_window.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/mat_mul.cpp
+++ b/test/autoschedulers/mullapudi2016/mat_mul.cpp
@@ -124,7 +124,7 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/max_filter.cpp
+++ b/test/autoschedulers/mullapudi2016/max_filter.cpp
@@ -123,7 +123,7 @@ double run_test(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/multi_output.cpp
+++ b/test/autoschedulers/mullapudi2016/multi_output.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/overlap.cpp
+++ b/test/autoschedulers/mullapudi2016/overlap.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
 
     int num_levels = 10;
 
-    if (target.arch == Target::X86 && target.bits == 32) {
+    if (target.arch() == Target::X86 && target.bits() == 32) {
         // Work around a slowdown in LLVM that seems to trigger in this particular case:
         // https://github.com/llvm/llvm-project/issues/156114
         num_levels = 3;

--- a/test/autoschedulers/mullapudi2016/param.cpp
+++ b/test/autoschedulers/mullapudi2016/param.cpp
@@ -115,7 +115,7 @@ void run_test_4() {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/reorder.cpp
+++ b/test/autoschedulers/mullapudi2016/reorder.cpp
@@ -168,7 +168,7 @@ double run_test_3(bool auto_schedule) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/small_pure_update.cpp
+++ b/test/autoschedulers/mullapudi2016/small_pure_update.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/tile_vs_inline.cpp
+++ b/test/autoschedulers/mullapudi2016/tile_vs_inline.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/unused_func.cpp
+++ b/test/autoschedulers/mullapudi2016/unused_func.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/autoschedulers/mullapudi2016/vectorize_var_in_update.cpp
+++ b/test/autoschedulers/mullapudi2016/vectorize_var_in_update.cpp
@@ -5,7 +5,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Autoschedulers do not support WebAssembly.\n");
         return 0;
     }

--- a/test/correctness/async.cpp
+++ b/test/correctness/async.cpp
@@ -13,7 +13,7 @@ extern "C" HALIDE_EXPORT_SYMBOL int expensive(int x) {
 HalideExtern_1(int, expensive, int);
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly does not support async() yet.\n");
         return 0;
     }

--- a/test/correctness/async_copy_chain.cpp
+++ b/test/correctness/async_copy_chain.cpp
@@ -21,11 +21,11 @@ void make_pipeline(Func &A, Func &B) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly does not support async() yet.\n");
         return 0;
     }
-    if (target.has_feature(Target::Vulkan) && (target.os == Target::Windows)) {
+    if (target.has_feature(Target::Vulkan) && (target.os() == Target::Windows)) {
         printf("[SKIP] Skipping test for Vulkan on Windows ... fails unless run on its own!\n");
         return 0;
     }

--- a/test/correctness/async_order.cpp
+++ b/test/correctness/async_order.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly does not support async() yet.\n");
         return 0;
     }

--- a/test/correctness/atomic_tuples.cpp
+++ b/test/correctness/atomic_tuples.cpp
@@ -18,7 +18,7 @@ public:
 };
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Skipping test for WebAssembly as it does not support atomics yet.\n");
         return 0;
     }

--- a/test/correctness/atomics.cpp
+++ b/test/correctness/atomics.cpp
@@ -1185,12 +1185,12 @@ void test_async_tuple(const Backend &backend) {
 
 int main(int argc, char **argv) {
     const Target t = get_jit_target_from_environment();
-    if (t.arch == Target::WebAssembly) {
+    if (t.arch() == Target::WebAssembly) {
         printf("[SKIP] Skipping test for WebAssembly as it does not support atomics yet.\n");
         return 0;
     }
 
-    if (t.os == Target::Windows && t.has_feature(Target::CUDA)) {
+    if (t.os() == Target::Windows && t.has_feature(Target::CUDA)) {
         printf("[SKIP] Skipping test for Windows + CUDA because of unexplained sporadic failures (https://github.com/halide/Halide/issues/7423).\n");
         return 0;
     }

--- a/test/correctness/boundary_conditions.cpp
+++ b/test/correctness/boundary_conditions.cpp
@@ -391,7 +391,7 @@ int main(int argc, char **argv) {
     if (target.has_feature(Target::OpenCL)) {
         vector_width_max = 16;
     }
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         // The wasm jit is very slow, so shorten this test here.
         vector_width_max = 8;
     }

--- a/test/correctness/callable.cpp
+++ b/test/correctness/callable.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
 
     // Override Halide's malloc and free (except under wasm),
     // make sure that Callable freezes the values
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         custom_malloc_called = false;
         custom_free_called = false;
 
@@ -142,7 +142,7 @@ int main(int argc, char **argv) {
     }
 
     // Check that Param<void*> works with Callables
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         Func f("f"), g("g");
         Var x("x");
         Param<void *> handle("handle");
@@ -187,7 +187,7 @@ int main(int argc, char **argv) {
     }
 
     // Check that JITExterns works with Callables
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         call_counter = 0;
 
         std::vector<ExternFuncArgument> args;

--- a/test/correctness/callable_generator.cpp
+++ b/test/correctness/callable_generator.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv) {
 
     // Override Halide's malloc and free (except under wasm),
     // make sure that Callable freezes the values
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         custom_malloc_called = false;
         custom_free_called = false;
 
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
     }
 
     // Check that Param<void*> works with Callables
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         class TestGen3 : public Generator<TestGen3> {
         public:
             GeneratorParam<bool> vectorize_{"vectorize", false};
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
     }
 
     // Check that JITExterns works with Callables
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         call_counter = 0;
 
         class TestGen4 : public Generator<TestGen4> {

--- a/test/correctness/callable_typed.cpp
+++ b/test/correctness/callable_typed.cpp
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
 
     // Override Halide's malloc and free (except under wasm),
     // make sure that Callable freezes the values
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         custom_malloc_called = false;
         custom_free_called = false;
 
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
     }
 
     // Check that Param<void*> works with Callables
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         Func f("f"), g("g");
         Var x("x");
         Param<void *> handle("handle");
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
     }
 
     // Check that JITExterns works with Callables
-    if (t.arch != Target::WebAssembly) {
+    if (t.arch() != Target::WebAssembly) {
         call_counter = 0;
 
         std::vector<ExternFuncArgument> args;

--- a/test/correctness/cast_handle.cpp
+++ b/test/correctness/cast_handle.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support Param<> for pointer types.\n");
         return 0;
     }

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -18,7 +18,7 @@ std::string get_output_path_prefix(const std::string &base) {
 
 void test_compile_to_static_library(Func j) {
     std::string filename_prefix = get_output_path_prefix("c1");
-    const char *a = get_host_target().os == Target::Windows ? ".lib" : ".a";
+    const char *a = get_host_target().os() == Target::Windows ? ".lib" : ".a";
 
     std::vector<Target> targets = {
         Target("host-profile-no_bounds_query"),
@@ -45,7 +45,7 @@ void test_compile_to_static_library(Func j) {
 
 void test_compile_to_object_files(Func j) {
     std::string filename_prefix = get_output_path_prefix("c2");
-    const char *o = get_host_target().os == Target::Windows ? ".obj" : ".o";
+    const char *o = get_host_target().os() == Target::Windows ? ".obj" : ".o";
 
     std::vector<std::string> target_strings = {
         "host-profile-no_bounds_query",
@@ -78,7 +78,7 @@ void test_compile_to_object_files(Func j) {
 
 void test_compile_to_object_files_no_runtime(Func j) {
     std::string filename_prefix = get_output_path_prefix("c3");
-    const char *o = get_host_target().os == Target::Windows ? ".obj" : ".o";
+    const char *o = get_host_target().os() == Target::Windows ? ".obj" : ".o";
 
     std::vector<std::string> target_strings = {
         "host-profile-no_bounds_query-no_runtime",
@@ -110,7 +110,7 @@ void test_compile_to_object_files_no_runtime(Func j) {
 
 void test_compile_to_object_files_single_target(Func j) {
     std::string filename_prefix = get_output_path_prefix("c4");
-    const char *o = get_host_target().os == Target::Windows ? ".obj" : ".o";
+    const char *o = get_host_target().os() == Target::Windows ? ".obj" : ".o";
 
     std::vector<std::string> target_strings = {
         "host-debug",
@@ -138,8 +138,8 @@ void test_compile_to_object_files_single_target(Func j) {
 
 void test_compile_to_everything(Func j, bool do_object) {
     std::string filename_prefix = get_output_path_prefix(do_object ? "c5" : "c6");
-    const char *a = get_host_target().os == Target::Windows ? ".lib" : ".a";
-    const char *o = get_host_target().os == Target::Windows ? ".obj" : ".o";
+    const char *a = get_host_target().os() == Target::Windows ? ".lib" : ".a";
+    const char *o = get_host_target().os() == Target::Windows ? ".obj" : ".o";
 
     std::vector<std::string> target_strings = {
         "host-profile-no_bounds_query",

--- a/test/correctness/custom_allocator.cpp
+++ b/test/correctness/custom_allocator.cpp
@@ -22,7 +22,7 @@ void my_free(JITUserContext *user_context, void *ptr) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/debug_to_file.cpp
+++ b/test/correctness/debug_to_file.cpp
@@ -10,7 +10,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support debug_to_file() yet.\n");
         return 0;
     }

--- a/test/correctness/debug_to_file_multiple_outputs.cpp
+++ b/test/correctness/debug_to_file_multiple_outputs.cpp
@@ -6,7 +6,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support debug_to_file() yet.\n");
         return 0;
     }

--- a/test/correctness/debug_to_file_reorder.cpp
+++ b/test/correctness/debug_to_file_reorder.cpp
@@ -6,7 +6,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support debug_to_file() yet.\n");
         return 0;
     }

--- a/test/correctness/device_buffer_copies_with_profile.cpp
+++ b/test/correctness/device_buffer_copies_with_profile.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv) {
     if (result != 0) {
         return 1;
     }
-    if (t.os == Target::Linux) {
+    if (t.os() == Target::Linux) {
         printf("Testing timer based profiler.\n");
         result = run_test(t.with_feature(Target::ProfileByTimer));
         if (result != 0) {

--- a/test/correctness/device_buffer_copy.cpp
+++ b/test/correctness/device_buffer_copy.cpp
@@ -24,7 +24,7 @@ Halide::Runtime::Buffer<int32_t> make_gpu_buffer(bool hexagon_rpc, int offset = 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
-    bool hexagon_rpc = (target.arch != Target::Hexagon) &&
+    bool hexagon_rpc = (target.arch() != Target::Hexagon) &&
                        target.has_feature(Target::HVX);
 
     if (!hexagon_rpc && !target.has_gpu_feature()) {

--- a/test/correctness/device_crop.cpp
+++ b/test/correctness/device_crop.cpp
@@ -22,7 +22,7 @@ Halide::Runtime::Buffer<int32_t> make_gpu_buffer(bool hexagon_rpc) {
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
-    bool hexagon_rpc = (target.arch != Target::Hexagon) &&
+    bool hexagon_rpc = (target.arch() != Target::Hexagon) &&
                        target.has_feature(Target::HVX);
 
     if (!hexagon_rpc && !target.has_gpu_feature()) {

--- a/test/correctness/device_slice.cpp
+++ b/test/correctness/device_slice.cpp
@@ -24,7 +24,7 @@ Halide::Runtime::Buffer<int32_t> make_gpu_buffer(bool hexagon_rpc) {
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
-    bool hexagon_rpc = (target.arch != Target::Hexagon) &&
+    bool hexagon_rpc = (target.arch() != Target::Hexagon) &&
                        target.has_feature(Target::HVX);
 
     if (!hexagon_rpc && !target.has_gpu_feature()) {

--- a/test/correctness/extern_consumer.cpp
+++ b/test/correctness/extern_consumer.cpp
@@ -59,7 +59,7 @@ bool check_result() {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
         return 0;
     }

--- a/test/correctness/extern_error.cpp
+++ b/test/correctness/extern_error.cpp
@@ -16,7 +16,7 @@ extern "C" HALIDE_EXPORT_SYMBOL void my_halide_error(JITUserContext *user_contex
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
         return 0;
     }

--- a/test/correctness/fallback_vscale_sve.cpp
+++ b/test/correctness/fallback_vscale_sve.cpp
@@ -68,7 +68,7 @@ bool test_vscale(int vectorization_factor, int vector_bits, int exp_vscale) {
     f.compute_root().vectorize(x, vectorization_factor);
 
     Target t("arm-64-linux-sve2-no_asserts-no_runtime-no_bounds_query");
-    t.vector_bits = vector_bits;
+    t.set_vector_bits(vector_bits);
 
     // sve or neon
     std::string intrin = exp_vscale > 0 ? "llvm.aarch64.sve.sabd" : "llvm.aarch64.neon.sabd";

--- a/test/correctness/float16_t.cpp
+++ b/test/correctness/float16_t.cpp
@@ -468,7 +468,7 @@ int main(int argc, char **argv) {
     // TODO(https://github.com/halide/Halide/issues/8985): LLVM's JIT emits
     // misaligned jump tables on arm-32 with arm_fp16, causing SIGILL.
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::ARM && target.bits == 32 &&
+    if (target.arch() == Target::ARM && target.bits() == 32 &&
         target.has_feature(Target::ARMFp16)) {
         printf("[SKIP] arm-32 JIT with arm_fp16 hits LLVM jump table misalignment bug.\n");
         return 0;

--- a/test/correctness/float16_t_neon_op_check.cpp
+++ b/test/correctness/float16_t_neon_op_check.cpp
@@ -26,9 +26,9 @@ public:
         // Error is thrown if there is unacceptable mismatch between jit_target and host_target.
         Target jit_target = get_jit_target_from_environment();
         bool can_run_the_code =
-            (target.arch == jit_target.arch &&
-             target.bits == jit_target.bits &&
-             target.os == jit_target.os);
+            (target.arch() == jit_target.arch() &&
+             target.bits() == jit_target.bits() &&
+             target.os() == jit_target.os());
         // A bunch of feature flags also need to match between the
         // compiled code and the host in order to run the code.
         for (Target::Feature f : {Target::ARMFp16, Target::NoNEON}) {

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -21,7 +21,7 @@ void my_error(JITUserContext *user_context, const char *msg) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/gpu_allocation_cache.cpp
+++ b/test/correctness/gpu_allocation_cache.cpp
@@ -24,11 +24,11 @@ int main(int argc, char **argv) {
         printf("[SKIP-WITH-ISSUE-5000] Allocation cache not yet implemented for D3D12Compute.\n");
         return 0;
     }
-    if (target.has_feature(Target::Vulkan) && ((target.os == Target::IOS) || target.os == Target::OSX)) {
+    if (target.has_feature(Target::Vulkan) && ((target.os() == Target::IOS) || target.os() == Target::OSX)) {
         printf("[SKIP] Skipping test for Vulkan on iOS/OSX (MoltenVK only allows 30 buffers to be allocated)!\n");
         return 0;
     }
-    if (target.has_feature(Target::Vulkan) && (target.os == Target::Windows)) {
+    if (target.has_feature(Target::Vulkan) && (target.os() == Target::Windows)) {
         printf("[SKIP] Skipping test for Vulkan on Windows ... fails unless run on its own!\n");
         return 0;
     }

--- a/test/correctness/gpu_dynamic_shared.cpp
+++ b/test/correctness/gpu_dynamic_shared.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv) {
             printf("[SKIP] Vulkan %d.%d is less than required 1.3.\n", major, minor);
             return 0;
         }
-        if ((t.os == Target::IOS) || (t.os == Target::OSX)) {
+        if ((t.os() == Target::IOS) || (t.os() == Target::OSX)) {
             printf("[SKIP] Skipping test for Vulkan on iOS/OSX (MoltenVK doesn't support dynamic LocalSizeId yet)!\n");
             return 0;
         }

--- a/test/correctness/gpu_metal_completion_handler_error_check.cpp
+++ b/test/correctness/gpu_metal_completion_handler_error_check.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
     // Apple Silicon GPUs do not enforce a per-command-buffer timeout, so this
     // test cannot trigger a GPU error on those devices. Restrict to Intel Macs
     // where the AMD/Intel GPU watchdog timer will fire.
-    if (t.arch == Target::ARM) {
+    if (t.arch() == Target::ARM) {
         printf("[SKIP] Apple Silicon does not enforce Metal GPU timeouts\n");
         return 0;
     }

--- a/test/correctness/gpu_reuse_shared_memory.cpp
+++ b/test/correctness/gpu_reuse_shared_memory.cpp
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
         }
 
         printf("Running dynamic shared test\n");
-        if (t.has_feature(Target::Vulkan) && ((t.os == Target::IOS) || t.os == Target::OSX)) {
+        if (t.has_feature(Target::Vulkan) && ((t.os() == Target::IOS) || t.os() == Target::OSX)) {
             printf("Skipping test for Vulkan on iOS/OSX (MoltenVK doesn't support dynamic sizes for shared memory)!\n");
         } else {
             if (dynamic_shared_test(memory_type) != 0) {

--- a/test/correctness/gpu_specialize.cpp
+++ b/test/correctness/gpu_specialize.cpp
@@ -9,7 +9,7 @@ int main(int argc, char **argv) {
         printf("[SKIP] No GPU target enabled.\n");
         return 0;
     }
-    if (target.has_feature(Target::Vulkan) && ((target.os == Target::IOS) || target.os == Target::OSX)) {
+    if (target.has_feature(Target::Vulkan) && ((target.os() == Target::IOS) || target.os() == Target::OSX)) {
         printf("[SKIP] Skipping test for Vulkan on iOS/OSX (MoltenVK doesn't support dynamically allocated shared mem)!\n");
         return 0;
     }

--- a/test/correctness/handle.cpp
+++ b/test/correctness/handle.cpp
@@ -17,7 +17,7 @@ extern "C" HALIDE_EXPORT_SYMBOL int my_strlen(const char *c) {
 HalideExtern_1(int, my_strlen, const char *);
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support Param<> for pointer types.\n");
         return 0;
     }

--- a/test/correctness/heap_cleanup.cpp
+++ b/test/correctness/heap_cleanup.cpp
@@ -28,7 +28,7 @@ void my_error_handler(JITUserContext *user_context, const char *) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/hoist_storage.cpp
+++ b/test/correctness/hoist_storage.cpp
@@ -19,7 +19,7 @@ void custom_free(JITUserContext *user_context, void *ptr) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/image_of_lists.cpp
+++ b/test/correctness/image_of_lists.cpp
@@ -19,7 +19,7 @@ extern "C" HALIDE_EXPORT_SYMBOL std::list<int> *list_maybe_insert(std::list<int>
 HalideExtern_3(std::list<int> *, list_maybe_insert, std::list<int> *, bool, int);
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
         return 0;
     }

--- a/test/correctness/input_larger_than_two_gigs.cpp
+++ b/test/correctness/input_larger_than_two_gigs.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
 
     Buffer<uint64_t> result;
-    if (t.bits != 32) {
+    if (t.bits() != 32) {
         grand_total.compile_jit(t.with_feature(Target::LargeBuffers));
         result = grand_total.realize();
         assert(!error_occurred);

--- a/test/correctness/interleave.cpp
+++ b/test/correctness/interleave.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
     // culprit. Just disabling it for now.
     {
         Target t = get_host_target();
-        if (t.arch == Target::ARM && t.bits == 32) {
+        if (t.arch() == Target::ARM && t.bits() == 32) {
             printf("[SKIP] Test is known to segfault on ARM-32 (see the source for more detail) .\n");
             return 0;
         }
@@ -289,7 +289,7 @@ int main(int argc, char **argv) {
 
     for (int elements = 1; elements <= 5; elements++) {
         const Target t = get_jit_target_from_environment();
-        if (t.arch == Target::WebAssembly &&
+        if (t.arch() == Target::WebAssembly &&
             t.has_feature(Target::WasmSimd128) &&
             elements == 5) {
             // TODO: this bug is still active in v7.5; when it is fixed,

--- a/test/correctness/interpreter.cpp
+++ b/test/correctness/interpreter.cpp
@@ -6,7 +6,7 @@ int main(int argc, char **argv) {
 
     // TODO(#5738): remove after winbots are upgraded
     Target target = get_jit_target_from_environment();
-    if (target.os == Target::Windows &&
+    if (target.os() == Target::Windows &&
         (target.has_feature(Target::OpenCL) ||
          target.has_feature(Target::D3D12Compute))) {
         printf("[SKIP-WITH-ISSUE-5738] workaround for issue #5738\n");

--- a/test/correctness/loop_invariant_extern_calls.cpp
+++ b/test/correctness/loop_invariant_extern_calls.cpp
@@ -27,7 +27,7 @@ int not_really_parallel_for(JITUserContext *ctx, int (*f)(JITUserContext *, int,
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Skipping test for WebAssembly as the wasm JIT cannot support custom parallel runtimes\n");
         return 0;
     }

--- a/test/correctness/make_struct.cpp
+++ b/test/correctness/make_struct.cpp
@@ -25,7 +25,7 @@ extern "C" HALIDE_EXPORT_SYMBOL int check_struct(struct_t *s) {
 HalideExtern_1(int, check_struct, struct_t *);
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Skipping test for WebAssembly as the wasm JIT cannot support passing arbitrary pointers to/from HalideExtern code.\n");
         return 0;
     }

--- a/test/correctness/memoize.cpp
+++ b/test/correctness/memoize.cpp
@@ -583,7 +583,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     } else {

--- a/test/correctness/metal_precompiled_shaders.cpp
+++ b/test/correctness/metal_precompiled_shaders.cpp
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
     // This test only runs on macOS with Metal support
     Target t = get_jit_target_from_environment();
 
-    if (t.os != Target::OSX || !t.has_feature(Target::Metal)) {
+    if (t.os() != Target::OSX || !t.has_feature(Target::Metal)) {
         printf("[SKIP] This test only runs on macOS with Metal support\n");
         return 0;
     }

--- a/test/correctness/nested_tail_strategies.cpp
+++ b/test/correctness/nested_tail_strategies.cpp
@@ -65,7 +65,7 @@ void check(Func out, int line, std::vector<TailStrategy> tails) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/out_of_memory.cpp
+++ b/test/correctness/out_of_memory.cpp
@@ -38,7 +38,7 @@ extern "C" void handler(JITUserContext *user_context, const char *msg) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/output_larger_than_two_gigs.cpp
+++ b/test/correctness/output_larger_than_two_gigs.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
 
     Target t = get_jit_target_from_environment();
 
-    if (t.bits != 32) {
+    if (t.bits() != 32) {
         identity_uint8.compile_jit(t.with_feature(Target::LargeBuffers));
         identity_uint8.realize(output);
         assert(!error_occurred);

--- a/test/correctness/parallel_fork.cpp
+++ b/test/correctness/parallel_fork.cpp
@@ -64,7 +64,7 @@ Func make(Schedule schedule) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] Skipping test for WebAssembly as it does not support async() yet.\n");
         return 0;
     }

--- a/test/correctness/pipeline_set_jit_externs_func.cpp
+++ b/test/correctness/pipeline_set_jit_externs_func.cpp
@@ -13,7 +13,7 @@ HalideExtern_2(float, my_func, int, float);
 int main(int argc, char **argv) {
     // set_jit_externs() implicitly adds a user_context arg to the externs, which
     // we can't yet support. TODO: this actually should work, but doesn't.
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support passing arbitrary pointers to/from HalideExtern code.\n");
         return 0;
     }

--- a/test/correctness/popc_clz_ctz_bounds.cpp
+++ b/test/correctness/popc_clz_ctz_bounds.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
     }
 
     for (int vectorize = 0; vectorize <= 1; vectorize++) {
-        if (vectorize && get_jit_target_from_environment().arch != Target::X86) {
+        if (vectorize && get_jit_target_from_environment().arch() != Target::X86) {
             // Not all architectures support vectorized popc/ctz/clz operations,
             // and will fail at LLVM time. Skipping for non-x86 for now.
             continue;

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -430,7 +430,7 @@ int vectorized_predicated_load_const_index_test(const Target &t) {
 }
 
 int vectorized_predicated_load_lut_test(const Target &t) {
-    if (t.arch != Target::X86) {
+    if (t.arch() != Target::X86) {
         // This test will fail on Hexagon as the LUT is larger than 16 bits.
         // Since using less than 16-bit LUT will make the predicate on the
         // vector store/load disappear, only run the test for X86.

--- a/test/correctness/prefetch.cpp
+++ b/test/correctness/prefetch.cpp
@@ -59,7 +59,7 @@ Expr get_max_byte_size(const Target &t) {
     Expr max_byte_size;
     if (t.has_feature(Target::HVX)) {
         max_byte_size = Expr();
-    } else if (t.arch == Target::ARM) {
+    } else if (t.arch() == Target::ARM) {
         max_byte_size = 32;
     } else {
         max_byte_size = 64;

--- a/test/correctness/pseudostack_shares_slots.cpp
+++ b/test/correctness/pseudostack_shares_slots.cpp
@@ -18,7 +18,7 @@ void my_free(JITUserContext *user_context, void *ptr) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/reorder_storage.cpp
+++ b/test/correctness/reorder_storage.cpp
@@ -20,7 +20,7 @@ void my_free(JITUserContext *user_context, void *ptr) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/ring_buffer.cpp
+++ b/test/correctness/ring_buffer.cpp
@@ -3,7 +3,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly does not support async() yet.\n");
         return 0;
     }

--- a/test/correctness/simd_op_check.h
+++ b/test/correctness/simd_op_check.h
@@ -106,15 +106,15 @@ public:
     }
 
     virtual bool can_run_code() const {
-        if (target.arch == Target::WebAssembly) {
+        if (target.arch() == Target::WebAssembly) {
             return Halide::Internal::WasmModule::can_jit_target(Target("wasm-32-wasmrt"));
         }
         // If we can (target matches host), run the error checking Halide::Func.
         Target host_target = get_host_target();
         bool can_run_the_code =
-            (target.arch == host_target.arch &&
-             target.bits == host_target.bits &&
-             target.os == host_target.os);
+            (target.arch() == host_target.arch() &&
+             target.bits() == host_target.bits() &&
+             target.os() == host_target.os());
         // A bunch of feature flags also need to match between the
         // compiled code and the host in order to run the code.
         for (Target::Feature f : {

--- a/test/correctness/simd_op_check_arm.cpp
+++ b/test/correctness/simd_op_check_arm.cpp
@@ -20,14 +20,14 @@ public:
     }
 
     void add_tests() override {
-        if (target.arch == Target::ARM) {
+        if (target.arch() == Target::ARM) {
             check_neon_all();
             check_streaming_accesses();
         }
     }
 
     void check_streaming_accesses() {
-        if (target.bits != 64) {
+        if (target.bits() != 64) {
             return;
         }
 
@@ -73,7 +73,7 @@ public:
         // to peephole match any with vector, so we just try 64-bits, 128
         // bits, 192 bits, and 256 bits for everything.
 
-        bool arm32 = (target.bits == 32);
+        bool arm32 = (target.bits() == 32);
 
         for (int w = 1; w <= 4; w++) {
 
@@ -324,7 +324,7 @@ public:
                 check(arm32 ? "vld1.32" : "ldr", 2 * w, in_f32(x + y));
             }
 
-            if (target.os != Target::IOS && target.os != Target::OSX) {
+            if (target.os() != Target::IOS && target.os() != Target::OSX) {
                 // VLD* are not profitable on Apple silicon
 
                 // Even on non-Apple silicon, LLVM occasionally decides it's
@@ -909,7 +909,7 @@ public:
             check(arm32 ? "vrsqrts.f32" : "frsqrts", 4 * w, fast_inverse_sqrt(f32_1));
 
             // VFRINTN
-            if (target.bits == 64) {
+            if (target.bits() == 64) {
                 // LLVM doesn't want to emit vfrintn on arm-32
                 if (target.has_feature(Target::ARMFp16)) {
                     check(arm32 ? "vfrintn.f16" : "frintn", 8 * w, round(f16_1));

--- a/test/correctness/simd_op_check_powerpc.cpp
+++ b/test/correctness/simd_op_check_powerpc.cpp
@@ -20,7 +20,7 @@ public:
     }
 
     void add_tests() override {
-        if (target.arch == Target::POWERPC) {
+        if (target.arch() == Target::POWERPC) {
             check_altivec_all();
         }
     }

--- a/test/correctness/simd_op_check_riscv.cpp
+++ b/test/correctness/simd_op_check_riscv.cpp
@@ -19,7 +19,7 @@ public:
     }
 
     void add_tests() override {
-        if (target.arch == Target::RISCV &&
+        if (target.arch() == Target::RISCV &&
             target.has_feature(Target::RVV)) {
             check_rvv_all();
         }
@@ -120,7 +120,7 @@ public:
     void check_rvv_all() {
         for (int i = 3; i < 7; i++) {
             int bit_width = (1 << i);
-            int natural_lanes = target.vector_bits / bit_width;
+            int natural_lanes = target.vector_bits() / bit_width;
             // TODO: This should work for all lanes from 2 to 8 * natural_lanes
             // but the vector predication paths require using vscale multiples.
             // This is using powers of two rather than vscale multiples for

--- a/test/correctness/simd_op_check_sve2.cpp
+++ b/test/correctness/simd_op_check_sve2.cpp
@@ -34,8 +34,8 @@ public:
         auto is_runtime_compatible = [](const Target &t1, const Target &t2,
                                         const vector<Target::Feature> features = {Target::SVE2}) -> bool {
             bool yes = true;
-            yes &= (t1.arch == t2.arch && t1.bits == t2.bits && t1.os == t2.os);
-            yes &= (t1.vector_bits == t2.vector_bits);
+            yes &= (t1.arch() == t2.arch() && t1.bits() == t2.bits() && t1.os() == t2.os());
+            yes &= (t1.vector_bits() == t2.vector_bits());
 
             // A bunch of feature flags also need to match between the
             // compiled code and the host in order to run the code.
@@ -678,7 +678,7 @@ private:
                 add_arm64("finite", is_vector ? sel_op("", "fcmge", "fcmeq") : "", is_inf(f_1));
             }
 
-            if (bits == 16 && target.os != Target::IOS && target.os != Target::OSX) {
+            if (bits == 16 && target.os() != Target::IOS && target.os() != Target::OSX) {
                 // Actually, the following ops are not vectorized because SIMD instruction is unavailable.
                 // The purpose of the test is just to confirm no error.
                 // In case the target has FP16 feature, native type conversion between fp16 and fp32 should be generated
@@ -725,7 +725,7 @@ private:
             // which makes it prone to false-positive detection as we only search strings line-by-line.
 
             // LDn       -       Structured Load strided elements
-            if (target.os != Target::IOS && target.os != Target::OSX &&
+            if (target.os() != Target::IOS && target.os() != Target::OSX &&
                 Halide::Internal::get_llvm_version() >= 220) {
                 for (int stride = 2; stride <= 4; ++stride) {
 
@@ -1100,7 +1100,7 @@ private:
         }
 
         string generate_pattern(const Target &target) const {
-            bool is_arm32 = target.bits == 32;
+            bool is_arm32 = target.bits() == 32;
 
             string opcode_pattern;
             string operand_pattern;
@@ -1124,7 +1124,7 @@ private:
         }
 
         static int natural_lanes(int bits, const Target &t) {
-            const int base_vector_bits = std::max(t.vector_bits, 128);
+            const int base_vector_bits = std::max(t.vector_bits(), 128);
             return base_vector_bits / bits;
         }
 
@@ -1440,7 +1440,7 @@ private:
     }
 
     inline bool is_arm32() const {
-        return target.bits == 32;
+        return target.bits() == 32;
     };
     inline bool has_neon() const {
         return !target.has_feature(Target::NoNEON);
@@ -1465,7 +1465,7 @@ private:
     }
 
     bool is_float16_supported() const {
-        return (target.bits == 64) &&
+        return (target.bits() == 64) &&
                target.features_any_of({Target::ARMFp16, Target::SVE, Target::SVE2, Target::SME2});
     }
 
@@ -1504,7 +1504,7 @@ int main(int argc, char **argv) {
             std::cerr << "Unsupported SME SVL " << svb << "\n";
             return 1;
         }
-        auto sme_target = Target(host_target.os, Target::ARM, 64, Target::ProcessorGeneric, {Target::SME2, sme_svl});
+        auto sme_target = Target(host_target.os(), Target::ARM, 64, Target::ProcessorGeneric, {Target::SME2, sme_svl});
         targets.emplace_back(sme_target);
     }
 

--- a/test/correctness/simd_op_check_wasm.cpp
+++ b/test/correctness/simd_op_check_wasm.cpp
@@ -21,7 +21,7 @@ public:
     }
 
     void add_tests() override {
-        if (target.arch == Target::WebAssembly) {
+        if (target.arch() == Target::WebAssembly) {
             check_wasm_all();
         }
     }

--- a/test/correctness/simd_op_check_x86.cpp
+++ b/test/correctness/simd_op_check_x86.cpp
@@ -40,7 +40,7 @@ public:
 
     void add_tests() override {
         // Queue up a bunch of tasks representing each test to run.
-        if (target.arch == Target::X86) {
+        if (target.arch() == Target::X86) {
             check_sse_and_avx();
             check_streaming_accesses();
         }

--- a/test/correctness/sliding_window.cpp
+++ b/test/correctness/sliding_window.cpp
@@ -18,7 +18,7 @@ extern "C" void *my_malloc(JITUserContext *, size_t x) {
 int main(int argc, char **argv) {
     Var x, y;
 
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -76,7 +76,7 @@ public:
 };
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/stack_allocations.cpp
+++ b/test/correctness/stack_allocations.cpp
@@ -17,7 +17,7 @@ void my_free(JITUserContext *ctx, void *ptr) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/storage_folding.cpp
+++ b/test/correctness/storage_folding.cpp
@@ -109,7 +109,7 @@ void realize_and_expect_error(Func f, int w, int h) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/store_in.cpp
+++ b/test/correctness/store_in.cpp
@@ -50,7 +50,7 @@ void check(MemoryType t1, MemoryType t2, MemoryType t3) {
 }
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support custom allocators.\n");
         return 0;
     }

--- a/test/correctness/strict_fma.cpp
+++ b/test/correctness/strict_fma.cpp
@@ -18,7 +18,7 @@ int test() {
         t.has_gpu_feature() &&
         // Metal on x86 does not seem to respect strict float despite setting
         // the appropriate pragma.
-        !(t.arch == Target::X86 && t.has_feature(Target::Metal)) &&
+        !(t.arch() == Target::X86 && t.has_feature(Target::Metal)) &&
         // TODO: Vulkan does not respect strict_float yet:
         // https://github.com/halide/Halide/issues/7239
         !t.has_feature(Target::Vulkan) &&

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -271,20 +271,20 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (Target().vector_bits != 0) {
+    if (Target().vector_bits() != 0) {
         printf("Default Target vector_bits not 0.\n");
         return 1;
     }
-    if (Target("arm-64-linux-sve2-vector_bits_512").vector_bits != 512) {
+    if (Target("arm-64-linux-sve2-vector_bits_512").vector_bits() != 512) {
         printf("Vector bits not parsed correctly.\n");
         return 1;
     }
     Target with_vector_bits(Target::Linux, Target::ARM, 64, Target::ProcessorGeneric, {Target::SVE}, 512);
-    if (with_vector_bits.vector_bits != 512) {
+    if (with_vector_bits.vector_bits() != 512) {
         printf("Vector bits not populated in constructor.\n");
         return 1;
     }
-    if (Target(with_vector_bits.to_string()).vector_bits != 512) {
+    if (Target(with_vector_bits.to_string()).vector_bits() != 512) {
         printf("Vector bits not round tripped properly.\n");
         return 1;
     }

--- a/test/correctness/target_query.cpp
+++ b/test/correctness/target_query.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
     // For simplicity, only run this test on hosts that we can predict.
     Target t = get_host_target();
-    if (t.arch != Target::X86 || t.bits != 64 || t.os != Target::OSX) {
+    if (t.arch() != Target::X86 || t.bits() != 64 || t.os() != Target::OSX) {
         printf("[SKIP] This test only runs on x86-64-osx.\n");
         return 0;
     }

--- a/test/correctness/thread_safety.cpp
+++ b/test/correctness/thread_safety.cpp
@@ -7,7 +7,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
     // Wasm JIT is substantially slower than others,
     // so do fewer iterations to avoid timing out.
-    const bool is_wasm = get_jit_target_from_environment().arch == Target::WebAssembly;
+    const bool is_wasm = get_jit_target_from_environment().arch() == Target::WebAssembly;
 
     // Test if the compiler itself is thread-safe. This test is
     // intended to be run in a thread-sanitizer.

--- a/test/correctness/tracing_thread_ids.cpp
+++ b/test/correctness/tracing_thread_ids.cpp
@@ -75,7 +75,7 @@ int parallel_task_ancestor_id(int id) {
 }  // namespace
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not support threads.\n");
         return 0;
     }

--- a/test/correctness/vector_cast.cpp
+++ b/test/correctness/vector_cast.cpp
@@ -32,7 +32,7 @@ bool is_type_supported(int vec_width, const Target &target) {
     }
     if (target.has_feature(Target::Vulkan)) {
         if (type_of<T>() == Float(64)) {
-            if ((target.os == Target::OSX || target.os == Target::IOS)) {
+            if ((target.os() == Target::OSX || target.os() == Target::IOS)) {
                 return false;  // MoltenVK doesn't support Float64
             }
         }
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
 
     // We only test power-of-two vector widths for now
     int vec_width_max = 64;
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         // The wasm jit is very slow, so shorten this test here.
         vec_width_max = 16;
     }

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -172,7 +172,7 @@ int main(int argc, char **argv) {
 
     // TODO(https://github.com/halide/Halide/issues/8985): LLVM's JIT emits
     // misaligned jump tables on arm-32 with arm_fp16, causing SIGILL.
-    if (target.arch == Target::ARM && target.bits == 32 &&
+    if (target.arch() == Target::ARM && target.bits() == 32 &&
         target.has_feature(Target::ARMFp16)) {
         printf("[SKIP] arm-32 JIT with arm_fp16 hits LLVM jump table misalignment bug.\n");
         return 0;
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
     std::vector<Task> tasks;
     add_tasks(target, tasks);
 
-    if (target.arch == Target::X86) {
+    if (target.arch() == Target::X86) {
         // LLVM has had SIMD codegen errors that we missed because we didn't test against
         // multiple SIMD architectures, using just 'host' instead. To remedy this, we'll
         // re-run this multiple times, downgrading the SIMD successively, to ensure we get
@@ -193,20 +193,20 @@ int main(int argc, char **argv) {
         // e.g. if you specify a target with AVX2, the codegen will automatically include
         // AVX and SSE41 as well.)
         if (target.has_feature(Target::AVX512)) {
-            Target avx2_target(target.os, target.arch, target.bits, {Target::AVX2});
+            Target avx2_target(target.os(), target.arch(), target.bits(), {Target::AVX2});
             add_tasks(avx2_target, tasks);
         }
         if (target.has_feature(Target::AVX2)) {
-            Target sse41_target(target.os, target.arch, target.bits, {Target::AVX});
+            Target sse41_target(target.os(), target.arch(), target.bits(), {Target::AVX});
             add_tasks(sse41_target, tasks);
         }
         if (target.has_feature(Target::AVX)) {
-            Target sse41_target(target.os, target.arch, target.bits, {Target::SSE41});
+            Target sse41_target(target.os(), target.arch(), target.bits(), {Target::SSE41});
             add_tasks(sse41_target, tasks);
         }
         if (target.has_feature(Target::SSE41)) {
             // Halide assumes that all x86 targets have at least sse2
-            Target sse2_target(target.os, target.arch, target.bits);
+            Target sse2_target(target.os(), target.arch(), target.bits());
             add_tasks(sse2_target, tasks);
         }
     }

--- a/test/correctness/widening_reduction.cpp
+++ b/test/correctness/widening_reduction.cpp
@@ -9,7 +9,7 @@ using namespace Halide::Internal;
 int main(int arch, char **argv) {
 
     Halide::Target target = get_jit_target_from_environment();
-    if (target.has_feature(Target::Vulkan) && ((target.os == Target::IOS) || target.os == Target::OSX)) {
+    if (target.has_feature(Target::Vulkan) && ((target.os() == Target::IOS) || target.os() == Target::OSX)) {
         printf("[SKIP] Skipping test for Vulkan on iOS/OSX (MoltenVK fails to convert max/min intrinsics correctly)!\n");
         return 0;
     }

--- a/test/error/async_require_fail.cpp
+++ b/test/error/async_require_fail.cpp
@@ -5,7 +5,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not yet support async().\n");
         _halide_user_assert(0);
     }

--- a/test/error/metal_threads_too_large.cpp
+++ b/test/error/metal_threads_too_large.cpp
@@ -4,7 +4,7 @@
 using namespace Halide;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().os != Target::OSX) {
+    if (get_jit_target_from_environment().os() != Target::OSX) {
         printf("[SKIP] error/metal_threads_too_large ignored for non-OSX targets\n");
         _halide_user_assert(0);
     }

--- a/test/error/mismatch_runtime_vscale.cpp
+++ b/test/error/mismatch_runtime_vscale.cpp
@@ -16,8 +16,8 @@ int main(int argc, char **argv) {
 
     f(x) = x;
 
-    const int wrong_vector_bits = target.vector_bits == 128 ? 256 : 128;
-    target.vector_bits = wrong_vector_bits;
+    const int wrong_vector_bits = target.vector_bits() == 128 ? 256 : 128;
+    target.set_vector_bits(wrong_vector_bits);
 
     // Compile with wrong vscale and run on host, which should end up with assertion failure.
     Buffer<int> out = f.realize({100}, target);

--- a/test/error/null_host_field.cpp
+++ b/test/error/null_host_field.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 using namespace Halide::Internal;
 
 int main(int argc, char **argv) {
-    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+    if (get_jit_target_from_environment().arch() == Target::WebAssembly) {
         printf("[SKIP] WebAssembly JIT does not yet support non-host buffers.\n");
         _halide_user_assert(0);
     }

--- a/test/performance/async_gpu.cpp
+++ b/test/performance/async_gpu.cpp
@@ -15,7 +15,7 @@ Expr expensive(Expr x, int c) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/blend_tail_strategies.cpp
+++ b/test/performance/blend_tail_strategies.cpp
@@ -10,7 +10,7 @@ int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
 
     // Make sure we don't have predicated instructions available
-    if ((t.arch != Target::X86 && t.arch != Target::ARM) ||
+    if ((t.arch() != Target::X86 && t.arch() != Target::ARM) ||
         t.has_feature(Target::AVX512) ||
         t.has_feature(Target::SVE)) {
         printf("[SKIP] This is a test for architectures without predication. "

--- a/test/performance/block_transpose.cpp
+++ b/test/performance/block_transpose.cpp
@@ -82,7 +82,7 @@ Result test_transpose(int block_width, int block_height, const Target &t) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/boundary_conditions.cpp
+++ b/test/performance/boundary_conditions.cpp
@@ -80,7 +80,7 @@ struct Test {
 
 int main(int argc, char **argv) {
     target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/clamped_vector_load.cpp
+++ b/test/performance/clamped_vector_load.cpp
@@ -39,7 +39,7 @@ double test(Func f, bool test_correctness = true) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/const_division.cpp
+++ b/test/performance/const_division.cpp
@@ -120,7 +120,7 @@ bool test(int w, bool div, bool round_to_zero) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/fan_in.cpp
+++ b/test/performance/fan_in.cpp
@@ -6,7 +6,7 @@ using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/fast_inverse.cpp
+++ b/test/performance/fast_inverse.cpp
@@ -7,13 +7,13 @@ using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }
 
-    if (target.arch == Target::ARM &&
-        target.os == Target::OSX) {
+    if (target.arch() == Target::ARM &&
+        target.os() == Target::OSX) {
         // vrecpe, vrecps, fmul have inverse throughputs of 1, 0.25, 0.25
         // respectively, while fdiv has inverse throughput of 1.
         printf("[SKIP] Apple M1 chips have division performance roughly on par with the reciprocal instruction\n");

--- a/test/performance/fast_pow.cpp
+++ b/test/performance/fast_pow.cpp
@@ -20,13 +20,13 @@ int main(int argc, char **argv) {
     printf("HL_TARGET is:     %s\n", hl_target.to_string().c_str());
     printf("HL_JIT_TARGET is: %s\n", hl_jit_target.to_string().c_str());
 
-    if (hl_jit_target.arch == Target::X86 &&
+    if (hl_jit_target.arch() == Target::X86 &&
         !hl_jit_target.has_feature(Target::SSE41)) {
         printf("[SKIP] These intrinsics are known to be slow on x86 without sse 4.1.\n");
         return 0;
     }
 
-    if (hl_jit_target.arch == Target::WebAssembly) {
+    if (hl_jit_target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/fast_sine_cosine.cpp
+++ b/test/performance/fast_sine_cosine.cpp
@@ -11,13 +11,13 @@ using namespace Halide::Tools;
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
-    if (target.arch == Target::X86 &&
+    if (target.arch() == Target::X86 &&
         !target.has_feature(Target::SSE41)) {
         printf("[SKIP] These intrinsics are known to be slow on x86 without sse 4.1.\n");
         return 0;
     }
 
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/gpu_half_throughput.cpp
+++ b/test/performance/gpu_half_throughput.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
-    if (t.arch == Target::WebAssembly) {
+    if (t.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/inner_loop_parallel.cpp
+++ b/test/performance/inner_loop_parallel.cpp
@@ -7,7 +7,7 @@ using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/interleave.cpp
+++ b/test/performance/interleave.cpp
@@ -114,7 +114,7 @@ Result test_deinterleave(int factor, const Target &t) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/jit_stress.cpp
+++ b/test/performance/jit_stress.cpp
@@ -8,7 +8,7 @@ using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/lots_of_inputs.cpp
+++ b/test/performance/lots_of_inputs.cpp
@@ -18,7 +18,7 @@ Func make_pipeline(int size) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/lots_of_small_allocations.cpp
+++ b/test/performance/lots_of_small_allocations.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/matrix_multiplication.cpp
+++ b/test/performance/matrix_multiplication.cpp
@@ -22,7 +22,7 @@ void simple_version(float *A, float *B, float *C, int width, int stride) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
     // ld1r post-increment serial dependency chain that occurs with 8 rows
     // (where only 2 temp registers cycle between rows), and produces balanced
     // load/compute throughput (4 cycles each at 4 FP units and 2 load ports).
-    const bool is_aarch64 = target.arch == Target::ARM && target.bits == 64;
+    const bool is_aarch64 = target.arch() == Target::ARM && target.bits() == 64;
     const bool is_avx512 = target.has_feature(Target::AVX512);
 
     // Size the inner loop tiles to fit into the number of registers available

--- a/test/performance/memcpy.cpp
+++ b/test/performance/memcpy.cpp
@@ -12,7 +12,7 @@ using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/memory_profiler.cpp
+++ b/test/performance/memory_profiler.cpp
@@ -98,7 +98,7 @@ void run_case(const char *desc, Fn body) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/nested_vectorization_gemm.cpp
+++ b/test/performance/nested_vectorization_gemm.cpp
@@ -6,7 +6,7 @@ using namespace Halide;
 int main(int argc, char **argv) {
 
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
             const int vec = target.natural_vector_size<uint8_t>();
 
             if (use_nested_vectorization) {
-                if (target.arch == Target::X86) {
+                if (target.arch() == Target::X86) {
                     // x86 schedule. Exploits the ability of pmaddwd
                     // to pull one arg from memory. Because we'll be
                     // intentionally spilling, the tile will be
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
             if (use_nested_vectorization) {
 
                 int reduce;
-                if (target.arch == Target::X86) {
+                if (target.arch() == Target::X86) {
                     reduce = 8;
                 } else if (target.has_feature(Target::ARMDotProd)) {
                     reduce = 4;
@@ -221,7 +221,7 @@ int main(int argc, char **argv) {
     // 16-bit blur into 32-bit accumulator, with reduction over
     // adjacent vector lanes at the same time as reduction over slices
     // of the vector. This is only a win on platforms with a pmaddwd-like instruction.
-    if (target.arch == Target::X86) {
+    if (target.arch() == Target::X86) {
 
         double times[2];
 

--- a/test/performance/packed_planar_fusion.cpp
+++ b/test/performance/packed_planar_fusion.cpp
@@ -50,7 +50,7 @@ Buffer<uint8_t> make_planar(uint8_t *host, int W, int H) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/parallel_performance.cpp
+++ b/test/performance/parallel_performance.cpp
@@ -10,7 +10,7 @@ using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/profiler.cpp
+++ b/test/performance/profiler.cpp
@@ -105,7 +105,7 @@ int run_test(bool use_timer_profiler) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
     if (run_test(false) != 0) {
         return 1;
     }
-    if (target.os == Target::Linux) {
+    if (target.os() == Target::Linux) {
         printf("Testing timer based profiler.\n");
         if (run_test(true) != 0) {
             return 1;

--- a/test/performance/realize_overhead.cpp
+++ b/test/performance/realize_overhead.cpp
@@ -13,7 +13,7 @@ int null_call() {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/rfactor.cpp
+++ b/test/performance/rfactor.cpp
@@ -397,7 +397,7 @@ int kitchen_sink() {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/rgb_interleaved.cpp
+++ b/test/performance/rgb_interleaved.cpp
@@ -145,7 +145,7 @@ void test_interleave(bool fast) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/sort.cpp
+++ b/test/performance/sort.cpp
@@ -138,7 +138,7 @@ Func merge_sort(Func input, int total_size) {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/stack_vs_heap.cpp
+++ b/test/performance/stack_vs_heap.cpp
@@ -5,7 +5,7 @@ using namespace Halide;
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/thread_safe_jit_callable.cpp
+++ b/test/performance/thread_safe_jit_callable.cpp
@@ -104,7 +104,7 @@ void same_func_per_thread() {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/vectorize.cpp
+++ b/test/performance/vectorize.cpp
@@ -94,7 +94,7 @@ bool test() {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/test/performance/wrap.cpp
+++ b/test/performance/wrap.cpp
@@ -111,7 +111,7 @@ Func build_wrap() {
 
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
-    if (target.arch == Target::WebAssembly) {
+    if (target.arch() == Target::WebAssembly) {
         printf("[SKIP] Performance tests are meaningless and/or misleading under WebAssembly interpreter.\n");
         return 0;
     }

--- a/tools/halide_trace_config.h
+++ b/tools/halide_trace_config.h
@@ -43,17 +43,17 @@ inline std::string unescape_spaces(const std::string &str) {
     return replace_all(str, "\\x20", " ");
 }
 
-inline std::ostream &write_halide_type(std::ostream &os, const halide_type_t &t) {
-    os << (int)t.code << " " << (int)t.bits;
+inline std::ostream &write_halide_type(std::ostream &os, const halide_type_t &type) {
+    os << (int)type.code << " " << (int)type.bits;
     return os;
 }
 
-inline std::istream &read_halide_type(std::istream &is, halide_type_t &t) {
+inline std::istream &read_halide_type(std::istream &is, halide_type_t &type) {
     // type.code is an enum; type.bits is a uint8 and might be read as char.
     int type_code, type_bits;
     is >> type_code >> type_bits;
-    t.code = (halide_type_code_t)type_code;
-    t.bits = (uint8_t)type_bits;
+    type.code = (halide_type_code_t)type_code;
+    type.bits = (uint8_t)type_bits;
     return is;
 }
 

--- a/tutorial/lesson_11_cross_compilation.cpp
+++ b/tutorial/lesson_11_cross_compilation.cpp
@@ -82,18 +82,18 @@ int main() {
 
     // Let's use this to compile a 32-bit arm android version of this code:
     Target target;
-    target.os = Target::Android;                // The operating system
-    target.arch = Target::ARM;                  // The CPU architecture
-    target.bits = 32;                           // The bit-width of the architecture
+    target.set_os(Target::Android);                // The operating system
+    target.set_arch(Target::ARM);                  // The CPU architecture
+    target.set_bits(32);                           // The bit-width of the architecture
     std::vector<Target::Feature> arm_features;  // A list of features to set
     target.set_features(arm_features);
     // We then pass the target as the last argument to compile_to_file.
     brighter.compile_to_file("lesson_11_arm_32_android", args, "brighter", target);
 
     // And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
-    target.os = Target::Windows;
-    target.arch = Target::X86;
-    target.bits = 64;
+    target.set_os(Target::Windows);
+    target.set_arch(Target::X86);
+    target.set_bits(64);
     std::vector<Target::Feature> x86_features;
     x86_features.push_back(Target::AVX);
     x86_features.push_back(Target::SSE41);
@@ -106,9 +106,9 @@ int main() {
     // this using the target features field.  Support for Apple's
     // 64-bit ARM processors is very new in llvm, and still somewhat
     // flaky.
-    target.os = Target::IOS;
-    target.arch = Target::ARM;
-    target.bits = 32;
+    target.set_os(Target::IOS);
+    target.set_arch(Target::ARM);
+    target.set_bits(32);
     std::vector<Target::Feature> armv7s_features;
     armv7s_features.push_back(Target::ARMv7s);
     target.set_features(armv7s_features);

--- a/tutorial/lesson_12_using_the_gpu.cpp
+++ b/tutorial/lesson_12_using_the_gpu.cpp
@@ -288,14 +288,14 @@ Target find_gpu_target() {
     Target target = get_host_target();
 
     std::vector<Target::Feature> features_to_try;
-    if (target.os == Target::Windows) {
+    if (target.os() == Target::Windows) {
         // Try D3D12 first; if that fails, try OpenCL.
         if (sizeof(void*) == 8) {
             // D3D12Compute support is only available on 64-bit systems at present.
             features_to_try.push_back(Target::D3D12Compute);
         }
         features_to_try.push_back(Target::OpenCL);
-    } else if (target.os == Target::OSX) {
+    } else if (target.os() == Target::OSX) {
         // OS X doesn't update its OpenCL drivers, so they tend to be broken.
         // CUDA would also be a fine choice on machines with NVidia GPUs.
         features_to_try.push_back(Target::Metal);

--- a/tutorial/lesson_19_wrapper_funcs.cpp
+++ b/tutorial/lesson_19_wrapper_funcs.cpp
@@ -291,7 +291,7 @@ int main() {
 
         // Select an appropriate GPU API, as we did in lesson 12
         Target target = get_host_target();
-        if (target.os == Target::OSX) {
+        if (target.os() == Target::OSX) {
             target.set_feature(Target::Metal);
         } else {
             target.set_feature(Target::OpenCL);


### PR DESCRIPTION
This PR sets the stage for the higher levels of the stack.

## Breaking changes

Public fields became getter/setter functions. Downstreams will need to add `()` around accesses and call `t.set_*(val)` instead of `t.* = val`.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [x] Python bindings updated (if public API changed)
- [x] Commits include AI attribution where applicable (see Code of Conduct)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>