### PR TITLE
Cancel terms that had a common factor distributed over them

### DIFF
--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -95,9 +95,6 @@ Expr Simplify::visit(const Add *op, ExprInfo *info) {
          rewrite((x - y) + (y + z), x + z) ||
          rewrite((x - y) + (z + y), x + z) ||
 
-         // The same cancellation, but with a factor distributed over each
-         // side. Without the w, z would be a factor of the whole expression,
-         // and hoisting it would expose the cancellation to the rules above.
          rewrite((x - y) * z + (y * z + w), x * z + w) ||
          rewrite((x - y) * z + (w + y * z), x * z + w) ||
          rewrite((x - y) * z + (y * z - w), x * z - w) ||

--- a/src/Simplify_Add.cpp
+++ b/src/Simplify_Add.cpp
@@ -95,6 +95,13 @@ Expr Simplify::visit(const Add *op, ExprInfo *info) {
          rewrite((x - y) + (y + z), x + z) ||
          rewrite((x - y) + (z + y), x + z) ||
 
+         // The same cancellation, but with a factor distributed over each
+         // side. Without the w, z would be a factor of the whole expression,
+         // and hoisting it would expose the cancellation to the rules above.
+         rewrite((x - y) * z + (y * z + w), x * z + w) ||
+         rewrite((x - y) * z + (w + y * z), x * z + w) ||
+         rewrite((x - y) * z + (y * z - w), x * z - w) ||
+
          rewrite(x + ((y - x) - z), y - z) ||
          rewrite(((x - y) - z) + y, x - z) ||
 
@@ -135,6 +142,7 @@ Expr Simplify::visit(const Add *op, ExprInfo *info) {
            rewrite(x + y * x, (y + 1) * x) ||
            rewrite(x * y + x, x * (y + 1)) ||
            rewrite(y * x + x, (y + 1) * x, !is_const(x)) ||
+
            rewrite(x + (x + y) / c0, (fold(c0 + 1) * x + y) / c0, c0 != 0) ||
            rewrite(x + (y + x) / c0, (fold(c0 + 1) * x + y) / c0, c0 != 0) ||
            rewrite(x + (y - x) / c0, (fold(c0 - 1) * x + y) / c0, c0 != 0) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -224,6 +224,14 @@ void check_algebra() {
     check(x * y + z * x, (y + z) * x);
     check(y * x + x * z, (y + z) * x);
     check(y * x + z * x, (y + z) * x);
+    check((x - y) * z + (y * z + w), x * z + w);
+    check((x - y) * z + (w + y * z), x * z + w);
+    check((x - y) * z + (y * z - w), x * z - w);
+    // The same cancellation reached by hoisting the common factor instead.
+    check((x - y) * z + y * z, x * z);
+    // The shape this comes up in: an index whose dimensions have a term
+    // shuffled between them, which cancels once the factors are distributed.
+    check(((y * 8 - z) * 16 + (z * 16 + x)) * 4, (y * 128 + x) * 4);
 
     check(x - 0, x);
     check((x / y) - (x / y), 0);


### PR DESCRIPTION
The rules that cancel a subtracted term against an added one match on Add and Sub nodes, so they miss the case where a factor has been distributed over each side, as in `(x - y)*z + (y*z + w)`. Nothing hoists the z back out, because the trailing w means z isn't a factor of the whole expression, so the y terms never meet and the expression sits in a local minimum.

Add the three cases of the family that were missing. They are all on the Add side; every member whose top node is a Sub already cancelled. These hold under wrapping arithmetic as well, being semi-ring identities, so they sit with the other cancellation rules rather than under a no-overflow guard.