### PR TITLE
[Target] Enforce invariants through setters

### DIFF
--- a/python_bindings/src/halide/halide_/PyEnums.cpp
+++ b/python_bindings/src/halide/halide_/PyEnums.cpp
@@ -149,7 +149,6 @@ void define_enums(py::module &m) {
         .value("CLDoubles", Target::Feature::CLDoubles)
         .value("CLHalf", Target::Feature::CLHalf)
         .value("CLAtomics64", Target::Feature::CLAtomics64)
-        .value("EGL", Target::Feature::EGL)
         .value("UserContext", Target::Feature::UserContext)
         .value("Profile", Target::Feature::Profile)
         .value("NoRuntime", Target::Feature::NoRuntime)

--- a/src/JITModule.cpp
+++ b/src/JITModule.cpp
@@ -918,15 +918,11 @@ JITModule &make_module(llvm::Module *for_module, Target target,
         // msan doesn't work for jit modules
         target.set_feature(Target::MSAN, false);
 
-        Target one_gpu(target);
+        // Build a target that selects exactly one device runtime: strip all
+        // device-offload features (and their sub-features), then enable the
+        // single one this runtime module is for, below.
+        Target one_gpu = target.without_device_features();
         one_gpu.set_feature(Target::Debug, false);
-        one_gpu.set_feature(Target::OpenCL, false);
-        one_gpu.set_feature(Target::Metal, false);
-        one_gpu.set_feature(Target::CUDA, false);
-        one_gpu.set_feature(Target::HVX, false);
-        one_gpu.set_feature(Target::D3D12Compute, false);
-        one_gpu.set_feature(Target::Vulkan, false);
-        one_gpu.set_feature(Target::WebGPU, false);
         string module_name;
         switch (runtime_kind) {
         case OpenCLDebug:

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -1212,6 +1212,40 @@ const std::map<Target::Arch, std::set<Target::Processor>> &legal_processors_by_a
     return table;
 }
 
+// Sub-features that refine a "parent" feature but do not imply it (so they are
+// not in implied_feature_pairs()): a capability/version/extension is only
+// meaningful when its parent device feature is also set. validate_features()
+// rejects a sub-feature whose parent is absent, and
+// Target::without_device_features() clears sub-features alongside their parent.
+// New capability/version features belong here.
+const std::map<Target::Feature, std::vector<Target::Feature>> &sub_features_by_parent() {
+    static const std::map<Target::Feature, std::vector<Target::Feature>> table = {
+        {
+            Target::CUDA,
+            {Target::CUDACapability30, Target::CUDACapability32, Target::CUDACapability35,
+             Target::CUDACapability50, Target::CUDACapability61, Target::CUDACapability70,
+             Target::CUDACapability75, Target::CUDACapability80, Target::CUDACapability86},
+        },
+        {
+            Target::OpenCL,
+            {Target::CLDoubles, Target::CLHalf, Target::CLAtomics64},
+        },
+        {
+            Target::Vulkan,
+            {Target::VulkanInt8, Target::VulkanInt16, Target::VulkanInt64,
+             Target::VulkanFloat16, Target::VulkanFloat64,
+             Target::VulkanV10, Target::VulkanV12, Target::VulkanV13},
+        },
+        {
+            Target::D3D12Compute,
+            {Target::HLSL_SM60, Target::HLSL_SM61, Target::HLSL_SM62, Target::HLSL_SM63,
+             Target::HLSL_SM64, Target::HLSL_SM65, Target::HLSL_SM66, Target::HLSL_SM67,
+             Target::HLSL_SM68, Target::HLSL_SM69},
+        },
+    };
+    return table;
+}
+
 }  // namespace
 
 void Target::validate_features() const {
@@ -1322,20 +1356,16 @@ void Target::validate_features() const {
                             });
     }
 
-    // D3D12Compute SM version features require D3D12Compute to also be set.
-    if (!has_feature(D3D12Compute)) {
-        do_check_bad(*this, {
-                                HLSL_SM60,
-                                HLSL_SM61,
-                                HLSL_SM62,
-                                HLSL_SM63,
-                                HLSL_SM64,
-                                HLSL_SM65,
-                                HLSL_SM66,
-                                HLSL_SM67,
-                                HLSL_SM68,
-                                HLSL_SM69,
-                            });
+    // Sub-features (device capability/version/extension refinements) are only
+    // meaningful when their parent device feature is also set.
+    for (const auto &[parent, subs] : sub_features_by_parent()) {
+        if (!has_feature(parent)) {
+            for (Feature s : subs) {
+                user_assert(!has_feature(s))
+                    << "Target feature " << feature_to_name(s) << " requires "
+                    << feature_to_name(parent) << " to also be set. (" << *this << ")\n";
+            }
+        }
     }
 
     const int num_sme_svl_features =
@@ -1359,6 +1389,32 @@ void Target::validate_features() const {
         auto it = table.find(arch_);
         user_assert(it != table.end() && it->second.count(processor_tune_))
             << "The selected processor tuning is not valid for this architecture. (" << *this << ")\n";
+    }
+
+    // A vector_bits value only means something for scalable-vector targets;
+    // for everyone else the vector width is fixed by the ISA.
+    if (vector_bits_ != 0) {
+        user_assert(features_any_of({SVE, SVE2, RVV, AVX10_1}))
+            << "vector_bits is only meaningful for a target with a scalable vector "
+               "feature (SVE, SVE2, RVV, or AVX10_1). ("
+            << *this << ")\n";
+    }
+
+    // Large buffers are addressed with 64-bit indices, so they can't exist on a
+    // 32-bit target. (bits == 0 is left alone: the width is not yet known.)
+    if (has_feature(LargeBuffers)) {
+        user_assert(bits_ == 64 || bits_ == 0)
+            << "The large_buffers feature requires a 64-bit target. (" << *this << ")\n";
+    }
+
+    // profile and profile_by_timer are two implementations of the same feature.
+    user_assert(!(has_feature(Profile) && has_feature(ProfileByTimer)))
+        << "At most one of the profile and profile_by_timer features may be set. (" << *this << ")\n";
+
+    // The simulator feature selects the iOS simulator environment.
+    if (has_feature(Simulator)) {
+        user_assert(os_ == IOS || os_ == OSUnknown)
+            << "The simulator feature is only valid for the iOS operating system. (" << *this << ")\n";
     }
 }
 
