### PR TITLE
Don't assert on empty hoisted storage nodes

### DIFF
--- a/src/StorageFlattening.cpp
+++ b/src/StorageFlattening.cpp
@@ -546,8 +546,14 @@ protected:
         // Record index in the stack.
         hoisted_storages_map[op->name] = hoisted_storages.size() - 1;
         Stmt body = mutate(op->body);
-        internal_assert(!hoisted_storages.back().hoisted_allocations.empty())
-            << "Couldn't find a matching Allocate node for hoisted storage " << op->name << "\n";
+        if (hoisted_storages.back().hoisted_allocations.empty()) {
+            // Nothing in here allocates it. A Func hoisted into the loops of a
+            // Func with update definitions gets one of these nodes per stage,
+            // but is only realized inside the stages that use it.
+            hoisted_storages_map.erase(op->name);
+            hoisted_storages.pop_back();
+            return body;
+        }
         const auto &alloc_info = hoisted_storages.back().hoisted_allocations.front();
         vector<Expr> extents = alloc_info.extents;
         Expr condition = alloc_info.condition;

--- a/test/correctness/hoist_storage.cpp
+++ b/test/correctness/hoist_storage.cpp
@@ -643,6 +643,33 @@ int main(int argc, char **argv) {
         output.realize({50, 50});
     }
 
+    {
+        // Hoisting into the loops of a Func with update definitions. Each
+        // stage of the consumer gets a hoisted storage node, but only the
+        // stages that use the producer realize it.
+        Func f("f"), g("g"), h("h");
+        Var x("x"), y("y");
+        f(x, y) = x + y;
+        g(x, y) = f(x, y);
+        RDom r(0, 3);
+        g(r, y) += 2;
+        h(x, y) = g(x, y);
+
+        f.hoist_storage(g, Var::outermost()).store_at(g, y).compute_at(g, x);
+        g.compute_at(h, y);
+
+        Buffer<int> im = h.realize({8, 8});
+        for (int y = 0; y < im.height(); y++) {
+            for (int x = 0; x < im.width(); x++) {
+                int correct = x + y + (x < 3 ? 2 : 0);
+                if (im(x, y) != correct) {
+                    printf("h(%d, %d) = %d instead of %d\n", x, y, im(x, y), correct);
+                    return 1;
+                }
+            }
+        }
+    }
+
     printf("Success!\n");
     return 0;
 }


### PR DESCRIPTION
Hoisting a Func into the loops of a Func with update definitions gives one HoistedStorage node per stage of the consumer, but the producer is only realized inside the stages that actually call it. The others are empty, and storage flattening asserted that every hoisted storage node contains a matching allocation:

  Internal error at src/StorageFlattening.cpp:549
  Condition failed: !hoisted_storages.back().hoisted_allocations.empty()
  Error: Couldn't find a matching Allocate node for hoisted storage f

Drop the empty nodes instead, mirroring what the success path already does with the map and the stack. Found by a sliding window fuzzer, so it's reachable from ordinary scheduling rather than a contrived case.
