### PR TITLE
ci: retry CI env sync to ride out pypi.halide-lang.org connect timeouts

### DIFF
--- a/.github/workflows/testing-arm-linux.yml
+++ b/.github/workflows/testing-arm-linux.yml
@@ -85,17 +85,33 @@ jobs:
       - name: Sync CI environment
         run: |
           # halide-llvm comes from pypi.halide-lang.org, whose upstream network
-          # path intermittently blackholes a source IP for ~tens of seconds
-          # (root-caused in halide/build_bot#362). uv's own retries only span a
-          # single blackhole (~47s), so wrap the fetch in an outer retry that
-          # waits one out before trying again.
+          # path intermittently blackholes a source IP for tens of seconds to
+          # a few minutes (root-caused in halide/build_bot#362, escalated to
+          # MIT network ops). uv's own retries only span ~47s, which wasn't
+          # always enough, so this retries harder (5 attempts, backoff
+          # doubling 60s -> 300s) and logs the runner's egress IP plus a path
+          # trace to the PyPI host on each failure, so a specific incident's
+          # 5-tuple/timestamp can be handed to MIT for correlation.
           retry() {
-            local i n=3
+            local i n=5 delay=60 max_delay=300
             for ((i = 1; i <= n; i++)); do
               if "$@"; then return 0; fi
               if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
-                sleep $((i * 60))
+                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
+                echo "::group::Network diagnostics (attempt $i/$n)"
+                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
+                if command -v tracepath >/dev/null 2>&1; then
+                  tracepath -m 15 pypi.halide-lang.org || true
+                elif command -v traceroute >/dev/null 2>&1; then
+                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
+                elif command -v tracert >/dev/null 2>&1; then
+                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
+                else
+                  echo "no traceroute tool available"
+                fi
+                echo "::endgroup::"
+                sleep "$delay"
+                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
               fi
             done
             return 1

--- a/.github/workflows/testing-arm-linux.yml
+++ b/.github/workflows/testing-arm-linux.yml
@@ -84,7 +84,24 @@ jobs:
 
       - name: Sync CI environment
         run: |
-          setarch ${{ matrix.arch }} bash -ec "
+          # halide-llvm comes from pypi.halide-lang.org, whose upstream network
+          # path intermittently blackholes a source IP for ~tens of seconds
+          # (root-caused in halide/build_bot#362). uv's own retries only span a
+          # single blackhole (~47s), so wrap the fetch in an outer retry that
+          # waits one out before trying again.
+          retry() {
+            local i n=3
+            for ((i = 1; i <= n; i++)); do
+              if "$@"; then return 0; fi
+              if [ "$i" -lt "$n" ]; then
+                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
+                sleep $((i * 60))
+              fi
+            done
+            return 1
+          }
+
+          retry setarch ${{ matrix.arch }} bash -ec "
             uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
             echo '${GITHUB_WORKSPACE}/.venv/bin' >> '$GITHUB_PATH'
             echo 'VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv' >> '$GITHUB_ENV'

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -80,7 +80,24 @@ jobs:
 
       - name: Sync CI environment
         run: |
-          setarch ${{ matrix.arch }} bash -ec "
+          # halide-llvm comes from pypi.halide-lang.org, whose upstream network
+          # path intermittently blackholes a source IP for ~tens of seconds
+          # (root-caused in halide/build_bot#362). uv's own retries only span a
+          # single blackhole (~47s), so wrap the fetch in an outer retry that
+          # waits one out before trying again.
+          retry() {
+            local i n=3
+            for ((i = 1; i <= n; i++)); do
+              if "$@"; then return 0; fi
+              if [ "$i" -lt "$n" ]; then
+                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
+                sleep $((i * 60))
+              fi
+            done
+            return 1
+          }
+
+          retry setarch ${{ matrix.arch }} bash -ec "
             CC='gcc -m${{ matrix.bits }}' CXX='g++ -m${{ matrix.bits }}' \
             uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
             echo '${GITHUB_WORKSPACE}/.venv/bin' >> '$GITHUB_PATH'

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -81,17 +81,33 @@ jobs:
       - name: Sync CI environment
         run: |
           # halide-llvm comes from pypi.halide-lang.org, whose upstream network
-          # path intermittently blackholes a source IP for ~tens of seconds
-          # (root-caused in halide/build_bot#362). uv's own retries only span a
-          # single blackhole (~47s), so wrap the fetch in an outer retry that
-          # waits one out before trying again.
+          # path intermittently blackholes a source IP for tens of seconds to
+          # a few minutes (root-caused in halide/build_bot#362, escalated to
+          # MIT network ops). uv's own retries only span ~47s, which wasn't
+          # always enough, so this retries harder (5 attempts, backoff
+          # doubling 60s -> 300s) and logs the runner's egress IP plus a path
+          # trace to the PyPI host on each failure, so a specific incident's
+          # 5-tuple/timestamp can be handed to MIT for correlation.
           retry() {
-            local i n=3
+            local i n=5 delay=60 max_delay=300
             for ((i = 1; i <= n; i++)); do
               if "$@"; then return 0; fi
               if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
-                sleep $((i * 60))
+                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
+                echo "::group::Network diagnostics (attempt $i/$n)"
+                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
+                if command -v tracepath >/dev/null 2>&1; then
+                  tracepath -m 15 pypi.halide-lang.org || true
+                elif command -v traceroute >/dev/null 2>&1; then
+                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
+                elif command -v tracert >/dev/null 2>&1; then
+                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
+                else
+                  echo "no traceroute tool available"
+                fi
+                echo "::endgroup::"
+                sleep "$delay"
+                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
               fi
             done
             return 1

--- a/.github/workflows/testing-macos.yml
+++ b/.github/workflows/testing-macos.yml
@@ -100,7 +100,24 @@ jobs:
 
       - name: Sync CI environment
         run: |
-          uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
+          # halide-llvm comes from pypi.halide-lang.org, whose upstream network
+          # path intermittently blackholes a source IP for ~tens of seconds
+          # (root-caused in halide/build_bot#362). uv's own retries only span a
+          # single blackhole (~47s), so wrap the fetch in an outer retry that
+          # waits one out before trying again.
+          retry() {
+            local i n=3
+            for ((i = 1; i <= n; i++)); do
+              if "$@"; then return 0; fi
+              if [ "$i" -lt "$n" ]; then
+                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
+                sleep $((i * 60))
+              fi
+            done
+            return 1
+          }
+
+          retry uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
           echo "${GITHUB_WORKSPACE}/.venv/bin" >> "$GITHUB_PATH"
           echo "VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv" >> "$GITHUB_ENV"
 

--- a/.github/workflows/testing-macos.yml
+++ b/.github/workflows/testing-macos.yml
@@ -101,17 +101,33 @@ jobs:
       - name: Sync CI environment
         run: |
           # halide-llvm comes from pypi.halide-lang.org, whose upstream network
-          # path intermittently blackholes a source IP for ~tens of seconds
-          # (root-caused in halide/build_bot#362). uv's own retries only span a
-          # single blackhole (~47s), so wrap the fetch in an outer retry that
-          # waits one out before trying again.
+          # path intermittently blackholes a source IP for tens of seconds to
+          # a few minutes (root-caused in halide/build_bot#362, escalated to
+          # MIT network ops). uv's own retries only span ~47s, which wasn't
+          # always enough, so this retries harder (5 attempts, backoff
+          # doubling 60s -> 300s) and logs the runner's egress IP plus a path
+          # trace to the PyPI host on each failure, so a specific incident's
+          # 5-tuple/timestamp can be handed to MIT for correlation.
           retry() {
-            local i n=3
+            local i n=5 delay=60 max_delay=300
             for ((i = 1; i <= n; i++)); do
               if "$@"; then return 0; fi
               if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
-                sleep $((i * 60))
+                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
+                echo "::group::Network diagnostics (attempt $i/$n)"
+                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
+                if command -v tracepath >/dev/null 2>&1; then
+                  tracepath -m 15 pypi.halide-lang.org || true
+                elif command -v traceroute >/dev/null 2>&1; then
+                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
+                elif command -v tracert >/dev/null 2>&1; then
+                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
+                else
+                  echo "no traceroute tool available"
+                fi
+                echo "::endgroup::"
+                sleep "$delay"
+                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
               fi
             done
             return 1

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -65,16 +65,33 @@ jobs:
           # a 32-bit build. Instead: read the pinned version from the lockfile (no download),
           # sync only ci-base (no LLVM), then fetch the correct win32 wheel directly.
           # pypi.halide-lang.org's upstream network path intermittently
-          # blackholes a source IP for ~tens of seconds (root-caused in
-          # halide/build_bot#362); uv's own retries only span a single
-          # blackhole (~47s), so wrap the halide-llvm fetch in an outer retry.
+          # blackholes a source IP for tens of seconds to a few minutes
+          # (root-caused in halide/build_bot#362, escalated to MIT network
+          # ops). uv's own retries only span ~47s, which wasn't always
+          # enough, so this retries harder (5 attempts, backoff doubling
+          # 60s -> 300s) and logs the runner's egress IP plus a path trace
+          # to the PyPI host on each failure, so a specific incident's
+          # 5-tuple/timestamp can be handed to MIT for correlation.
           retry() {
-            local i n=3
+            local i n=5 delay=60 max_delay=300
             for ((i = 1; i <= n; i++)); do
               if "$@"; then return 0; fi
               if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
-                sleep $((i * 60))
+                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
+                echo "::group::Network diagnostics (attempt $i/$n)"
+                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
+                if command -v tracepath >/dev/null 2>&1; then
+                  tracepath -m 15 pypi.halide-lang.org || true
+                elif command -v traceroute >/dev/null 2>&1; then
+                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
+                elif command -v tracert >/dev/null 2>&1; then
+                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
+                else
+                  echo "no traceroute tool available"
+                fi
+                echo "::endgroup::"
+                sleep "$delay"
+                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
               fi
             done
             return 1

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -64,11 +64,27 @@ jobs:
           # Python, so on Windows it would download x86_64 halide-llvm (~250MB) even for
           # a 32-bit build. Instead: read the pinned version from the lockfile (no download),
           # sync only ci-base (no LLVM), then fetch the correct win32 wheel directly.
+          # pypi.halide-lang.org's upstream network path intermittently
+          # blackholes a source IP for ~tens of seconds (root-caused in
+          # halide/build_bot#362); uv's own retries only span a single
+          # blackhole (~47s), so wrap the halide-llvm fetch in an outer retry.
+          retry() {
+            local i n=3
+            for ((i = 1; i <= n; i++)); do
+              if "$@"; then return 0; fi
+              if [ "$i" -lt "$n" ]; then
+                echo "::warning::CI env sync attempt $i/$n failed; retrying in $((i * 60))s"
+                sleep $((i * 60))
+              fi
+            done
+            return 1
+          }
+
           LLVM_VER=$(uv export --group '${{ matrix.uv_group }}' --no-emit-project \
             | awk -F'==' '/^halide-llvm==/ { gsub(/ .*/, "", $2); print $2 }')
 
           uv sync --python '${{ matrix.python }}' --group ci-base --no-install-project
-          uv pip install --python-platform i686-pc-windows-msvc --only-binary :all: \
+          retry uv pip install --python-platform i686-pc-windows-msvc --only-binary :all: \
             --extra-index-url https://pypi.halide-lang.org/simple/ \
             "halide-llvm==${LLVM_VER}"
 


### PR DESCRIPTION
## Problem

The **Sync CI environment** step intermittently (~10%) fails fetching `halide-llvm` from `pypi.halide-lang.org` with:

```
error: Request failed after 3 retries in 47.2s
  Caused by: Failed to fetch: `https://pypi.halide-lang.org/simple/halide-llvm/`
  Caused by: client error (Connect)
```

It's a **connect timeout** (never establishes a connection), on both wheel and index URLs, across Linux/Windows runners.

## Root cause (halide/build_bot#362)

Instrumented the server (Caddy access log + host TCP-counter sampler) and caught it live. During a failing runner's 47s retry window:
- Caddy served the **identical `/simple/halide-llvm/` request from three other runners** (`200` in ~15 ms), and the failing runner's request **never reached the server**.
- Every host drop counter stayed flat (`listen_drops`/`overflows`/`reqq_full_drop` = 0, conntrack ~20/262144, load < 0.5).

So the SYNs are dropped on the **upstream network path** (MIT/OpenStack ↔ cloud), a source-specific transient blackhole — not something the server (Caddy/pypiserver) can fix. Escalation to the network owner is filed separately; this PR is the client-side mitigation.

## Fix

uv's built-in retries only span a single ~47 s blackhole. This adds a small `retry()` helper — mirroring the existing `apt_update` retry loop — with a longer backoff (60 s, then 120 s) around the `halide-llvm` fetch, so a transient blackhole is waited out and the next attempt lands on a cleared path.

Applied to the four workflows that pull `halide-llvm` from the Halide index: `testing-linux`, `testing-arm-linux`, `testing-macos`, `testing-windows`. `testing-make` uses `ci-base` (no LLVM) and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)