### PR TITLE
Publish nightly builds to halide/pypi instead of pypi.halide-lang.org

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -162,6 +162,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    env:
+      GH_TOKEN: ${{ secrets.PYPI_RELEASES_TOKEN }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -169,12 +171,38 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish nightly build to halide/pypi
         if: github.event_name == 'push' && github.ref_name == 'main'
-        with:
-          user: upload
-          password: ${{ secrets.HALIDE_PYPI_PASSWORD }}
-          repository-url: https://pypi.halide-lang.org/
+        run: |
+          set -euo pipefail
+
+          shopt -s nullglob
+          files=(dist/halide-*.whl)
+          shopt -u nullglob
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "no wheels found in dist/, nothing to publish"
+            exit 1
+          fi
+
+          # Wheel filenames are "{name}-{version}-{python tag}-{abi
+          # tag}-{platform tag}.whl"; any hyphens in name/version are
+          # normalized to underscores specifically so "-" is an unambiguous
+          # field separator, so plain splitting is safe here.
+          filename=$(basename "${files[0]}")
+          version="${filename#halide-}"
+          version="${version%%-*}"
+          tag="halide@${version}"
+
+          if gh release view "$tag" --repo halide/pypi >/dev/null 2>&1; then
+            gh release upload "$tag" "${files[@]}" --repo halide/pypi --clobber
+          else
+            gh release create "$tag" "${files[@]}" \
+              --repo halide/pypi --title "$tag" --notes "Automated nightly build from Halide"
+          fi
+
+      - name: Trigger index rebuild
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        run: gh workflow run rebuild-index.yml --repo halide/pypi
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/testing-arm-linux.yml
+++ b/.github/workflows/testing-arm-linux.yml
@@ -84,40 +84,7 @@ jobs:
 
       - name: Sync CI environment
         run: |
-          # halide-llvm comes from pypi.halide-lang.org, whose upstream network
-          # path intermittently blackholes a source IP for tens of seconds to
-          # a few minutes (root-caused in halide/build_bot#362, escalated to
-          # MIT network ops). uv's own retries only span ~47s, which wasn't
-          # always enough, so this retries harder (5 attempts, backoff
-          # doubling 60s -> 300s) and logs the runner's egress IP plus a path
-          # trace to the PyPI host on each failure, so a specific incident's
-          # 5-tuple/timestamp can be handed to MIT for correlation.
-          retry() {
-            local i n=5 delay=60 max_delay=300
-            for ((i = 1; i <= n; i++)); do
-              if "$@"; then return 0; fi
-              if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
-                echo "::group::Network diagnostics (attempt $i/$n)"
-                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
-                if command -v tracepath >/dev/null 2>&1; then
-                  tracepath -m 15 pypi.halide-lang.org || true
-                elif command -v traceroute >/dev/null 2>&1; then
-                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
-                elif command -v tracert >/dev/null 2>&1; then
-                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
-                else
-                  echo "no traceroute tool available"
-                fi
-                echo "::endgroup::"
-                sleep "$delay"
-                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
-              fi
-            done
-            return 1
-          }
-
-          retry setarch ${{ matrix.arch }} bash -ec "
+          setarch ${{ matrix.arch }} bash -ec "
             uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
             echo '${GITHUB_WORKSPACE}/.venv/bin' >> '$GITHUB_PATH'
             echo 'VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv' >> '$GITHUB_ENV'

--- a/.github/workflows/testing-linux.yml
+++ b/.github/workflows/testing-linux.yml
@@ -80,40 +80,7 @@ jobs:
 
       - name: Sync CI environment
         run: |
-          # halide-llvm comes from pypi.halide-lang.org, whose upstream network
-          # path intermittently blackholes a source IP for tens of seconds to
-          # a few minutes (root-caused in halide/build_bot#362, escalated to
-          # MIT network ops). uv's own retries only span ~47s, which wasn't
-          # always enough, so this retries harder (5 attempts, backoff
-          # doubling 60s -> 300s) and logs the runner's egress IP plus a path
-          # trace to the PyPI host on each failure, so a specific incident's
-          # 5-tuple/timestamp can be handed to MIT for correlation.
-          retry() {
-            local i n=5 delay=60 max_delay=300
-            for ((i = 1; i <= n; i++)); do
-              if "$@"; then return 0; fi
-              if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
-                echo "::group::Network diagnostics (attempt $i/$n)"
-                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
-                if command -v tracepath >/dev/null 2>&1; then
-                  tracepath -m 15 pypi.halide-lang.org || true
-                elif command -v traceroute >/dev/null 2>&1; then
-                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
-                elif command -v tracert >/dev/null 2>&1; then
-                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
-                else
-                  echo "no traceroute tool available"
-                fi
-                echo "::endgroup::"
-                sleep "$delay"
-                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
-              fi
-            done
-            return 1
-          }
-
-          retry setarch ${{ matrix.arch }} bash -ec "
+          setarch ${{ matrix.arch }} bash -ec "
             CC='gcc -m${{ matrix.bits }}' CXX='g++ -m${{ matrix.bits }}' \
             uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
             echo '${GITHUB_WORKSPACE}/.venv/bin' >> '$GITHUB_PATH'

--- a/.github/workflows/testing-macos.yml
+++ b/.github/workflows/testing-macos.yml
@@ -100,40 +100,7 @@ jobs:
 
       - name: Sync CI environment
         run: |
-          # halide-llvm comes from pypi.halide-lang.org, whose upstream network
-          # path intermittently blackholes a source IP for tens of seconds to
-          # a few minutes (root-caused in halide/build_bot#362, escalated to
-          # MIT network ops). uv's own retries only span ~47s, which wasn't
-          # always enough, so this retries harder (5 attempts, backoff
-          # doubling 60s -> 300s) and logs the runner's egress IP plus a path
-          # trace to the PyPI host on each failure, so a specific incident's
-          # 5-tuple/timestamp can be handed to MIT for correlation.
-          retry() {
-            local i n=5 delay=60 max_delay=300
-            for ((i = 1; i <= n; i++)); do
-              if "$@"; then return 0; fi
-              if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
-                echo "::group::Network diagnostics (attempt $i/$n)"
-                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
-                if command -v tracepath >/dev/null 2>&1; then
-                  tracepath -m 15 pypi.halide-lang.org || true
-                elif command -v traceroute >/dev/null 2>&1; then
-                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
-                elif command -v tracert >/dev/null 2>&1; then
-                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
-                else
-                  echo "no traceroute tool available"
-                fi
-                echo "::endgroup::"
-                sleep "$delay"
-                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
-              fi
-            done
-            return 1
-          }
-
-          retry uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
+          uv sync --python '${{ matrix.python }}' --group '${{ matrix.uv_group }}' --no-install-project
           echo "${GITHUB_WORKSPACE}/.venv/bin" >> "$GITHUB_PATH"
           echo "VIRTUAL_ENV=${GITHUB_WORKSPACE}/.venv" >> "$GITHUB_ENV"
 

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -64,44 +64,11 @@ jobs:
           # Python, so on Windows it would download x86_64 halide-llvm (~250MB) even for
           # a 32-bit build. Instead: read the pinned version from the lockfile (no download),
           # sync only ci-base (no LLVM), then fetch the correct win32 wheel directly.
-          # pypi.halide-lang.org's upstream network path intermittently
-          # blackholes a source IP for tens of seconds to a few minutes
-          # (root-caused in halide/build_bot#362, escalated to MIT network
-          # ops). uv's own retries only span ~47s, which wasn't always
-          # enough, so this retries harder (5 attempts, backoff doubling
-          # 60s -> 300s) and logs the runner's egress IP plus a path trace
-          # to the PyPI host on each failure, so a specific incident's
-          # 5-tuple/timestamp can be handed to MIT for correlation.
-          retry() {
-            local i n=5 delay=60 max_delay=300
-            for ((i = 1; i <= n; i++)); do
-              if "$@"; then return 0; fi
-              if [ "$i" -lt "$n" ]; then
-                echo "::warning::CI env sync attempt $i/$n failed at $(date -u +%FT%TZ); retrying in ${delay}s"
-                echo "::group::Network diagnostics (attempt $i/$n)"
-                echo "egress IP: $(curl -s --max-time 5 https://api.ipify.org || echo unknown)"
-                if command -v tracepath >/dev/null 2>&1; then
-                  tracepath -m 15 pypi.halide-lang.org || true
-                elif command -v traceroute >/dev/null 2>&1; then
-                  traceroute -m 15 -w 2 pypi.halide-lang.org || true
-                elif command -v tracert >/dev/null 2>&1; then
-                  tracert -h 15 -w 2000 pypi.halide-lang.org || true
-                else
-                  echo "no traceroute tool available"
-                fi
-                echo "::endgroup::"
-                sleep "$delay"
-                delay=$((delay * 2 > max_delay ? max_delay : delay * 2))
-              fi
-            done
-            return 1
-          }
-
           LLVM_VER=$(uv export --group '${{ matrix.uv_group }}' --no-emit-project \
             | awk -F'==' '/^halide-llvm==/ { gsub(/ .*/, "", $2); print $2 }')
 
           uv sync --python '${{ matrix.python }}' --group ci-base --no-install-project
-          retry uv pip install --python-platform i686-pc-windows-msvc --only-binary :all: \
+          uv pip install --python-platform i686-pc-windows-msvc --only-binary :all: \
             --extra-index-url https://pypi.halide-lang.org/simple/ \
             "halide-llvm==${LLVM_VER}"
 


### PR DESCRIPTION
## Summary
- Replaces the push-to-main nightly publish step (`pypa/gh-action-pypi-publish` targeting `pypi.halide-lang.org`) with `gh release create/upload` against `halide/pypi`, tagged `halide@<version>`, plus an explicit index-rebuild trigger. The tagged-release publish step below it (real releases -> pypi.org via OIDC trusted publishing) is untouched.
- Removes the retry/diagnostics wrappers (5 attempts, 60s->300s backoff, egress IP + traceroute logging) around `uv sync`/`uv pip install` in `testing-linux.yml`, `testing-arm-linux.yml`, `testing-macos.yml`, and `testing-windows.yml`. Those existed specifically to work around MIT's border-security IP quarantines on the old pypiserver VM; now that `pypi.halide-lang.org` serves `halide/pypi` (GitHub Releases + Pages), which CI already trusts implicitly for everything else, that failure mode no longer applies.
- Same publish pattern already proven out on `halide-llvm` (merged, halide/halide-llvm#1) and `halide-wheel-deps`.

## Why
`pypi.halide-lang.org` now serves `halide/pypi` instead of the retired MIT-hosted pypiserver, for the same reason as the `halide-llvm` migration: that VM's network path was subject to intermittent border-security IP quarantines outside anyone's control. This was deliberately held back from the earlier `halide-llvm` migration to validate the consumption side first; that's now confirmed working end-to-end (real `halide-llvm` wheels built, published, and merged), so this closes the loop for `Halide`'s own nightly builds and removes the now-dead workaround code.

## Test plan
- [x] `actionlint` passes on all five modified workflow files.
- [x] Confirmed `halide`'s wheel filenames start with `halide-<version>-...` (no normalization surprises, matches `dist/halide-*.whl` cleanly).
- [x] Confirmed the only remaining "retry" hits in `testing-linux.yml`/`testing-arm-linux.yml` are an unrelated `apt-get update` retry loop, correctly left alone.
- [ ] Publish step not yet exercised for real (nightly-only trigger) -- recommend merging and watching the next `main` push's `publish` job.