### PR TITLE
Make Codecov project/patch checks informational only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    # This build's coverage run doesn't collect enough data (subset of
+    # targets/tests, no autoschedulers_cpu, etc.) to be a trustworthy signal
+    # for blocking a PR on a coverage percentage. Keep these checks
+    # informational so coverage is still visible for manual inspection, but
+    # only the "successfully collected data" status (i.e. whether Codecov
+    # actually received and processed the report; see fail_ci_if_error in
+    # testing-macos.yml) can fail CI.
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- Our coverage CI run doesn't exercise enough of the test matrix (subset of targets/tests, no `autoschedulers_cpu`, etc.) to be a trustworthy signal for blocking a PR on coverage percentage.
- Adds `codecov.yml` marking the `project` and `patch` status checks `informational`, so coverage stays visible on PRs for manual inspection but can never fail the check.
- CI still fails if data collection itself fails, via the existing `fail_ci_if_error: true` on the Codecov upload step in `testing-macos.yml`.

## Test plan
- [ ] Confirm the `codecov/project` and `codecov/patch` checks report as informational (non-blocking) on this PR