### PR TITLE
Fix TBAA metadata for loads/stores with negative indices

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -2231,19 +2231,29 @@ void CodeGen_LLVM::add_tbaa_metadata(llvm::Instruction *inst, string buffer, con
                 // We want to find the smallest aligned width and offset
                 // that contains this ramp.
                 int64_t stride = *pstride;
-                base = *pbase;
-                internal_assert(base >= 0);
-                width = next_power_of_two(ramp->lanes * stride);
-
-                while (base % width) {
-                    base -= base % width;
-                    width *= 2;
+                int64_t lo = *pbase;
+                int64_t hi = lo + (ramp->lanes - 1) * stride;
+                if (stride < 0) {
+                    std::swap(lo, hi);
                 }
-                constant_index = true;
+                // Indices below zero can only come from lanes masked off by
+                // a predicate. The blocks below are aligned relative to the
+                // start of the buffer, so they can't describe a range that
+                // straddles it. Fall back to just the buffer-level node.
+                if (lo >= 0) {
+                    base = lo;
+                    width = next_power_of_two(hi - lo + 1);
+
+                    while (base % width) {
+                        base -= base % width;
+                        width *= 2;
+                    }
+                    constant_index = true;
+                }
             }
         } else {
             auto pbase = as_const_int(index);
-            if (pbase) {
+            if (pbase && *pbase >= 0) {
                 base = *pbase;
                 constant_index = true;
             }

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -126,6 +126,7 @@ tests(
     fast_trigonometric.cpp
     fibonacci.cpp
     fit_function.cpp
+    flipped_vector_load_before_buffer_start.cpp
     float16_t.cpp
     float16_t_comparison.cpp
     float16_t_constants.cpp

--- a/test/correctness/flipped_vector_load_before_buffer_start.cpp
+++ b/test/correctness/flipped_vector_load_before_buffer_start.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // A predicated load with a negative stride can address lanes before the
+    // start of the buffer. The predicate masks them off, so no out-of-bounds
+    // access actually happens, but the codegen still has to cope with the
+    // negative indices.
+    Func f, g, h;
+    Var x;
+    f(x) = cast<uint8_t>(x);
+    g(x) = f(-x);
+    h(x) = g(x) + g(x - 1);
+    f.compute_at(g, x);
+    g.compute_at(h, x).vectorize(x, 4, TailStrategy::GuardWithIf);
+
+    Buffer<uint8_t> result = h.realize({15});
+
+    for (int i = 0; i < result.width(); i++) {
+        uint8_t correct = (uint8_t)(-i) + (uint8_t)(1 - i);
+        if (result(i) != correct) {
+            printf("result(%d) = %d instead of %d\n", i, result(i), correct);
+            return 1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
A predicated vector load with a negative stride is codegen'd as a dense load of the flipped ramp followed by a shuffle. If the load reaches the first element of the buffer, the flipped ramp starts before it, and the masked-off lanes give the ramp a negative base. add_tbaa_metadata asserted that the base was non-negative.

The TBAA tree describes power-of-two-sized blocks aligned relative to the start of the buffer, so it can't name a range that straddles the start. Emit metadata only down to the buffer level in that case.

Found while working on a fuzzer for sliding window schedules, but not actually related to sliding window.
