### PR TITLE
Rename register GPU allocations that collide with a block allocation

### DIFF
--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -242,44 +242,6 @@ bool allocation_goes_to_registers(const Allocate *op, bool in_threads) {
 // Rename an allocation and all of its loads, stores, and frees. Relies on the
 // invariant that no allocation of the same name is nested inside this one, so
 // every reference in the body belongs to it.
-class RenameAllocation : public IRMutator {
-    const string &from, &to;
-
-    using IRMutator::visit;
-
-    Expr visit(const Load *op) override {
-        if (op->name == from) {
-            return Load::make(op->type, to, mutate(op->index), op->image, op->param,
-                              mutate(op->predicate), op->alignment, op->is_streaming);
-        }
-        return IRMutator::visit(op);
-    }
-
-    Stmt visit(const Store *op) override {
-        if (op->name == from) {
-            return Store::make(to, mutate(op->value), mutate(op->index), op->param,
-                               mutate(op->predicate), op->alignment, op->is_streaming);
-        }
-        return IRMutator::visit(op);
-    }
-
-    Stmt visit(const Free *op) override {
-        if (op->name == from) {
-            return Free::make(to);
-        }
-        return op;
-    }
-
-public:
-    RenameAllocation(const string &from, const string &to)
-        : from(from), to(to) {
-    }
-
-    Stmt operator()(const Stmt &s) {
-        return mutate(s);
-    }
-};
-
 class ExtractSharedAndHeapAllocations : public IRMutator {
 protected:
     using IRMutator::visit;
@@ -1216,7 +1178,30 @@ protected:
         Stmt body = op->body;
         if (block_alloc_names.count(op->name)) {
             name = unique_name(op->name);
-            body = RenameAllocation(op->name, name)(body);
+            const string &from = op->name;
+            const string &to = name;
+            body = mutate_with(
+                body,
+                [&](auto *self, const Load *load) -> Expr {
+                    if (load->name == from) {
+                        return Load::make(load->type, to, self->mutate(load->index), load->image, load->param,
+                                          self->mutate(load->predicate), load->alignment, load->is_streaming);
+                    }
+                    return self->visit_base(load);
+                },
+                [&](auto *self, const Store *store) -> Stmt {
+                    if (store->name == from) {
+                        return Store::make(to, self->mutate(store->value), self->mutate(store->index), store->param,
+                                           self->mutate(store->predicate), store->alignment, store->is_streaming);
+                    }
+                    return self->visit_base(store);
+                },
+                [&](auto *, const Free *free) -> Stmt {
+                    if (free->name == from) {
+                        return Free::make(to);
+                    }
+                    return free;
+                });
         }
 
         RegisterAllocation alloc;

--- a/src/FuseGPUThreadLoops.cpp
+++ b/src/FuseGPUThreadLoops.cpp
@@ -225,6 +225,61 @@ public:
     }
 };
 