@@ -1534,12 +1590,18 @@ void Target::set_os(OS o) {
 void Target::set_bits(int b) {
     user_assert(b == 0 || b == 32 || b == 64)
         << "Target bits must be 0, 32, or 64; got " << b << ".\n";
+    Target candidate = *this;
+    candidate.bits_ = b;
+    candidate.validate_features();
     bits_ = b;
 }
 
 void Target::set_vector_bits(int vb) {
     user_assert(vb >= 0)
         << "Target vector_bits must be non-negative; got " << vb << ".\n";
+    Target candidate = *this;
+    candidate.vector_bits_ = vb;
+    candidate.validate_features();
     vector_bits_ = vb;
 }
 
@@ -1736,6 +1798,33 @@ Target Target::with_feature(Feature f) const {
 Target Target::without_feature(Feature f) const {
     Target copy = *this;
     copy.set_feature(f, false);
+    return copy;
+}
+
+Target Target::without_device_features() const {
+    // Every feature that selects a device-offload runtime. Clearing one must
+    // also clear its dependent sub-features (via sub_features_by_parent),
+    // otherwise the result would be an internally-inconsistent Target.
+    static const Feature device_features[] = {
+        CUDA,
+        OpenCL,
+        Metal,
+        HVX,
+        D3D12Compute,
+        Vulkan,
+        WebGPU,
+    };
+    Target copy = *this;
+    const auto &subs = sub_features_by_parent();
+    for (Feature parent : device_features) {
+        copy.set_feature_raw(parent, false);
+        auto it = subs.find(parent);
+        if (it != subs.end()) {
+            for (Feature s : it->second) {
+                copy.set_feature_raw(s, false);
+            }
+        }
+    }
     return copy;
 }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -1211,6 +1211,17 @@ const std::map<Target::Arch, std::set<Target::Processor>> &legal_processors_by_a
     return table;
 }
 
+// A processor tuning is specific to an architecture. ProcessorGeneric is always
+// legal; every other tuning is legal only for the architecture that defines it.
+bool processor_tune_valid_for_arch(Target::Processor p, Target::Arch a) {
+    if (p == Target::Processor::ProcessorGeneric) {
+        return true;
+    }
+    const auto &table = legal_processors_by_arch();
+    auto it = table.find(a);
+    return it != table.end() && it->second.count(p);
+}
+
 // Sub-features that refine a "parent" feature but do not imply it (so they are
 // not in implied_feature_pairs()): a capability/version/extension is only
 // meaningful when its parent device feature is also set. validate_features()
@@ -1243,6 +1254,13 @@ const std::map<Target::Feature, std::vector<Target::Feature>> &sub_features_by_p
         },
     };
     return table;
+}
+
+// The scalable-vector features: ones whose vector width isn't fixed by the ISA
+// but is instead carried in the Target's vector_bits. vector_bits is only
+// meaningful when one of these is present.
+bool has_scalable_vector_feature(const Target &t) {
+    return t.features_any_of({Target::SVE, Target::SVE2, Target::RVV, Target::AVX10_1});
 }
 
 }  // namespace
