### PR TITLE
enforce buffer_constraints size matches dimensions in Parameter ctor

### DIFF
--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -88,6 +88,14 @@ Parameter::Parameter(const Type &t, int dimensions, const std::string &name,
                      const Buffer<void> &buffer, int host_alignment, const std::vector<BufferConstraint> &buffer_constraints,
                      MemoryType memory_type)
     : contents(new Internal::ParameterContents(t, /*is_buffer*/ true, dimensions, name)) {
+    // Every other constructor keeps buffer_constraints sized to the
+    // dimensionality, and check_dim_ok() relies on that when indexing it. This
+    // reconstruction path takes the vector verbatim, so a serialized pipeline
+    // claiming more dimensions than it carries constraints for would let the
+    // constraint accessors read past the vector.
+    user_assert(buffer_constraints.size() == (size_t)std::max(0, dimensions))
+        << "Buffer Parameter " << name << " has " << dimensions
+        << " dimensions but " << buffer_constraints.size() << " dimension constraints\n";
     contents->buffer = buffer;
     contents->host_alignment = host_alignment;
     contents->buffer_constraints = buffer_constraints;


### PR DESCRIPTION
The buffer Parameter reconstruction constructor takes buffer_constraints verbatim but reads dimensions from a separate argument, so a serialized pipeline declaring more dimensions than it has constraints for leaves the vector shorter than dimensions(). check_dim_ok() only bounds a dimension index against dimensions(), so stride_constraint/min_constraint/extent_constraint (reached from AddImageChecks during lowering) then index buffer_constraints past its end and read adjacent heap memory as Expr handles. Require the sizes to agree in the constructor, the invariant every other Parameter constructor already maintains.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)