### PR TITLE
fix out-of-bounds coordinate read in do_fill_realization

### DIFF
--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -973,7 +973,12 @@ struct Surface {
     void do_fill_realization(uint32_t *dst, uint32_t color,
                              const FuncInfo &fi, const halide_trace_packet_t &p,
                              int current_dimension = 0, int x_off = 0, int y_off = 0) {
-        if (2 * current_dimension == p.dimensions) {
+        // Each dimension consumes a (min, extent) pair of coordinates. A
+        // realization packet from an untrusted trace can declare an odd number
+        // of coordinates, in which case an == test never matches and the
+        // recursion walks off the end of coordinates(); stop once fewer than a
+        // full pair remains.
+        if (2 * current_dimension + 1 >= p.dimensions) {
             const int x_min = x_off * fi.config.zoom + fi.config.pos.x;
             const int y_min = y_off * fi.config.zoom + fi.config.pos.y;
             const int izoom = (int)std::ceil(fi.config.zoom);


### PR DESCRIPTION
do_fill_realization walks a realization packet's coordinates as (min, extent) pairs and only stops when 2 * current_dimension equals the packet's dimensions. dimensions and the coordinate bytes come from an untrusted binary trace, and the packet reader validates only that the coordinate bytes fit the payload, not that the count is even, so a realization event with an odd dimensions never reaches that base case and the recursion reads coordinates() past the validated region and off the end of the payload buffer. Stop once fewer than a full pair of coordinates remains; well-formed packets always carry an even count, so their output is unchanged.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)