### PR TITLE
Fix unique_name() returning duplicate names

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -217,6 +217,9 @@ string unique_name(const std::string &prefix) {
         if (sanitized[i] == '$') {
             num_dollars++;
             sanitized[i] = '_';
+            // The '$' itself isn't part of the numeric suffix that must
+            // follow it, so don't let it trip the checks below.
+            continue;
         }
         if (i > 0 && !isdigit(sanitized[i])) {
             // Found a non-digit after the first char

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -352,6 +352,7 @@ tests(
     undef.cpp
     uninitialized_read.cpp
     unique_func_image.cpp
+    unique_name.cpp
     unroll_dynamic_loop.cpp
     unroll_huge_mux.cpp
     unroll_loop_with_implied_constant_bounds.cpp

--- a/test/correctness/unique_name.cpp
+++ b/test/correctness/unique_name.cpp
@@ -1,0 +1,23 @@
+#include "Halide.h"
+
+#include <cstdio>
+
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    // unique_name() must never return a string it has already returned
+    std::string name = unique_name("foo");    // "foo"
+    std::string first = unique_name(name);    // "foo$1"
+    std::string second = unique_name(first);  // "foo_1$0"
+
+    if (name == first || first == second || name == second) {
+        std::cout << "unique_name() produced a collision: "
+                  << '"' << name << "\", "
+                  << '"' << first << "\", "
+                  << '"' << second << "\"\n";
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
When the input to `unique_name()` matched `prefix$number`, the sanitization loop replaced the `$` with `_` and then immediately checked `isdigit()` on the `_`. This was treated as "a non-digit found after `$`", which then set `matches_string_pattern` to false and incorrectly returned the name unchanged.

## Breaking changes

None

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Commits include AI attribution where applicable (see Code of Conduct)
