### PR TITLE
Fix int64 overflow promotion under pybind11 3.1+, bump pybind11 pin

### DIFF
--- a/python_bindings/src/halide/halide_/PyBinaryOperators.h
+++ b/python_bindings/src/halide/halide_/PyBinaryOperators.h
@@ -105,14 +105,32 @@ struct DoubleToExprCheck {
     }
 };
 
+// Wrapping int64_t values in an Expr before applying the operator (rather
+// than calling e.g. self_t::operator+(int64_t) directly) sidesteps a C++
+// overload-resolution ambiguity: Halide's operators are only overloaded for
+// (Expr, int) and (Expr, float), so a bare int64_t argument is ambiguous
+// between the two. Every self_t already supports the (self_t, Expr) form.
+struct Int64ToExprCheck {
+    const Expr e;
+    explicit Int64ToExprCheck(int64_t v)
+        : e(Expr(v)) {
+    }
+    operator Expr() const {
+        return e;
+    }
+};
+
 template<typename other_t, typename PythonClass>
 void add_binary_operators_with(PythonClass &class_instance) {
     using self_t = typename PythonClass::type;
-    // If 'other_t' is double, we want to wrap it as an Expr() prior to calling the binary op
-    // (so that double literals that lose precision when converted to float issue warnings).
-    // For any other type, we just want to leave it as-is.
+    // If 'other_t' is double or int64_t, we want to wrap it as an Expr()
+    // prior to calling the binary op (so that double literals that lose
+    // precision when converted to float issue warnings, and so that
+    // int64_t doesn't hit ambiguous overload resolution). For any other
+    // type, we just want to leave it as-is.
     using Promote = std::conditional_t<
-        std::is_same_v<other_t, double>, DoubleToExprCheck, other_t>;
+        std::is_same_v<other_t, double>, DoubleToExprCheck,
+        std::conditional_t<std::is_same_v<other_t, int64_t>, Int64ToExprCheck, other_t>>;
 
 #define BINARY_OP(op, method)                                   \
     do {                                                        \
@@ -212,14 +230,17 @@ void add_binary_operators(PythonClass &class_instance) {
     // The order of definitions matters: pybind11 tries overloads in
     // registration order, and (as of pybind11 3.1) a Python int is an
     // acceptable non-converting match for a C++ double parameter (per PEP
-    // 484 numeric tower rules), not just for int. So int must be registered
-    // before double, or a plain Python int (e.g. from a GeneratorParam<int>)
-    // silently binds to the double overload and produces a float Expr.
+    // 484 numeric tower rules), not just for int/int64_t. So int and
+    // int64_t must both be registered before double, or a plain Python int
+    // (e.g. from a GeneratorParam<int>, or one too large to fit in an
+    // int32) silently binds to the double overload and produces a float
+    // Expr instead of an Int(32) or Int(64) one.
     // (We skip 'float' because we should never encounter that in python;
     // all floating-point literals should be double.)
     add_binary_operators_with<self_t>(class_instance);
     add_binary_operators_with<Expr>(class_instance);
     add_binary_operators_with<int>(class_instance);
+    add_binary_operators_with<int64_t>(class_instance);
     add_binary_operators_with<double>(class_instance);
 
     // Halide::pow() has only an Expr, Expr variant

--- a/uv.lock
+++ b/uv.lock
@@ -929,11 +929,11 @@ wheels = [
 
 [[package]]
 name = "pybind11"
-version = "3.0.1"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/7b/a6d8dcb83c457e24a9df1e4d8fd5fb8034d4bbc62f3c324681e8a9ba57c2/pybind11-3.0.1.tar.gz", hash = "sha256:9c0f40056a016da59bab516efb523089139fcc6f2ba7e4930854c61efb932051", size = 546914, upload-time = "2025-08-22T20:09:27.265Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/f3/95b0f40b31df41dbfe6bb0857419c9442c15839cbac4796f1c26ae0b6081/pybind11-3.1.0.tar.gz", hash = "sha256:a1cc06b524ab3edca51f8ad3895f9c4fa20b8b19283173dff4ae781449dc9639", size = 603746, upload-time = "2026-08-06T23:33:00.675Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/8a/37362fc2b949d5f733a8b0f2ff51ba423914cabefe69f1d1b6aab710f5fe/pybind11-3.0.1-py3-none-any.whl", hash = "sha256:aa8f0aa6e0a94d3b64adfc38f560f33f15e589be2175e103c0a33c6bce55ee89", size = 293611, upload-time = "2025-08-22T20:09:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fd/8762f7ee3e4e4be6d1d846cffb4916dd9bb02b2f800d3603718a0efe494c/pybind11-3.1.0-py3-none-any.whl", hash = "sha256:b8488090f8acffbcb6b5d6a85571a6827a0a2981ffb75e5a0b27b87c4a6b7dd0", size = 319402, upload-time = "2026-08-06T23:32:59.047Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Stacked on #9301. That PR fixed the reported wheel-test CI failure (a Python `int` that fits in an `int32`, e.g. from a `GeneratorParam<int>`, silently binding to the `double` operator overload under pybind11 3.1+ and producing a `float32` `Expr` instead of `int32`). This PR fixes the same class of bug for Python ints that overflow `int32` but fit in `int64`, which should promote to an `Int(64)` `Expr` (e.g. `hl.i32(0) + (0x7FFFFFFF + 1)`).

- Under pybind11 3.1+, this int64 promotion previously fell through to `float32` too: it relied on the `(self_t, Expr)` overload's implicit `Expr(int64_t)` conversion, but that conversion is only tried in pybind11's *second* (conversion-allowed) resolution pass, and the `(self_t, double)` overload now matches Python ints without conversion in the *first* pass (pybind11 3.1's PEP 484 numeric-tower change), so the second pass is never reached.
- Fix: register an explicit `(self_t, int64_t)` overload before `double`, mirroring the `int`-before-`double` fix in #9301. The `int64_t` argument is wrapped in an `Expr` before applying the operator (`Int64ToExprCheck`, parallel to the existing `DoubleToExprCheck`) rather than calling `self_t::operator+(int64_t)` directly, because Halide's operators are only overloaded for `(Expr, int)` and `(Expr, float)` -- a bare `int64_t` argument is ambiguous between the two. Every `self_t` already supports the `(self_t, Expr)` form via the existing `Expr` overload registration.
- Also bumps the `pybind11` pin in `uv.lock` to 3.1.0 via `uv lock -P pybind11`, now that both of its behavioral changes are accounted for. Without this, regular (non-wheel) CI would keep silently resolving to the older, already-compatible pybind11 version and never actually exercise this code path.

## Test plan

- [x] Rebuilt the Python bindings against pybind11 3.0.4 and 3.1.0 (Python 3.10).
- [x] Confirmed identical, correct behavior under both versions for: an int32-range literal, an int64-range (overflow-int32) literal, a float literal, and a Python int too large even for int64 (falls back to float, matching prior behavior).
- [x] Re-ran the `python_bindings/test/correctness` suite under pybind11 3.1.0; `basics.py`'s `test_implicit_convert_int64` (previously failing under 3.1.0 even with #9301 alone) now passes, with no other regressions.
- [x] `uv lock --check` passes after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
