### PR TITLE
Simplify nested selects on the same condition under affine arithmetic

### DIFF
--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -205,6 +205,7 @@ Expr Simplify::visit(const Min *op, ExprInfo *info) {
          rewrite(min(z, select(x, y, max(z, w))), select(x, min(z, y), z)) ||
 
          rewrite(min(select(x, y, z), select(x, w, u)), select(x, min(y, w), min(z, u))) ||
+         rewrite(min(select(x, y, z), select(x, w, u)/c0), select(x, min(y, w/c0), min(z, u/c0))) ||
          rewrite(min(select(x, min(z, y), w), y), min(select(x, z, w), y)) ||
          rewrite(min(select(x, min(z, y), w), z), min(select(x, y, w), z)) ||
          rewrite(min(select(x, w, min(z, y)), y), min(select(x, w, z), y)) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -205,7 +205,8 @@ Expr Simplify::visit(const Min *op, ExprInfo *info) {
          rewrite(min(z, select(x, y, max(z, w))), select(x, min(z, y), z)) ||
 
          rewrite(min(select(x, y, z), select(x, w, u)), select(x, min(y, w), min(z, u))) ||
-         rewrite(min(select(x, y, z), select(x, w, u)/c0), select(x, min(y, w/c0), min(z, u/c0))) ||
+         rewrite(min(select(x, y, z), select(x, w, u) / c0), select(x, min(y, w / c0), min(z, u / c0))) ||
+         rewrite(min(select(x, y, z), select(x, w, u) * c0), select(x, min(y, w * c0), min(z, u * c0))) ||
          rewrite(min(select(x, min(z, y), w), y), min(select(x, z, w), y)) ||
          rewrite(min(select(x, min(z, y), w), z), min(select(x, y, w), z)) ||
          rewrite(min(select(x, w, min(z, y)), y), min(select(x, w, z), y)) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -206,7 +206,6 @@ Expr Simplify::visit(const Min *op, ExprInfo *info) {
 
          rewrite(min(select(x, y, z), select(x, w, u)), select(x, min(y, w), min(z, u))) ||
          rewrite(min(select(x, y, z), select(x, w, u) / c0), select(x, min(y, w / c0), min(z, u / c0))) ||
-         rewrite(min(select(x, y, z), select(x, w, u) * c0), select(x, min(y, w * c0), min(z, u * c0))) ||
          rewrite(min(select(x, min(z, y), w), y), min(select(x, z, w), y)) ||
          rewrite(min(select(x, min(z, y), w), z), min(select(x, y, w), z)) ||
          rewrite(min(select(x, w, min(z, y)), y), min(select(x, w, z), y)) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -51,6 +51,27 @@ Expr Simplify::visit(const Select *op, ExprInfo *info) {
          rewrite(select(x, y, select(z, w, y)), select(x || !z, y, w)) ||
          rewrite(select(x, select(x, y, z), w), select(x, y, w)) ||
          rewrite(select(x, y, select(x, z, w)), select(x, y, w)) ||
+         // The same, but where the inner select is buried under some
+         // affine arithmetic. Substituting the branch the condition selects
+         // never introduces an operand that wasn't already being evaluated.
+         rewrite(select(x, select(x, z, w) + u, y), select(x, z + u, y)) ||
+         rewrite(select(x, u + select(x, z, w), y), select(x, u + z, y)) ||
+         rewrite(select(x, select(x, z, w) - u, y), select(x, z - u, y)) ||
+         rewrite(select(x, u - select(x, z, w), y), select(x, u - z, y)) ||
+         rewrite(select(x, y, select(x, z, w) + u), select(x, y, w + u)) ||
+         rewrite(select(x, y, u + select(x, z, w)), select(x, y, u + w)) ||
+         rewrite(select(x, y, select(x, z, w) - u), select(x, y, w - u)) ||
+         rewrite(select(x, y, u - select(x, z, w)), select(x, y, u - w)) ||
+         rewrite(select(x, (select(x, z, w) + u)/v, y), select(x, (z + u)/v, y)) ||
+         rewrite(select(x, (u + select(x, z, w))/v, y), select(x, (u + z)/v, y)) ||
+         rewrite(select(x, (select(x, z, w) - u)/v, y), select(x, (z - u)/v, y)) ||
+         rewrite(select(x, (u - select(x, z, w))/v, y), select(x, (u - z)/v, y)) ||
+         rewrite(select(x, y, (select(x, z, w) + u)/v), select(x, y, (w + u)/v)) ||
+         rewrite(select(x, y, (u + select(x, z, w))/v), select(x, y, (u + w)/v)) ||
+         rewrite(select(x, y, (select(x, z, w) - u)/v), select(x, y, (w - u)/v)) ||
+         rewrite(select(x, y, (u - select(x, z, w))/v), select(x, y, (u - w)/v)) ||
+         rewrite(select(x, select(x, z, w)/v, y), select(x, z/v, y)) ||
+         rewrite(select(x, y, select(x, z, w)/v), select(x, y, w/v)) ||
          rewrite(select(x, y + z, y + w), y + select(x, z, w)) ||
          rewrite(select(x, y + z, w + y), y + select(x, z, w)) ||
          rewrite(select(x, z + y, y + w), y + select(x, z, w)) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -52,8 +52,12 @@ Expr Simplify::visit(const Select *op, ExprInfo *info) {
          rewrite(select(x, select(x, y, z), w), select(x, y, w)) ||
          rewrite(select(x, y, select(x, z, w)), select(x, y, w)) ||
          // The same, but where the inner select is buried under some
-         // affine arithmetic. Substituting the branch the condition selects
-         // never introduces an operand that wasn't already being evaluated.
+         // quasi-affine arithmetic. A branch's value only matters when the
+         // condition selects it, and under that condition the inner select
+         // equals one of its operands. Note this is not the same as assuming
+         // the condition holds while simplifying a branch, which would be
+         // unsound because both branches are always evaluated. Here we only
+         // ever replace an expression with one of its own subexpressions.
          rewrite(select(x, select(x, z, w) + u, y), select(x, z + u, y)) ||
          rewrite(select(x, u + select(x, z, w), y), select(x, u + z, y)) ||
          rewrite(select(x, select(x, z, w) - u, y), select(x, z - u, y)) ||
@@ -62,16 +66,28 @@ Expr Simplify::visit(const Select *op, ExprInfo *info) {
          rewrite(select(x, y, u + select(x, z, w)), select(x, y, u + w)) ||
          rewrite(select(x, y, select(x, z, w) - u), select(x, y, w - u)) ||
          rewrite(select(x, y, u - select(x, z, w)), select(x, y, u - w)) ||
-         rewrite(select(x, (select(x, z, w) + u)/v, y), select(x, (z + u)/v, y)) ||
-         rewrite(select(x, (u + select(x, z, w))/v, y), select(x, (u + z)/v, y)) ||
-         rewrite(select(x, (select(x, z, w) - u)/v, y), select(x, (z - u)/v, y)) ||
-         rewrite(select(x, (u - select(x, z, w))/v, y), select(x, (u - z)/v, y)) ||
-         rewrite(select(x, y, (select(x, z, w) + u)/v), select(x, y, (w + u)/v)) ||
-         rewrite(select(x, y, (u + select(x, z, w))/v), select(x, y, (u + w)/v)) ||
-         rewrite(select(x, y, (select(x, z, w) - u)/v), select(x, y, (w - u)/v)) ||
-         rewrite(select(x, y, (u - select(x, z, w))/v), select(x, y, (u - w)/v)) ||
-         rewrite(select(x, select(x, z, w)/v, y), select(x, z/v, y)) ||
-         rewrite(select(x, y, select(x, z, w)/v), select(x, y, w/v)) ||
+         rewrite(select(x, (select(x, z, w) + u) / v, y), select(x, (z + u) / v, y)) ||
+         rewrite(select(x, (u + select(x, z, w)) / v, y), select(x, (u + z) / v, y)) ||
+         rewrite(select(x, (select(x, z, w) - u) / v, y), select(x, (z - u) / v, y)) ||
+         rewrite(select(x, (u - select(x, z, w)) / v, y), select(x, (u - z) / v, y)) ||
+         rewrite(select(x, y, (select(x, z, w) + u) / v), select(x, y, (w + u) / v)) ||
+         rewrite(select(x, y, (u + select(x, z, w)) / v), select(x, y, (u + w) / v)) ||
+         rewrite(select(x, y, (select(x, z, w) - u) / v), select(x, y, (w - u) / v)) ||
+         rewrite(select(x, y, (u - select(x, z, w)) / v), select(x, y, (u - w) / v)) ||
+         rewrite(select(x, select(x, z, w) / v, y), select(x, z / v, y)) ||
+         rewrite(select(x, y, select(x, z, w) / v), select(x, y, w / v)) ||
+         rewrite(select(x, select(x, z, w) * u, y), select(x, z * u, y)) ||
+         rewrite(select(x, u * select(x, z, w), y), select(x, u * z, y)) ||
+         rewrite(select(x, y, select(x, z, w) * u), select(x, y, w * u)) ||
+         rewrite(select(x, y, u * select(x, z, w)), select(x, y, u * w)) ||
+         rewrite(select(x, (select(x, z, w) * u) + v, y), select(x, (z * u) + v, y)) ||
+         rewrite(select(x, (u * select(x, z, w)) + v, y), select(x, (u * z) + v, y)) ||
+         rewrite(select(x, v + (select(x, z, w) * u), y), select(x, v + (z * u), y)) ||
+         rewrite(select(x, v + (u * select(x, z, w)), y), select(x, v + (u * z), y)) ||
+         rewrite(select(x, y, (select(x, z, w) * u) + v), select(x, y, (w * u) + v)) ||
+         rewrite(select(x, y, (u * select(x, z, w)) + v), select(x, y, (u * w) + v)) ||
+         rewrite(select(x, y, v + (select(x, z, w) * u)), select(x, y, v + (w * u))) ||
+         rewrite(select(x, y, v + (u * select(x, z, w))), select(x, y, v + (u * w))) ||
          rewrite(select(x, y + z, y + w), y + select(x, z, w)) ||
          rewrite(select(x, y + z, w + y), y + select(x, z, w)) ||
          rewrite(select(x, z + y, y + w), y + select(x, z, w)) ||

--- a/src/Simplify_Select.cpp
+++ b/src/Simplify_Select.cpp
@@ -49,15 +49,14 @@ Expr Simplify::visit(const Select *op, ExprInfo *info) {
          rewrite(select(x, select(y, z, w), w), select(x && y, z, w)) ||
          rewrite(select(x, y, select(z, y, w)), select(x || z, y, w)) ||
          rewrite(select(x, y, select(z, w, y)), select(x || !z, y, w)) ||
+
+         // Simplify an inner select on the same condition, possibly buried
+         // under some math. Restricted to cases actually seen in the wild. Note
+         // that we can't use scoped facts for this. You can't assume a
+         // condition is true under its branch in a select because it's still
+         // evaluated when its condition is false.
          rewrite(select(x, select(x, y, z), w), select(x, y, w)) ||
          rewrite(select(x, y, select(x, z, w)), select(x, y, w)) ||
-         // The same, but where the inner select is buried under some
-         // quasi-affine arithmetic. A branch's value only matters when the
-         // condition selects it, and under that condition the inner select
-         // equals one of its operands. Note this is not the same as assuming
-         // the condition holds while simplifying a branch, which would be
-         // unsound because both branches are always evaluated. Here we only
-         // ever replace an expression with one of its own subexpressions.
          rewrite(select(x, select(x, z, w) + u, y), select(x, z + u, y)) ||
          rewrite(select(x, u + select(x, z, w), y), select(x, u + z, y)) ||
          rewrite(select(x, select(x, z, w) - u, y), select(x, z - u, y)) ||
@@ -76,18 +75,7 @@ Expr Simplify::visit(const Select *op, ExprInfo *info) {
          rewrite(select(x, y, (u - select(x, z, w)) / v), select(x, y, (u - w) / v)) ||
          rewrite(select(x, select(x, z, w) / v, y), select(x, z / v, y)) ||
          rewrite(select(x, y, select(x, z, w) / v), select(x, y, w / v)) ||
-         rewrite(select(x, select(x, z, w) * u, y), select(x, z * u, y)) ||
-         rewrite(select(x, u * select(x, z, w), y), select(x, u * z, y)) ||
-         rewrite(select(x, y, select(x, z, w) * u), select(x, y, w * u)) ||
-         rewrite(select(x, y, u * select(x, z, w)), select(x, y, u * w)) ||
-         rewrite(select(x, (select(x, z, w) * u) + v, y), select(x, (z * u) + v, y)) ||
-         rewrite(select(x, (u * select(x, z, w)) + v, y), select(x, (u * z) + v, y)) ||
-         rewrite(select(x, v + (select(x, z, w) * u), y), select(x, v + (z * u), y)) ||
-         rewrite(select(x, v + (u * select(x, z, w)), y), select(x, v + (u * z), y)) ||
-         rewrite(select(x, y, (select(x, z, w) * u) + v), select(x, y, (w * u) + v)) ||
-         rewrite(select(x, y, (u * select(x, z, w)) + v), select(x, y, (u * w) + v)) ||
-         rewrite(select(x, y, v + (select(x, z, w) * u)), select(x, y, v + (w * u))) ||
-         rewrite(select(x, y, v + (u * select(x, z, w))), select(x, y, v + (u * w))) ||
+
          rewrite(select(x, y + z, y + w), y + select(x, z, w)) ||
          rewrite(select(x, y + z, w + y), y + select(x, z, w)) ||
          rewrite(select(x, z + y, y + w), y + select(x, z, w)) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1138,10 +1138,14 @@ void check_bounds() {
     check(select(x < y, z, select(x < y, w, x) + 3), select(x < y, z, x + 3));
     check(select(x < y, select(x < y, w, x) + 3, z), select(x < y, w + 3, z));
     check(select(x < y, z, 3 - select(x < y, w, x)), select(x < y, z, 3 - x));
-    check(select(x < y, z, (select(x < y, w, x) + 3)/2), select(x < y, z, (x + 3)/2));
-    check(select(x < y, (select(x < y, w, x) + 3)/2, z), select(x < y, (w + 3)/2, z));
-    check(select(x < y, z, select(x < y, w, x)/2), select(x < y, z, x/2));
-    check(min(select(x < y, z, w), select(x < y, x, z)/2), select(x < y, min(x/2, z), min(z/2, w)));
+    check(select(x < y, z, (select(x < y, w, x) + 3) / 2), select(x < y, z, (x + 3) / 2));
+    check(select(x < y, (select(x < y, w, x) + 3) / 2, z), select(x < y, (w + 3) / 2, z));
+    check(select(x < y, z, select(x < y, w, x) / 2), select(x < y, z, x / 2));
+    check(min(select(x < y, z, w), select(x < y, x, z) / 2), select(x < y, min(x / 2, z), min(z / 2, w)));
+    check(select(x < y, z, select(x < y, w, x) * 3), select(x < y, z, x * 3));
+    check(select(x < y, select(x < y, w, x) * 3, z), select(x < y, w * 3, z));
+    check(select(x < y, z, (select(x < y, w, x) * 3) + 5), select(x < y, z, (x * 3) + 5));
+    check(min(select(x < y, z, w), select(x < y, x, z) * 3), select(x < y, min(x * 3, z), min(z * 3, w)));
 
     check(min(x + 1, y) - min(x, y - 1), 1);
     check(max(x + 1, y) - max(x, y - 1), 1);

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1133,6 +1133,16 @@ void check_bounds() {
     check(select(x < y, x + y, x), select(x < y, y, 0) + x);
     check(select(x < y, x, x + y), select(x < y, 0, y) + x);
 
+    // A select nested in a branch of a select on the same condition, under
+    // some affine arithmetic. The inner select's outcome is known.
+    check(select(x < y, z, select(x < y, w, x) + 3), select(x < y, z, x + 3));
+    check(select(x < y, select(x < y, w, x) + 3, z), select(x < y, w + 3, z));
+    check(select(x < y, z, 3 - select(x < y, w, x)), select(x < y, z, 3 - x));
+    check(select(x < y, z, (select(x < y, w, x) + 3)/2), select(x < y, z, (x + 3)/2));
+    check(select(x < y, (select(x < y, w, x) + 3)/2, z), select(x < y, (w + 3)/2, z));
+    check(select(x < y, z, select(x < y, w, x)/2), select(x < y, z, x/2));
+    check(min(select(x < y, z, w), select(x < y, x, z)/2), select(x < y, min(x/2, z), min(z/2, w)));
+
     check(min(x + 1, y) - min(x, y - 1), 1);
     check(max(x + 1, y) - max(x, y - 1), 1);
     check(min(x + 1, y) - min(y - 1, x), 1);

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1142,10 +1142,6 @@ void check_bounds() {
     check(select(x < y, (select(x < y, w, x) + 3) / 2, z), select(x < y, (w + 3) / 2, z));
     check(select(x < y, z, select(x < y, w, x) / 2), select(x < y, z, x / 2));
     check(min(select(x < y, z, w), select(x < y, x, z) / 2), select(x < y, min(x / 2, z), min(z / 2, w)));
-    check(select(x < y, z, select(x < y, w, x) * 3), select(x < y, z, x * 3));
-    check(select(x < y, select(x < y, w, x) * 3, z), select(x < y, w * 3, z));
-    check(select(x < y, z, (select(x < y, w, x) * 3) + 5), select(x < y, z, (x * 3) + 5));
-    check(min(select(x < y, z, w), select(x < y, x, z) * 3), select(x < y, min(x * 3, z), min(z * 3, w)));
 
     check(min(x + 1, y) - min(x, y - 1), 1);
     check(max(x + 1, y) - max(x, y - 1), 1);


### PR DESCRIPTION
The simplifier already collapses select(x, select(x, y, z), w) when the inner select is at the root of a branch, but in practice it is usually buried under some arithmetic, e.g.

  select(x, p, (select(x, q, r) + s)/c0)

which shows up in the bounds expressions of multi-resolution pipelines (interpolate, local_laplacian). Add the wrapped forms, covering an addition or subtraction in either operand order, with and without a division, for both branches. Also add the corresponding rule for a min of two selects on the same condition where one is divided.

All rules formally verified to be correct and to follow the reduction order using the super_simplify_v3 branch (which desperately needs bringing up to date with main).