### PR TITLE
Declare per-subtarget entrypoints in multitarget headers (#9313)

### DIFF
--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -18,6 +18,7 @@
 #include "Pipeline.h"
 #include "PythonExtensionGen.h"
 #include "StmtToHTML.h"
+#include "Util.h"
 
 namespace Halide {
 namespace Internal {
@@ -887,6 +888,7 @@ void compile_multitarget(const std::string &fn_name,
 
     TemporaryFileDir temp_obj_dir;
     std::vector<Expr> wrapper_args;
+    std::vector<std::string> sub_fn_names;
     std::vector<LoweredArgument> base_target_args;
     std::vector<AutoSchedulerResults> auto_scheduler_results;
     MetadataNameMap metadata_name_map;
@@ -921,7 +923,7 @@ void compile_multitarget(const std::string &fn_name,
 
         // Each sub-target has a function name that is the 'real' name plus a suffix
         std::string suffix = suffix_for_entry(i);
-        std::string sub_fn_name = needs_wrapper ? (fn_name + suffix) : fn_name;
+        std::string sub_fn_name = fn_name + (needs_wrapper ? c_print_name(suffix.substr(1), true) : "");
 
         // We always produce the runtime separately, so add NoRuntime explicitly.
         Target sub_fn_target = target.with_feature(Target::NoRuntime);
@@ -978,6 +980,7 @@ void compile_multitarget(const std::string &fn_name,
 
         wrapper_args.push_back(can_use != 0);
         wrapper_args.emplace_back(sub_fn_name);
+        sub_fn_names.push_back(sub_fn_name);
     }
 
     // If we haven't specified "no runtime", build a runtime with the base target
@@ -1040,6 +1043,12 @@ void compile_multitarget(const std::string &fn_name,
     if (contains(output_files, OutputFileType::c_header)) {
         Module header_module(fn_name, base_target);
         header_module.append(LoweredFunc(fn_name, base_target_args, {}, LinkageType::ExternalPlusMetadata));
+        // Also declare each subtarget's entrypoint, so that callers can bypass
+        // the runtime-feature-detecting wrapper above and call a specific
+        // subtarget directly (e.g. for benchmarking purposes).
+        for (const std::string &sub_fn_name : sub_fn_names) {
+            header_module.append(LoweredFunc(sub_fn_name, base_target_args, {}, LinkageType::ExternalPlusMetadata));
+        }
         std::map<OutputFileType, std::string> header_out = {{OutputFileType::c_header, output_files.at(OutputFileType::c_header)}};
         debug(1) << "compile_multitarget: c_header " << header_out.at(OutputFileType::c_header) << "\n";
         header_module.compile(header_out);

--- a/test/correctness/compile_to_multitarget.cpp
+++ b/test/correctness/compile_to_multitarget.cpp
@@ -2,6 +2,7 @@
 #include "halide_test_dirs.h"
 
 #include <cstdio>
+#include <string_view>
 
 using namespace Halide;
 
@@ -14,6 +15,27 @@ std::string leaf_name(const std::string &path) {
 
 std::string get_output_path_prefix(const std::string &base) {
     return Internal::get_test_tmp_dir() + "halide_test_correctness_compile_to_multitarget_" + base;
+}
+
+// Verify that the header declares an entrypoint for the wrapper (fn_name) as
+// well as for each subtarget (fn_name + suffix, suitably legalized into a
+// valid identifier), so that callers can bypass the runtime-dispatching
+// wrapper and call a specific subtarget directly.
+void check_header_declares_all_entrypoints(const std::string &header_path,
+                                           const std::string &fn_name,
+                                           const std::vector<std::string> &suffixes) {
+    auto header_data = Internal::read_entire_file(header_path);
+    std::string_view header{header_data.data(), header_data.size()};
+
+    std::vector<std::string> expected_names = {fn_name};
+    for (const auto &suffix : suffixes) {
+        expected_names.push_back(fn_name + "_" + Internal::c_print_name(suffix, false));
+    }
+    for (const auto &name : expected_names) {
+        std::string decl = "int " + name + "(";
+        internal_assert(header.find(decl) != std::string::npos)
+            << "Did not find expected declaration '" << decl << "' in " << header_path;
+    }
 }
 
 void test_compile_to_static_library(Func j) {
@@ -74,6 +96,8 @@ void test_compile_to_object_files(Func j) {
     for (auto f : files) {
         Internal::assert_file_exists(f);
     }
+
+    check_header_declares_all_entrypoints(filename_prefix + ".h", j.name(), target_strings);
 }
 
 void test_compile_to_object_files_no_runtime(Func j) {
@@ -216,6 +240,8 @@ void test_compile_to_everything(Func j, bool do_object) {
     for (auto f : files) {
         Internal::assert_file_exists(f);
     }
+
+    check_header_declares_all_entrypoints(filename_prefix + ".h", function_name, target_strings);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
`compile_multitarget()` previously only declared the runtime-dispatching wrapper function in the generated header. Legalize the per-subtarget function name so it can be declared directly, letting callers invoke a specific variant (e.g. avx2 vs sse2) without going through the wrapper.

Fixes #9313

## Breaking changes

It reserves a few more symbol names, but... if someone was using these, they will likely be happy to know they don't have to anymore.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Commits include AI attribution where applicable (see Code of Conduct)