+// An allocation inside the thread loops stays in register/local memory
+// (handled by ExtractRegisterAllocations) rather than being pulled out to the
+// block level (handled by ExtractSharedAndHeapAllocations) if it has a fixed
+// size or an explicit register/stack memory type.
+bool allocation_goes_to_registers(const Allocate *op, bool in_threads) {
+    bool fixed_size_thread_allocation = (op->constant_allocation_size() != 0) && in_threads;
+    return (fixed_size_thread_allocation &&
+            op->memory_type != MemoryType::Heap &&
+            op->memory_type != MemoryType::GPUShared &&
+            op->memory_type != MemoryType::GPUTexture) ||
+           op->memory_type == MemoryType::Register ||
+           op->memory_type == MemoryType::Stack;
+}
+
+// Rename an allocation and all of its loads, stores, and frees. Relies on the
+// invariant that no allocation of the same name is nested inside this one, so
+// every reference in the body belongs to it.
+class RenameAllocation : public IRMutator {
+    const string &from, &to;
+
+    using IRMutator::visit;
+
+    Expr visit(const Load *op) override {
+        if (op->name == from) {
+            return Load::make(op->type, to, mutate(op->index), op->image, op->param,
+                              mutate(op->predicate), op->alignment, op->is_streaming);
+        }
+        return IRMutator::visit(op);
+    }
+
+    Stmt visit(const Store *op) override {
+        if (op->name == from) {
+            return Store::make(to, mutate(op->value), mutate(op->index), op->param,
+                               mutate(op->predicate), op->alignment, op->is_streaming);
+        }
+        return IRMutator::visit(op);
+    }
+
+    Stmt visit(const Free *op) override {
+        if (op->name == from) {
+            return Free::make(to);
+        }
+        return op;
+    }
+
+public:
+    RenameAllocation(const string &from, const string &to)
+        : from(from), to(to) {
+    }
+
+    Stmt operator()(const Stmt &s) {
+        return mutate(s);
+    }
+};
+
 class ExtractSharedAndHeapAllocations : public IRMutator {
 protected:
     using IRMutator::visit;
@@ -457,14 +512,7 @@ protected:
             << "Allocate node inside GPU kernel has custom new expression.\n"
             << "(Memoization is not supported inside GPU kernels at present.)\n";
 
-        bool fixed_size_thread_allocation = (op->constant_allocation_size() != 0) && in_threads;
-
-        if ((fixed_size_thread_allocation &&
-             op->memory_type != MemoryType::Heap &&
-             op->memory_type != MemoryType::GPUShared &&
-             op->memory_type != MemoryType::GPUTexture) ||
-            op->memory_type == MemoryType::Register ||
-            op->memory_type == MemoryType::Stack) {
+        if (allocation_goes_to_registers(op, in_threads)) {
             // These allocations go in register or local memory
             return IRMutator::visit(op);
         }
@@ -1060,6 +1108,15 @@ public:
         return result;
     }
 
+    // Returns the names of every allocation pulled out to the block level.
+    std::set<string> allocation_names() const {
+        std::set<string> names;
+        for (const SharedAllocation &a : allocations) {
+            names.insert(a.name);
+        }
+        return names;
+    }
+
     ExtractSharedAndHeapAllocations(DeviceAPI d)
         : device_api(d),
           thread_id_var_name(unique_name('t')),
@@ -1083,6 +1140,10 @@ protected:
     };
 
     bool in_lane_loop = false;
+
+    // Names of allocations pulled out to the block level, so we can rename any
+    // register allocation that would otherwise collide with one.
+    const std::set<string> block_alloc_names;
 
     Stmt visit(const For *op) override {
         ScopedValue<string> old_loop_var(loop_var);
@@ -1146,8 +1207,20 @@ protected:
             << "it must live in stack memory, heap memory, or registers. "
             << "Shared allocations at this loop level are not yet supported.\n";
 
+        // If this name also lives at the block level, rename this register copy
+        // so it doesn't shadow the block allocation once it gets hoisted to wrap
+        // the thread body. The block copy keeps the Func's name for the
+        // profiler. By the no-shadowing invariant, every load/store of this name
+        // in the body belongs to this allocation.
+        string name = op->name;
+        Stmt body = op->body;
+        if (block_alloc_names.count(op->name)) {
+            name = unique_name(op->name);
+            body = RenameAllocation(op->name, name)(body);
+        }
+
         RegisterAllocation alloc;
-        alloc.name = op->name;
+        alloc.name = name;
         alloc.type = op->type;
         alloc.size = 1;
         alloc.loop_var = loop_var;
@@ -1158,7 +1231,7 @@ protected:
         alloc.memory_type = op->memory_type;
 
         allocations.push_back(alloc);
-        return mutate(op->body);
+        return mutate(body);
     }
 
     template<typename LetOrLetStmt>
@@ -1191,6 +1264,10 @@ protected:
 
 public:
     vector<RegisterAllocation> allocations;
+
+    ExtractRegisterAllocations(std::set<string> block_alloc_names)
+        : block_alloc_names(std::move(block_alloc_names)) {
+    }
 
     // Multiple realizations of the same Func inside the thread loops (e.g. from
     // unrolling a loop that holds a register allocation) share a name with
@@ -1415,7 +1492,7 @@ protected:
                      << body << "\n\n";
 
             Expr block_size_x = block_size.threads_dimensions() ? block_size.num_threads(0) : 1;
