### PR TITLE
Fix lossless_negate() for unsigned expressions

### DIFF
--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -578,6 +578,15 @@ Expr lossless_cast(Type t,
 }
 
 Expr lossless_negate(const Expr &x) {
+    if (x.type().is_uint()) {
+        // An unsigned type can only exactly represent the negation of zero:
+        // any other value would have to be negative, which doesn't fit. In
+        // particular, this rules out e.g. treating cast(uint8, -v) as if it
+        // were -cast(uint8, v) when v doesn't fit in a uint8 to begin with
+        // (the two differ by 256, not just in sign).
+        return is_const_zero(x) ? x : Expr();
+    }
+
     if (const Mul *m = x.as<Mul>()) {
         // Check the terms can't multiply to produce the most negative value.
         if (x.type().is_int() &&


### PR DESCRIPTION
## Summary

`lossless_negate()` had no guard for unsigned-typed expressions. Its `Cast`
branch would treat `cast(uint8, -v)` as interchangeable with
`-cast(uint8, v)` whenever the *negated* inner value fit in the outer type,
without checking that the *original* (non-negated) cast was itself lossless.
When `v` doesn't fit `uint8` (e.g. `v = -67`, which wraps to `189`),
`cast(uint8, -v)` (`= 67`) is **not** equal to `-cast(uint8, v)` (`= -189`) —
they differ by 256, not just in sign, since zero-extension of a nonzero
unsigned value can never produce a negative wide value.

This fed a bogus operand into `FindIntrinsics`' `Sub` -> `widening_add`
rewrite, baking a mathematically wrong wide add into the lowered `Stmt`.
For the reported repro, the scalar `realize()` produced the correct value
while the vectorized `realize()` was off by exactly 256 — a wrong-code bug
in vectorized codegen, not a `constant_integer_bounds` bug (that was just the
check that happened to catch it).

Fix: a single guard at the top of `lossless_negate()` — an unsigned type can
only exactly represent the negation of zero, so bail out unless the value is
provably zero. This subsumes fixing both the `Mul` branch (which had no
unsigned handling at all) and the `Cast` branch (which was unsound for
narrowing casts to unsigned types) without touching the signed/float logic.

Fixes #9278

## Test plan

- [x] Reproduced the exact seed from the issue (`13483149009523507644`) against
      unmodified `main`, matching the reported expression/bounds/output
      byte-for-byte; confirmed it passes cleanly after the fix.
- [x] Ran 2000 additional random iterations of `fuzz_lossless_cast` — clean.
- [x] Ran `correctness_simplify`, `correctness_lossless_cast`,
      `correctness_widening_reduction`, `correctness_intrinsics`,
      `correctness_mul_div_mod`, `correctness_vector_math`, `correctness_cast`,
      `correctness_saturating_casts`, `correctness_bounds_of_multiply`,
      `correctness_bounds_of_cast`, `correctness_div_round_to_zero`,
      `correctness_vector_cast`, `correctness_vectorize_mixed_widths`,
      `correctness_tiled_matmul`, `correctness_bounds_of_pure_intrinsics` — all
      pass.