### PR TITLE
CodeGen_LLVM: fix sign extension of negative switch case constants

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -4338,7 +4338,7 @@ void CodeGen_LLVM::visit(const IfThenElse *op) {
         for (int i = 0; i < (int)blocks.size(); i++) {
             string name = "case_" + std::to_string(rhs[i]) + "_bb";
             BasicBlock *case_bb = BasicBlock::Create(*context, name, function);
-            switch_inst->addCase(ConstantInt::get(IntegerType::get(*context, 32), rhs[i]), case_bb);
+            switch_inst->addCase(ConstantInt::get(IntegerType::get(*context, 32), rhs[i], /*isSigned=*/true), case_bb);
             builder->SetInsertPoint(case_bb);
             codegen(blocks[i].second);
             builder->CreateBr(after_bb);

--- a/test/correctness/specialize.cpp
+++ b/test/correctness/specialize.cpp
@@ -300,6 +300,31 @@ int main(int argc, char **argv) {
     }
 
     {
+        // Chained equality specializations against a consistent expr and
+        // distinct constants, including a negative one, compile down to a
+        // single switch statement in CodeGen_LLVM. The negative case value
+        // must be sign-extended correctly when building the LLVM constant.
+        Var x;
+        Param<int> p;
+
+        Func f;
+        f(x) = 0;
+        f.specialize(p == 1).vectorize(x, 4);
+        f.specialize(p == -1).unroll(x, 4);
+
+        for (int val : {-1, 0, 1, 2}) {
+            p.set(val);
+            Buffer<int> out = f.realize({16});
+            for (int i = 0; i < out.width(); i++) {
+                if (out(i) != 0) {
+                    printf("out(%d) = %d instead of 0 (p = %d)\n", i, out(i), val);
+                    return 1;
+                }
+            }
+        }
+    }
+
+    {
         // Bounds required of the input change depending on the param
         ImageParam im(Int(32), 1);
         Param<bool> param;


### PR DESCRIPTION
## Summary
- \`CodeGen_LLVM::visit(const IfThenElse *)\` lowers chains of \`expr == constant\` conditions into a single LLVM \`switch\`. Building each case's \`ConstantInt\` always treated the case value as unsigned, so a negative constant (e.g. \`-1\`) got implicitly converted to a 64-bit value with the upper bits sign-extended -- not a valid 32-bit unsigned value. Passes \`isSigned=true\` so negative case constants round-trip correctly.
- Found while investigating CI failures on a downstream stack: \`apps/HelloAndroidCamera2\`'s \`edge_detect\` generator ends with \`result.specialize(input.dim(0).stride() == 1); result.specialize(input.dim(0).stride() == -1);\`, which hits exactly this switch-lowering path with a \`-1\` case. Under LLVM builds with assertions enabled (e.g. this repo's \`ci-llvm-main\`), constructing the malformed \`APInt\` aborts; under release LLVM builds the malformed constant is built silently, so this is a real (if rare) miscompilation risk on any target, not just an assertion nuisance.

## Test plan
- [x] Added a regression test in \`test/correctness/specialize.cpp\` that chains equality specializations against \`1\` and \`-1\` on the same param and checks output correctness for several values of the param.
- [x] Verified the new test crashes on `main` (pre-fix) when built against an assertions-enabled LLVM, and passes with the fix.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>