### PR TITLE
Document and test HL_DEBUG_CODEGEN filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,13 @@ $ make -f ../Halide/Makefile
 `HL_JIT_TARGET=...` will set Halide's JIT compilation target.
 
 `HL_DEBUG_CODEGEN=1` will print out pseudocode for what Halide is compiling.
-Higher numbers will print more detail.
+Higher numbers will print more detail. The output can be filtered by source
+location using the grammar `verbosity[,filename[:line_low[-line_high]]][@func]`,
+with rules separated by `;` and OR-ed together (filenames and function names are
+matched as suffixes). For example, `HL_DEBUG_CODEGEN=3,Simplify.cpp:100-180`
+prints verbosity-3 output only from lines 100–180 of `Simplify.cpp`. See
+[doc/Testing.md](doc/Testing.md) for more, including the LLDB/GDB debugger
+helpers.
 
 `HL_NUM_THREADS=...` specifies the number of threads to create for the thread
 pool. When the async scheduling directive is used, more threads than this number

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -120,14 +120,71 @@ std::vector<DebugRule> parse_rules(const std::string &env) {
     return rules;
 }
 
+bool rules_accept(const std::vector<DebugRule> &rules, const int verbosity,
+                  const char *file, const char *function, const int line) {
+    return std::any_of(rules.begin(), rules.end(), [&](const auto &rule) {
+        return rule.accepts(verbosity, file, function, line);
+    });
+}
+
 }  // namespace
 
 bool debug_is_active_impl(const int verbosity, const char *file, const char *function,
                           const int line) {
     static const std::vector<DebugRule> rules = parse_rules(get_env_variable("HL_DEBUG_CODEGEN"));
-    return std::any_of(rules.begin(), rules.end(), [&](const auto &rule) {
-        return rule.accepts(verbosity, file, function, line);
-    });
+    return rules_accept(rules, verbosity, file, function, line);
+}
+
+bool debug_spec_accepts(const std::string &spec, const int verbosity,
+                        const char *file, const char *function, const int line) {
+    return rules_accept(parse_rules(spec), verbosity, file, function, line);
+}
+
+void debug_filter_test() {
+    // A bare verbosity matches purely on level, at any location.
+    internal_assert(debug_spec_accepts("2", 0, "any.cpp", "any", 1));
+    internal_assert(debug_spec_accepts("2", 2, "any.cpp", "any", 1));
+    internal_assert(!debug_spec_accepts("2", 3, "any.cpp", "any", 1));
+
+    // Filenames are matched as suffixes, subject to the verbosity bound.
+    internal_assert(debug_spec_accepts("4,CodeGen_LLVM.cpp", 4, "src/CodeGen_LLVM.cpp", "f", 10));
+    internal_assert(!debug_spec_accepts("4,CodeGen_LLVM.cpp", 4, "src/Simplify.cpp", "f", 10));
+    internal_assert(!debug_spec_accepts("4,CodeGen_LLVM.cpp", 5, "src/CodeGen_LLVM.cpp", "f", 10));
+
+    // Line ranges are inclusive on both ends.
+    internal_assert(debug_spec_accepts("3,Simplify.cpp:100-180", 3, "src/Simplify.cpp", "f", 100));
+    internal_assert(debug_spec_accepts("3,Simplify.cpp:100-180", 3, "src/Simplify.cpp", "f", 180));
+    internal_assert(!debug_spec_accepts("3,Simplify.cpp:100-180", 3, "src/Simplify.cpp", "f", 99));
+    internal_assert(!debug_spec_accepts("3,Simplify.cpp:100-180", 3, "src/Simplify.cpp", "f", 181));
+
+    // A single line means low == high.
+    internal_assert(debug_spec_accepts("3,Simplify.cpp:100", 3, "src/Simplify.cpp", "f", 100));
+    internal_assert(!debug_spec_accepts("3,Simplify.cpp:100", 3, "src/Simplify.cpp", "f", 101));
+
+    // Functions are also matched as suffixes.
+    internal_assert(debug_spec_accepts("2@visit", 2, "any.cpp", "visit", 1));
+    internal_assert(debug_spec_accepts("2@visit", 2, "any.cpp", "IRVisitor::visit", 1));
+    internal_assert(!debug_spec_accepts("2@visit", 2, "any.cpp", "mutate", 1));
+
+    // File, line, and function qualifiers combine (all must hold).
+    internal_assert(debug_spec_accepts("3,Simplify.cpp:100-180@visit", 3, "Simplify.cpp", "visit", 150));
+    internal_assert(!debug_spec_accepts("3,Simplify.cpp:100-180@visit", 3, "Simplify.cpp", "mutate", 150));
+
+    // Rules separated by ';' are OR-ed together.
+    internal_assert(debug_spec_accepts("1;4,CodeGen_LLVM.cpp@compile", 1, "whatever.cpp", "g", 5));
+    internal_assert(debug_spec_accepts("1;4,CodeGen_LLVM.cpp@compile", 4, "CodeGen_LLVM.cpp", "compile", 5));
+    internal_assert(!debug_spec_accepts("1;4,CodeGen_LLVM.cpp@compile", 4, "CodeGen_LLVM.cpp", "other", 5));
+
+    // An empty spec behaves like verbosity 0: only debug(0) prints.
+    internal_assert(debug_spec_accepts("", 0, "any.cpp", "f", 1));
+    internal_assert(!debug_spec_accepts("", 1, "any.cpp", "f", 1));
+
+    // A malformed rule is skipped (and warns on stderr); with no valid rules,
+    // nothing matches. A valid rule alongside it still takes effect.
+    internal_assert(!debug_spec_accepts("garbage", 0, "any.cpp", "f", 1));
+    internal_assert(debug_spec_accepts("2;garbage", 2, "any.cpp", "f", 1));
+
+    debug(0) << "debug_filter_test passed\n";
 }
 
 }  // namespace Halide::Internal

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -35,6 +35,23 @@ std::ostream &operator<<(std::ostream &, const LoweredFunc &);
 bool debug_is_active_impl(int verbosity, const char *file, const char *function, int line);
 #define debug_is_active(n) (::Halide::Internal::debug_is_active_impl((n), __FILE__, __FUNCTION__, __LINE__))
 
