### PR TITLE
Lazily load HalideAutoschedulers for add_halide_library(PLUGINS)

### DIFF
--- a/cmake/HalideGeneratorHelpers.cmake
+++ b/cmake/HalideGeneratorHelpers.cmake
@@ -310,8 +310,13 @@ function(_Halide_library_from_generator TARGET)
         message(FATAL_ERROR "`${ARG_TYPE}` not among: c_source, object, static_library")
     endif ()
 
-    ## Validate plugins
+    ## Validate plugins, lazily loading autoscheduler plugins that live in
+    # their own package (e.g. when named directly via PLUGINS instead of the
+    # add_halide_library(... AUTOSCHEDULER ...) convenience keyword).
     foreach (plugin IN LISTS ARG_PLUGINS)
+        if (NOT TARGET "${plugin}" AND "${plugin}" MATCHES "::")
+            find_package(HalideAutoschedulers QUIET)
+        endif ()
         if (NOT TARGET "${plugin}")
             message(FATAL_ERROR "Plugin `${plugin}` is not a target.")
         endif ()

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -154,6 +154,21 @@ set_tests_properties(
     FAIL_REGULAR_EXPRESSION "Autoscheduler Halide::[A-Za-z0-9_]+ does not exist"
 )
 
+# Regression test: naming an autoscheduler plugin directly via PLUGINS must
+# still resolve against an installed HalideAutoschedulers package, even
+# though it bypasses the AUTOSCHEDULER keyword's own lazy find_package() call.
+add_test(
+    NAME aot_shared_generator_plugins_direct
+    COMMAND
+        ${CMAKE_CTEST_COMMAND}
+        --build-and-test "${CMAKE_CURRENT_LIST_DIR}/aot"
+        "${CMAKE_CURRENT_BINARY_DIR}/aot-shared-plugins-direct"
+        --build-generator Ninja
+        --build-options -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_BUILD_TYPE=Release
+        -Daot_USE_PLUGINS_DIRECTLY=YES
+        --test-command ${CMAKE_CTEST_COMMAND} --output-on-failure
+)
+
 ##
 # Generator compile cache (HL_CACHE_DIR) tests
 #

--- a/test/integration/aot/CMakeLists.txt
+++ b/test/integration/aot/CMakeLists.txt
@@ -5,9 +5,18 @@ enable_testing()
 
 find_package(Halide REQUIRED)
 
-option(aot_USE_AUTOSCHEDULER "Use the autoscheduler" OFF)
-if (aot_USE_AUTOSCHEDULER)
+option(aot_USE_AUTOSCHEDULER "Use the autoscheduler via the AUTOSCHEDULER keyword" OFF)
+option(aot_USE_PLUGINS_DIRECTLY
+    "Use the autoscheduler by naming it directly via PLUGINS, bypassing the \
+AUTOSCHEDULER keyword's lazy find_package(HalideAutoschedulers)"
+    OFF
+)
+if (aot_USE_AUTOSCHEDULER AND aot_USE_PLUGINS_DIRECTLY)
+    message(FATAL_ERROR "aot_USE_AUTOSCHEDULER and aot_USE_PLUGINS_DIRECTLY are mutually exclusive")
+elseif (aot_USE_AUTOSCHEDULER)
     set(extra_options AUTOSCHEDULER Halide::Adams2019)
+elseif (aot_USE_PLUGINS_DIRECTLY)
+    set(extra_options PLUGINS Halide::Adams2019 PARAMS autoscheduler=Adams2019)
 endif ()
 
 add_executable(add_gen add.cpp)


### PR DESCRIPTION
## Summary
- #9292 split autoscheduler targets out of `HalideCompiler` into their own `HalideAutoschedulers` package, and taught `add_halide_library(... AUTOSCHEDULER ...)` to lazily `find_package()` it when needed.
- Callers that reference an autoscheduler target directly via `PLUGINS` (bypassing the `AUTOSCHEDULER` convenience keyword) never triggered that load, so consuming the *installed* package this way failed with `Plugin `Halide::Adams2019` is not a target.`
- This broke the "Build wheels" CI job on `main`, since `python_bindings/apps/CMakeLists.txt` configures standalone against the installed package and lists autoscheduler plugins via `PLUGINS` directly (the two other `PLUGINS`-using call sites, `test/generator/CMakeLists.txt` and `python_bindings/test/generators/CMakeLists.txt`, are built in-tree and so never hit the missing `find_package`).
- Fix: in `_Halide_library_from_generator`'s plugin-validation loop, lazily `find_package(HalideAutoschedulers QUIET)` for any `PLUGINS` entry that looks like a namespaced target and isn't already resolvable, mirroring the existing `AUTOSCHEDULER` lazy-load behavior.
- Added a regression test (`test/integration/aot`, new `aot_USE_PLUGINS_DIRECTLY` option + `aot_shared_generator_plugins_direct` ctest) that names the autoscheduler directly via `PLUGINS`. This runs in the PR-gated "Ecosystem" workflow, which configures `test/integration` against a real `cmake --install`'d prefix — the same condition that exposed the original bug.

## Test plan
- [x] Reproduced the CI failure locally: built + installed `main` from `build/macOS`, then configured `python_bindings/apps` standalone against the install (`find_package(Halide REQUIRED COMPONENTS Python)`) — hit the exact same `Plugin \`Halide::Adams2019\` is not a target.` error.
- [x] Applied the fix and confirmed `cmake` configure now succeeds and `cmake --build` completes, producing all Adams2019/Li2018/Mullapudi2016 generator variants.
- [x] Added `aot_shared_generator_plugins_direct` to `test/integration`; confirmed it fails against the pre-fix helper and passes against the post-fix helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)