### PR TITLE
Fix extent alignment inference

### DIFF
--- a/src/AddImageChecks.cpp
+++ b/src/AddImageChecks.cpp
@@ -710,9 +710,11 @@ Stmt add_image_checks_inner(Stmt s,
     // all in reverse order compared to execution, as we incrementally
     // prepending code.
 
-    // Inject the code that checks the constraints are correct.
-    prepend_stmts(&asserts_constrained);
+    // Inject the buffer constraints before the required-region checks so that
+    // simplification can use the constraints when reasoning about the checks.
+    // These calls are in reverse execution order because they prepend stmts.
     prepend_stmts(&asserts_required);
+    prepend_stmts(&asserts_constrained);
     prepend_stmts(&asserts_type_checks);
 
     // Inject the code that returns early for inference mode.

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -216,52 +216,17 @@ void Simplify::ScopedFact::learn_true(const Expr &fact) {
             }
             simplify->bounds_and_alignment_info.push(vb->name, expr_info);
             bounds_pop_list.push_back(vb);
-        } else if (modulus && remainder) {
-            // Learn from expressions of the form x % 8 == 3, or
-            // (x + c) % 8 == 3.
-            ModulusRemainder inferred_alignment{*modulus, *remainder};
-            v = m->a.as<Variable>();
-            if (!v) {
-                if (const Add *add = m->a.as<Add>()) {
-                    if ((v = add->a.as<Variable>())) {
-                        if (const auto offset = as_const_int(add->b)) {
-                            inferred_alignment = inferred_alignment - *offset;
-                        } else {
-                            v = nullptr;
-                        }
-                    } else if ((v = add->b.as<Variable>())) {
-                        if (const auto offset = as_const_int(add->a)) {
-                            inferred_alignment = inferred_alignment - *offset;
-                        } else {
-                            v = nullptr;
-                        }
-                    }
-                } else if (const Sub *sub = m->a.as<Sub>()) {
-                    if ((v = sub->a.as<Variable>())) {
-                        if (const auto offset = as_const_int(sub->b)) {
-                            inferred_alignment = inferred_alignment + *offset;
-                        } else {
-                            v = nullptr;
-                        }
-                    } else if ((v = sub->b.as<Variable>())) {
-                        if (const auto offset = as_const_int(sub->a)) {
-                            inferred_alignment = ModulusRemainder{0, *offset} - inferred_alignment;
-                        } else {
-                            v = nullptr;
-                        }
-                    }
-                }
+        } else if (modulus && remainder && (v = m->a.as<Variable>())) {
+            // Learn from expressions of the form x % 8 == 3
+            Simplify::ExprInfo expr_info;
+            expr_info.alignment.modulus = *modulus;
+            expr_info.alignment.remainder = *remainder;
+            if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
+                // We already know something about this variable and don't want to suppress it.
+                expr_info.intersect(*info);
             }
-            if (v) {
-                Simplify::ExprInfo expr_info;
-                expr_info.alignment = inferred_alignment;
-                if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
-                    // We already know something about this variable and don't want to suppress it.
-                    expr_info.intersect(*info);
-                }
-                simplify->bounds_and_alignment_info.push(v->name, expr_info);
-                bounds_pop_list.push_back(v);
-            }
+            simplify->bounds_and_alignment_info.push(v->name, expr_info);
+            bounds_pop_list.push_back(v);
         }
     } else if (const LT *lt = fact.as<LT>()) {
         const Variable *v = lt->a.as<Variable>();

--- a/src/Simplify.cpp
+++ b/src/Simplify.cpp
@@ -216,17 +216,52 @@ void Simplify::ScopedFact::learn_true(const Expr &fact) {
             }
             simplify->bounds_and_alignment_info.push(vb->name, expr_info);
             bounds_pop_list.push_back(vb);
-        } else if (modulus && remainder && (v = m->a.as<Variable>())) {
-            // Learn from expressions of the form x % 8 == 3
-            Simplify::ExprInfo expr_info;
-            expr_info.alignment.modulus = *modulus;
-            expr_info.alignment.remainder = *remainder;
-            if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
-                // We already know something about this variable and don't want to suppress it.
-                expr_info.intersect(*info);
+        } else if (modulus && remainder) {
+            // Learn from expressions of the form x % 8 == 3, or
+            // (x + c) % 8 == 3.
+            ModulusRemainder inferred_alignment{*modulus, *remainder};
+            v = m->a.as<Variable>();
+            if (!v) {
+                if (const Add *add = m->a.as<Add>()) {
+                    if ((v = add->a.as<Variable>())) {
+                        if (const auto offset = as_const_int(add->b)) {
+                            inferred_alignment = inferred_alignment - *offset;
+                        } else {
+                            v = nullptr;
+                        }
+                    } else if ((v = add->b.as<Variable>())) {
+                        if (const auto offset = as_const_int(add->a)) {
+                            inferred_alignment = inferred_alignment - *offset;
+                        } else {
+                            v = nullptr;
+                        }
+                    }
+                } else if (const Sub *sub = m->a.as<Sub>()) {
+                    if ((v = sub->a.as<Variable>())) {
+                        if (const auto offset = as_const_int(sub->b)) {
+                            inferred_alignment = inferred_alignment + *offset;
+                        } else {
+                            v = nullptr;
+                        }
+                    } else if ((v = sub->b.as<Variable>())) {
+                        if (const auto offset = as_const_int(sub->a)) {
+                            inferred_alignment = ModulusRemainder{0, *offset} - inferred_alignment;
+                        } else {
+                            v = nullptr;
+                        }
+                    }
+                }
             }
-            simplify->bounds_and_alignment_info.push(v->name, expr_info);
-            bounds_pop_list.push_back(v);
+            if (v) {
+                Simplify::ExprInfo expr_info;
+                expr_info.alignment = inferred_alignment;
+                if (const auto *info = simplify->bounds_and_alignment_info.find(v->name)) {
+                    // We already know something about this variable and don't want to suppress it.
+                    expr_info.intersect(*info);
+                }
+                simplify->bounds_and_alignment_info.push(v->name, expr_info);
+                bounds_pop_list.push_back(v);
+            }
         }
     } else if (const LT *lt = fact.as<LT>()) {
         const Variable *v = lt->a.as<Variable>();

--- a/src/Simplify_EQ.cpp
+++ b/src/Simplify_EQ.cpp
@@ -308,7 +308,8 @@ Expr Simplify::visit(const EQ *op, ExprInfo *info) {
           false)) ||
 
         (no_overflow_int(a.type()) &&
-         (rewrite(x == x % c0, x / c0 == 0, c0 != 0) ||
+         (rewrite((x + c0) % c1 == c2, x % c1 == fold((c2 - c0) % c1)) ||
+          rewrite(x == x % c0, x / c0 == 0, c0 != 0) ||
           rewrite(x % c0 == x, x / c0 == 0, c0 != 0) ||
           rewrite(x == (x / c0) * c0, x % c0 == 0, c0 != 0) ||
           rewrite((x / c0) * c0 == x, x % c0 == 0, c0 != 0) ||

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -389,6 +389,7 @@ tests(
     vector_extern.cpp
     vector_print_bug.cpp
     vector_shuffle.cpp
+    vector_store_alignment.cpp
     vector_tile.cpp
     vectorize_guard_with_if.cpp
     vectorize_mixed_widths.cpp

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -61,18 +61,6 @@ void check_in_bounds(const Expr &a, const Expr &b, const Scope<Interval> &bi) {
     }
 }
 
-void check_with_assumptions(const Expr &a, const Expr &b, const std::vector<Expr> &assumptions) {
-    Expr simpler = simplify(a, Scope<Interval>(), Scope<ModulusRemainder>(), assumptions);
-    if (!equal(simpler, b)) {
-        std::cerr
-            << "\nSimplification failure:\n"
-            << "Input: " << a << "\n"
-            << "Output: " << simpler << "\n"
-            << "Expected output: " << b << "\n";
-        abort();
-    }
-}
-
 // Helper functions to use in the tests below
 Expr interleave_vectors(const std::vector<Expr> &e) {
     return Shuffle::make_interleave(e);
@@ -450,6 +438,8 @@ void check_algebra() {
     check((y - 8) % 4, y % 4);
     check((y - x * 8) % 4, y % 4);
     check((x * 8 - y) % 4, (-y) % 4);
+    check((x + 31) % 32 == 31, x % 32 == 0);
+    check((x - 1) % 32 == 31, x % 32 == 0);
 
     // Check an optimization important for fusing dimensions
     check((x / 3) * 3 + x % 3, x);
@@ -2332,15 +2322,6 @@ void check_unreachable() {
           Evaluate::make(0));
 }
 
-void check_assumptions() {
-    Expr x = Var("x");
-
-    check_with_assumptions(x % 32, 0, {(x + 31) % 32 == 31});
-    check_with_assumptions(x % 32, 0, {(31 + x) % 32 == 31});
-    check_with_assumptions(x % 32, 0, {(x - 1) % 32 == 31});
-    check_with_assumptions(x % 32, 0, {(31 - x) % 32 == 31});
-}
-
 int main(int argc, char **argv) {
     check_invariant();
     check_casts();
@@ -2352,7 +2333,6 @@ int main(int argc, char **argv) {
     check_overflow();
     check_bitwise();
     check_lets();
-    check_assumptions();
     check_unreachable();
 
     // Miscellaneous cases that don't fit into one of the categories above.

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -61,6 +61,18 @@ void check_in_bounds(const Expr &a, const Expr &b, const Scope<Interval> &bi) {
     }
 }
 
+void check_with_assumptions(const Expr &a, const Expr &b, const std::vector<Expr> &assumptions) {
+    Expr simpler = simplify(a, Scope<Interval>(), Scope<ModulusRemainder>(), assumptions);
+    if (!equal(simpler, b)) {
+        std::cerr
+            << "\nSimplification failure:\n"
+            << "Input: " << a << "\n"
+            << "Output: " << simpler << "\n"
+            << "Expected output: " << b << "\n";
+        abort();
+    }
+}
+
 // Helper functions to use in the tests below
 Expr interleave_vectors(const std::vector<Expr> &e) {
     return Shuffle::make_interleave(e);
@@ -2320,6 +2332,15 @@ void check_unreachable() {
           Evaluate::make(0));
 }
 
+void check_assumptions() {
+    Expr x = Var("x");
+
+    check_with_assumptions(x % 32, 0, {(x + 31) % 32 == 31});
+    check_with_assumptions(x % 32, 0, {(31 + x) % 32 == 31});
+    check_with_assumptions(x % 32, 0, {(x - 1) % 32 == 31});
+    check_with_assumptions(x % 32, 0, {(31 - x) % 32 == 31});
+}
+
 int main(int argc, char **argv) {
     check_invariant();
     check_casts();
@@ -2331,6 +2352,7 @@ int main(int argc, char **argv) {
     check_overflow();
     check_bitwise();
     check_lets();
+    check_assumptions();
     check_unreachable();
 
     // Miscellaneous cases that don't fit into one of the categories above.

--- a/test/correctness/vector_store_alignment.cpp
+++ b/test/correctness/vector_store_alignment.cpp
@@ -11,15 +11,15 @@ class CheckVectorStoreAlignment : public IRVisitor {
     void visit(const Store *op) override {
         if (op->name == "output" && op->value.type().lanes() == 32) {
             found_vector_store = true;
-            alignment_is_known = op->alignment.modulus % 32 == 0 &&
-                                 op->alignment.remainder % 32 == 0;
+            all_vector_stores_aligned &= op->alignment.modulus % 32 == 0 &&
+                                         op->alignment.remainder % 32 == 0;
         }
         IRVisitor::visit(op);
     }
 
 public:
     bool found_vector_store = false;
-    bool alignment_is_known = false;
+    bool all_vector_stores_aligned = true;
 };
 
 }  // namespace
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
         printf("Did not find the vectorized output store.\n");
         return 1;
     }
-    if (!checker.alignment_is_known) {
+    if (!checker.all_vector_stores_aligned) {
         printf("The vectorized output store was not known to be aligned by 32 elements.\n");
         return 1;
     }

--- a/test/correctness/vector_store_alignment.cpp
+++ b/test/correctness/vector_store_alignment.cpp
@@ -1,0 +1,65 @@
+#include "Halide.h"
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+namespace {
+
+class CheckVectorStoreAlignment : public IRVisitor {
+    using IRVisitor::visit;
+
+    void visit(const Store *op) override {
+        if (op->name == "output" && op->value.type().lanes() == 32) {
+            found_vector_store = true;
+            alignment_is_known = op->alignment.modulus % 32 == 0 &&
+                                 op->alignment.remainder % 32 == 0;
+        }
+        IRVisitor::visit(op);
+    }
+
+public:
+    bool found_vector_store = false;
+    bool alignment_is_known = false;
+};
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    Var x{"x"}, y{"y"}, xi{"xi"}, yi{"yi"};
+    ImageParam input{UInt(16), 2, "input"};
+
+    Func output{"output"};
+    output(x, y) = input(x, y);
+
+    output.align_extent(x, 32)
+        .tile(x, y, xi, yi, 32, 4)
+        .vectorize(xi);
+
+    output.output_buffer().dim(0).set_min(0);
+    output.output_buffer().dim(1).set_min(0);
+    output.output_buffer().dim(1).set_stride(output.output_buffer().dim(0).extent());
+    output.output_buffer().set_host_alignment(64);
+
+    Target target = get_jit_target_from_environment()
+                        .with_feature(Target::NoAsserts)
+                        .with_feature(Target::NoBoundsQuery)
+                        .with_feature(Target::NoRuntime);
+    Module module = output.compile_to_module({input}, "vector_store_alignment", target);
+
+    CheckVectorStoreAlignment checker;
+    for (const LoweredFunc &f : module.functions()) {
+        f.body.accept(&checker);
+    }
+
+    if (!checker.found_vector_store) {
+        printf("Did not find the vectorized output store.\n");
+        return 1;
+    }
+    if (!checker.alignment_is_known) {
+        printf("The vectorized output store was not known to be aligned by 32 elements.\n");
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -10,6 +10,7 @@ int main(int argc, char **argv) {
 
 #include <iostream>
 #include <limits>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -42,7 +43,7 @@ enum {
 const void *output_base = nullptr;
 const void *output_previous = nullptr;
 int bounds_inference_count = 0;
-bool expect_intermediate_buffer_error = false;
+bool expect_constraint_violation_error = false;
 bool skip_extern_copy = false;
 uint64_t input_contents_checked = 0;
 uint64_t input_contents_uninitialized = 0;
@@ -56,7 +57,7 @@ void reset_state(const MsanBuffer &in, const MsanBuffer &out) {
     output_base = out.data();
     output_previous = nullptr;
     bounds_inference_count = 0;
-    expect_intermediate_buffer_error = false;
+    expect_constraint_violation_error = false;
     skip_extern_copy = false;
     input_contents_uninitialized = 0;
     input_contents_checked = 0;
@@ -194,9 +195,16 @@ extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, co
             annotate_stage = AnnotateBoundsInferenceBuffer;
         }
     } else if (annotate_stage == AnnotateIntermediateBuffer) {
-        if (expect_intermediate_buffer_error) {
-            if (len != 80) {
-                fprintf(stderr, "Failure: Expected error message of len=80, saw %d bytes\n", (unsigned int)len);
+        if (expect_constraint_violation_error) {
+            constexpr std::string_view expected_error =
+                "Constraint violated: input.extent.0 (1) == 4 (4)";
+            std::string_view actual_error{static_cast<const char *>(ptr), len};
+            if (!actual_error.empty() && actual_error.back() == '\0') {
+                actual_error.remove_suffix(1);
+            }
+            if (actual_error != expected_error) {
+                fprintf(stderr, "Failure: Unexpected error message: %.*s\n",
+                        (int)len, static_cast<const char *>(ptr));
                 exit(1);
             }
             return 0;  // stay in this state
@@ -428,7 +436,7 @@ int main() {
         auto out = MsanBuffer(1, 1, 1);
         auto in = make_input_for(out);
         reset_state(in, out);
-        expect_intermediate_buffer_error = true;
+        expect_constraint_violation_error = true;
         if (msan(in, out) == 0) {
             fprintf(stderr, "Failure (expected failure but did not)!\n");
             exit(1);

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -198,7 +198,7 @@ extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, co
         if (expect_constraint_violation_error) {
             constexpr std::string_view expected_error =
                 "Constraint violated: input.extent.0 (1) == 4 (4)";
-            std::string_view actual_error{static_cast<const char *>(ptr), len};
+            std::string_view actual_error{static_cast<const char *>(ptr), (size_t)len};
             if (!actual_error.empty() && actual_error.back() == '\0') {
                 actual_error.remove_suffix(1);
             }

--- a/test/generator/msan_aottest.cpp
+++ b/test/generator/msan_aottest.cpp
@@ -204,7 +204,7 @@ extern "C" int halide_msan_annotate_memory_is_initialized(void *user_context, co
             }
             if (actual_error != expected_error) {
                 fprintf(stderr, "Failure: Unexpected error message: %.*s\n",
-                        (int)len, static_cast<const char *>(ptr));
+                        (int)actual_error.size(), actual_error.data());
                 exit(1);
             }
             return 0;  // stay in this state


### PR DESCRIPTION
I was helping @mcourteaux debug an alignment issue. It was insufficient to pass the typical shape checks, such as:

```
f.output_buffer().dim(1).set_stride(f.output_buffer().dim(0).extent());
```

Instead, we had to write:

```
f.output_buffer().dim(1).set_stride(f.output_buffer().dim(1).stride() / 32 * 32);
```

But even then we were faced with a problem of the store being _under_ aligned (to 4 instead of 16 two-byte elements).

The schedule was using `.align_extent(x, 32)` and `f.output_buffer().set_host_alignment(64)`. The `.align_storage()` scheduling directive does not work here because Halide doesn't control the allocation. This ought to _error_ in JIT mode or do something reasonable to the output buffer. @abadams — I'm interested in your input here.

This was caused by two issues:

1. The image checks were passed such that the scheduling _constraints_ were processed after the _requirements_, when the constraints ought to influence the requirements. This fixes the inference issue.
2. The simplifier was unable to recognize round-up modulo facts. There was a rule for `x % b == c`, but not the affine variant `(x + a) % b == c`. Adding this recovered the precise alignment.

## Breaking changes

None that I'm aware of

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Commits include AI attribution where applicable (see Code of Conduct)
