### PR TITLE
Move one simplification call in lowering.

### DIFF
--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -450,13 +450,13 @@ void lower_impl(const vector<Function> &output_funcs,
     if (t.has_feature(Target::Profile) || t.has_feature(Target::ProfileByTimer)) {
         debug(1) << "Injecting profiling...\n";
         s = inject_profiling(s, pipeline_name, env, t);
-        s = simplify(s);
         log("Lowering after injecting profiling:", s);
     }
 
     debug(1) << "Finding intrinsics...\n";
     // Must be run after the last simplification, because it turns
     // divisions into shifts, which the simplifier reverses.
+    s = simplify(s);
     s = find_intrinsics(s);
     log("Lowering after finding intrinsics:", s);
 
@@ -470,9 +470,6 @@ void lower_impl(const vector<Function> &output_funcs,
         log("Lowering after stripping asserts:", s);
     }
 
-    debug(1) << "Lowering after final simplification:\n"
-             << s << "\n\n";
-
     if (!custom_passes.empty()) {
         for (size_t i = 0; i < custom_passes.size(); i++) {
             debug(1) << "Running custom lowering pass " << i << "...\n";
@@ -484,6 +481,8 @@ void lower_impl(const vector<Function> &output_funcs,
 
     // Make a copy of the Stmt code, before we lower anything to less human-readable code.
     result_module.set_conceptual_code_stmt(s);
+    debug(1) << "Lowering after reaching conceptual Stmt:\n"
+             << s << "\n\n";
 
     if (t.arch != Target::Hexagon && t.has_feature(Target::HVX)) {
         debug(1) << "Splitting off Hexagon offload...\n";


### PR DESCRIPTION
When debugging some stuff not part of this PR, I spotted a missing simplification, which Andrew determined to be AFTER hoist_loop_invariant_xxx. This moves the simplification in the right spot.

## Breaking changes

I hope none, let's see.

These do not necessarily disqualify a PR from being merged, but they should at
least be tagged with the `release_notes` label.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