+/** Decide whether a debug() call at the given verbosity/location would print
+ * under the rules in `spec`, which uses the same grammar as the
+ * HL_DEBUG_CODEGEN environment variable:
+ *
+ *     verbosity[,filename[:line_low[-line_high]]][@func]
+ *
+ * Rules are separated by ';' and OR-ed together; a call prints if any rule
+ * accepts it. `filename` and `func` are matched as suffixes. Malformed rules
+ * are ignored. This is the pure core behind debug_is_active_impl(), exposed so
+ * the parser/matcher can be unit tested without touching the process
+ * environment. */
+bool debug_spec_accepts(const std::string &spec, int verbosity,
+                        const char *file, const char *function, int line);
+
+/** Test the HL_DEBUG_CODEGEN rule parser/matcher (see debug_spec_accepts). */
+void debug_filter_test();
+
 /** For optional debugging during codegen, use the debug macro as
  * follows:
  *

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -4,6 +4,7 @@
 #include "CPlusPlusMangle.h"
 #include "CSE.h"
 #include "CodeGen_C.h"
+#include "Debug.h"
 #include "Deinterleave.h"
 #include "Func.h"
 #include "Generator.h"
@@ -25,6 +26,7 @@ using namespace Halide::Internal;
 int main(int argc, const char **argv) {
     IRPrinter::test();
     CodeGen_C::test();
+    debug_filter_test();
     ir_equality_test();
     bounds_test();
     expr_match_test();


### PR DESCRIPTION
Expose `debug_spec_accepts()` for the rule parser/matcher, add a unit test
in the internal suite, and document the filter grammar in the README.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)