### PR TITLE
Fix Python int/double operator overload order for pybind11 3.1+

### DIFF
--- a/python_bindings/src/halide/halide_/PyBinaryOperators.h
+++ b/python_bindings/src/halide/halide_/PyBinaryOperators.h
@@ -209,14 +209,18 @@ template<typename PythonClass>
 void add_binary_operators(PythonClass &class_instance) {
     using self_t = typename PythonClass::type;
 
-    // The order of definitions matters.
-    // Python first will try input value as int, then double, then self_t
-    // (note that we skip 'float' because we should never encounter that in python;
-    // all floating-point literals should be double)
+    // The order of definitions matters: pybind11 tries overloads in
+    // registration order, and (as of pybind11 3.1) a Python int is an
+    // acceptable non-converting match for a C++ double parameter (per PEP
+    // 484 numeric tower rules), not just for int. So int must be registered
+    // before double, or a plain Python int (e.g. from a GeneratorParam<int>)
+    // silently binds to the double overload and produces a float Expr.
+    // (We skip 'float' because we should never encounter that in python;
+    // all floating-point literals should be double.)
     add_binary_operators_with<self_t>(class_instance);
     add_binary_operators_with<Expr>(class_instance);
-    add_binary_operators_with<double>(class_instance);
     add_binary_operators_with<int>(class_instance);
+    add_binary_operators_with<double>(class_instance);
 
     // Halide::pow() has only an Expr, Expr variant
     class_instance


### PR DESCRIPTION
## Summary

- The wheel-test step of `Build PyPI package` CI started failing on all platforms with `Implicit cast from float32 to int in argument 1 in call to "repeat_edge"` in `bilateral_grid_generator.py`.
- Root cause: pybind11 3.1.0 (released 2026-08-06) changed strict-mode numeric conversions per PEP 484 so that a Python `int` is now an acceptable *non-converting* match for a C++ `double` parameter, not just `int`. `add_binary_operators()` in `PyBinaryOperators.h` registered the `double` overload before the `int` overload, so under pybind11 3.1+ a plain Python `int` (e.g. `GeneratorParam<int>`) now silently binds to the `double` overload, producing a float `Expr` instead of an int one. In `bilateral_grid_generator.py`, `x * g.s_sigma` became `float32` and was then correctly rejected when used as an integer index into `repeat_edge()`.
- Only the wheel-build job was affected: its `cibuildwheel`-driven build resolves `pyproject.toml`'s `build-system.requires` (`pybind11>=2.11.1`, no upper bound) fresh via pip, bypassing `uv.lock`, which pins the rest of CI to a known-good `pybind11==3.0.1`.
- Fix: register `int` before `double` in `add_binary_operators()`, matching the existing "int before double/float" ordering precedent already used for `Expr`'s own constructor/implicit-conversion registration in `PyExpr.cpp`. This makes the exact-`int` match win pybind11's first (no-conversion) resolution pass regardless of pybind11 version, rather than just pinning around the behavior change.

## Test plan

- [x] Rebuilt the Python bindings locally against pybind11 3.0.4, 3.1.0, and 2.13.6 (Python 3.10).
- [x] Confirmed the bug reproduces exactly with the unmodified source under pybind11 3.1.0 (`x * g.s_sigma` → `float32`), and that both `bilateral_grid` and `bilateral_grid_Adams2019` generators fail identically to the CI log.
- [x] Confirmed the fix resolves it under pybind11 3.1.0 (`x * g.s_sigma` → `int32`) and both generators build cleanly.
- [x] Confirmed no regression under pybind11 3.0.4 (the version actually pinned in `uv.lock`), including the pre-existing `hl.i32(0) + (0x7FFFFFFF + 1)` → `Int(64)` overflow-promotion behavior.
- [x] Ran the full `python_bindings/test/correctness` suite under pybind11 3.1.0 with the fix; no new failures (remaining failures are pre-existing environmental gaps in my ad-hoc local setup, plus one latent pybind11-3.1-only int64-promotion edge case that is untouched by this fix and not exercised by any real CI job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
