### PR TITLE
Simplify division of a nested vector by a broadcast

### DIFF
--- a/src/Simplify_Div.cpp
+++ b/src/Simplify_Div.cpp
@@ -204,9 +204,34 @@ Expr Simplify::visit(const Div *op, ExprInfo *info) {
            (op->type.is_float() && rewrite(x / c0, x * fold(1 / c0))))) ||
          (no_overflow_int(op->type) &&
           (rewrite(ramp(x, c0, lanes) / broadcast(c1, lanes), ramp(x / c1, fold(c0 / c1), lanes), (c0 % c1 == 0)) ||
-           rewrite(ramp(x, c0, lanes) / broadcast(c1, lanes), broadcast(x / c1, lanes),
-                   // First and last lanes are the same when...
-                   can_prove((x % c1 + c0 * (lanes - 1)) / c1 == 0, this)))) ||
+           // Every lane gives the same quotient when the base is a multiple of
+           // the denominator and the ramp doesn't span far enough to reach the
+           // next one. In the affine case the offset just has to leave room
+           // within its own multiple for the rest of the ramp.
+           rewrite(ramp(x * c1, c0, lanes) / broadcast(c2, lanes),
+                   broadcast(x * fold(c1 / c2), lanes),
+                   c2 > 0 && c1 % c2 == 0 && c0 >= 0 && c0 * (lanes - 1) < c2) ||
+           rewrite(ramp(x * c1 + c5, c0, lanes) / broadcast(c2, lanes),
+                   broadcast(x * fold(c1 / c2) + fold(c5 / c2), lanes),
+                   c2 > 0 && c1 % c2 == 0 && c0 >= 0 &&
+                       c5 % c2 + c0 * (lanes - 1) < c2) ||
+           // The rules above require the numerator and the denominator to be
+           // vectorized the same way, which they aren't when the numerator is
+           // a nested vector. Push the division inwards to line them up.
+           rewrite(broadcast(x, c0) / broadcast(y, c1),
+                   broadcast(x / broadcast(y, fold(c1 / c0)), c0),
+                   c0 < c1 && c1 % c0 == 0) ||
+           // The same argument, for a ramp whose lanes are each repeated by an
+           // inner broadcast. Repeating a lane doesn't change the set of
+           // values, so the span condition is unchanged.
+           rewrite(ramp(broadcast(x * c1, c3), broadcast(c0, c3), c4) / broadcast(c2, lanes),
+                   broadcast(x * fold(c1 / c2), lanes),
+                   c2 > 0 && c1 % c2 == 0 && c0 >= 0 && c0 * (c4 - 1) < c2 &&
+                       c3 * c4 == lanes) ||
+           rewrite(ramp(broadcast(x * c1 + c5, c3), broadcast(c0, c3), c4) / broadcast(c2, lanes),
+                   broadcast(x * fold(c1 / c2) + fold(c5 / c2), lanes),
+                   c2 > 0 && c1 % c2 == 0 && c0 >= 0 &&
+                       c5 % c2 + c0 * (c4 - 1) < c2 && c3 * c4 == lanes))) ||
          (no_overflow_scalar_int(op->type) &&
           (rewrite(x / -1, -x) ||
            (denominator_non_zero && rewrite(c0 / y, select(y < 0, fold(-c0), c0), c0 == -1)) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -606,6 +606,26 @@ void check_vectors() {
     check(ramp(ramp(cast<uint8_t>(x), cast<uint8_t>(-1), 4), cast(UInt(8, 4), -4), 3),
           ramp(cast<uint8_t>(x), cast<uint8_t>(-1), 12));
 
+    // Dividing a nested vector by a broadcast should give the same answer as
+    // dividing the equivalent flat one, even though the lanes are laid out
+    // differently.
+    check(ramp(broadcast(x * 16, 16), broadcast(1, 16), 16) / broadcast(16, 256),
+          broadcast(x, 256));
+    check(broadcast(ramp(broadcast(x * 16, 16), broadcast(1, 16), 16), 16) / broadcast(16, 4096),
+          broadcast(x, 4096));
+    check(broadcast(ramp(x, 1, 4), 2) / broadcast(y, 8),
+          broadcast(ramp(x, 1, 4) / broadcast(y, 4), 2));
+
+    // An affine base works too, as long as the offset leaves room within its
+    // own multiple of the denominator for the rest of the ramp.
+    check(ramp(x * 16 + 4, 1, 4) / broadcast(16, 4), broadcast(x, 4));
+    check(ramp(x * 16 - 4, 1, 4) / broadcast(16, 4), broadcast(x + (-1), 4));
+    check(ramp(broadcast(x * 16 + 4, 16), broadcast(1, 16), 4) / broadcast(16, 64),
+          broadcast(x, 64));
+    // ... but not when it spills over into the next one.
+    check(ramp(x * 16 + 14, 1, 4) / broadcast(16, 4),
+          ramp(x * 16 + 14, 1, 4) / broadcast(16, 4));
+
     // Any linear combination of simple ramps and broadcasts should
     // reduce to a single ramp or broadcast.
     std::mt19937 rng(0);


### PR DESCRIPTION
Dividing a vector by a broadcast only folds when the two are vectorized the same way, which they aren't when the numerator is a nested vector. Add rules for the two shapes that come up: a broadcast numerator, where the division can be pushed inwards until the two line up, and a ramp whose lanes are each repeated by an inner broadcast, where repeating a lane doesn't change the set of values so the existing first-and-last-lane argument still applies.

While here, replace the can_prove predicate on the rule being generalized with a structural one. Matching the base as a multiple of the denominator is enough to know the quotient is uniform, given the ramp doesn't span far enough to reach the next multiple. The structural form also generalizes it: the stride may be any non-negative constant, the base's multiplier need only be a multiple of the denominator rather than equal to it, and the base may be affine rather than linear.
