### PR TITLE
Fix specialize() branches getting merged away by Simplify

### DIFF
--- a/src/IR.cpp
+++ b/src/IR.cpp
@@ -878,6 +878,7 @@ constexpr const char *intrinsic_op_names[] = {
     "skip_stages_marker",
     "sliding_window_marker",
     "sorted_avg",
+    "specialization_branch_marker",
     "stream_store_fence",
     "strict_add",
     "strict_cast",

--- a/src/IR.h
+++ b/src/IR.h
@@ -846,6 +846,13 @@ struct Call : public ExprNode<Call> {
         sliding_window_marker,
         // Compute (arg[0] + arg[1]) / 2, assuming arg[0] < arg[1].
         sorted_avg,
+        // Single string-literal arg uniquely identifying a specialize()
+        // branch. Injected by mark_specialization_branch()
+        // (ScheduleFunctions.cpp) so sibling branches that are still
+        // textually identical this early in lowering aren't merged by
+        // Simplify before they've had a chance to diverge; stripped by
+        // remove_specialization_branch_markers() (StorageFlattening.cpp).
+        specialization_branch_marker,
         // Emits a target-specific memory fence after a Stage that
         // contains non-temporal (streaming) stores.
         stream_store_fence,

--- a/src/ScheduleFunctions.cpp
+++ b/src/ScheduleFunctions.cpp
@@ -19,6 +19,7 @@
 #include "Solve.h"
 #include "Substitute.h"
 #include "Target.h"
+#include "Util.h"
 #include "Var.h"
 
 namespace Halide {
@@ -488,6 +489,44 @@ bool any_specialization_requests_streaming(const Definition &def) {
     return false;
 }
 
+// Brackets a specialize() branch's body with a pair of uniquely-named
+// Call::specialization_branch_marker Evaluates, inside any leading LetStmt
+// chain rather than outside it.
+//
+// Sibling branches are often identical until the specialize() guard's
+// implications simplify them apart, so without markers Simplify's
+// branch-merging rules treat "identical" as "redundant" and merge them.
+// Both ends need marking, since a shared prefix or suffix can still get
+// hoisted out even when the marked ends differ.
+//
+// Markers go inside the leading LetStmt chain, not outside it, because
+// build_produce_definition()'s compute_with/fused-loop path peels that
+// chain off the result to hoist per-dimension loop bound bindings into a
+// scope shared with any fused Func. A Block wrapping the whole result
+// would hide those lets from that peel, so we peel them off here
+// ourselves and rewrap them around the marked body.
+//
+// remove_specialization_branch_markers() (StorageFlattening.cpp) strips
+// these back out once branches have actually diverged for real.
+Stmt mark_specialization_branch(Stmt body) {
+    vector<pair<string, Expr>> lets;
+    while (const LetStmt *let = body.as<LetStmt>()) {
+        lets.emplace_back(let->name, let->value);
+        body = let->body;
+    }
+
+    Expr front_marker = Call::make(Int(32), Call::specialization_branch_marker,
+                                   {StringImm::make(unique_name('s'))}, Call::Intrinsic);
+    Expr back_marker = Call::make(Int(32), Call::specialization_branch_marker,
+                                  {StringImm::make(unique_name('s'))}, Call::Intrinsic);
+    body = Block::make({Evaluate::make(front_marker), std::move(body), Evaluate::make(back_marker)});
+
+    for (const auto &[name, value] : reverse_view(lets)) {
+        body = LetStmt::make(name, value, body);
+    }
+    return body;
+}
+
 // Build a loop nest about a provide node using a schedule
 Stmt build_provide_loop_nest(const map<string, Function> &env,
                              const string &prefix,
@@ -551,12 +590,22 @@ Stmt build_provide_loop_nest(const map<string, Function> &env,
     Stmt stmt = build_loop_nest(body, prefix, start_fuse, func, def);
     stmt = inject_placeholder_prefetch(stmt, env, prefix, def.schedule().prefetches());
 
-    // Make any specialized copies
+    // Make any specialized copies. Mark every sibling branch at this level
+    // (this base case, and each then_case below) so equal() can't merge two
+    // of them once they've simplified to look alike. Funcs with no
+    // specializations are left untouched: no siblings to disambiguate, so
+    // marking would just be needless overhead.
     const vector<Specialization> &specializations = def.specializations();
+    if (!specializations.empty()) {
+        stmt = mark_specialization_branch(stmt);
+    }
     for (size_t i = specializations.size(); i > 0; i--) {
         const Specialization &s = specializations[i - 1];
         if (s.failure_message.empty()) {
             Stmt then_case = build_provide_loop_nest(env, prefix, func, s.definition, start_fuse, is_update);
+            // Only marks s.definition's own nested specializations, if any --
+            // doesn't know it's also our sibling here, so we mark it too.
+            then_case = mark_specialization_branch(then_case);
             stmt = IfThenElse::make(s.condition, then_case, stmt);
         } else {
             internal_assert(is_const_one(s.condition));

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -682,36 +682,15 @@ protected:
     }
 };
 
-bool is_specialization_branch_marker(const Stmt &s) {
-    if (const Evaluate *eval = s.as<Evaluate>()) {
-        if (const Call *call = eval->value.as<Call>()) {
-            return call->is_intrinsic(Call::specialization_branch_marker);
-        }
-    }
-    return false;
-}
-
 // Strips the markers mark_specialization_branch() (ScheduleFunctions.cpp)
 // brackets each specialize() branch with. Safe here because by the time
 // storage flattening has run, sibling branches have diverged for real (e.g.
 // a stride-1 specialization now has literal contiguous Store/Load nodes
 // where the generic fallback has stride-multiplied ones).
 Stmt remove_specialization_branch_markers(Stmt s) {
-    return mutate_with(s, [](auto *self, const Block *op) -> Stmt {
-        // Markers bracket both ends of a branch's body, so both first and
-        // rest need checking. If the real body between them simplified away
-        // entirely, this Block may already be a bare (front_marker,
-        // back_marker) pair with nothing left in between -- handle that
-        // directly, since recursing into a lone marker Evaluate (not itself
-        // a Block) would never visit it again to strip it.
-        bool first_is_marker = is_specialization_branch_marker(op->first);
-        bool rest_is_marker = is_specialization_branch_marker(op->rest);
-        if (first_is_marker && rest_is_marker) {
-            return Evaluate::make(0);
-        } else if (first_is_marker) {
-            return self->mutate(op->rest);
-        } else if (rest_is_marker) {
-            return self->mutate(op->first);
+    return mutate_with(s, [](auto *self, const Call *op) -> Expr {
+        if (op->is_intrinsic(Call::specialization_branch_marker)) {
+            return make_zero(op->type);
         }
         return self->visit_base(op);
     });

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -682,6 +682,41 @@ protected:
     }
 };
 
+bool is_specialization_branch_marker(const Stmt &s) {
+    if (const Evaluate *eval = s.as<Evaluate>()) {
+        if (const Call *call = eval->value.as<Call>()) {
+            return call->is_intrinsic(Call::specialization_branch_marker);
+        }
+    }
+    return false;
+}
+
+// Strips the markers mark_specialization_branch() (ScheduleFunctions.cpp)
+// brackets each specialize() branch with. Safe here because by the time
+// storage flattening has run, sibling branches have diverged for real (e.g.
+// a stride-1 specialization now has literal contiguous Store/Load nodes
+// where the generic fallback has stride-multiplied ones).
+Stmt remove_specialization_branch_markers(Stmt s) {
+    return mutate_with(s, [](auto *self, const Block *op) -> Stmt {
+        // Markers bracket both ends of a branch's body, so both first and
+        // rest need checking. If the real body between them simplified away
+        // entirely, this Block may already be a bare (front_marker,
+        // back_marker) pair with nothing left in between -- handle that
+        // directly, since recursing into a lone marker Evaluate (not itself
+        // a Block) would never visit it again to strip it.
+        bool first_is_marker = is_specialization_branch_marker(op->first);
+        bool rest_is_marker = is_specialization_branch_marker(op->rest);
+        if (first_is_marker && rest_is_marker) {
+            return Evaluate::make(0);
+        } else if (first_is_marker) {
+            return self->mutate(op->rest);
+        } else if (rest_is_marker) {
+            return self->mutate(op->first);
+        }
+        return self->visit_base(op);
+    });
+}
+
 }  // namespace
 
 Stmt storage_flattening(Stmt s,
@@ -706,6 +741,7 @@ Stmt storage_flattening(Stmt s,
     s = FlattenDimensions(tuple_env, outputs, target)(s);
     s = HoistStorage()(s);
     s = PromoteToMemoryType()(s);
+    s = remove_specialization_branch_markers(s);
 
     return s;
 }

--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -687,7 +687,7 @@ protected:
 // storage flattening has run, sibling branches have diverged for real (e.g.
 // a stride-1 specialization now has literal contiguous Store/Load nodes
 // where the generic fallback has stride-multiplied ones).
-Stmt remove_specialization_branch_markers(Stmt s) {
+Stmt remove_specialization_branch_markers(const Stmt &s) {
     return mutate_with(s, [](auto *self, const Call *op) -> Expr {
         if (op->is_intrinsic(Call::specialization_branch_marker)) {
             return make_zero(op->type);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -328,6 +328,7 @@ tests(
     solve.cpp
     sort_exprs.cpp
     specialize.cpp
+    specialize_stride_lowering.cpp
     specialize_to_gpu.cpp
     specialize_trim_condition.cpp
     spirv_ir.cpp

--- a/test/correctness/specialize_stride_lowering.cpp
+++ b/test/correctness/specialize_stride_lowering.cpp
@@ -1,0 +1,57 @@
+#include "Halide.h"
+#include <cstdio>
+
+using namespace Halide;
+
+// Regression test for https://github.com/halide/Halide/pull/8858 ("Change
+// for loops from min/extent to min/max"): a Func with an unconstrained
+// output-buffer stride, specialized on stride==1, silently loses that
+// specialization during lowering -- every call falls through to the
+// generic (always-strided) path, even when the buffer really is contiguous.
+//
+// The condition itself has no effect on the IR this early in lowering (the
+// stride only shows up once storage flattening turns indices into flat
+// addresses), so the specialized and generic branches are textually
+// identical when Simplify runs. That made Simplify's "merge branches with
+// equal bodies" rule collapse them into one, discarding the specialization.
+//
+// dst.parallel(y) makes each surviving specialize() branch lower to its own
+// distinct parallel-closure helper function; dropping the specialization
+// collapses that back down to a single generic function. Counting those
+// functions is a precise, non-textual way to detect whether the
+// specialization survived lowering. Not target-specific: reproduces under
+// the default JIT/host target.
+int main(int argc, char **argv) {
+    ImageParam src(UInt(8), 2, "src");
+
+    Var x("x"), y("y");
+
+    Func dst("dst");
+    dst(x, y) = src(x, y);
+
+    dst.output_buffer().dim(0).set_stride(Expr());
+
+    dst.parallel(y);
+
+    dst.specialize(dst.output_buffer().dim(0).stride() == 1);
+
+    Module m = dst.compile_to_module({src}, "dst", get_jit_target_from_environment());
+
+    int par_for_count = 0;
+    for (const auto &f : m.functions()) {
+        if (f.name.find("_par_for_") != std::string::npos) {
+            par_for_count++;
+        }
+    }
+
+    // Expect 2: one for the specialized branch, one for the generic fallback.
+    if (par_for_count <= 1) {
+        printf("Specialize() branch did not survive lowering: expected "
+               "2 distinct parallel-closure functions, found %d\n",
+               par_for_count);
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Simplify_Stmts.cpp's `visit(const IfThenElse *)` merges sibling branches that compare equal, on the theory that specializations are simplified early enough that any two which still match by the time Simplify sees them really are redundant. That's not true for a specialize() on something with no effect on the IR until much later -- a buffer's stride, say -- since nothing before storage flattening gives the two branches any reason to differ yet. Changing For loops from storing (min, extent) to (min, max) removed some incidental differences in generated temp-variable names that had been keeping such branches from ever comparing equal in practice, which turned this from a latent risk into an actual one: a stride-based specialize() can now silently collapse to its generic fallback, which may be many times slower for the common (contiguous) case it was written to catch.

Fix by bracketing each specialize() branch's body, including the unspecialized fallback, with a pair of uniquely-named marker statements that keep sibling branches from ever comparing equal until storage flattening -- the earliest point at which they're guaranteed to have actually diverged -- where the markers are then stripped back out. Both ends of the body need a marker: one alone stops the whole-branch merge, but leaves the untouched end identical across branches, so a second rule that hoists a common prefix or suffix out of the if/else fires instead and merges them just as thoroughly.

The markers go inside any leading LetStmt chain rather than outside it, because `build_produce_definition()`'s compute_with/fused-loop handling peels that chain off of each Func's provide loop nest to hoist the per-dimension loop bound bindings into a scope shared with whatever it's fused with. A Block wrapping the whole thing instead of just the inner body would make that peel find nothing to hoist, leaving those bindings unavailable where the fused Func's own loop header needs them.

Found via a downstream generator that specializes an output buffer's stride, whose stride-1 fast path was silently regressing to 10-15x slower than the generic path after picking up a newer Halide. Bisection pointed at the min/max loop refactor; the actual bug turned out to be this pre-existing (if previously unreachable in practice) fragility in the branch-merging rule itself.

Added `test/correctness/specialize_stride_lowering.cpp` as a regression test: it specializes a parallelized copy Func on an unconstrained output stride and asserts that the specialization survives lowering as a distinct compiled function.
