### PR TITLE
Support non-caching behavior in call_cached_indirect_function.

### DIFF
--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -3611,29 +3611,57 @@ void CodeGen_LLVM::visit(const Call *op) {
         //    ...
         //    cond_N, "sub_function_name_N"
         //
+        // Unlike standard boolean conditions, these evaluate to one of four integer states:
+        //    0: Stable False   (Skip this function, try the next one)
+        //    1: Stable True    (Use this function, and cache the result)
+        //    2: Volatile False (Skip this function, but disable caching)
+        //    3: Volatile True  (Use this function, but disable caching)
+        //
         // This will generate code that corresponds (roughly) to
         //
-        //    static FunctionPtr f = []{
-        //      if (cond_1) return sub_function_name_1;
-        //      if (cond_2) return sub_function_name_2;
-        //      ...
-        //      if (cond_N) return sub_function_name_N;
+        //    static FunctionPtr cached_f = nullptr;
+        //    if (cached_f != nullptr) return cached_f(args);
+        //
+        //    FunctionPtr selected_f = nullptr;
+        //    bool should_cache = true;
+        //
+        //    int c1 = cond_1;
+        //    if (c1 == 2 || c1 == 3) should_cache = false;
+        //    if (c1 == 1 || c1 == 3) {
+        //        selected_f = sub_function_name_1;
+        //    } else {
+        //        int c2 = cond_2;
+        //        if (c2 == 2 || c2 == 3) should_cache = false;
+        //        if (c2 == 1 || c2 == 3) {
+        //            selected_f = sub_function_name_2;
+        //        } else {
+        //            ...
+        //        }
         //    }
-        //    return f(args)
         //
-        // i.e.: the conditions will be evaluated *in order*; the first one
-        // evaluating to true will have its corresponding function cached,
-        // which will be used to complete this (and all subsequent) calls.
+        //    if (should_cache) cached_f = selected_f;
+        //    return selected_f(args);
         //
-        // The final condition (cond_N) must evaluate to a constant TRUE
-        // value (so that the final function will be selected if all others
+        // i.e.: the conditions conceptually evaluate *in order*; the first one
+        // evaluating to True (1 or 3) will have its corresponding function selected.
+        // However, if the selected condition is Volatile True (3), or if *any*
+        // preceding skipped condition evaluated to Volatile False (2), the
+        // caching mechanism is bypassed for the current invocation.
+        //
+        // (Note: In the actual emitted LLVM IR, all conditions are evaluated
+        // unconditionally using `select` instructions to avoid basic-block explosion,
+        // but the semantic result is identical to short-circuiting.)
+        //
+        // The final condition (cond_N) must evaluate to a constant Stable True (1)
+        // value (so that the final function will be selected and cached if all others
         // fail); failure to do so will cause unpredictable results.
         //
-        // There is currently no way to clear the cached function pointer.
+        // There is currently no way to clear the cached function pointer manually.
         //
-        // It is assumed/required that all of the conditions are "pure"; each
-        // must evaluate to the same value (within a given runtime environment)
-        // across multiple evaluations.
+        // It is assumed/required that all of the conditions are side-effect free.
+        // Conditions returning 0 or 1 must be "pure" (evaluating to the same value
+        // across multiple evaluations within a given runtime environment), while
+        // conditions returning 2 or 3 are expected to be dynamic/volatile.
         //
         // It is assumed/required that all of the sub-functions have arguments
         // (and return values) that are identical to those of this->function.
@@ -3717,15 +3745,40 @@ void CodeGen_LLVM::visit(const Call *op) {
 
         // Build the not-already-inited case
         builder->SetInsertPoint(global_not_inited_bb);
-        llvm::Value *selected_value = nullptr;
+        Value *selected_value = nullptr;
+        // Keep track of whether any of the results was marked as a non-cacheable value (2 or 3).
+        Value *should_cache = builder->getInt1(true);
         for (const auto &sub_fn : reverse_view(sub_fns)) {
             if (!selected_value) {
                 selected_value = sub_fn.fn_ptr;
             } else {
                 Value *c = codegen(sub_fn.cond);
-                selected_value = builder->CreateSelect(c, sub_fn.fn_ptr, selected_value);
+                Value *c_ext = builder->CreateZExtOrTrunc(c, builder->getInt32Ty());
+                // Check the lower bit: 0:no or 1:yes
+                Value *is_true = builder->CreateICmpNE(
+                    builder->CreateAnd(c_ext, builder->getInt32(1)),
+                    builder->getInt32(0));
+                // Check the upper bit: 0:cacheable or 1:volatile
+                Value *is_volatile = builder->CreateICmpNE(
+                    builder->CreateAnd(c_ext, builder->getInt32(2)),
+                    builder->getInt32(0));
+
+                // Update the selected function to the current one under test, as it passes
+                // the test, and is earlier in the list.
+                selected_value = builder->CreateSelect(is_true, sub_fn.fn_ptr, selected_value);
+
+                // Update should_cache.
+                Value *stable_true = builder->CreateAnd(is_true, builder->CreateNot(is_volatile));
+                Value *new_should_cache = builder->CreateSelect(stable_true, builder->getInt1(true), should_cache);
+                should_cache = builder->CreateSelect(is_volatile, builder->getInt1(false), new_should_cache);
             }
         }
+        // Create a basic block for storing
+        BasicBlock *store_bb = BasicBlock::Create(*context, "store_bb", function);
+        builder->CreateCondBr(should_cache, store_bb, call_fn_bb);
+
+        // Build the store bb
+        builder->SetInsertPoint(store_bb);
         builder->CreateStore(selected_value, global);
         builder->CreateBr(call_fn_bb);
 
@@ -3734,9 +3787,10 @@ void CodeGen_LLVM::visit(const Call *op) {
         builder->CreateBr(call_fn_bb);
 
         builder->SetInsertPoint(call_fn_bb);
-        PHINode *phi = builder->CreatePHI(selected_value->getType(), 2);
-        phi->addIncoming(selected_value, global_not_inited_bb);
-        phi->addIncoming(loaded_value, global_inited_bb);
+        PHINode *phi = builder->CreatePHI(selected_value->getType(), 3);
+        phi->addIncoming(selected_value, global_not_inited_bb);  // Selected it, but not cached it.
+        phi->addIncoming(selected_value, store_bb);              // Selected and cached it.
+        phi->addIncoming(loaded_value, global_inited_bb);        // It was already cached.
 
         std::vector<llvm::Value *> call_args;
         for (auto &arg : function->args()) {

--- a/src/Module.cpp
+++ b/src/Module.cpp
@@ -976,7 +976,7 @@ void compile_multitarget(const std::string &fn_name,
             runtime_features[i] &= cur_target_features[i];
         }
 
-        wrapper_args.push_back(can_use != 0);
+        wrapper_args.push_back(can_use);
         wrapper_args.emplace_back(sub_fn_name);
     }
 

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1619,20 +1619,22 @@ typedef enum halide_target_processor_t {
  * control the whether or not this procedure will be called again next invocation of a pipeline to determine
  * which version is eligible for calling.
  *
+ * You may use the convenience enum below to write your return statements.
+ *
  * The default implementation simply calls halide_default_can_use_target_features.
  *
  * Note that `features` points to an array of `count` uint64_t; this array must contain enough
  * bits to represent all the currently known features. Any excess bits must be set to zero.
  */
 // @{
-typedef enum {
+enum {
     halide_can_use_target_never = 0,
     halide_can_use_target_always = 1,
     halide_can_use_target_not_right_now = 2,
     halide_can_use_target_for_the_moment = 3,
-} halide_can_use_target_result_t;
-extern halide_can_use_target_result_t halide_can_use_target_features(int count, const uint64_t *features);
-typedef halide_can_use_target_result_t (*halide_can_use_target_features_t)(int count, const uint64_t *features);
+};
+extern int halide_can_use_target_features(int count, const uint64_t *features);
+typedef int (*halide_can_use_target_features_t)(int count, const uint64_t *features);
 extern halide_can_use_target_features_t halide_set_custom_can_use_target_features(halide_can_use_target_features_t);
 // @}
 
@@ -1641,7 +1643,7 @@ extern halide_can_use_target_features_t halide_set_custom_can_use_target_feature
  * for convenience of user code that may wish to extend halide_can_use_target_features
  * but continue providing existing support, e.g.
  *
- *     halide_can_use_target_result_t halide_can_use_target_features(int count, const uint64_t *features) {
+ *     int halide_can_use_target_features(int count, const uint64_t *features) {
  *          if (features[halide_target_somefeature >> 6] & (1LL << (halide_target_somefeature & 63))) {
  *              if (!can_use_somefeature()) {
  *                  return halide_can_use_target_never;
@@ -1650,7 +1652,7 @@ extern halide_can_use_target_features_t halide_set_custom_can_use_target_feature
  *          return halide_default_can_use_target_features(count, features);
  *     }
  */
-extern halide_can_use_target_result_t halide_default_can_use_target_features(int count, const uint64_t *features);
+extern int halide_default_can_use_target_features(int count, const uint64_t *features);
 
 typedef struct halide_dimension_t {
 #if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)

--- a/src/runtime/HalideRuntime.h
+++ b/src/runtime/HalideRuntime.h
@@ -1604,13 +1604,20 @@ typedef enum halide_target_processor_t {
  * if the current execution environment can support the given set of
  * halide_target_feature_t flags. The implementation must do the following:
  *
- * -- If there are flags set in features that the function knows *cannot* be supported, return 0.
- * -- Otherwise, return 1.
+ * -- If there are flags set in features that the function knows *cannot* be supported, return 0 (never) or 2 (not right now).
+ * -- Otherwise, return 1 (always) or 3 (for the moment).
  * -- Note that any flags set in features that the function doesn't know how to test should be ignored;
- * this implies that a return value of 1 means "not known to be bad" rather than "known to be good".
+ * this implies that a return value of 1 or 3 means "not known to be bad" rather than "known to be good".
  *
- * In other words: a return value of 0 means "It is not safe to use code compiled with these features",
- * while a return value of 1 means "It is not obviously unsafe to use code compiled with these features".
+ * In other words: a return value of 0 or 2 means "It is not safe to use code compiled with these features",
+ * while a return value of 1 or 3 means "It is not obviously unsafe to use code compiled with these features".
+ *
+ * Notice that there are four values to chose from: permanent decisions (0:never and 1:always) and temporary
+ * decisions (2:not_right_now and 3:for_the_moment). Halide multi-target pipeline wrappers select which version
+ * of the pipeline can be run based on halide_can_use_target_features. Historically, they would cache this
+ * decision in a global variable. With the introduction of the two non-permanent decision values, one can
+ * control the whether or not this procedure will be called again next invocation of a pipeline to determine
+ * which version is eligible for calling.
  *
  * The default implementation simply calls halide_default_can_use_target_features.
  *
@@ -1618,8 +1625,14 @@ typedef enum halide_target_processor_t {
  * bits to represent all the currently known features. Any excess bits must be set to zero.
  */
 // @{
-extern int halide_can_use_target_features(int count, const uint64_t *features);
-typedef int (*halide_can_use_target_features_t)(int count, const uint64_t *features);
+typedef enum {
+    halide_can_use_target_never = 0,
+    halide_can_use_target_always = 1,
+    halide_can_use_target_not_right_now = 2,
+    halide_can_use_target_for_the_moment = 3,
+} halide_can_use_target_result_t;
+extern halide_can_use_target_result_t halide_can_use_target_features(int count, const uint64_t *features);
+typedef halide_can_use_target_result_t (*halide_can_use_target_features_t)(int count, const uint64_t *features);
 extern halide_can_use_target_features_t halide_set_custom_can_use_target_features(halide_can_use_target_features_t);
 // @}
 
@@ -1628,16 +1641,16 @@ extern halide_can_use_target_features_t halide_set_custom_can_use_target_feature
  * for convenience of user code that may wish to extend halide_can_use_target_features
  * but continue providing existing support, e.g.
  *
- *     int halide_can_use_target_features(int count, const uint64_t *features) {
+ *     halide_can_use_target_result_t halide_can_use_target_features(int count, const uint64_t *features) {
  *          if (features[halide_target_somefeature >> 6] & (1LL << (halide_target_somefeature & 63))) {
  *              if (!can_use_somefeature()) {
- *                  return 0;
+ *                  return halide_can_use_target_never;
  *              }
  *          }
  *          return halide_default_can_use_target_features(count, features);
  *     }
  */
-extern int halide_default_can_use_target_features(int count, const uint64_t *features);
+extern halide_can_use_target_result_t halide_default_can_use_target_features(int count, const uint64_t *features);
 
 typedef struct halide_dimension_t {
 #if (__cplusplus >= 201103L || _MSVC_LANG >= 201103L)

--- a/src/runtime/can_use_target.cpp
+++ b/src/runtime/can_use_target.cpp
@@ -24,11 +24,11 @@ WEAK halide_can_use_target_features_t halide_set_custom_can_use_target_features(
     return result;
 }
 
-WEAK int halide_can_use_target_features(int count, const uint64_t *features) {
+WEAK halide_can_use_target_result_t halide_can_use_target_features(int count, const uint64_t *features) {
     return (*custom_can_use_target_features)(count, features);
 }
 
-WEAK int halide_default_can_use_target_features(int count, const uint64_t *features) {
+WEAK halide_can_use_target_result_t halide_default_can_use_target_features(int count, const uint64_t *features) {
     // cpu features should never change, so call once and cache.
     // Note that since CpuFeatures has a (trivial) ctor, compilers may insert guards
     // for threadsafe initialization (per C++11); this can fail at link time
@@ -60,11 +60,11 @@ WEAK int halide_default_can_use_target_features(int count, const uint64_t *featu
         uint64_t m;
         if ((m = (features[i] & cpu_features->known[i])) != 0) {
             if ((m & cpu_features->available[i]) != m) {
-                return 0;
+                return halide_can_use_target_never;
             }
         }
     }
 
-    return 1;
+    return halide_can_use_target_always;
 }
 }

--- a/src/runtime/can_use_target.cpp
+++ b/src/runtime/can_use_target.cpp
@@ -24,11 +24,11 @@ WEAK halide_can_use_target_features_t halide_set_custom_can_use_target_features(
     return result;
 }
 
-WEAK halide_can_use_target_result_t halide_can_use_target_features(int count, const uint64_t *features) {
+WEAK int halide_can_use_target_features(int count, const uint64_t *features) {
     return (*custom_can_use_target_features)(count, features);
 }
 
-WEAK halide_can_use_target_result_t halide_default_can_use_target_features(int count, const uint64_t *features) {
+WEAK int halide_default_can_use_target_features(int count, const uint64_t *features) {
     // cpu features should never change, so call once and cache.
     // Note that since CpuFeatures has a (trivial) ctor, compilers may insert guards
     // for threadsafe initialization (per C++11); this can fail at link time


### PR DESCRIPTION
This allows one to dynamically change CPU target features which are allowed and which are not allowed to run performance benchmarks. Also can be used to latency-hide GPU Compute API setup by returning "not_right_now" when asked for e.g. CUDA.

The LLVM bit was done with the help of Gemini Pro 3.1, but I went through it and understood it all. Validated the logic with Hopper Disassembler:

<img width="625" height="763" alt="image" src="https://github.com/user-attachments/assets/8137529c-d775-4675-bae4-face4f093e37" />


## Breaking changes

~~While not technically ABI breaking, your compiler might complain if you have created your own `halide_can_use_target_features()` as the return-type is now `halide_can_use_target_features_result_t` instead of `int`.~~

~~We could revert it to `int` if people want that. Personally, I would like to get an error about this, as that reveals to me there is a new feature. Dealing with this change is trivial:~~

 - ~~`return 0;` becomes `return halide_can_use_feature_never;`~~
 - ~~`return 1;` becomes `return halide_can_use_feature_always;`~~
 - ~~Change the return type, like I stated above.~~

**UPDATE**: I reverted the return type of that function to `int` to not break anyone's existing code.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
