### PR TITLE
Let the driver choose the CUDA register count

### DIFF
--- a/apps/conv_layer/process.cpp
+++ b/apps/conv_layer/process.cpp
@@ -43,15 +43,6 @@ int main(int argc, char **argv) {
 
     Buffer<float, 4> output(CO, W, H, N);
 
-// This is necessary to get the PTX compiler to do a good
-// job. TODO: This should be a scheduling directive or a runtime
-// function.
-#ifdef _WIN32
-    _putenv_s("HL_CUDA_JIT_MAX_REGISTERS", "256");
-#else
-    setenv("HL_CUDA_JIT_MAX_REGISTERS", "256", 1);
-#endif
-
     conv_layer(input, filter, bias, output);
 
     // Timing code

--- a/apps/cuda_mat_mul/Makefile
+++ b/apps/cuda_mat_mul/Makefile
@@ -22,7 +22,7 @@ $(BIN)/%/runner: runner.cpp $(BIN)/%/mat_mul.a
 	$(CXX) $(CXXFLAGS) -I$(BIN)/$* -Wall $^ -o $@ $(LDFLAGS) -lcudart -lcublas
 
 test: $(BIN)/$(HL_TARGET)/runner
-	HL_CUDA_JIT_MAX_REGISTERS=256 $^ $(MATRIX_SIZE)
+	$^ $(MATRIX_SIZE)
 
 clean:
 	rm -rf $(BIN)

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -526,19 +526,11 @@ WEAK int validate_device_pointer(void *user_context, halide_buffer_t *buf, size_
 WEAK CUmodule compile_kernel(void *user_context, const char *ptx_src, int size) {
     debug(user_context) << "CUDA: compile_kernel cuModuleLoadData " << (void *)ptx_src << ", " << size << " -> ";
 
-    CUjit_option options[] = {CU_JIT_MAX_REGISTERS};
-    unsigned int max_regs_per_thread = 64;
-
-    // A hack to enable control over max register count for
-    // testing. This should be surfaced in the schedule somehow
-    // instead.
-    char *regs = getenv("HL_CUDA_JIT_MAX_REGISTERS");
-    if (regs) {
-        max_regs_per_thread = atoi(regs);
-    }
-    void *optionValues[] = {(void *)(uintptr_t)max_regs_per_thread};
+    // Let the driver pick the register count. Capping it trades spilling
+    // against occupancy, and the driver has more information about the kernel
+    // and the device than we do.
     CUmodule loaded_module;
-    CUresult err = cuModuleLoadDataEx(&loaded_module, ptx_src, 1, options, optionValues);
+    CUresult err = cuModuleLoadData(&loaded_module, ptx_src);
 
     if (err != CUDA_SUCCESS) {
         error(user_context) << "CUDA: cuModuleLoadData failed: "

--- a/src/runtime/cuda.cpp
+++ b/src/runtime/cuda.cpp
@@ -526,9 +526,7 @@ WEAK int validate_device_pointer(void *user_context, halide_buffer_t *buf, size_
 WEAK CUmodule compile_kernel(void *user_context, const char *ptx_src, int size) {
     debug(user_context) << "CUDA: compile_kernel cuModuleLoadData " << (void *)ptx_src << ", " << size << " -> ";
 
-    // Let the driver pick the register count. Capping it trades spilling
-    // against occupancy, and the driver has more information about the kernel
-    // and the device than we do.
+    // Use driver defaults for all JIT options.
     CUmodule loaded_module;
     CUresult err = cuModuleLoadData(&loaded_module, ptx_src);
 


### PR DESCRIPTION
The cuda runtime capped kernels at 64 registers per thread when loading a module, with an HL_CUDA_JIT_MAX_REGISTERS environment variable as an escape hatch. Capping registers trades spilling against occupancy, and ptxas has more information about the kernel and the device than we do.

Two apps set the escape hatch to 256 to compensate. Both are removed here; on an sm_86 device the 256 cap is now slightly slower than letting the driver decide.