-            ExtractRegisterAllocations register_allocs;
+            ExtractRegisterAllocations register_allocs(block_allocations.allocation_names());
             ForType innermost_loop_type = ForType::GPUThread;
             if (block_size.threads_dimensions()) {
                 body = register_allocs(body);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -140,6 +140,7 @@ tests(
     gpu_cpu_simultaneous_read.cpp
     gpu_data_flows.cpp
     gpu_different_blocks_threads_dimensions.cpp
+    gpu_dynamic_and_register_realization.cpp
     gpu_dynamic_shared.cpp
     gpu_f16_intrinsics.cpp
     gpu_free_sync.cpp

--- a/test/correctness/gpu_dynamic_and_register_realization.cpp
+++ b/test/correctness/gpu_dynamic_and_register_realization.cpp
@@ -1,0 +1,80 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+
+// With no explicit schedule for the intermediate Funcs, a Func can be realized
+// more than once inside a single GPU kernel. Here h_blur is realized twice: once
+// as a fixed-size scalar (v_blur's pure definition, which lives in a register)
+// and once as a dynamically-sized sliding window over a radius Param (v_blur's
+// update, which must live in a block-level heap allocation). Both realizations
+// share the Func's name. fuse_gpu_thread_loops hoists the register allocation to
+// wrap the whole thread body, where it would shadow the same-named block
+// allocation, so the register copy must be renamed apart. The gpu_tile tail uses
+// GuardWithIf, producing several boundary-condition branches that each realize
+// both copies.
+int main(int argc, char **argv) {
+    Target t = get_jit_target_from_environment();
+    if (!t.has_feature(Target::CUDA)) {
+        printf("[SKIP] CUDA not enabled\n");
+        return 0;
+    }
+
+    Var x("x"), y("y");
+
+    Func input("input");
+    input(x, y) = cast<int16_t>((x * 7 + y * 13) % 100);
+
+    Param<int> radius("radius");
+    radius.set(3);
+
+    Func h_blur("h_blur"), v_blur("v_blur"), result("result");
+
+    RDom rh(1, radius, "rh");
+    h_blur(x, y) = cast<int32_t>(input(x, y));
+    h_blur(x, y) += cast<int32_t>(input(x - rh.x, y)) + cast<int32_t>(input(x + rh.x, y));
+
+    RDom rv(1, radius, "rv");
+    v_blur(x, y) = h_blur(x, y);
+    v_blur(x, y) += h_blur(x, y - rv.x) + h_blur(x, y + rv.x);
+
+    result(x, y) = cast<int16_t>(v_blur(x, y) >> 4);
+
+    Var xi, yi;
+    result.gpu_tile(x, y, xi, yi, 16, 16, TailStrategy::GuardWithIf);
+
+    constexpr int radius_val = 3, w = 33, h = 33;
+    Buffer<int16_t> actual = result.realize({w, h}, t);
+    actual.copy_to_host();
+
+    auto in = [](int x, int y) -> int32_t {
+        // Halide's % is Euclidean (always non-negative for a positive
+        // divisor); replicate that here since x, y can be negative.
+        int32_t v = (x * 7 + y * 13) % 100;
+        if (v < 0) v += 100;
+        return (int16_t)v;
+    };
+    auto h_blur_ref = [&](int x, int y) -> int32_t {
+        int32_t v = in(x, y);
+        for (int i = 1; i <= radius_val; i++) {
+            v += in(x - i, y) + in(x + i, y);
+        }
+        return v;
+    };
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            int32_t v_blur_ref = h_blur_ref(x, y);
+            for (int i = 1; i <= radius_val; i++) {
+                v_blur_ref += h_blur_ref(x, y - i) + h_blur_ref(x, y + i);
+            }
+            int16_t expected = (int16_t)(v_blur_ref >> 4);
+            if (actual(x, y) != expected) {
+                printf("Mismatch at (%d, %d): expected %d, got %d\n", x, y, expected, actual(x, y));
+                return 1;
+            }
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/gpu_dynamic_and_register_realization.cpp
+++ b/test/correctness/gpu_dynamic_and_register_realization.cpp
@@ -15,8 +15,8 @@ using namespace Halide;
 // both copies.
 int main(int argc, char **argv) {
     Target t = get_jit_target_from_environment();
-    if (!t.has_feature(Target::CUDA)) {
-        printf("[SKIP] CUDA not enabled\n");
+    if (!t.has_gpu_feature()) {
+        printf("[SKIP] No GPU target enabled.\n");
         return 0;
     }
 


### PR DESCRIPTION
When a Func is realized more than once inside a GPU kernel with no explicit schedule, one realization can be pulled to the block level (a heap allocation, for a dynamically-sized sliding window) while another stays in registers (a fixed-size scalar). Both share the Func's name. fuse_gpu_thread_loops hoists register allocations to wrap the whole thread body, where the register copy shadows the same-named block allocation and corrupts its accesses, producing wrong results.

Give the register copy a fresh name when its name also lives at the block level, so the block copy keeps the Func's name (needed for profiler attribution) and is no longer shadowed. This relies on the existing invariant that no same-name allocation is nested inside another at this stage of lowering, so every load/store in the register allocation's body belongs to it.

Add a regression test.
