### PR TITLE
Add more let peeling and rewrapping helpers

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -681,14 +681,6 @@ Stmt add_image_checks_inner(Stmt s,
         }
     };
 
-    auto prepend_lets = [&](vector<pair<string, Expr>> *lets) {
-        while (!lets->empty()) {
-            auto &p = lets->back();
-            s = LetStmt::make(p.first, std::move(p.second), s);
-            lets->pop_back();
-        }
-    };
-
     // After all asserts, set host dirty on outputs if this is a CPU-only
     // pipeline
     prepend_stmts(&set_host_dirty);
@@ -698,7 +690,7 @@ Stmt add_image_checks_inner(Stmt s,
     prepend_stmts(&asserts_host_alignment);
     prepend_stmts(&asserts_device_not_dirty);
     prepend_stmts(&dims_no_overflow_asserts);
-    prepend_lets(&lets_overflow);
+    s = rewrap_all_lets(s, lets_overflow);
 
     // Replace uses of the var with the constrained versions in the
     // rest of the program. We also need to respect the existence of
@@ -724,13 +716,13 @@ Stmt add_image_checks_inner(Stmt s,
     prepend_stmts(&asserts_proposed);
 
     // Inject the code that defines the proposed sizes.
-    prepend_lets(&lets_proposed);
+    s = rewrap_all_lets(s, lets_proposed);
 
     // Inject the code that defines the constrained sizes.
-    prepend_lets(&lets_constrained);
+    s = rewrap_all_lets(s, lets_constrained);
 
     // Inject the code that defines the required sizes produced by bounds inference.
-    prepend_lets(&lets_required);
+    s = rewrap_all_lets(s, lets_required);
 
     // Inject the code that checks that does msan checks. (Note that this ignores no_asserts.)
     prepend_stmts(&msan_checks);

--- a/src/AsyncProducers.cpp
+++ b/src/AsyncProducers.cpp
@@ -507,11 +507,7 @@ protected:
             body = mutate(op->body);
             // Peel off any enclosing let expressions from the value
             vector<pair<string, Expr>> lets;
-            Expr value = op->value;
-            while (const Let *l = value.as<Let>()) {
-                lets.emplace_back(l->name, l->value);
-                value = l->body;
-            }
+            Expr value = peel_lets(op->value, &lets);
             const Call *call = value.as<Call>();
             if (call && call->name == "halide_make_semaphore") {
                 internal_assert(call->args.size() == 1);
@@ -525,9 +521,7 @@ protected:
                 body = op->with(sema_allocate, body);
 
                 // Re-wrap any other lets
-                for (const auto &[var, value] : reverse_view(lets)) {
-                    body = LetStmt::make(var, value, std::move(body));
-                }
+                body = rewrap_all_lets(body, lets);
             }
         } else {
             body = mutate(frames.back()->body);

--- a/src/BoundConstantExtentLoops.cpp
+++ b/src/BoundConstantExtentLoops.cpp
@@ -62,9 +62,7 @@ protected:
             if (e == nullptr) {
                 // We're about to hard fail. Get really aggressive
                 // with the simplifier.
-                for (const auto &[var, value] : reverse_view(lets)) {
-                    extent = Let::make(var, value, extent);
-                }
+                extent = rewrap_used_lets(extent, lets);
                 extent = remove_likelies(extent);
                 extent = substitute_in_all_lets(extent);
                 extent = simplify(extent,

--- a/src/CSE.cpp
+++ b/src/CSE.cpp
@@ -233,10 +233,7 @@ protected:
         Expr dummy = Call::make(Int(32), Call::bundle, {op->value, op->index}, Call::PureIntrinsic);
         dummy = common_subexpression_elimination(dummy, lift_all);
         vector<pair<string, Expr>> lets;
-        while (const Let *let = dummy.as<Let>()) {
-            lets.emplace_back(let->name, let->value);
-            dummy = let->body;
-        }
+        dummy = peel_lets(dummy, &lets);
         const Call *bundle = Call::as_intrinsic(dummy, {Call::bundle});
         internal_assert(bundle && bundle->args.size() == 2);
 

--- a/src/Closure.cpp
+++ b/src/Closure.cpp
@@ -153,20 +153,20 @@ Stmt Closure::unpack_from_struct(const Expr &e, const Stmt &s) const {
 
     const Call *c = packed.as<Call>();
 
-    Stmt result = s;
-    for (int idx = (int)c->args.size() - 1; idx >= 0; idx--) {
-        Expr arg = c->args[idx];
-        const Variable *var = arg.as<Variable>();
-        Expr val = Call::make(var->type,
-                              Call::load_typed_struct_member,
-                              {e, prototype_var, idx},
-                              Call::Intrinsic);
-        if (stmt_uses_var(result, var->name)) {
-            // If a closure is generated for multiple consuming blocks of IR,
-            // then some of those blocks might only need some of the field.
-            result = LetStmt::make(var->name, val, result);
-        }
+    // If a closure is generated for multiple consuming blocks of IR, then some
+    // of those blocks might only need some of the fields, so only bind the ones
+    // that are used.
+    std::vector<std::pair<std::string, Expr>> lets;
+    lets.reserve(c->args.size());
+    for (int idx = 0; idx < (int)c->args.size(); idx++) {
+        const Variable *var = c->args[idx].as<Variable>();
+        lets.emplace_back(var->name,
+                          Call::make(var->type,
+                                     Call::load_typed_struct_member,
+                                     {e, prototype_var, idx},
+                                     Call::Intrinsic));
     }
+    Stmt result = rewrap_used_lets(s, lets);
     result = LetStmt::make(prototype_name, prototype, result);
 
     return result;

--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -1577,12 +1577,8 @@ void CodeGen_ARM::visit(const Store *op) {
     }
 
     // First dig through let expressions
-    Expr rhs = op->value;
     vector<pair<string, Expr>> lets;
-    while (const Let *let = rhs.as<Let>()) {
-        rhs = let->body;
-        lets.emplace_back(let->name, let->value);
-    }
+    Expr rhs = peel_lets(op->value, &lets);
     const Shuffle *shuffle = rhs.as<Shuffle>();
 
     // Interleaving store instructions only exist for certain types.
@@ -1690,11 +1686,7 @@ void CodeGen_ARM::visit(const Store *op) {
             // And we make sure the deinterleaved predicates are all the same.
 
             // Dig through let expressions
-            Expr rhs = op->predicate;
-            while (const Let *let = rhs.as<Let>()) {
-                rhs = let->body;
-                lets_pred.emplace_back(let->name, let->value);
-            }
+            Expr rhs = peel_lets(op->predicate, &lets_pred);
 
             Expr vpred_predicated_store;
             bool predicates_are_same = true;

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -21,11 +21,12 @@ class StoreCollector : public IRMutator {
 public:
     const std::string store_name;
     const int store_stride, max_stores;
-    std::vector<Stmt> &let_stmts;
+    std::vector<std::pair<std::string, Expr>> &let_stmts;
     std::vector<Stmt> &stores;
 
     StoreCollector(const std::string &name, int stride, int ms,
-                   std::vector<Stmt> &lets, std::vector<Stmt> &ss)
+                   std::vector<std::pair<std::string, Expr>> &lets,
+                   std::vector<Stmt> &ss)
         : store_name(name), store_stride(stride), max_stores(ms),
           let_stmts(lets), stores(ss) {
     }
@@ -59,7 +60,7 @@ private:
     // These are lets that we've encountered since the last collected
     // store. If we collect another store, these "potential" lets
     // become lets used by the collected stores.
-    std::vector<Stmt> potential_lets;
+    std::vector<std::pair<std::string, Expr>> potential_lets;
 
     Expr visit(const Load *op) override {
         if (!collecting) {
@@ -143,11 +144,7 @@ private:
 
         // If we're still collecting, we need to save the entire let chain as potential lets.
         if (collecting) {
-            Stmt body;
-            do {
-                potential_lets.emplace_back(op);
-                body = op->body;
-            } while ((op = body.as<LetStmt>()));
+            peel_lets(op, &potential_lets);
         }
         return stmt;
     }
@@ -168,7 +165,8 @@ private:
 };
 
 Stmt collect_strided_stores(const Stmt &stmt, const std::string &name, int stride, int max_stores,
-                            std::vector<Stmt> lets, std::vector<Stmt> &stores) {
+                            std::vector<std::pair<std::string, Expr>> lets,
+                            std::vector<Stmt> &stores) {
 
     return StoreCollector(name, stride, max_stores, lets, stores)(stmt);
 }
@@ -645,16 +643,9 @@ class Interleaver : public IRMutator {
     }
 
     HALIDE_NEVER_INLINE Stmt gather_stores(const Block *op) {
-        const LetStmt *let = op->first.as<LetStmt>();
-        const Store *store = op->first.as<Store>();
-
         // Gather all the let stmts surrounding the first.
-        std::vector<Stmt> let_stmts;
-        while (let) {
-            let_stmts.emplace_back(let);
-            store = let->body.as<Store>();
-            let = let->body.as<LetStmt>();
-        }
+        std::vector<std::pair<std::string, Expr>> let_stmts;
+        const Store *store = peel_lets(op->first, &let_stmts).as<Store>();
 
         // There was no inner store.
         if (!store) {
@@ -771,11 +762,7 @@ class Interleaver : public IRMutator {
         Stmt new_store = store->with(value, index, predicate, ModulusRemainder());
 
         // Rewrap the let statements we pulled off.
-        while (!let_stmts.empty()) {
-            const LetStmt *let = let_stmts.back().as<LetStmt>();
-            new_store = let->with(let->value, new_store);
-            let_stmts.pop_back();
-        }
+        new_store = rewrap_all_lets(new_store, let_stmts);
 
         // Continue recursively into the stuff that
         // collect_strided_stores didn't collect.

--- a/src/DerivativeUtils.cpp
+++ b/src/DerivativeUtils.cpp
@@ -115,23 +115,14 @@ map<string, ReductionVariableInfo> gather_rvariables(const Expr &expr) {
 Expr add_let_expression(const Expr &expr,
                         const map<string, Expr> &let_var_mapping,
                         const vector<string> &let_variables) {
-    // TODO: find a faster way to do this
-    Expr ret = StripLets()(expr);
-    bool changed = true;
-    vector<bool> injected(let_variables.size(), false);
-    while (changed) {
-        changed = false;
-        for (size_t i = 0; i < let_variables.size(); i++) {
-            const auto &let_variable = let_variables[i];
-            if (!injected[i] && expr_uses_var(ret, let_variable)) {
-                auto value = let_var_mapping.find(let_variable)->second;
-                ret = Let::make(let_variable, value, ret);
-                injected[i] = true;
-                changed = true;
-            }
-        }
+    // sort_expressions lists Lets innermost first, so reverse them to get the
+    // outermost-to-innermost order rewrap_used_lets expects.
+    vector<pair<string, Expr>> lets;
+    lets.reserve(let_variables.size());
+    for (const auto &let_variable : reverse_view(let_variables)) {
+        lets.emplace_back(let_variable, let_var_mapping.find(let_variable)->second);
     }
-    return ret;
+    return rewrap_used_lets(StripLets()(expr), lets);
 }
 
 namespace {

--- a/src/ExtractTileOperations.cpp
+++ b/src/ExtractTileOperations.cpp
@@ -67,11 +67,7 @@ Matmul convert_to_matmul(const Store *op, const string &new_name) {
 
     // Peel lets
     std::vector<std::pair<std::string, Expr>> peeled_lets;
-    Expr value = op->value;
-    while (const Let *let = value.as<Let>()) {
-        peeled_lets.emplace_back(let->name, let->value);
-        value = let->body;
-    }
+    Expr value = peel_lets(op->value, &peeled_lets);
 
     // The RHS must be an add
     const auto *add = value.as<Add>();
@@ -317,10 +313,8 @@ Matmul convert_to_matmul(const Store *op, const string &new_name) {
     auto matmul = Call::make(res_type, "tile_matmul",
                              {I, col_bytes, K, out_load, lhs_call, rhs_call},
                              Call::Intrinsic);
-    auto store = Store::make(new_name, matmul, std::move(subtile_idx));
-    for (auto &[name, value] : reverse_view(peeled_lets)) {
-        store = LetStmt::make(name, std::move(value), store);
-    }
+    Stmt store = Store::make(new_name, matmul, std::move(subtile_idx));
+    store = rewrap_all_lets(store, peeled_lets);
     return {true, std::move(store), I, J, K};
 }
 

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <set>
 #include <sstream>
+#include <type_traits>
 #include <utility>
 
 #include "CSE.h"
@@ -1161,7 +1162,7 @@ Body rewrap_used_lets_impl(const Body &body,
     body.accept(&used);
     Body result = body;
     for (const auto &[name, value] : reverse_view(lets)) {
-        if (used.names.erase(name)) {
+        if (used.names.count(name)) {
             value.accept(&used);
             if constexpr (std::is_same_v<Body, Expr>) {
                 result = Let::make(name, value, result);

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <cmath>
 #include <iostream>
+#include <set>
 #include <sstream>
 #include <utility>
 
@@ -13,6 +14,7 @@
 #include "IRMutator.h"
 #include "IROperator.h"
 #include "IRPrinter.h"
+#include "IRVisitor.h"
 #include "Interval.h"
 #include "StrictifyFloat.h"
 #include "Util.h"
@@ -1111,6 +1113,90 @@ Expr peel_lets(const Expr &e, std::vector<std::pair<std::string, Expr>> *lets) {
         body = let->body;
     }
     return body;
+}
+
+Stmt peel_lets(const Stmt &s, std::vector<std::pair<std::string, Expr>> *lets) {
+    Stmt body = s;
+    while (const LetStmt *let = body.as<LetStmt>()) {
+        lets->emplace_back(let->name, let->value);
+        body = let->body;
+    }
+    return body;
+}
+
+namespace {
+
+/** Gather the names an Expr or Stmt might get from a wrapping let: the names of
+ * Variables, and the buffer names of Loads and Stores. Conservatively assumes
+ * every such name refers to one of the peeled lets, even where an inner let
+ * shadows it. One instance is reused across an entire rewrap so that shared
+ * subexpressions are only visited once. */
+class CollectUsedNames : public IRGraphVisitor {
+    using IRGraphVisitor::visit;
+
+    void visit(const Variable *op) override {
+        names.insert(op->name);
+    }
+
+    void visit(const Load *op) override {
+        names.insert(op->name);
+        IRGraphVisitor::visit(op);
+    }
+
+    void visit(const Store *op) override {
+        names.insert(op->name);
+        IRGraphVisitor::visit(op);
+    }
+
+public:
+    std::set<std::string> names;
+};
+
+template<typename Body>
+Body rewrap_used_lets_impl(const Body &body,
+                           const std::vector<std::pair<std::string, Expr>> &lets) {
+    // The set of names the growing body refers to. Maintaining it as we go
+    // avoids rescanning the body once per let.
+    CollectUsedNames used;
+    body.accept(&used);
+    Body result = body;
+    for (const auto &[name, value] : reverse_view(lets)) {
+        if (used.names.erase(name)) {
+            value.accept(&used);
+            if constexpr (std::is_same_v<Body, Expr>) {
+                result = Let::make(name, value, result);
+            } else {
+                result = LetStmt::make(name, value, result);
+            }
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
+Expr rewrap_used_lets(const Expr &body, const std::vector<std::pair<std::string, Expr>> &lets) {
+    return rewrap_used_lets_impl(body, lets);
+}
+
+Stmt rewrap_used_lets(const Stmt &body, const std::vector<std::pair<std::string, Expr>> &lets) {
+    return rewrap_used_lets_impl(body, lets);
+}
+
+Expr rewrap_all_lets(const Expr &body, const std::vector<std::pair<std::string, Expr>> &lets) {
+    Expr result = body;
+    for (const auto &[name, value] : reverse_view(lets)) {
+        result = Let::make(name, value, result);
+    }
+    return result;
+}
+
+Stmt rewrap_all_lets(const Stmt &body, const std::vector<std::pair<std::string, Expr>> &lets) {
+    Stmt result = body;
+    for (const auto &[name, value] : reverse_view(lets)) {
+        result = LetStmt::make(name, value, result);
+    }
+    return result;
 }
 
 Expr remove_likelies(const Expr &e) {

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -320,14 +320,36 @@ inline double div_imp<double>(double a, double b) {
     return a / b;
 }
 
-/** Strip any Let nodes off the front of an Expr, appending the name and value
- * of each to `lets` from outermost to innermost, and return what they wrapped.
- * Analysing an Expr that CSE or LICM has lifted subexpressions out of means
- * getting past the Lets first. Substituting them back in also does that, but it
- * repeats each value at every use, which is what lifting them out avoided.
- * Callers rewrap the Lets around whatever they build, or, in codegen, put them
- * in scope while they build it. */
+/** Strip any Let nodes off the front of an Expr, or LetStmt nodes off the front
+ * of a Stmt, appending the name and value of each to `lets` from outermost to
+ * innermost, and return what they wrapped. Analysing an Expr or Stmt that CSE
+ * or LICM has lifted subexpressions out of means getting past the Lets first.
+ * Substituting them back in also does that, but it repeats each value at every
+ * use, which is what lifting them out avoided. Callers rewrap the Lets around
+ * whatever they build (see rewrap_used_lets and rewrap_all_lets), or, in
+ * codegen, put them in scope while they build it. */
+// @{
 Expr peel_lets(const Expr &e, std::vector<std::pair<std::string, Expr>> *lets);
+Stmt peel_lets(const Stmt &s, std::vector<std::pair<std::string, Expr>> *lets);
+// @}
+
+/** Rewrap a list of lets produced by peel_lets around a new body, skipping any
+ * the body doesn't use. Conservatively treats every name the body mentions as a
+ * possible reference to a peeled let, even where an inner let shadows it.
+ * Gathers those names once and updates them as it goes, so it takes time
+ * linearithmic in the size of the result rather than the quadratic time taken
+ * by testing each let in turn with expr_uses_var. */
+// @{
+Expr rewrap_used_lets(const Expr &body, const std::vector<std::pair<std::string, Expr>> &lets);
+Stmt rewrap_used_lets(const Stmt &body, const std::vector<std::pair<std::string, Expr>> &lets);
+// @}
+
+/** Rewrap a list of lets produced by peel_lets around a new body, without
+ * checking whether the body uses them. */
+// @{
+Expr rewrap_all_lets(const Expr &body, const std::vector<std::pair<std::string, Expr>> &lets);
+Stmt rewrap_all_lets(const Stmt &body, const std::vector<std::pair<std::string, Expr>> &lets);
+// @}
 
 /** Return an Expr that is identical to the input Expr, but with
  * all calls to likely() and likely_if_innermost() removed. */

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -276,10 +276,7 @@ protected:
 
             // Peel off containing lets. These will be lifted.
             vector<pair<string, Expr>> lets;
-            while (const Let *let = dummy_call.as<Let>()) {
-                lets.emplace_back(let->name, let->value);
-                dummy_call = let->body;
-            }
+            dummy_call = peel_lets(dummy_call, &lets);
 
             // Track the set of variables used by the inner loop
             set<string> vars;
@@ -327,12 +324,7 @@ protected:
             }
 
             // Wrap the lets pulled out by CSE
-            while (!lets.empty()) {
-                new_stmt = LetStmt::make(lets.back().first, lets.back().second, new_stmt);
-                lets.pop_back();
-            }
-
-            return new_stmt;
+            return rewrap_all_lets(new_stmt, lets);
         }
     }
 };

--- a/src/LoopCarry.cpp
+++ b/src/LoopCarry.cpp
@@ -457,10 +457,7 @@ class LoopCarryOverLoop : public IRMutator {
             // Run CSE
             call = simplify(common_subexpression_elimination(call));
             // Peel off lets
-            while (const Let *l = call.as<Let>()) {
-                initial_lets.emplace_back(l->name, l->value);
-                call = l->body;
-            }
+            call = peel_lets(call, &initial_lets);
             internal_assert(call.as<Call>());
             initial_scratch_values = call.as<Call>()->args;
 
@@ -476,16 +473,10 @@ class LoopCarryOverLoop : public IRMutator {
             Stmt initial_stores = Block::make(initial_scratch_stores);
 
             // Wrap them in the appropriate lets
-            for (const auto &[var, value] : reverse_view(initial_lets)) {
-                initial_stores = LetStmt::make(var, value, initial_stores);
-            }
+            initial_stores = rewrap_all_lets(initial_stores, initial_lets);
             // We may be lifting the initial stores out of let stmts,
             // so rewrap them in the necessary ones.
-            for (const auto &[var, value] : reverse_view(containing_lets)) {
-                if (stmt_uses_var(initial_stores, var)) {
-                    initial_stores = LetStmt::make(var, value, initial_stores);
-                }
-            }
+            initial_stores = rewrap_used_lets(initial_stores, containing_lets);
 
             allocs.push_back({scratch,
                               loads[c.front()][0]->type.element_of(),

--- a/src/LowerWarpShuffles.cpp
+++ b/src/LowerWarpShuffles.cpp
@@ -743,13 +743,10 @@ class HoistWarpShufflesFromSingleIfStmt : public IRMutator {
 public:
     bool success = true;
 
-    Stmt rewrap(Stmt s) {
-        while (!lifted_lets.empty()) {
-            const pair<string, Expr> &p = lifted_lets.back();
-            s = LetStmt::make(p.first, p.second, s);
-            lifted_lets.pop_back();
-        }
-        return s;
+    Stmt rewrap(const Stmt &s) {
+        Stmt result = rewrap_all_lets(s, lifted_lets);
+        lifted_lets.clear();
+        return result;
     }
 };
 

--- a/src/PartitionLoops.cpp
+++ b/src/PartitionLoops.cpp
@@ -878,12 +878,8 @@ class RenormalizeGPULoops : public IRMutator {
 
         if (in_gpu_loop && !old_in_gpu_loop) {
             // This was the outermost GPU loop. Dump any lifted lets here.
-            while (!lifted_lets.empty()) {
-                stmt = LetStmt::make(lifted_lets.back().first,
-                                     lifted_lets.back().second,
-                                     stmt);
-                lifted_lets.pop_back();
-            }
+            stmt = rewrap_all_lets(stmt, lifted_lets);
+            lifted_lets.clear();
         }
 
         in_gpu_loop = old_in_gpu_loop;

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -1576,10 +1576,7 @@ private:
         // Strip off the containing lets. The bounds of the parent fused loop
         // (i.e. the union bounds) might refer to them, so we need to move them
         // to the topmost position.
-        while (const auto *let = produce.as<LetStmt>()) {
-            add_lets.emplace_back(let->name, let->value);
-            produce = let->body;
-        }
+        produce = peel_lets(produce, &add_lets);
 
         // Only one branch runs at a time, so a single trailing fence
         // after the whole (specialized) production is equivalent to,
@@ -1853,9 +1850,7 @@ private:
         internal_assert(producer.defined());
 
         // Rewrap the loop in the containing lets.
-        for (const auto &[var, value] : reverse_view(add_lets)) {
-            producer = LetStmt::make(var, value, producer);
-        }
+        producer = rewrap_all_lets(producer, add_lets);
 
         // The original bounds of the loop nests (without any loop-fusion)
         auto bounds = CollectBounds::collect_bounds(producer);

--- a/src/Simplify_Stmts.cpp
+++ b/src/Simplify_Stmts.cpp
@@ -471,21 +471,14 @@ Stmt Simplify::visit(const Evaluate *op) {
 
     // Rewrite Lets inside an evaluate as LetStmts outside the Evaluate.
     vector<pair<string, Expr>> lets;
-    while (const Let *let = value.as<Let>()) {
-        lets.emplace_back(let->name, let->value);
-        value = let->body;
-    }
+    value = peel_lets(value, &lets);
 
     if (value.same_as(op->value)) {
         internal_assert(lets.empty());
         return op;
     } else {
         // Rewrap the lets outside the evaluate node
-        Stmt stmt = Evaluate::make(value);
-        for (const auto &[var, value] : reverse_view(lets)) {
-            stmt = LetStmt::make(var, value, stmt);
-        }
-        return stmt;
+        return rewrap_all_lets(Evaluate::make(value), lets);
     }
 }
 

--- a/src/SplitTuples.cpp
+++ b/src/SplitTuples.cpp
@@ -181,11 +181,7 @@ class SplitTuples : public IRMutator {
                         aliases = aliases && (a[i] == b[i]);
                     }
                     // Might need some of the containing lets
-                    for (const auto &[var, value] : reverse_view(lets)) {
-                        if (expr_uses_var(aliases, var)) {
-                            aliases = Let::make(var, value, aliases);
-                        }
-                    }
+                    aliases = rewrap_used_lets(aliases, lets);
                     return !can_prove(!aliases);
                 }
 
@@ -281,13 +277,7 @@ class SplitTuples : public IRMutator {
                     provides.push_back(Provide::make(name, {val}, args, op->predicate));
                 }
 
-                s = Block::make(provides);
-
-                while (!lets.empty()) {
-                    auto p = lets.back();
-                    lets.pop_back();
-                    s = LetStmt::make(p.first, p.second, s);
-                }
+                s = rewrap_all_lets(Block::make(provides), lets);
             }
 
             if (atomic && separate_atomic_nodes_per_store) {
@@ -422,11 +412,7 @@ class SplitScatterGather : public IRMutator {
         body = substitute(op->name, gather_replacement, body);
         body = mutate(body);
 
-        for (const auto &[var, value] : reverse_view(lets)) {
-            body = LetStmt::make(var, value, body);
-        }
-
-        return body;
+        return rewrap_all_lets(body, lets);
     }
 
     Stmt visit(const LetStmt *op) override {
@@ -451,11 +437,7 @@ class SplitScatterGather : public IRMutator {
             body = mutate(body);
         }
 
-        for (const auto &[var, value] : reverse_view(lets)) {
-            body = LetStmt::make(var, value, body);
-        }
-
-        return body;
+        return rewrap_all_lets(body, lets);
     }
 
     Stmt visit(const Provide *op) override {
@@ -499,10 +481,7 @@ class SplitScatterGather : public IRMutator {
         bundle = common_subexpression_elimination(bundle);
 
         vector<pair<string, Expr>> lets;
-        while (const Let *let = bundle.as<Let>()) {
-            lets.emplace_back(let->name, let->value);
-            bundle = let->body;
-        }
+        bundle = peel_lets(bundle, &lets);
         const Call *c = bundle.as<Call>();
         internal_assert(c && c->is_intrinsic(Call::bundle));
         for (size_t i = 0; i < exprs.size(); i++) {
@@ -515,11 +494,7 @@ class SplitScatterGather : public IRMutator {
             }
         }
 
-        for (const auto &[var, value] : reverse_view(lets)) {
-            s = LetStmt::make(var, value, s);
-        }
-
-        return s;
+        return rewrap_all_lets(s, lets);
     }
 };
 

--- a/src/VectorizeLoops.cpp
+++ b/src/VectorizeLoops.cpp
@@ -1359,9 +1359,7 @@ protected:
             s = SerializeLoops()(s);
         }
         // We'll need the original scalar versions of any containing lets.
-        for (const auto &[var, value] : reverse_view(containing_lets)) {
-            s = LetStmt::make(var, value, s);
-        }
+        s = rewrap_all_lets(s, containing_lets);
 
         for (int ix = vectorized_vars.size() - 1; ix >= 0; ix--) {
             s = For::make(vectorized_vars[ix].name, vectorized_vars[ix].min,
@@ -1608,12 +1606,7 @@ protected:
         LiftVectorizableExprsOutOfSingleAtomicNode lifter(finder.liftable);
         Stmt new_body = lifter.mutate(op->body);
         new_body = op->with(new_body);
-        while (!lifter.lifted.empty()) {
-            auto p = lifter.lifted.back();
-            new_body = LetStmt::make(p.first, p.second, new_body);
-            lifter.lifted.pop_back();
-        }
-        return new_body;
+        return rewrap_all_lets(new_body, lifter.lifted);
     }
 
     const map<string, Function> &env;


### PR DESCRIPTION
Peeling Lets or LetStmts into a vector of name/value pairs, doing
something to the body, and then rewrapping is a common pattern in the
compiler. Rewrapping conditionally was done by calling expr_uses_var on
the partially-rebuilt body once per let, which is quadratic.

Adds a Stmt overload of peel_lets, plus rewrap_used_lets and
rewrap_all_lets for Expr and Stmt. rewrap_used_lets gathers the names
the body mentions once and extends the set with the value of each let it
keeps, so it is n log(n) instead of n^2. It conservatively treats every name
mentioned as a possible reference to a peeled let, even where an inner
let shadows it.

There should be no functional changes here, but while working on it Claude
noticed that the peeled lets in the store collector in Deinterleave.cpp are 
unused. It looks like it was supposed to take the lets by reference instead of
by value, but if you do that you get duplicates in the list. It is currently trying
to figure out if this is just dead code or if this masks a bug.