@@ -1381,19 +1399,14 @@ void Target::validate_features() const {
     user_assert(has_feature(SME2) || num_sme_svl_features == 0)
         << "Target features SME_SVL128, SME_SVL256, SME_SVL512, SME_SVL1024, and SME_SVL2048 require target feature sme2.\n";
 
-    // Processor tuning must be legal for the architecture. ProcessorGeneric is
-    // always legal, so check it first as a fast path that skips the table.
-    if (processor_tune_ != ProcessorGeneric) {
-        const auto &table = legal_processors_by_arch();
-        auto it = table.find(arch_);
-        user_assert(it != table.end() && it->second.count(processor_tune_))
-            << "The selected processor tuning is not valid for this architecture. (" << *this << ")\n";
-    }
+    // Processor tuning must be legal for the architecture.
+    user_assert(processor_tune_valid_for_arch(processor_tune_, arch_))
+        << "The selected processor tuning is not valid for this architecture. (" << *this << ")\n";
 
     // A vector_bits value only means something for scalable-vector targets;
     // for everyone else the vector width is fixed by the ISA.
     if (vector_bits_ != 0) {
-        user_assert(features_any_of({SVE, SVE2, RVV, AVX10_1}))
+        user_assert(has_scalable_vector_feature(*this))
             << "vector_bits is only meaningful for a target with a scalable vector "
                "feature (SVE, SVE2, RVV, or AVX10_1). ("
             << *this << ")\n";
@@ -1575,8 +1588,15 @@ void Target::set_feature_raw(Feature f, bool value) {
 void Target::set_arch(Arch a) {
     Target candidate = *this;
     candidate.arch_ = a;
+    // A processor tuning is architecture-specific; changing the arch can orphan
+    // it, just as removing a feature orphans the features it implied. Drop it
+    // rather than reject the new arch. (Setting an invalid tuning directly via
+    // set_processor_tune still errors.)
+    if (!processor_tune_valid_for_arch(candidate.processor_tune_, candidate.arch_)) {
+        candidate.processor_tune_ = Processor::ProcessorGeneric;
+    }
     candidate.validate_features();
-    arch_ = a;
+    *this = candidate;
 }
 
 void Target::set_os(OS o) {
@@ -1618,8 +1638,13 @@ void Target::set_feature(Feature f, bool value) {
     user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
     Target candidate = *this;
     candidate.features.set(f, value);
+    // vector_bits is meaningless without a scalable-vector feature; drop it if
+    // this change removed the last one (e.g. deriving a non-SVE target).
+    if (candidate.vector_bits_ != 0 && !has_scalable_vector_feature(candidate)) {
+        candidate.vector_bits_ = 0;
+    }
     candidate.validate_features();
-    features.set(f, value);
+    *this = candidate;
 }
 
 void Target::set_features(const std::vector<Feature> &features_to_set, bool value) {
@@ -1630,8 +1655,13 @@ void Target::set_features(const std::vector<Feature> &features_to_set, bool valu
     for (Feature f : features_to_set) {
         candidate.set_feature_raw(f, value);
     }
+    // vector_bits is meaningless without a scalable-vector feature; drop it if
+    // this batch removed the last one (e.g. deriving a non-SVE target).
+    if (candidate.vector_bits_ != 0 && !has_scalable_vector_feature(candidate)) {
+        candidate.vector_bits_ = 0;
+    }
     candidate.validate_features();
-    features = candidate.features;
+    *this = candidate;
 }
 
 namespace {

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -1,5 +1,7 @@
 #include <array>
 #include <iostream>
+#include <map>
+#include <set>
 #include <string>
 
 #include "Target.h"
@@ -1182,6 +1184,34 @@ void do_check_bad(const Target &t, const std::initializer_list<Target::Feature> 
     }
 }
 
+// The processor-tuning values that are legal for each architecture, beyond the
+// universally-legal Target::ProcessorGeneric (which is omitted here and checked
+// as a fast path in validate_features()). Today only x86 defines specific CPU
+// tunings; per-CPU tunings for ARM or other arches would be added here. Any
+// Processor added to the enum should be listed for exactly one arch below.
+const std::map<Target::Arch, std::set<Target::Processor>> &legal_processors_by_arch() {
+    static const std::map<Target::Arch, std::set<Target::Processor>> table = {
+        {Target::X86,
+         {
+             Target::K8,
+             Target::K8_SSE3,
+             Target::AMDFam10,
+             Target::BtVer1,
+             Target::BdVer1,
+             Target::BdVer2,
+             Target::BdVer3,
+             Target::BdVer4,
+             Target::BtVer2,
+             Target::ZnVer1,
+             Target::ZnVer2,
+             Target::ZnVer3,
+             Target::ZnVer4,
+             Target::ZnVer5,
+         }},
+    };
+    return table;
+}
+
 }  // namespace
 
 void Target::validate_features() const {
@@ -1321,6 +1351,15 @@ void Target::validate_features() const {
         << "Target feature sme2 requires exactly one SME_SVL feature.\n";
     user_assert(has_feature(SME2) || num_sme_svl_features == 0)
         << "Target features SME_SVL128, SME_SVL256, SME_SVL512, SME_SVL1024, and SME_SVL2048 require target feature sme2.\n";
+
+    // Processor tuning must be legal for the architecture. ProcessorGeneric is
+    // always legal, so check it first as a fast path that skips the table.
+    if (processor_tune_ != ProcessorGeneric) {
+        const auto &table = legal_processors_by_arch();
+        auto it = table.find(arch_);
+        user_assert(it != table.end() && it->second.count(processor_tune_))
+            << "The selected processor tuning is not valid for this architecture. (" << *this << ")\n";
+    }
 }
 
 Target::Target(const std::string &target) {
@@ -1505,6 +1544,9 @@ void Target::set_vector_bits(int vb) {
 }
 
 void Target::set_processor_tune(Processor pt) {
+    Target candidate = *this;
+    candidate.processor_tune_ = pt;
+    candidate.validate_features();
     processor_tune_ = pt;
 }
 

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -850,7 +850,6 @@ const std::map<std::string, Target::Feature> feature_name_map = {
     {"cl_doubles", Target::CLDoubles},
     {"cl_half", Target::CLHalf},
     {"cl_atomics64", Target::CLAtomics64},
-    {"egl", Target::EGL},
     {"user_context", Target::UserContext},
     {"profile", Target::Profile},
     {"no_runtime", Target::NoRuntime},

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -1009,8 +1009,7 @@ Target get_jit_target_from_environment() {
     }
 }
 
-namespace {
-bool merge_string(Target &t, const std::string &target) {
+bool Target::merge_string(Target &t, const std::string &target) {
     string rest = target;
     vector<string> tokens;
     size_t first_dash;
@@ -1041,33 +1040,35 @@ bool merge_string(Target &t, const std::string &target) {
                 return false;
             }
             bits_specified = true;
-            t.set_bits(std::stoi(tok));
+            t.bits_ = std::stoi(tok);
         } else if (Target::Arch arch; lookup_arch(tok, arch)) {
             if (arch_specified) {
                 return false;
             }
             arch_specified = true;
-            t.set_arch(arch);
+            t.arch_ = arch;
         } else if (Target::OS os; lookup_os(tok, os)) {
             if (os_specified) {
                 return false;
             }
             os_specified = true;
-            t.set_os(os);
+            t.os_ = os;
         } else if (Target::Processor processor_tune; lookup_processor(tok, processor_tune)) {
             if (processor_specified) {
                 return false;
             }
             processor_specified = true;
-            t.set_processor_tune(processor_tune);
+            t.processor_tune_ = processor_tune;
         } else if (lookup_feature(tok, feature)) {
-            t.set_feature(feature);
+            t.set_feature_raw(feature);
             features_specified = true;
         } else if (tok == "trace_all") {
-            t.set_features({Target::TraceLoads, Target::TraceStores, Target::TraceRealizations});
+            t.set_feature_raw(Target::TraceLoads);
+            t.set_feature_raw(Target::TraceStores);
+            t.set_feature_raw(Target::TraceRealizations);
             features_specified = true;
         } else if ((vector_bits = parse_vector_bits(tok)) >= 0) {
-            t.set_vector_bits(vector_bits);
+            t.vector_bits_ = vector_bits;
         } else {
             return false;
         }
@@ -1089,7 +1090,7 @@ bool merge_string(Target &t, const std::string &target) {
         !t.has_feature(Target::CUDACapability100) &&
         !t.has_feature(Target::CUDACapability120)) {
         // Detect host cuda capability
-        t.set_feature(get_host_cuda_capability(t));
+        t.set_feature_raw(get_host_cuda_capability(t));
     }
 
     if (is_host &&
@@ -1098,7 +1099,7 @@ bool merge_string(Target &t, const std::string &target) {
         !t.has_feature(Target::VulkanV12) &&
         !t.has_feature(Target::VulkanV13)) {
         // Detect host vulkan capability
-        t.set_feature(get_host_vulkan_capability(t));
+        t.set_feature_raw(get_host_vulkan_capability(t));
     }
 
     if (arch_specified && !bits_specified) {
@@ -1117,6 +1118,8 @@ bool merge_string(Target &t, const std::string &target) {
 
     return true;
 }
+
+namespace {
 
 void bad_target_string(const std::string &target) {
     const char *separator = "";
@@ -1188,7 +1191,16 @@ void Target::validate_features() const {
                                 ARMDotProd,
                                 ARMFp16,
                                 ARMv7s,
+                                ARMv8a,
                                 ARMv81a,
+                                ARMv82a,
+                                ARMv83a,
+                                ARMv84a,
+                                ARMv85a,
+                                ARMv86a,
+                                ARMv87a,
+                                ARMv88a,
+                                ARMv89a,
                                 NoNEON,
                                 POWER_ARCH_2_07,
                                 RVV,
@@ -1235,7 +1247,16 @@ void Target::validate_features() const {
                                 ARMDotProd,
                                 ARMFp16,
                                 ARMv7s,
+                                ARMv8a,
                                 ARMv81a,
+                                ARMv82a,
+                                ARMv83a,
+                                ARMv84a,
+                                ARMv85a,
+                                ARMv86a,
+                                ARMv87a,
+                                ARMv88a,
+                                ARMv89a,
                                 AVX,
                                 AVX2,
                                 AVXVNNI,
@@ -1449,7 +1470,7 @@ bool Target::has_unknowns() const {
     return os_ == OSUnknown || arch_ == ArchUnknown || bits_ == 0;
 }
 
-void Target::set_feature(Feature f, bool value) {
+void Target::set_feature_raw(Feature f, bool value) {
     if (f == FeatureEnd) {
         return;
     }
@@ -1457,10 +1478,57 @@ void Target::set_feature(Feature f, bool value) {
     features.set(f, value);
 }
 
-void Target::set_features(const std::vector<Feature> &features_to_set, bool value) {
-    for (Feature f : features_to_set) {
-        set_feature(f, value);
+void Target::set_arch(Arch a) {
+    Target candidate = *this;
+    candidate.arch_ = a;
+    candidate.validate_features();
+    arch_ = a;
+}
+
+void Target::set_os(OS o) {
+    Target candidate = *this;
+    candidate.os_ = o;
+    candidate.validate_features();
+    os_ = o;
+}
+
+void Target::set_bits(int b) {
+    user_assert(b == 0 || b == 32 || b == 64)
+        << "Target bits must be 0, 32, or 64; got " << b << ".\n";
+    bits_ = b;
+}
+
+void Target::set_vector_bits(int vb) {
+    user_assert(vb >= 0)
+        << "Target vector_bits must be non-negative; got " << vb << ".\n";
+    vector_bits_ = vb;
+}
+
+void Target::set_processor_tune(Processor pt) {
+    processor_tune_ = pt;
+}
+
+void Target::set_feature(Feature f, bool value) {
+    if (f == FeatureEnd) {
+        return;
     }
+    user_assert(f < FeatureEnd) << "Invalid Target feature.\n";
+    Target candidate = *this;
+    candidate.features.set(f, value);
+    candidate.validate_features();
+    features.set(f, value);
+}
+
+void Target::set_features(const std::vector<Feature> &features_to_set, bool value) {
+    // Set every feature into a candidate copy and validate once, so that a
+    // batch that is only valid as a whole (e.g. an HLSL shader-model feature
+    // together with d3d12compute) is accepted regardless of order.
+    Target candidate = *this;
+    for (Feature f : features_to_set) {
+        candidate.set_feature_raw(f, value);
+    }
+    candidate.validate_features();
+    features = candidate.features;
 }
 
 namespace {

--- a/src/Target.h
+++ b/src/Target.h
@@ -203,10 +203,12 @@ struct Target {
            int vb = 0)
         : os_(o), arch_(a), processor_tune_(pt) {
         set_bits(b);
-        set_vector_bits(vb);
         for (const auto &f : initial_features) {
             set_feature_raw(f);
         }
+        // Set vector_bits after the features, since its validity depends on
+        // them (a scalable-vector feature must be present).
+        set_vector_bits(vb);
         validate_features();
     }
 
@@ -284,6 +286,12 @@ struct Target {
      * in an initialization list, where the target to be mutated may be
      * a const reference. */
     Target without_feature(Feature f) const;
+
+    /** Return a copy of the target with every device-offload feature (CUDA,
+     * OpenCL, Metal, Hexagon/HVX, D3D12Compute, Vulkan, WebGPU) and their
+     * dependent sub-features (e.g. cuda capabilities, vulkan versions) cleared.
+     * Useful for building a runtime that targets exactly one device API. */
+    Target without_device_features() const;
 
     /** Is a fully feature GPU compute runtime enabled? I.e. is
      * Func::gpu_tile and similar going to work? Currently includes

--- a/src/Target.h
+++ b/src/Target.h
@@ -108,7 +108,6 @@ struct Target {
         CLDoubles = halide_target_feature_cl_doubles,
         CLHalf = halide_target_feature_cl_half,
         CLAtomics64 = halide_target_feature_cl_atomic64,
-        EGL = halide_target_feature_egl,
         UserContext = halide_target_feature_user_context,
         Profile = halide_target_feature_profile,
         NoRuntime = halide_target_feature_no_runtime,

--- a/src/Target.h
+++ b/src/Target.h
@@ -201,9 +201,11 @@ struct Target {
     Target() = default;
     Target(OS o, Arch a, int b, Processor pt, const std::vector<Feature> &initial_features = std::vector<Feature>(),
            int vb = 0)
-        : os_(o), arch_(a), bits_(b), vector_bits_(vb), processor_tune_(pt) {
+        : os_(o), arch_(a), processor_tune_(pt) {
+        set_bits(b);
+        set_vector_bits(vb);
         for (const auto &f : initial_features) {
-            set_feature(f);
+            set_feature_raw(f);
         }
         validate_features();
     }
@@ -311,41 +313,35 @@ struct Target {
      * will be an arbitrary DeviceAPI. */
     DeviceAPI get_required_device_api() const;
 
-    /** Getters and setters for target properties. */
+    /** Getters and setters for target properties.
+     *
+     * The setters validate their result: a setter that would produce a Target
+     * which is internally inconsistent fails with a user_error and leaves the
+     * Target unchanged. */
     OS os() const {
         return os_;
     }
-    void set_os(OS o) {
-        os_ = o;
-    }
+    void set_os(OS o);
 
     Arch arch() const {
         return arch_;
     }
-    void set_arch(Arch a) {
-        arch_ = a;
-    }
+    void set_arch(Arch a);
 
     int bits() const {
         return bits_;
     }
-    void set_bits(int b) {
-        bits_ = b;
-    }
+    void set_bits(int b);
 
     int vector_bits() const {
         return vector_bits_;
     }
-    void set_vector_bits(int vb) {
-        vector_bits_ = vb;
-    }
+    void set_vector_bits(int vb);
 
     Processor processor_tune() const {
         return processor_tune_;
     }
-    void set_processor_tune(Processor pt) {
-        processor_tune_ = pt;
-    }
+    void set_processor_tune(Processor pt);
 
     bool operator==(const Target &other) const {
         return os_ == other.os_ &&
@@ -468,6 +464,14 @@ private:
      * This is *not* guaranteed to get all invalid combinations, but is intended
      * to catch at least the most common (e.g., setting arm-specific features on x86). */
     void validate_features() const;
+
+    /** Set (or clear) a feature bit without running validation. */
+    void set_feature_raw(Feature f, bool value = true);
+
+    /** Parse a target string into \p t, without validating that the resulting
+     * feature set is sensible for the arch. Returns false if the string is not
+     * well-formed. */
+    static bool merge_string(Target &t, const std::string &target);
 };
 
 /** Return the target corresponding to the host machine. */

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1533,7 +1533,6 @@ typedef enum halide_target_feature_t {
     halide_target_feature_sme_svl512,             ///< Assume ARM SME streaming vector length is 512 bits.
     halide_target_feature_sme_svl1024,            ///< Assume ARM SME streaming vector length is 1024 bits.
     halide_target_feature_sme_svl2048,            ///< Assume ARM SME streaming vector length is 2048 bits.
-    halide_target_feature_egl,                    ///< Force use of EGL support.
     halide_target_feature_arm_dot_prod,           ///< Enable ARMv8.2-a dotprod extension (i.e. udot and sdot instructions)
     halide_target_feature_arm_fp16,               ///< Enable ARMv8.2-a half-precision floating point data processing
     halide_llvm_large_code_model,                 ///< Use the LLVM large code model to compile

--- a/test/correctness/realize_larger_than_two_gigs.cpp
+++ b/test/correctness/realize_larger_than_two_gigs.cpp
@@ -11,6 +11,14 @@ void halide_error(JITUserContext *ctx, const char *msg) {
 }
 
 int main(int argc, char **argv) {
+    Target t = get_jit_target_from_environment();
+    if (t.bits() != 64) {
+        // This test exercises the large_buffers feature and allocations larger
+        // than 2^31; neither is representable on a 32-bit target.
+        printf("[SKIP] large_buffers requires a 64-bit target.\n");
+        return 0;
+    }
+
     Param<int> extent;
     Var x, y, z, w;
     RDom r(0, extent, 0, extent, 0, extent, 0, extent / 2 + 1);
@@ -22,7 +30,6 @@ int main(int argc, char **argv) {
     grand_total() = cast<uint8_t>(sum(big(r.x, r.y, r.z, r.w)));
     grand_total.jit_handlers().custom_error = halide_error;
 
-    Target t = get_jit_target_from_environment();
     t.set_feature(Target::LargeBuffers);
     grand_total.compile_jit(t);
 

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -127,6 +127,19 @@ tests(
     store_root_without_compute_root.cpp
     stream_loads_illegal_self.cpp
     stream_stores_illegal_rvar.cpp
+    target_bad_bit_width.cpp
+    target_feature_wrong_arch.cpp
+    target_hexagon_without_hvx.cpp
+    target_invalid_feature.cpp
+    target_jit_no_bounds_query.cpp
+    target_large_buffers_requires_64_bit.cpp
+    target_negative_vector_bits.cpp
+    target_processor_wrong_arch.cpp
+    target_profile_and_profile_by_timer.cpp
+    target_simulator_requires_ios.cpp
+    target_subfeature_without_parent.cpp
+    target_unrecognized_feature.cpp
+    target_vector_bits_without_scalable_feature.cpp
     thread_id_outside_block_id.cpp
     too_many_args.cpp
     treat_rvar_as_var.cpp

--- a/test/error/target_bad_bit_width.cpp
+++ b/test/error/target_bad_bit_width.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t(Target::Linux, Target::X86, 64);
+    // Only 0, 32, and 64 are valid bit widths.
+    t.set_bits(17);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_feature_wrong_arch.cpp
+++ b/test/error/target_feature_wrong_arch.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // sve2 is an ARM feature; it is not valid on x86.
+    Target t("x86-64-linux-sve2");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_hexagon_without_hvx.cpp
+++ b/test/error/target_hexagon_without_hvx.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // natural_vector_size on a hexagon target without hvx is an error.
+    Target t("hexagon-32-qurt");
+    (void)t.natural_vector_size<int32_t>();
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_invalid_feature.cpp
+++ b/test/error/target_invalid_feature.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t(Target::Linux, Target::X86, 64);
+    // Setting an out-of-range feature is an error.
+    t.set_feature((Target::Feature)10000);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_jit_no_bounds_query.cpp
+++ b/test/error/target_jit_no_bounds_query.cpp
@@ -1,0 +1,19 @@
+#include "Halide.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+#ifdef _WIN32
+    printf("[SKIP] Windows does not have a working setenv\n");
+    return 0;
+#else
+    // The JIT requires bounds query, so no_bounds_query in HL_JIT_TARGET is an error.
+    setenv("HL_JIT_TARGET", "host-no_bounds_query", 1);
+    (void)get_jit_target_from_environment();
+
+    printf("Success!\n");
+    return 0;
+#endif
+}

--- a/test/error/target_large_buffers_requires_64_bit.cpp
+++ b/test/error/target_large_buffers_requires_64_bit.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // large_buffers needs 64-bit indexing.
+    Target t("x86-32-linux-large_buffers");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_negative_vector_bits.cpp
+++ b/test/error/target_negative_vector_bits.cpp
@@ -1,0 +1,13 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    Target t(Target::Linux, Target::ARM, 64, {Target::SVE2});
+    // vector_bits must be non-negative.
+    t.set_vector_bits(-128);
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_processor_wrong_arch.cpp
+++ b/test/error/target_processor_wrong_arch.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // tune_znver4 is an x86 processor; it is not valid on ARM.
+    Target t("arm-64-linux-tune_znver4");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_profile_and_profile_by_timer.cpp
+++ b/test/error/target_profile_and_profile_by_timer.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // profile and profile_by_timer are mutually exclusive.
+    Target t("x86-64-linux-profile-profile_by_timer");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_simulator_requires_ios.cpp
+++ b/test/error/target_simulator_requires_ios.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // The simulator feature is only valid for iOS.
+    Target t("x86-64-linux-simulator");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_subfeature_without_parent.cpp
+++ b/test/error/target_subfeature_without_parent.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // A cuda capability is meaningless without the cuda feature.
+    Target t("x86-64-linux-cuda_capability_50");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_unrecognized_feature.cpp
+++ b/test/error/target_unrecognized_feature.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // "frobnicate" is not a known target token.
+    Target t("x86-64-linux-frobnicate");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/error/target_vector_bits_without_scalable_feature.cpp
+++ b/test/error/target_vector_bits_without_scalable_feature.cpp
@@ -1,0 +1,12 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // vector_bits is only meaningful with a scalable-vector feature.
+    Target t("x86-64-linux-vector_bits_128");
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -14,6 +14,7 @@ tests(
         lossless_cast.cpp
         simplify.cpp
         solve.cpp
+        target_invariants.cpp
         widening_lerp.cpp
     # By default, the libfuzzer harness runs with a timeout of 1200 seconds.
     # Let's dial that back:

--- a/test/fuzz/target_invariants.cpp
+++ b/test/fuzz/target_invariants.cpp
@@ -1,0 +1,228 @@
+#include "fuzz_helpers.h"
+
+#include <Halide.h>
+
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace Halide;
+
+namespace {
+
+// The concrete values we sample each Target property from.
+constexpr Target::Arch archs[] = {
+    Target::ArchUnknown,
+    Target::X86,
+    Target::ARM,
+    Target::POWERPC,
+    Target::Hexagon,
+    Target::WebAssembly,
+    Target::RISCV,
+};
+
+constexpr Target::OS oses[] = {
+    Target::OSUnknown,
+    Target::Linux,
+    Target::Windows,
+    Target::OSX,
+    Target::Android,
+    Target::IOS,
+    Target::QuRT,
+    Target::NoOS,
+    Target::Fuchsia,
+    Target::WebAssemblyRuntime,
+};
+
+// Weighted toward the concrete widths (32/64): a 0 makes the whole target
+// "unknown", which is excluded from the round-trip guarantee, so we only want a
+// minority of bases to land there.
+constexpr int bits_settings[] = {0, 32, 32, 64, 64};
+
+constexpr Target::Processor processors[] = {
+    Target::ProcessorGeneric,
+    Target::K8,
+    Target::K8_SSE3,
+    Target::AMDFam10,
+    Target::BtVer1,
+    Target::BdVer1,
+    Target::BdVer2,
+    Target::BdVer3,
+    Target::BdVer4,
+    Target::BtVer2,
+    Target::ZnVer1,
+    Target::ZnVer2,
+    Target::ZnVer3,
+    Target::ZnVer4,
+    Target::ZnVer5,
+};
+
+constexpr int vector_bits_settings[] = {0, 64, 128, 256, 512, 1024};
+
+// Raised when one of the invariants below is violated (i.e. we found a real
+// bug). This is deliberately distinct from Halide::Error: a Halide::Error
+// thrown *by a setter* is the API correctly refusing to build an invalid
+// target, which is allowed, whereas an InvariantViolation is a failure of
+// the properties we are testing.
+struct InvariantViolation : std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
+void require(bool cond, const std::string &msg) {
+    if (!cond) {
+        throw InvariantViolation{msg};
+    }
+}
+
+// Any complete target reachable through the public API must round-trip through
+// to_string() unchanged, and reconstructing it must never throw.
+void check_roundtrip(const Target &t) {
+    // Targets with unknown arch/os/bits intentionally produce strings that
+    // cannot be parsed back, so they are excluded by the round-trip guarantee.
+    if (t.has_unknowns()) {
+        return;
+    }
+
+    const std::string s = t.to_string();
+
+    Target parsed;
+    try {
+        parsed = Target(s);
+    } catch (const Error &e) {
+        throw InvariantViolation{
+            "Target(t.to_string()) threw, i.e. to_string() produced a string "
+            "that cannot be parsed back:\n"
+            "  to_string() = " +
+            s + "\n  error = " + e.what()};
+    }
+
+    require(parsed == t,
+            "Round-trip through to_string() changed the target:\n"
+            "  original = " +
+                s + "\n  reparsed = " + parsed.to_string());
+
+    // Parsing a canonical string is stable (re-parsing yields the same target).
+    require(Target(parsed.to_string()) == parsed,
+            "Re-parsing a to_string() result was not stable:\n  " + s);
+}
+
+// Attempt a mutation via a public setter. The public setters are required to
+// be transactional: if a mutation would produce an invalid target the setter
+// rejects it by throwing, and in that case must leave the target completely
+// unchanged. Returns true if the mutation was applied.
+template<typename Fn>
+bool try_mutate(Target &t, Fn fn) {
+    const Target before = t;
+    try {
+        fn(t);
+    } catch (const Error &) {
+        // The API refused to perform this mutation. That's fine, but the
+        // target must be exactly as it was.
+        require(t == before,
+                "A rejected setter left the target in a mutated state "
+                "(not transactional):\n  before = " +
+                    before.to_string() + "\n  after  = " + t.to_string());
+        return false;
+    }
+    return true;
+}
+
+Target::Feature random_feature(FuzzingContext &fuzz) {
+    return static_cast<Target::Feature>(fuzz.ConsumeIntegralInRange<int>(0, static_cast<int>(Target::FeatureEnd) - 1));
+}
+
+void test_one_target(FuzzingContext &fuzz) {
+    // Pick a random starting base target.
+    Target t;
+    try_mutate(t, [&](Target &t_) { t_.set_arch(fuzz.PickValueInArray(archs)); });
+    try_mutate(t, [&](Target &t_) { t_.set_bits(fuzz.PickValueInArray(bits_settings)); });
+    try_mutate(t, [&](Target &t_) { t_.set_os(fuzz.PickValueInArray(oses)); });
+    try_mutate(t, [&](Target &t_) { t_.set_processor_tune(fuzz.PickValueInArray(processors)); });
+    try_mutate(t, [&](Target &t_) { t_.set_vector_bits(fuzz.PickValueInArray(vector_bits_settings)); });
+
+    // All bases must round-trip
+    check_roundtrip(t);
+
+    // Saturate the target with features. We add them one at a time (rather than
+    // as a batch, which validates as a whole and would be rejected outright if
+    // any single feature is incompatible): each incompatible add is rejected on
+    // its own, so the compatible ones accumulate into a feature-rich,
+    // arch-consistent target. This is what pushes the checked targets toward the
+    // dense feature combinations where implied/sub-feature interactions live.
+    const int adds = fuzz.ConsumeIntegralInRange(0, 80);
+    for (int i = 0; i < adds; i++) {
+        try_mutate(t, [&](Target &t_) { t_.set_feature(random_feature(fuzz), true); });
+    }
+    check_roundtrip(t);
+
+    // Now apply a random sequence of individual setter calls, including removals
+    // and structural changes. After *every* step, whatever state the API left
+    // the target in must round-trip.
+    const int steps = fuzz.ConsumeIntegralInRange(0, 50);
+    for (int i = 0; i < steps; i++) {
+        switch (fuzz.ConsumeIntegralInRange(0, 6)) {
+        case 0:
+            try_mutate(t, [&](Target &t_) { t_.set_feature(random_feature(fuzz), fuzz.ConsumeBool()); });
+            break;
+        case 1:
+            try_mutate(t, [&](Target &t_) { t_.set_arch(fuzz.PickValueInArray(archs)); });
+            break;
+        case 2:
+            try_mutate(t, [&](Target &t_) { t_.set_os(fuzz.PickValueInArray(oses)); });
+            break;
+        case 3:
+            try_mutate(t, [&](Target &t_) { t_.set_bits(fuzz.PickValueInArray(bits_settings)); });
+            break;
+        case 4:
+            try_mutate(t, [&](Target &t_) { t_.set_vector_bits(fuzz.PickValueInArray(vector_bits_settings)); });
+            break;
+        case 5:
+            try_mutate(t, [&](Target &t_) { t_.set_processor_tune(fuzz.PickValueInArray(processors)); });
+            break;
+        case 6: {
+            // Batch feature set: a vector of features set/cleared together.
+            std::vector<Target::Feature> fs;
+            const int n = fuzz.ConsumeIntegralInRange(0, 5);
+            fs.reserve(n);
+            for (int k = 0; k < n; k++) {
+                fs.push_back(random_feature(fuzz));
+            }
+            const bool value = fuzz.ConsumeBool();
+            try_mutate(t, [&](Target &t_) { t_.set_features(fs, value); });
+            break;
+        }
+        default: {
+            internal_error;
+        }
+        }
+
+        check_roundtrip(t);
+    }
+
+    // Check that implied-feature canonicalization round-trips safely.
+    check_roundtrip(t.with_implied_features());
+    check_roundtrip(t.without_implied_features());
+
+    // Check that implied-feature canonicalization is idempotent
+    const Target wi = t.with_implied_features();
+    require(wi.with_implied_features() == wi,
+            "with_implied_features() is not idempotent:\n  " + t.to_string());
+
+    const Target wo = t.without_implied_features();
+    require(wo.without_implied_features() == wo,
+            "without_implied_features() is not idempotent:\n  " + t.to_string());
+}
+
+}  // namespace
+
+FUZZ_TEST(target_invariants, FuzzingContext &fuzz) {
+    try {
+        test_one_target(fuzz);
+    } catch (const InvariantViolation &v) {
+        std::cerr << "Target invariant violated:\n"
+                  << v.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tutorial/lesson_11_cross_compilation.cpp
+++ b/tutorial/lesson_11_cross_compilation.cpp
@@ -90,7 +90,12 @@ int main() {
     // We then pass the target as the last argument to compile_to_file.
     brighter.compile_to_file("lesson_11_arm_32_android", args, "brighter", target);
 
-    // And now a Windows object file for 64-bit x86 with AVX and SSE 4.1:
+    // And now a Windows object file for 64-bit x86 with AVX and SSE 4.1.
+    // Each cross-compilation target is independent, so start from a fresh
+    // Target rather than mutating the previous one: features that were
+    // meaningful for the last architecture (or missing for this one) would
+    // otherwise linger and produce an inconsistent target.
+    target = Target();
     target.set_os(Target::Windows);
     target.set_arch(Target::X86);
     target.set_bits(64);
@@ -106,6 +111,7 @@ int main() {
     // this using the target features field.  Support for Apple's
     // 64-bit ARM processors is very new in llvm, and still somewhat
     // flaky.
+    target = Target();
     target.set_os(Target::IOS);
     target.set_arch(Target::ARM);
     target.set_bits(32);


### PR DESCRIPTION
Strengthen the contract on setters to ensure that `Target(t.to_string()) == t` holds. Previously, `t` could be pushed into an invalid state that the `Target()` constructor would reject via its validation function.

Add a fuzz tester for target invariants.

Drive-by: Removes unused EGL feature.

## Breaking changes

Downstreams that construct illegal target strings will now see exceptions upon construction, rather than upon use.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [x] Python bindings updated (if public API changed)
- [x] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>