### PR TITLE
Simplify a clamp against a shifted clamp at the same bound

### DIFF
--- a/src/Simplify_Max.cpp
+++ b/src/Simplify_Max.cpp
@@ -218,7 +218,9 @@ Expr Simplify::visit(const Max *op, ExprInfo *info) {
          rewrite(max(transpose(x, c0), transpose(y, c0)), transpose(max(x, y), c0)) ||
 
          (no_overflow(op->type) &&
-          (rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||
+          (rewrite(max(min(x, c0), min(y, c1) + c2), min(max(x, y + c2), c0), c0 == c1 + c2) ||
+
+           rewrite(max(max(x, y) + c0, x), max(x, y + c0), c0 < 0) ||
            rewrite(max(max(x, y) + c0, x), max(x, y) + c0, c0 > 0) ||
            rewrite(max(max(y, x) + c0, x), max(y + c0, x), c0 < 0) ||
            rewrite(max(max(y, x) + c0, x), max(y, x) + c0, c0 > 0) ||

--- a/src/Simplify_Min.cpp
+++ b/src/Simplify_Min.cpp
@@ -219,7 +219,9 @@ Expr Simplify::visit(const Min *op, ExprInfo *info) {
          rewrite(min(slice(x, c0, c1, c2), min(z, slice(y, c0, c1, c2))), min(slice(min(x, y), c0, c1, c2), z), c2 > 1 && lanes_of(x) == lanes_of(y)) ||
          rewrite(min(transpose(x, c0), transpose(y, c0)), transpose(min(x, y), c0)) ||
          (no_overflow(op->type) &&
-          (rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||
+          (rewrite(min(max(x, c0), max(y, c1) + c2), max(min(x, y + c2), c0), c0 == c1 + c2) ||
+
+           rewrite(min(min(x, y) + c0, x), min(x, y + c0), c0 > 0) ||
            rewrite(min(min(x, y) + c0, x), min(x, y) + c0, c0 < 0) ||
            rewrite(min(min(y, x) + c0, x), min(y + c0, x), c0 > 0) ||
            rewrite(min(min(y, x) + c0, x), min(y, x) + c0, c0 < 0) ||

--- a/test/correctness/simplify.cpp
+++ b/test/correctness/simplify.cpp
@@ -1146,6 +1146,14 @@ void check_bounds() {
     check(min(select(x < y, z, w), select(x < y, x, z) / 2), select(x < y, min(x / 2, z), min(z / 2, w)));
 
     check(min(x + 1, y) - min(x, y - 1), 1);
+
+    // A clamp at one bound and a shifted clamp at the same effective bound.
+    // The clamps coincide, so the shift can be pushed inside.
+    check(min(max(x, 3), max(y, -1) + 4), max(min(y + 4, x), 3));
+    check(max(min(x, 3), min(y, -1) + 4), min(max(y + 4, x), 3));
+    // The condition c0 == c1 + c2 is necessary; these must not fire.
+    check(min(max(x, 3), max(y, -1) + 5), min(max(x, 3), max(y, -1) + 5));
+    check(max(min(x, 3), min(y, -1) + 5), max(min(x, 3), min(y, -1) + 5));
     check(max(x + 1, y) - max(x, y - 1), 1);
     check(min(x + 1, y) - min(y - 1, x), 1);
     check(max(x + 1, y) - max(y - 1, x), 1);


### PR DESCRIPTION
A min of a clamped value and a differently-clamped, shifted value where the two clamps land on the same bound, e.g.

  min(max(x, 3), max(y, -1) + 4)  ->  max(min(x, y + 4), 3)

The shift can be pushed inside because the clamps coincide, which is what c0 == c1 + c2 checks. Verified with z3 and with apps/super_simplify/filter_rewrite_rules, which also confirms they obey the reduction order. In the no_overflow block because the condition adds two constants and the result introduces an addition.

These shapes arise in the bounds expressions of pipelines where several Funcs slide over the same loop and warm their windows up over different numbers of iterations, so each clamps at a different constant. Without this the footprint can't be bounded and storage folding gives up.
