### PR TITLE
[Target] Keep all implied features in canonical representation

### DIFF
--- a/python_bindings/src/halide/halide_/PyTarget.cpp
+++ b/python_bindings/src/halide/halide_/PyTarget.cpp
@@ -40,6 +40,7 @@ void define_target(py::module &m) {
             .def("__repr__", &target_repr)
             .def("__str__", &Target::to_string)
             .def("to_string", &Target::to_string)
+            .def("to_complete_string", &Target::to_complete_string)
 
             .def("has_feature", static_cast<bool (Target::*)(Target::Feature) const>(&Target::has_feature))
             .def("features_any_of", &Target::features_any_of, py::arg("features"))

--- a/python_bindings/test/correctness/target.py
+++ b/python_bindings/test/correctness/target.py
@@ -84,7 +84,8 @@ def test_target():
     assert not t1.has_feature(hl.TargetFeature.AVX)
     t1.set_feature(hl.TargetFeature.AVX)
     t1.set_feature(hl.TargetFeature.SSE41, False)
-    assert t1.has_feature(hl.TargetFeature.AVX)
+    # Clearing an implied feature also clears features that imply it.
+    assert not t1.has_feature(hl.TargetFeature.AVX)
     assert not t1.has_feature(hl.TargetFeature.SSE41)
 
     # set_features
@@ -95,7 +96,9 @@ def test_target():
     t1.set_features([hl.TargetFeature.AVX, hl.TargetFeature.AVX2], True)
     assert t1.has_feature(hl.TargetFeature.AVX)
     assert t1.has_feature(hl.TargetFeature.AVX2)
-    assert not t1.has_feature(hl.TargetFeature.SSE41)
+    assert t1.has_feature(hl.TargetFeature.SSE41)
+    assert t1.to_string() == "x86-32-linux-avx2"
+    assert t1.to_complete_string() == "x86-32-linux-avx-avx2-f16c-fma-sse41"
 
     # with_feature
     t1 = hl.Target(hl.TargetOS.Linux, hl.TargetArch.X86, 32, [hl.TargetFeature.SSE41])

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -1772,6 +1772,8 @@ string CodeGen_X86::mcpu_tune() const {
 
     case Target::Processor::ProcessorGeneric:
         break;
+    case Target::Processor::ProcessorEnd:
+        internal_error << "ProcessorEnd is not a valid processor tuning.\n";
     }
     internal_assert(target.processor_tune() == Target::Processor::ProcessorGeneric && "The switch should be exhaustive.");
     return mcpu_target();  // Detect "best" CPU from the enabled ISA's.

--- a/src/CodeGen_X86.cpp
+++ b/src/CodeGen_X86.cpp
@@ -1694,8 +1694,8 @@ string CodeGen_X86::mcpu_target() const {
     } else if (target.has_feature(Target::AVX2)) {
         // x86-64-v3: SSE4.2, POPCNT, AVX, AVX2, BMI1/2, F16C, FMA,
         // LZCNT, MOVBE. Also covers AVX512 / AVX512_KNL, since both
-        // imply AVX2 (via set_implied_features), but neither requires
-        // BW/DQ/VL which would come for free with v4.
+        // imply AVX2, but neither requires BW/DQ/VL which would come
+        // for free with v4.
         return "x86-64-v3";
     } else if (target.has_feature(Target::AVX)) {
         // x86-64-v2: SSE3, SSSE3, SSE4.1, SSE4.2, POPCNT. AVX is
@@ -1816,12 +1816,10 @@ string CodeGen_X86::mattrs() const {
         attrs.emplace_back("+f16c");
     }
 
-    // AVX512 features. Any AVX512 variant implies AVX2 (via
-    // set_implied_features), so the mcpu baseline is at least
-    // x86-64-v3. Skylake-and-above selects x86-64-v4, which already
-    // includes F/CD/BW/DQ/VL, but we still add those features
-    // explicitly so the bare AVX512 / AVX512_KNL paths (which use
-    // x86-64-v3) also get them.
+    // AVX512 features. Any AVX512 variant implies AVX2, so the mcpu baseline
+    // is at least x86-64-v3. Skylake-and-above selects x86-64-v4, which already
+    // includes F/CD/BW/DQ/VL, but we still add those features explicitly so the
+    // bare AVX512 / AVX512_KNL paths (which use x86-64-v3) also get them.
     if (target.has_feature(Target::AVX512)) {
         attrs.emplace_back("+avx512f");
         attrs.emplace_back("+avx512cd");

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -93,8 +93,7 @@ ostream &operator<<(ostream &stream, const Module &m) {
         stream << s << "\n";
     }
 
-    // The module retains implied features, but print it in minimal form.
-    stream << "module name=" << m.name() << ", target=" << m.target().without_implied_features().to_string() << "\n";
+    stream << "module name=" << m.name() << ", target=" << m.target().to_string() << "\n";
     for (const auto &b : m.buffers()) {
         stream << b << "\n";
     }

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -631,14 +631,9 @@ Module lower(const vector<Function> &output_funcs,
              const vector<Stmt> &requirements,
              bool trace_pipeline,
              const vector<IRMutator *> &custom_passes) {
-    // Lowering and code generation inspect a target with all implied features
-    // set, so that (e.g.) a check for SSE41 succeeds on an AVX2 target.
-    // Normalize once here; the module retains the implied features, and is
-    // printed back in minimal form by unsetting them at the print sites.
-    Target target = t.with_implied_features();
-    Module result_module{strip_namespaces(pipeline_name), target};
-    run_with_large_stack([&]() {
-        lower_impl(output_funcs, pipeline_name, target, args, linkage_type, requirements, trace_pipeline, custom_passes, result_module);
+    Module result_module{strip_namespaces(pipeline_name), t};
+    run_with_large_stack([&] {
+        lower_impl(output_funcs, pipeline_name, t, args, linkage_type, requirements, trace_pipeline, custom_passes, result_module);
     });
     return result_module;
 }

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -531,10 +531,8 @@ Module Pipeline::compile_to_module(const vector<Argument> &args,
 
     const Module &old_module = contents->module;
 
-    // A lowered module stores the target with implied features set, so compare
-    // against the same normalized form of the requested target.
     bool same_compile = !old_module.functions().empty() &&
-                        old_module.target() == target.with_implied_features();
+                        old_module.target() == target;
     // Either generated name or one of the LoweredFuncs in the existing module has the same name.
     same_compile = same_compile && fn_name.empty();
     bool found_name = false;

--- a/src/StmtToHTML.cpp
+++ b/src/StmtToHTML.cpp
@@ -718,8 +718,7 @@ public:
         // -- print text
         print_opening_tag("span", "matched");
         print_html_element("span", "keyword", "module");
-        // The module retains implied features, but print it in minimal form.
-        print_text(" name=" + m.name() + ", target=" + m.target().without_implied_features().to_string());
+        print_text(" name=" + m.name() + ", target=" + m.target().to_string());
         print_closing_tag("span");
 
         // Open code block to hold module body
@@ -768,8 +767,7 @@ public:
         // -- print text
         print_opening_tag("span", "matched");
         print_html_element("span", "keyword", "module");
-        // The module retains implied features, but print it in minimal form.
-        print_text(" name=" + m.name() + ", target=" + m.target().without_implied_features().to_string());
+        print_text(" name=" + m.name() + ", target=" + m.target().to_string());
         print_closing_tag("span");
 
         // Open code block to hold module body

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -1383,24 +1383,6 @@ constexpr std::pair<Target::Arch, Target::Processor> legal_processor_pairs[] = {
     {Target::X86, Target::ZnVer5},
 };
 
-}  // namespace
-
-template<typename T>
-void Target::assign_validated(T &field, T value) {
-    if (field == value) {
-        return;
-    }
-
-    Target old = *this;
-    unset_implied_features();
-    field = std::move(value);
-    set_implied_features();
-    if (const auto error = validate_features()) {
-        *this = std::move(old);
-        user_error << *error;
-    }
-}
-
 // A processor tuning is specific to an architecture. ProcessorGeneric is always
 // legal; every other tuning is legal only for the architecture that defines it.
 bool processor_tune_valid_for_arch(Target::Processor p, Target::Arch a) {
@@ -1424,14 +1406,30 @@ bool has_scalable_vector_feature(const Target &t) {
 
 }  // namespace
 
+template<typename T>
+void Target::assign_validated(T &field, T value) {
+    if (field == value) {
+        return;
+    }
+
+    Target old = *this;
+    unset_implied_features();
+    field = std::move(value);
+    set_implied_features();
+    if (const auto error = validate_features()) {
+        *this = old;
+        user_error << *error;
+    }
+}
+
 std::optional<std::string> Target::validate_features() const {
     if (arch_ < ArchUnknown || arch_ >= ArchEnd) {
         return "Invalid Target architecture.\n";
     }
-    if (os_ < OSUnknown || os_ > WebAssemblyRuntime) {
+    if (os_ < OSUnknown || os_ >= OSEnd) {
         return "Invalid Target operating system.\n";
     }
-    if (processor_tune_ < ProcessorGeneric || processor_tune_ > ZnVer5) {
+    if (processor_tune_ < ProcessorGeneric || processor_tune_ >= ProcessorEnd) {
         return "Invalid Target processor tuning.\n";
     }
 
@@ -1626,7 +1624,11 @@ std::string Target::to_string_impl(const std::bitset<FeatureEnd> &features_to_pr
     if (use_feature_aliases &&
         features_to_print[Target::TraceLoads] &&
         features_to_print[Target::TraceStores]) {
-        result = Internal::replace_all(std::move(result), "trace_loads-trace_stores", "trace_all");
+        // Collapse the loads+stores pair into the trace_all alias. Replacing the
+        // tokens independently keeps this correct even when another trace_*
+        // feature sorts between them, so they aren't adjacent in the string.
+        result = Internal::replace_all(std::move(result), "-trace_loads", "-trace_all");
+        result = Internal::replace_all(std::move(result), "-trace_stores", "");
     }
     if (vector_bits_ != 0) {
         result += "-vector_bits_" + std::to_string(vector_bits_);
@@ -1743,6 +1745,32 @@ void Target::set_processor_tune(Processor pt) {
     assign_validated(processor_tune_, pt);
 }
 
+void Target::clear_orphaned_features() {
+    // A down-closed set cannot contain a feature while omitting one of its
+    // consequences. Walking the implication rules in reverse clears the upward
+    // closure of any already-removed feature in a single pass, because the rule
+    // table is topologically sorted.
+    for (const FeatureRule &rule : Internal::reverse_view(feature_rules())) {
+        if (rule.kind == FeatureRuleKind::Implies && !has_feature(rule.other)) {
+            set_feature_raw(rule.feature, false);
+        }
+    }
+    // AVX10.1's implied features are keyed off vector_bits rather than another
+    // feature, so its removal isn't captured by the rule table above.
+    if (arch_ == X86 && has_feature(AVX10_1) &&
+        ((vector_bits_ >= 256 && !has_feature(AVX2)) ||
+         (vector_bits_ >= 512 && !has_feature(AVX512_SapphireRapids)))) {
+        set_feature_raw(AVX10_1, false);
+    }
+
+    // vector_bits only means something alongside a scalable-vector feature.
+    // Once the last such feature is removed (e.g. deriving a non-SVE target
+    // from an SVE host), the leftover width is orphaned, so clear it too.
+    if (vector_bits_ != 0 && !has_scalable_vector_feature(*this)) {
+        vector_bits_ = 0;
+    }
+}
+
 void Target::set_feature(Feature f, bool value) {
     if (f == FeatureEnd) {
         return;
@@ -1756,23 +1784,7 @@ void Target::set_feature(Feature f, bool value) {
     const int old_vector_bits = vector_bits_;
     set_feature_raw(f, value);
     if (!value) {
-        // A down-closed set cannot contain a feature while omitting one of its
-        // consequences. Clear the upward closure of the requested feature.
-        for (const FeatureRule &rule : Internal::reverse_view(feature_rules())) {
-            if (rule.kind == FeatureRuleKind::Implies && !has_feature(rule.other)) {
-                set_feature_raw(rule.feature, false);
-            }
-        }
-        if (arch_ == X86 && has_feature(AVX10_1) &&
-            ((vector_bits_ >= 256 && !has_feature(AVX2)) ||
-             (vector_bits_ >= 512 && !has_feature(AVX512_SapphireRapids)))) {
-            set_feature_raw(AVX10_1, false);
-        }
-        // vector_bits is meaningless without a scalable-vector feature; drop it
-        // if this removal cleared the last one.
-        if (vector_bits_ != 0 && !has_scalable_vector_feature(*this)) {
-            vector_bits_ = 0;
-        }
+        clear_orphaned_features();
     }
     set_implied_features();
     if (const auto error = validate_features()) {
@@ -1794,30 +1806,16 @@ void Target::set_features(const std::vector<Feature> &features_to_set, bool valu
     }
 
     const auto old_features = features;
+    const int old_vector_bits = vector_bits_;
     for (Feature f : features_to_set) {
         set_feature_raw(f, value);
     }
     if (!value) {
-        for (const FeatureRule &rule : Internal::reverse_view(feature_rules())) {
-            if (rule.kind == FeatureRuleKind::Implies && !has_feature(rule.other)) {
-                set_feature_raw(rule.feature, false);
-            }
-        }
-        if (arch_ == X86 && has_feature(AVX10_1) &&
-            ((vector_bits_ >= 256 && !has_feature(AVX2)) ||
-             (vector_bits_ >= 512 && !has_feature(AVX512_SapphireRapids)))) {
-            set_feature_raw(AVX10_1, false);
-        }
+        clear_orphaned_features();
     }
     set_implied_features();
     if (features == old_features) {
         return;
-    }
-    // vector_bits is meaningless without a scalable-vector feature; drop it if
-    // this batch removed the last one (e.g. deriving a non-SVE target).
-    const int old_vector_bits = vector_bits_;
-    if (vector_bits_ != 0 && !has_scalable_vector_feature(*this)) {
-        vector_bits_ = 0;
     }
     if (const auto error = validate_features()) {
         features = old_features;

--- a/src/Target.cpp
+++ b/src/Target.cpp
@@ -632,35 +632,6 @@ Target calculate_host_target() {
     return {os, arch, bits, processor, initial_features, vector_bits};
 }
 
-bool is_using_hexagon(const Target &t) {
-    return (t.has_feature(Target::HVX) ||
-            t.has_feature(Target::HVX_v62) ||
-            t.has_feature(Target::HVX_v65) ||
-            t.has_feature(Target::HVX_v66) ||
-            t.has_feature(Target::HVX_v68) ||
-            t.has_feature(Target::HexagonDma) ||
-            t.arch() == Target::Hexagon);
-}
-
-int get_hvx_lower_bound(const Target &t) {
-    if (!is_using_hexagon(t)) {
-        return -1;
-    }
-    if (t.has_feature(Target::HVX_v62)) {
-        return 62;
-    }
-    if (t.has_feature(Target::HVX_v65)) {
-        return 65;
-    }
-    if (t.has_feature(Target::HVX_v66)) {
-        return 66;
-    }
-    if (t.has_feature(Target::HVX_v68)) {
-        return 68;
-    }
-    return 60;
-}
-
 }  // namespace
 
 Target get_host_target() {
@@ -1118,6 +1089,7 @@ bool Target::merge_string(Target &t, const std::string &target) {
         }
     }
 
+    t.set_implied_features();
     return true;
 }
 
@@ -1341,6 +1313,36 @@ const std::vector<FeatureRule> &feature_rules() {
         implies(Target::AVX2, Target::AVX),
         implies(Target::AVX, Target::SSE41),
 
+        // CUDA compute capabilities.
+        implies(Target::CUDACapability86, Target::CUDACapability80),
+        implies(Target::CUDACapability80, Target::CUDACapability75),
+        implies(Target::CUDACapability75, Target::CUDACapability70),
+        implies(Target::CUDACapability70, Target::CUDACapability61),
+        implies(Target::CUDACapability61, Target::CUDACapability50),
+        implies(Target::CUDACapability50, Target::CUDACapability35),
+        implies(Target::CUDACapability35, Target::CUDACapability32),
+        implies(Target::CUDACapability32, Target::CUDACapability30),
+
+        // Hexagon ISA versions.
+        implies(Target::HVX_v68, Target::HVX_v66),
+        implies(Target::HVX_v66, Target::HVX_v65),
+        implies(Target::HVX_v65, Target::HVX_v62),
+
+        // Vulkan versions.
+        implies(Target::VulkanV13, Target::VulkanV12),
+        implies(Target::VulkanV12, Target::VulkanV10),
+
+        // D3D12 shader-model versions.
+        implies(Target::HLSL_SM69, Target::HLSL_SM68),
+        implies(Target::HLSL_SM68, Target::HLSL_SM67),
+        implies(Target::HLSL_SM67, Target::HLSL_SM66),
+        implies(Target::HLSL_SM66, Target::HLSL_SM65),
+        implies(Target::HLSL_SM65, Target::HLSL_SM64),
+        implies(Target::HLSL_SM64, Target::HLSL_SM63),
+        implies(Target::HLSL_SM63, Target::HLSL_SM62),
+        implies(Target::HLSL_SM62, Target::HLSL_SM61),
+        implies(Target::HLSL_SM61, Target::HLSL_SM60),
+
         // ARM implications.
         implies(Target::SVE2, Target::ARMDotProd),
         implies(Target::SVE2, Target::ARMFp16),
@@ -1381,15 +1383,20 @@ constexpr std::pair<Target::Arch, Target::Processor> legal_processor_pairs[] = {
     {Target::X86, Target::ZnVer5},
 };
 
-template<typename T, typename Validate>
-void assign_validated(T &field, T value, Validate &&validate) {
+}  // namespace
+
+template<typename T>
+void Target::assign_validated(T &field, T value) {
     if (field == value) {
         return;
     }
-    T old_value = field;
+
+    Target old = *this;
+    unset_implied_features();
     field = std::move(value);
-    if (const auto error = validate()) {
-        field = std::move(old_value);
+    set_implied_features();
+    if (const auto error = validate_features()) {
+        *this = std::move(old);
         user_error << *error;
     }
 }
@@ -1510,14 +1517,15 @@ std::optional<std::string> Target::validate_features() const {
 }
 
 Target::Target(OS o, Arch a, int b, Processor pt, const std::vector<Feature> &initial_features, int vb)
-    : os_(o), arch_(a), processor_tune_(pt) {
-    set_bits(b);
+    : os_(o), arch_(a), bits_(b), vector_bits_(vb), processor_tune_(pt) {
+    user_assert(b == 0 || b == 32 || b == 64)
+        << "Target bits must be 0, 32, or 64; got " << b << ".\n";
+    user_assert(vb >= 0)
+        << "Target vector_bits must be non-negative; got " << vb << ".\n";
     for (Feature f : initial_features) {
         set_feature_raw(f);
     }
-    // Set vector_bits after the features, since its validity depends on them
-    // (a scalable-vector feature must be present).
-    set_vector_bits(vb);
+    set_implied_features();
     if (const auto error = validate_features()) {
         user_error << *error;
     }
@@ -1586,7 +1594,8 @@ Target::Feature Target::sme_svl_feature_from_bits(int bits) {
     }
 }
 
-std::string Target::to_string() const {
+std::string Target::to_string_impl(const std::bitset<FeatureEnd> &features_to_print,
+                                   bool use_feature_aliases) const {
     string result;
     for (const auto &arch_entry : arch_name_map) {
         if (arch_entry.second == arch_) {
@@ -1610,20 +1619,30 @@ std::string Target::to_string() const {
         }
     }
     for (const auto &feature_entry : feature_name_map) {
-        if (has_feature(feature_entry.second)) {
+        if (features_to_print[feature_entry.second]) {
             result += "-" + feature_entry.first;
         }
     }
-    // Use has_feature() multiple times (rather than features_any_of())
-    // to avoid constructing a temporary vector for this rather-common call.
-    if (has_feature(Target::TraceLoads) && has_feature(Target::TraceStores) && has_feature(Target::TraceRealizations)) {
-        result = Internal::replace_all(std::move(result), "trace_loads-trace_realizations-trace_stores", "trace_all");
+    if (use_feature_aliases &&
+        features_to_print[Target::TraceLoads] &&
+        features_to_print[Target::TraceStores]) {
+        result = Internal::replace_all(std::move(result), "trace_loads-trace_stores", "trace_all");
     }
     if (vector_bits_ != 0) {
         result += "-vector_bits_" + std::to_string(vector_bits_);
     }
 
     return result;
+}
+
+std::string Target::to_string() const {
+    Target minimal = *this;
+    minimal.unset_implied_features();
+    return to_string_impl(minimal.features, true);
+}
+
+std::string Target::to_complete_string() const {
+    return to_string_impl(features, false);
 }
 
 /** Was libHalide compiled with support for this target? */
@@ -1688,6 +1707,7 @@ void Target::set_arch(Arch a) {
         return;
     }
     Target old = *this;
+    unset_implied_features();
     arch_ = a;
     // A processor tuning is architecture-specific; changing the arch can orphan
     // it, just as removing a feature orphans the features it implied. Drop it
@@ -1696,6 +1716,7 @@ void Target::set_arch(Arch a) {
     if (!processor_tune_valid_for_arch(processor_tune_, arch_)) {
         processor_tune_ = Processor::ProcessorGeneric;
     }
+    set_implied_features();
     if (const auto error = validate_features()) {
         *this = old;
         user_error << *error;
@@ -1703,23 +1724,23 @@ void Target::set_arch(Arch a) {
 }
 
 void Target::set_os(OS o) {
-    assign_validated(os_, o, [this] { return validate_features(); });
+    assign_validated(os_, o);
 }
 
 void Target::set_bits(int b) {
     user_assert(b == 0 || b == 32 || b == 64)
         << "Target bits must be 0, 32, or 64; got " << b << ".\n";
-    assign_validated(bits_, b, [this] { return validate_features(); });
+    assign_validated(bits_, b);
 }
 
 void Target::set_vector_bits(int vb) {
     user_assert(vb >= 0)
         << "Target vector_bits must be non-negative; got " << vb << ".\n";
-    assign_validated(vector_bits_, vb, [this] { return validate_features(); });
+    assign_validated(vector_bits_, vb);
 }
 
 void Target::set_processor_tune(Processor pt) {
-    assign_validated(processor_tune_, pt, [this] { return validate_features(); });
+    assign_validated(processor_tune_, pt);
 }
 
 void Target::set_feature(Feature f, bool value) {
@@ -1727,19 +1748,35 @@ void Target::set_feature(Feature f, bool value) {
         return;
     }
     user_assert(f >= 0 && f < FeatureEnd) << "Invalid Target feature.\n";
-    const bool old_value = features[f];
-    if (old_value == value) {
+    if (features[f] == value) {
         return;
     }
-    features.set(f, value);
-    // vector_bits is meaningless without a scalable-vector feature; drop it if
-    // this change removed the last one (e.g. deriving a non-SVE target).
+
+    const auto old_features = features;
     const int old_vector_bits = vector_bits_;
-    if (vector_bits_ != 0 && !has_scalable_vector_feature(*this)) {
-        vector_bits_ = 0;
+    set_feature_raw(f, value);
+    if (!value) {
+        // A down-closed set cannot contain a feature while omitting one of its
+        // consequences. Clear the upward closure of the requested feature.
+        for (const FeatureRule &rule : Internal::reverse_view(feature_rules())) {
+            if (rule.kind == FeatureRuleKind::Implies && !has_feature(rule.other)) {
+                set_feature_raw(rule.feature, false);
+            }
+        }
+        if (arch_ == X86 && has_feature(AVX10_1) &&
+            ((vector_bits_ >= 256 && !has_feature(AVX2)) ||
+             (vector_bits_ >= 512 && !has_feature(AVX512_SapphireRapids)))) {
+            set_feature_raw(AVX10_1, false);
+        }
+        // vector_bits is meaningless without a scalable-vector feature; drop it
+        // if this removal cleared the last one.
+        if (vector_bits_ != 0 && !has_scalable_vector_feature(*this)) {
+            vector_bits_ = 0;
+        }
     }
+    set_implied_features();
     if (const auto error = validate_features()) {
-        features.set(f, old_value);
+        features = old_features;
         vector_bits_ = old_vector_bits;
         user_error << *error;
     }
@@ -1760,6 +1797,19 @@ void Target::set_features(const std::vector<Feature> &features_to_set, bool valu
     for (Feature f : features_to_set) {
         set_feature_raw(f, value);
     }
+    if (!value) {
+        for (const FeatureRule &rule : Internal::reverse_view(feature_rules())) {
+            if (rule.kind == FeatureRuleKind::Implies && !has_feature(rule.other)) {
+                set_feature_raw(rule.feature, false);
+            }
+        }
+        if (arch_ == X86 && has_feature(AVX10_1) &&
+            ((vector_bits_ >= 256 && !has_feature(AVX2)) ||
+             (vector_bits_ >= 512 && !has_feature(AVX512_SapphireRapids)))) {
+            set_feature_raw(AVX10_1, false);
+        }
+    }
+    set_implied_features();
     if (features == old_features) {
         return;
     }
@@ -1782,22 +1832,22 @@ void Target::set_implied_features() {
         // AVX10.1 at a given vector width supports the corresponding legacy
         // AVX feature set. The pairs below then cascade further.
         if (vector_bits_ >= 256) {
-            set_feature(AVX2);
+            set_feature_raw(AVX2);
         }
         if (vector_bits_ >= 512) {
-            set_feature(AVX512_SapphireRapids);
+            set_feature_raw(AVX512_SapphireRapids);
         }
     }
     if (arch_ == ARM && os_ == OSX) {
         // Apple silicon implements at least the ARM v8.4-A spec.
-        set_feature(ARMv84a);
+        set_feature_raw(ARMv84a);
     }
 
     // Simple feature -> feature implications. One forward pass suffices because
     // the table is topologically sorted.
     for (const FeatureRule &rule : feature_rules()) {
         if (rule.kind == FeatureRuleKind::Implies && has_feature(rule.feature)) {
-            set_feature(rule.other);
+            set_feature_raw(rule.other);
         }
     }
 }
@@ -1810,7 +1860,7 @@ void Target::unset_implied_features() {
     // feature in one pass.
     for (const FeatureRule &rule : Internal::reverse_view(feature_rules())) {
         if (rule.kind == FeatureRuleKind::Implies && has_feature(rule.feature)) {
-            set_feature(rule.other, false);
+            set_feature_raw(rule.other, false);
         }
     }
 
@@ -1818,27 +1868,15 @@ void Target::unset_implied_features() {
     // after the pair loop, mirroring how their seeds run before it there.
     if (arch_ == X86 && has_feature(AVX10_1)) {
         if (vector_bits_ >= 512) {
-            set_feature(AVX512_SapphireRapids, false);
+            set_feature_raw(AVX512_SapphireRapids, false);
         }
         if (vector_bits_ >= 256) {
-            set_feature(AVX2, false);
+            set_feature_raw(AVX2, false);
         }
     }
     if (arch_ == ARM && os_ == OSX) {
-        set_feature(ARMv84a, false);
+        set_feature_raw(ARMv84a, false);
     }
-}
-
-Target Target::with_implied_features() const {
-    Target copy = *this;
-    copy.set_implied_features();
-    return copy;
-}
-
-Target Target::without_implied_features() const {
-    Target copy = *this;
-    copy.unset_implied_features();
-    return copy;
 }
 
 bool Target::has_feature(Feature f) const {
@@ -1917,32 +1955,32 @@ int Target::get_cuda_capability_lower_bound() const {
     if (!has_feature(Target::CUDA)) {
         return -1;
     }
-    if (has_feature(Target::CUDACapability30)) {
-        return 30;
-    }
-    if (has_feature(Target::CUDACapability32)) {
-        return 32;
-    }
-    if (has_feature(Target::CUDACapability35)) {
-        return 35;
-    }
-    if (has_feature(Target::CUDACapability50)) {
-        return 50;
-    }
-    if (has_feature(Target::CUDACapability61)) {
-        return 61;
-    }
-    if (has_feature(Target::CUDACapability70)) {
-        return 70;
-    }
-    if (has_feature(Target::CUDACapability75)) {
-        return 75;
+    if (has_feature(Target::CUDACapability86)) {
+        return 86;
     }
     if (has_feature(Target::CUDACapability80)) {
         return 80;
     }
-    if (has_feature(Target::CUDACapability86)) {
-        return 86;
+    if (has_feature(Target::CUDACapability75)) {
+        return 75;
+    }
+    if (has_feature(Target::CUDACapability70)) {
+        return 70;
+    }
+    if (has_feature(Target::CUDACapability61)) {
+        return 61;
+    }
+    if (has_feature(Target::CUDACapability50)) {
+        return 50;
+    }
+    if (has_feature(Target::CUDACapability35)) {
+        return 35;
+    }
+    if (has_feature(Target::CUDACapability32)) {
+        return 32;
+    }
+    if (has_feature(Target::CUDACapability30)) {
+        return 30;
     }
     if (has_feature(Target::CUDACapability89)) {
         return 89;
@@ -1963,14 +2001,14 @@ int Target::get_vulkan_capability_lower_bound() const {
     if (!has_feature(Target::Vulkan)) {
         return -1;
     }
-    if (has_feature(Target::VulkanV10)) {
-        return 10;
+    if (has_feature(Target::VulkanV13)) {
+        return 13;
     }
     if (has_feature(Target::VulkanV12)) {
         return 12;
     }
-    if (has_feature(Target::VulkanV13)) {
-        return 13;
+    if (has_feature(Target::VulkanV10)) {
+        return 10;
     }
     return 10;
 }
@@ -1979,69 +2017,69 @@ int Target::get_d3d12compute_capability_lower_bound() const {
     if (!has_feature(Target::D3D12Compute)) {
         return -1;
     }
-    if (has_feature(Target::HLSL_SM60)) {
-        return 60;
-    }
-    if (has_feature(Target::HLSL_SM61)) {
-        return 61;
-    }
-    if (has_feature(Target::HLSL_SM62)) {
-        return 62;
-    }
-    if (has_feature(Target::HLSL_SM63)) {
-        return 63;
-    }
-    if (has_feature(Target::HLSL_SM64)) {
-        return 64;
-    }
-    if (has_feature(Target::HLSL_SM65)) {
-        return 65;
-    }
-    if (has_feature(Target::HLSL_SM66)) {
-        return 66;
-    }
-    if (has_feature(Target::HLSL_SM67)) {
-        return 67;
+    if (has_feature(Target::HLSL_SM69)) {
+        return 69;
     }
     if (has_feature(Target::HLSL_SM68)) {
         return 68;
     }
-    if (has_feature(Target::HLSL_SM69)) {
-        return 69;
+    if (has_feature(Target::HLSL_SM67)) {
+        return 67;
+    }
+    if (has_feature(Target::HLSL_SM66)) {
+        return 66;
+    }
+    if (has_feature(Target::HLSL_SM65)) {
+        return 65;
+    }
+    if (has_feature(Target::HLSL_SM64)) {
+        return 64;
+    }
+    if (has_feature(Target::HLSL_SM63)) {
+        return 63;
+    }
+    if (has_feature(Target::HLSL_SM62)) {
+        return 62;
+    }
+    if (has_feature(Target::HLSL_SM61)) {
+        return 61;
+    }
+    if (has_feature(Target::HLSL_SM60)) {
+        return 60;
     }
     return 51;  // default: SM 5.1 (FXC)
 }
 
 int Target::get_arm_v8_lower_bound() const {
-    if (has_feature(Target::ARMv8a)) {
-        return 80;
-    }
-    if (has_feature(Target::ARMv81a)) {
-        return 81;
-    }
-    if (has_feature(Target::ARMv82a)) {
-        return 82;
-    }
-    if (has_feature(Target::ARMv83a)) {
-        return 83;
-    }
-    if (has_feature(Target::ARMv84a)) {
-        return 84;
-    }
-    if (has_feature(Target::ARMv85a)) {
-        return 85;
-    }
-    if (has_feature(Target::ARMv86a)) {
-        return 86;
-    }
-    if (has_feature(Target::ARMv87a)) {
-        return 87;
+    if (has_feature(Target::ARMv89a)) {
+        return 89;
     }
     if (has_feature(Target::ARMv88a)) {
         return 88;
     }
-    if (has_feature(Target::ARMv89a)) {
-        return 89;
+    if (has_feature(Target::ARMv87a)) {
+        return 87;
+    }
+    if (has_feature(Target::ARMv86a)) {
+        return 86;
+    }
+    if (has_feature(Target::ARMv85a)) {
+        return 85;
+    }
+    if (has_feature(Target::ARMv84a)) {
+        return 84;
+    }
+    if (has_feature(Target::ARMv83a)) {
+        return 83;
+    }
+    if (has_feature(Target::ARMv82a)) {
+        return 82;
+    }
+    if (has_feature(Target::ARMv81a)) {
+        return 81;
+    }
+    if (has_feature(Target::ARMv8a)) {
+        return 80;
     }
     return -1;
 }
@@ -2287,7 +2325,7 @@ int Target::natural_vector_size(const Halide::Type &t) const {
 }
 
 bool Target::get_runtime_compatible_target(const Target &other, Target &result) {
-    // Create mask to select features that:
+    // Create masks to select features that:
     // (a) must be included if either target has the feature (union)
     // (b) must be included if both targets have the feature (intersection)
     // (c) must match across both targets; it is an error if one target has the feature and the other doesn't
@@ -2301,9 +2339,26 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
         OpenCL,
         Vulkan,
         WebGPU,
+    }};
 
-        // These features are actually intersection-y, but because targets only record the _highest_,
-        // we have to put their union in the result and then take a lower bound.
+    const std::vector<Feature> intersection_features = {{
+        ARMv7s,
+        AVX,
+        AVX2,
+        AVXVNNI,
+        AVX512,
+        AVX512_Cannonlake,
+        AVX512_KNL,
+        AVX512_SapphireRapids,
+        AVX512_Skylake,
+        AVX512_Zen4,
+        AVX512_Zen5,
+        F16C,
+        FMA,
+        FMA4,
+        SSE41,
+        VSX,
+
         CUDACapability30,
         CUDACapability32,
         CUDACapability35,
@@ -2348,25 +2403,6 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
         ARMv87a,
         ARMv88a,
         ARMv89a,
-    }};
-
-    const std::vector<Feature> intersection_features = {{
-        ARMv7s,
-        AVX,
-        AVX2,
-        AVXVNNI,
-        AVX512,
-        AVX512_Cannonlake,
-        AVX512_KNL,
-        AVX512_SapphireRapids,
-        AVX512_Skylake,
-        AVX512_Zen4,
-        AVX512_Zen5,
-        F16C,
-        FMA,
-        FMA4,
-        SSE41,
-        VSX,
     }};
 
     const std::vector<Feature> matching_features = {{
@@ -2419,163 +2455,7 @@ bool Target::get_runtime_compatible_target(const Target &other, Target &result) 
     // We merge the bits via bitwise or.
     Target output = Target{os_, arch_, bits_, processor_tune_};
     output.features = ((features | other.features) & union_mask) | ((features | other.features) & matching_mask) | ((features & other.features) & intersection_mask);
-
-    // Pick tight lower bound for CUDA capability. Use fall-through to clear redundant features
-    int cuda_a = get_cuda_capability_lower_bound();
-    int cuda_b = other.get_cuda_capability_lower_bound();
-
-    // get_cuda_capability_lower_bound returns -1 when unused. Casting to unsigned makes this
-    // large, so min selects the true lower bound when one target doesn't specify a capability,
-    // and the other doesn't use CUDA at all.
-    int cuda_capability = std::min((unsigned)cuda_a, (unsigned)cuda_b);
-    if (cuda_capability < 30) {
-        output.features.reset(CUDACapability30);
-    }
-    if (cuda_capability < 32) {
-        output.features.reset(CUDACapability32);
-    }
-    if (cuda_capability < 35) {
-        output.features.reset(CUDACapability35);
-    }
-    if (cuda_capability < 50) {
-        output.features.reset(CUDACapability50);
-    }
-    if (cuda_capability < 61) {
-        output.features.reset(CUDACapability61);
-    }
-    if (cuda_capability < 70) {
-        output.features.reset(CUDACapability70);
-    }
-    if (cuda_capability < 75) {
-        output.features.reset(CUDACapability75);
-    }
-    if (cuda_capability < 80) {
-        output.features.reset(CUDACapability80);
-    }
-    if (cuda_capability < 86) {
-        output.features.reset(CUDACapability86);
-    }
-    if (cuda_capability < 89) {
-        output.features.reset(CUDACapability89);
-    }
-    if (cuda_capability < 90) {
-        output.features.reset(CUDACapability90);
-    }
-    if (cuda_capability < 100) {
-        output.features.reset(CUDACapability100);
-    }
-    if (cuda_capability < 120) {
-        output.features.reset(CUDACapability120);
-    }
-
-    // Pick tight lower bound for Vulkan capability. Use fall-through to clear redundant features
-    int vulkan_a = get_vulkan_capability_lower_bound();
-    int vulkan_b = other.get_vulkan_capability_lower_bound();
-
-    // Same trick as above for CUDA
-    int vulkan_capability = std::min((unsigned)vulkan_a, (unsigned)vulkan_b);
-    if (vulkan_capability < 10) {
-        output.features.reset(VulkanV10);
-    }
-    if (vulkan_capability < 12) {
-        output.features.reset(VulkanV12);
-    }
-    if (vulkan_capability < 13) {
-        output.features.reset(VulkanV13);
-    }
-
-    // Pick tight lower bound for D3D12Compute SM version. Use fall-through to clear redundant features
-    int d3d12_sm_a = get_d3d12compute_capability_lower_bound();
-    int d3d12_sm_b = other.get_d3d12compute_capability_lower_bound();
-
-    // Same trick as CUDA: -1 (unused) becomes large when cast to unsigned, so min gives the true lower bound.
-    int d3d12_sm = std::min((unsigned)d3d12_sm_a, (unsigned)d3d12_sm_b);
-    if (d3d12_sm < 60) {
-        output.features.reset(HLSL_SM60);
-    }
-    if (d3d12_sm < 61) {
-        output.features.reset(HLSL_SM61);
-    }
-    if (d3d12_sm < 62) {
-        output.features.reset(HLSL_SM62);
-    }
-    if (d3d12_sm < 63) {
-        output.features.reset(HLSL_SM63);
-    }
-    if (d3d12_sm < 64) {
-        output.features.reset(HLSL_SM64);
-    }
-    if (d3d12_sm < 65) {
-        output.features.reset(HLSL_SM65);
-    }
-    if (d3d12_sm < 66) {
-        output.features.reset(HLSL_SM66);
-    }
-    if (d3d12_sm < 67) {
-        output.features.reset(HLSL_SM67);
-    }
-    if (d3d12_sm < 68) {
-        output.features.reset(HLSL_SM68);
-    }
-    if (d3d12_sm < 69) {
-        output.features.reset(HLSL_SM69);
-    }
-
-    // Pick tight lower bound for HVX version. Use fall-through to clear redundant features
-    int hvx_a = get_hvx_lower_bound(*this);
-    int hvx_b = get_hvx_lower_bound(other);
-
-    // Same trick as above for CUDA
-    int hvx_version = std::min((unsigned)hvx_a, (unsigned)hvx_b);
-    if (hvx_version < 62) {
-        output.features.reset(HVX_v62);
-    }
-    if (hvx_version < 65) {
-        output.features.reset(HVX_v65);
-    }
-    if (hvx_version < 66) {
-        output.features.reset(HVX_v66);
-    }
-    if (hvx_version < 68) {
-        output.features.reset(HVX_v68);
-    }
-
-    // Pick tight lower bound for ARM capability. Use fall-through to clear redundant features
-    int arm_v8_a = get_arm_v8_lower_bound();
-    int arm_v8_b = other.get_arm_v8_lower_bound();
-
-    // Same trick as above for CUDA
-    int arm_v8_capability = (int)std::min((unsigned)arm_v8_a, (unsigned)arm_v8_b);
-    if (arm_v8_capability < 80) {
-        output.features.reset(ARMv8a);
-    }
-    if (arm_v8_capability < 81) {
-        output.features.reset(ARMv81a);
-    }
-    if (arm_v8_capability < 82) {
-        output.features.reset(ARMv82a);
-    }
-    if (arm_v8_capability < 83) {
-        output.features.reset(ARMv83a);
-    }
-    if (arm_v8_capability < 84) {
-        output.features.reset(ARMv84a);
-    }
-    if (arm_v8_capability < 85) {
-        output.features.reset(ARMv85a);
-    }
-    if (arm_v8_capability < 86) {
-        output.features.reset(ARMv86a);
-    }
-    if (arm_v8_capability < 87) {
-        output.features.reset(ARMv87a);
-    }
-    if (arm_v8_capability < 88) {
-        output.features.reset(ARMv88a);
-    }
-    if (arm_v8_capability < 89) {
-        output.features.reset(ARMv89a);
-    }
+    output.set_implied_features();
 
     result = output;
     return true;

--- a/src/Target.h
+++ b/src/Target.h
@@ -233,29 +233,6 @@ struct Target {
 
     void set_features(const std::vector<Feature> &features_to_set, bool value = true);
 
-    /** Set any feature flags that are implied by the flags currently set. For
-     * example, setting AVX2 implies AVX, so calling this on a target with the
-     * AVX2 feature will also set the AVX feature. The set of implications is a
-     * DAG, so this reaches a fixed point in a single pass. Call this before
-     * inspecting a target's features, so that (e.g.) a check for SSE41
-     * succeeds on an AVX2 target. */
-    void set_implied_features();
-
-    /** Unset any feature flags that are implied by other flags that remain
-     * set, producing the minimal set of feature flags that
-     * set_implied_features() would expand back to the same target. For
-     * example, on a target with both AVX2 and AVX set, this unsets AVX (since
-     * AVX2 implies it), but on a target with only AVX set it leaves AVX
-     * alone. Call this before emitting a target as a string, to get a compact
-     * canonical form. */
-    void unset_implied_features();
-
-    /** Return a copy of the target with set_implied_features() applied. */
-    Target with_implied_features() const;
-
-    /** Return a copy of the target with unset_implied_features() applied. */
-    Target without_implied_features() const;
-
     bool has_feature(Feature f) const;
 
     bool has_feature(halide_target_feature_t f) const {
@@ -366,18 +343,23 @@ struct Target {
      */
     bool get_runtime_compatible_target(const Target &other, Target &result);
 
-    /** Convert the Target into a string form that can be reconstituted
-     * by merge_string(), which will always be of the form
+    /** Convert the Target into a minimal string form that can be reconstituted
+     * by merge_string(). Features implied by other features (or by the base
+     * Target) are omitted. The result will always be of the form
      *
      *   arch-bits-os-processor-feature1-feature2...featureN.
      *
-     * Note that is guaranteed that Target(t1.to_string()) == t1,
-     * but not that Target(s).to_string() == s (since there can be
-     * multiple strings that parse to the same Target)...
-     * *unless* t1 contains 'unknown' fields (in which case you'll get a string
-     * that can't be parsed, which is intentional).
+     * Note that it is guaranteed that Target(t1.to_string()) == t1, but not that
+     * Target(s).to_string() == s (since there can be multiple strings that parse
+     * to the same Target), *unless* t1 contains 'unknown' fields (in which case
+     * you'll get a string that can't be parsed, which is intentional).
      */
     std::string to_string() const;
+
+    /** Convert the Target into a string that includes every implied feature.
+     * This is primarily intended for debugging and testing the internal,
+     * implication-complete representation. */
+    std::string to_complete_string() const;
 
     /** Given a data type, return an estimate of the "natural" vector size
      * for that data type when compiling for this Target. */
@@ -429,9 +411,8 @@ struct Target {
     /** Was libHalide compiled with support for this target? */
     bool supported() const;
 
-    /** Return a bitset of the Featuress set in this Target (set = 1).
-     * Note that while this happens to be the current internal representation,
-     * that might not always be the case. */
+    /** Return a bitset of the Features set in this Target (set = 1).
+     * The returned set includes all implied features. */
     const std::bitset<FeatureEnd> &get_features_bitset() const {
         return features;
     }
@@ -466,6 +447,22 @@ private:
 
     /** Set (or clear) a feature bit without running validation. */
     void set_feature_raw(Feature f, bool value = true);
+
+    /** Assign a Target property while maintaining implied-feature closure.
+     * The assignment is transactional: if validation fails, restore the
+     * entire Target before reporting the error. */
+    template<typename T>
+    void assign_validated(T &field, T value);
+
+    /** Restore the invariant that every implied feature is set. */
+    void set_implied_features();
+
+    /** Remove features implied by other features or by the base Target. */
+    void unset_implied_features();
+
+    /** Format the supplied feature representation. */
+    std::string to_string_impl(const std::bitset<FeatureEnd> &features_to_print,
+                               bool use_feature_aliases) const;
 
     /** Parse a target string into \p t, without validating that the resulting
      * feature set is sensible for the arch. Returns false if the string is not

--- a/src/Target.h
+++ b/src/Target.h
@@ -32,6 +32,7 @@ struct Target {
         NoOS,
         Fuchsia,
         WebAssemblyRuntime,
+        OSEnd,
     };
 
     /** The architecture used by the target. Determines the
@@ -69,6 +70,7 @@ struct Target {
         ZnVer3,    /// Tune for AMD Zen 3 CPU (AMD Family 19h, launched 2020).
         ZnVer4,    /// Tune for AMD Zen 4 CPU (AMD Family 19h, launched 2022).
         ZnVer5,    /// Tune for AMD Zen 5 CPU (AMD Family 1Ah, launched 2024).
+        ProcessorEnd,
     };
 
     /** Optional features a target can have.
@@ -459,6 +461,11 @@ private:
 
     /** Remove features implied by other features or by the base Target. */
     void unset_implied_features();
+
+    /** After a feature has been cleared, clear any remaining feature whose
+     * implied consequences are no longer all present, keeping the feature set
+     * down-closed. */
+    void clear_orphaned_features();
 
     /** Format the supplied feature representation. */
     std::string to_string_impl(const std::bitset<FeatureEnd> &features_to_print,

--- a/src/Tracing.cpp
+++ b/src/Tracing.cpp
@@ -73,9 +73,6 @@ public:
         : env(e),
           trace_all_loads(t.has_feature(Target::TraceLoads)),
           trace_all_stores(t.has_feature(Target::TraceStores)),
-          // TraceLoads and TraceStores imply TraceRealizations (see
-          // set_implied_features), because tracing loads or stores doesn't work
-          // without the enclosing realization begin/end events.
           trace_all_realizations(t.has_feature(Target::TraceRealizations)) {
     }
 

--- a/test/correctness/target.cpp
+++ b/test/correctness/target.cpp
@@ -224,7 +224,7 @@ int main(int argc, char **argv) {
         return 1;
     }
     ts = t1.to_string();
-    if (ts != "arm-64-linux-armv8a") {
+    if (ts != "arm-64-linux-armv83a") {
         printf("get_runtime_compatible_target failure: %s\n", ts.c_str());
         return 1;
     }
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
     const GcdTest gcd_tests[] = {
         {"x86-64-linux-sse41-fma", "x86-64-linux-sse41-fma", "x86-64-linux-sse41-fma"},
         {"x86-64-linux-sse41-fma-no_asserts-no_runtime", "x86-64-linux-sse41-fma", "x86-64-linux-sse41-fma"},
-        {"x86-64-linux-avx2-sse41", "x86-64-linux-sse41-fma", "x86-64-linux-sse41"},
+        {"x86-64-linux-avx2-sse41", "x86-64-linux-sse41-fma", "x86-64-linux-sse41-fma"},
         {"x86-64-linux-avx2-sse41", "x86-32-linux-sse41-fma", ""},
         {"x86-64-linux-cuda", "x86-64-linux", "x86-64-linux-cuda"},
         {"x86-64-linux-cuda-cuda_capability_50", "x86-64-linux-cuda", "x86-64-linux-cuda"},
@@ -321,70 +321,88 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    // Feature implications. Each entry is {input, set_implied_features result,
-    // set-then-unset (minimal) result}.
+    // Feature implications. Each entry is {input, complete representation,
+    // minimal representation}.
     struct ImpliedTest {
         const char *input;
-        const char *set_implied;
+        const char *complete;
         const char *minimal;
     };
     const ImpliedTest implied_tests[] = {
         // x86 AVX family
         {"x86-64-linux-avx2",
-         "x86-64-linux-sse41-avx-avx2-f16c-fma",
+         "x86-64-linux-avx-avx2-f16c-fma-sse41",
          "x86-64-linux-avx2"},
         {"x86-64-linux-avx512_skylake",
-         "x86-64-linux-sse41-avx-avx2-f16c-fma-avx512-avx512_skylake",
+         "x86-64-linux-avx-avx2-avx512-avx512_skylake-f16c-fma-sse41",
          "x86-64-linux-avx512_skylake"},
         {"x86-64-linux-avx512_sapphirerapids",
-         "x86-64-linux-sse41-avx-avx2-f16c-fma-avxvnni-avx512-avx512_skylake-avx512_cannonlake-avx512_zen4-avx512_sapphirerapids",
+         "x86-64-linux-avx-avx2-avx512-avx512_cannonlake-avx512_sapphirerapids-avx512_skylake-avx512_zen4-avxvnni-f16c-fma-sse41",
          "x86-64-linux-avx512_sapphirerapids"},
         // Redundantly-specified features collapse to the minimal form.
         {"x86-64-linux-sse41-avx-avx2-f16c-fma",
-         "x86-64-linux-sse41-avx-avx2-f16c-fma",
+         "x86-64-linux-avx-avx2-f16c-fma-sse41",
          "x86-64-linux-avx2"},
         // AVX10.1 implications depend on vector_bits.
         {"x86-64-linux-avx10_1-vector_bits_512",
-         "x86-64-linux-sse41-avx-avx2-f16c-fma-avxvnni-avx512-avx512_skylake-avx512_cannonlake-avx512_zen4-avx512_sapphirerapids-avx10_1-vector_bits_512",
+         "x86-64-linux-avx-avx10_1-avx2-avx512-avx512_cannonlake-avx512_sapphirerapids-avx512_skylake-avx512_zen4-avxvnni-f16c-fma-sse41-vector_bits_512",
          "x86-64-linux-avx10_1-vector_bits_512"},
         {"x86-64-linux-avx10_1",
          "x86-64-linux-avx10_1",
          "x86-64-linux-avx10_1"},
         // ARM v8.x cascade, and SVE/SVE2 cascading through arm_fp16.
         {"arm-64-linux-armv84a",
-         "arm-64-linux-armv8a-armv81a-armv82a-armv83a-armv84a",
+         "arm-64-linux-armv81a-armv82a-armv83a-armv84a-armv8a",
          "arm-64-linux-armv84a"},
         {"arm-64-linux-sve2",
-         "arm-64-linux-armv8a-armv81a-armv82a-arm_fp16-arm_dot_prod-sve2",
+         "arm-64-linux-arm_dot_prod-arm_fp16-armv81a-armv82a-armv8a-sve2",
          "arm-64-linux-sve2"},
         {"arm-64-linux-sme2-sme_svl512",
          "arm-64-linux-armv8a-armv81a-armv82a-arm_fp16-arm_dot_prod-sme2-sme_svl512",
          "arm-64-linux-sme2-sme_svl512"},
         // Apple silicon implies at least ARM v8.4a.
         {"arm-64-osx",
-         "arm-64-osx-armv8a-armv81a-armv82a-armv83a-armv84a",
+         "arm-64-osx-armv81a-armv82a-armv83a-armv84a-armv8a",
          "arm-64-osx"},
         // Tracing loads/stores implies tracing realizations.
         {"x86-64-linux-trace_loads",
          "x86-64-linux-trace_loads-trace_realizations",
          "x86-64-linux-trace_loads"},
+        // Ordered device capability/version chains.
+        {"x86-64-linux-cuda-cuda_capability_50",
+         "x86-64-linux-cuda-cuda_capability_30-cuda_capability_32-cuda_capability_35-cuda_capability_50",
+         "x86-64-linux-cuda-cuda_capability_50"},
+        {"x86-64-linux-vulkan-vk_v13",
+         "x86-64-linux-vk_v10-vk_v12-vk_v13-vulkan",
+         "x86-64-linux-vk_v13-vulkan"},
+        {"x86-64-windows-d3d12compute-hlsl_sm63",
+         "x86-64-windows-d3d12compute-hlsl_sm60-hlsl_sm61-hlsl_sm62-hlsl_sm63",
+         "x86-64-windows-d3d12compute-hlsl_sm63"},
     };
     for (const auto &test : implied_tests) {
-        Target set_result(test.input);
-        set_result.set_implied_features();
-        if (set_result.get_features_bitset() != Target(test.set_implied).get_features_bitset()) {
-            printf("set_implied_features(%s) gave %s but expected %s\n",
-                   test.input, set_result.to_string().c_str(), test.set_implied);
+        const Target result(test.input);
+        if (result.to_complete_string() != test.complete) {
+            printf("The complete form of %s was %s but expected %s\n",
+                   test.input, result.to_complete_string().c_str(), test.complete);
             return 1;
         }
-        Target norm_result(test.input);
-        norm_result.set_implied_features();
-        norm_result.unset_implied_features();
-        if (norm_result.get_features_bitset() != Target(test.minimal).get_features_bitset()) {
-            printf("set then unset implied features on %s gave %s but expected %s\n",
-                   test.input, norm_result.to_string().c_str(), test.minimal);
+        if (result.to_string() != test.minimal) {
+            printf("The minimal form of %s was %s but expected %s\n",
+                   test.input, result.to_string().c_str(), test.minimal);
             return 1;
         }
+        if (Target(result.to_string()) != result) {
+            printf("The minimal form of %s did not round-trip\n", test.input);
+            return 1;
+        }
+    }
+
+    if (Target("x86-64-linux-cuda-cuda_capability_80").get_cuda_capability_lower_bound() != 80 ||
+        Target("x86-64-linux-vulkan-vk_v13").get_vulkan_capability_lower_bound() != 13 ||
+        Target("x86-64-windows-d3d12compute-hlsl_sm67").get_d3d12compute_capability_lower_bound() != 67 ||
+        Target("arm-64-linux-armv88a").get_arm_v8_lower_bound() != 88) {
+        printf("Capability lower-bound getter failure\n");
+        return 1;
     }
 
     printf("Success!\n");

--- a/test/fuzz/target_invariants.cpp
+++ b/test/fuzz/target_invariants.cpp
@@ -200,18 +200,14 @@ void test_one_target(FuzzingContext &fuzz) {
         check_roundtrip(t);
     }
 
-    // Check that implied-feature canonicalization round-trips safely.
-    check_roundtrip(t.with_implied_features());
-    check_roundtrip(t.without_implied_features());
-
-    // Check that implied-feature canonicalization is idempotent
-    const Target wi = t.with_implied_features();
-    require(wi.with_implied_features() == wi,
-            "with_implied_features() is not idempotent:\n  " + t.to_string());
-
-    const Target wo = t.without_implied_features();
-    require(wo.without_implied_features() == wo,
-            "without_implied_features() is not idempotent:\n  " + t.to_string());
+    // Both the minimal public representation and the complete debugging
+    // representation must name the same Target.
+    if (!t.has_unknowns()) {
+        std::string complete = t.to_complete_string();
+        require(Target(complete) == t,
+                "Round-trip through to_complete_string() changed the target:\n  " +
+                    complete);
+    }
 }
 
 }  // namespace


### PR DESCRIPTION
Following up on [my comment in #9241](https://github.com/halide/Halide/pull/9241#issuecomment-5079090563).

This adjusts Target to always have a single, stable, representation by filling in implied target features.

This leans into the mathematical lattice structure targets have.

## Breaking changes

The `target.to_string()` function now shows a minimal target; clients wanting to see everything should use `.to_complete_target()`.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [x] Python bindings updated (if public API changed)
- [x] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>