### PR TITLE
Remove configure_file(COPYONLY) from the codebase

### DIFF
--- a/apps/HelloWasm/app/CMakeLists.txt
+++ b/apps/HelloWasm/app/CMakeLists.txt
@@ -17,11 +17,23 @@ find_package(Halide REQUIRED CMAKE_FIND_ROOT_PATH_BOTH)
 find_package(HelloWasm-halide_generators REQUIRED CMAKE_FIND_ROOT_PATH_BOTH)
 set(GEN_TARGET HelloWasm::halide_generators::reaction_diffusion_generator)
 
-# Keep the static assets next to the build outputs they reference (CMake
-# practice: nothing gets written back into the source tree).
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../index.html index.html COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../main.js main.js COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../sw.js sw.js COPYONLY)
+# Keep the static assets next to the build outputs they reference
+set(STATIC_ASSETS index.html main.js sw.js)
+set(STATIC_ASSET_OUTPUTS "")
+foreach (asset IN LISTS STATIC_ASSETS)
+    set(output "${CMAKE_CURRENT_BINARY_DIR}/${asset}")
+    add_custom_command(
+        OUTPUT "${output}"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/../${asset}" "${output}"
+        DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../${asset}"
+        VERBATIM
+    )
+    list(APPEND STATIC_ASSET_OUTPUTS "${output}")
+endforeach ()
+
+# The complete demo webpage: the static assets plus every wasm variant
+add_custom_target(HelloWasm ALL DEPENDS ${STATIC_ASSET_OUTPUTS})
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/js")
 
@@ -71,5 +83,7 @@ foreach (simd IN ITEMS "" "_simd")
             target_link_libraries(${config} PRIVATE Threads::Threads)
             target_link_options(${config} PRIVATE -matomics)
         endif ()
+
+        add_dependencies(HelloWasm ${config})
     endforeach ()
 endforeach ()

--- a/apps/auto_viz/CMakeLists.txt
+++ b/apps/auto_viz/CMakeLists.txt
@@ -49,15 +49,14 @@ endif ()
 
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb_small.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb_small.png COPYONLY)
     foreach (schedule IN ITEMS naive lessnaive complex)
         add_test(
             NAME auto_viz_demo_${schedule}_up
-            COMMAND auto_viz_demo rgb_small.png out_${schedule}_up.png -s ${schedule} -f 4.0
+            COMMAND auto_viz_demo ${IMAGE} out_${schedule}_up.png -s ${schedule} -f 4.0
         )
         add_test(
             NAME auto_viz_demo_${schedule}_down
-            COMMAND auto_viz_demo rgb_small.png out_${schedule}_down.png -s ${schedule} -f 0.25
+            COMMAND auto_viz_demo ${IMAGE} out_${schedule}_down.png -s ${schedule} -f 0.25
         )
         set_tests_properties(
             auto_viz_demo_${schedule}_up auto_viz_demo_${schedule}_down

--- a/apps/bgu/CMakeLists.txt
+++ b/apps/bgu/CMakeLists.txt
@@ -39,8 +39,7 @@ target_link_libraries(bgu_filter PRIVATE Halide::ImageIO bgu bgu_auto_schedule)
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-    add_test(NAME bgu_filter COMMAND bgu_filter rgb.png out.png)
+    add_test(NAME bgu_filter COMMAND bgu_filter ${IMAGE} out.png)
     set_tests_properties(
         bgu_filter
         PROPERTIES

--- a/apps/bilateral_grid/CMakeLists.txt
+++ b/apps/bilateral_grid/CMakeLists.txt
@@ -54,8 +54,7 @@ target_link_libraries(
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/gray.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} gray.png COPYONLY)
-    add_test(NAME bilateral_grid_process COMMAND bilateral_grid_process gray.png out.png 0.1 10)
+    add_test(NAME bilateral_grid_process COMMAND bilateral_grid_process ${IMAGE} out.png 0.1 10)
     set_tests_properties(
         bilateral_grid_process
         PROPERTIES

--- a/apps/camera_pipe/CMakeLists.txt
+++ b/apps/camera_pipe/CMakeLists.txt
@@ -40,10 +40,9 @@ target_link_libraries(
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/bayer_raw.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} bayer_raw.png COPYONLY)
     add_test(
         NAME camera_pipe_process
-        COMMAND camera_pipe_process bayer_raw.png 3700 2.0 50 1.0 5 out.png
+        COMMAND camera_pipe_process ${IMAGE} 3700 2.0 50 1.0 5 out.png
     )
     set_tests_properties(
         camera_pipe_process

--- a/apps/compositing/CMakeLists.txt
+++ b/apps/compositing/CMakeLists.txt
@@ -41,8 +41,7 @@ target_link_libraries(
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgba.png COPYONLY)
-    add_test(NAME compositing_process COMMAND compositing_process rgba.png 10 out.png)
+    add_test(NAME compositing_process COMMAND compositing_process ${IMAGE} 10 out.png)
     set_tests_properties(
         compositing_process
         PROPERTIES

--- a/apps/gaussian_blur/CMakeLists.txt
+++ b/apps/gaussian_blur/CMakeLists.txt
@@ -47,8 +47,7 @@ target_include_directories(gaussian_blur_filter PRIVATE "${CMAKE_CURRENT_BINARY_
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/gray.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} gray.png COPYONLY)
-    add_test(NAME gaussian_blur_filter COMMAND gaussian_blur_filter gray.png 10)
+    add_test(NAME gaussian_blur_filter COMMAND gaussian_blur_filter ${IMAGE} 10)
     set_tests_properties(
         gaussian_blur_filter
         PROPERTIES

--- a/apps/harris/CMakeLists.txt
+++ b/apps/harris/CMakeLists.txt
@@ -31,8 +31,7 @@ target_link_libraries(harris_filter PRIVATE Halide::ImageIO harris harris_auto_s
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgba.png COPYONLY)
-    add_test(NAME harris_filter COMMAND harris_filter rgba.png out.png)
+    add_test(NAME harris_filter COMMAND harris_filter ${IMAGE} out.png)
     set_tests_properties(
         harris_filter
         PROPERTIES

--- a/apps/hist/CMakeLists.txt
+++ b/apps/hist/CMakeLists.txt
@@ -31,8 +31,7 @@ target_link_libraries(hist_filter PRIVATE Halide::ImageIO Halide::Tools hist his
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgba.png COPYONLY)
-    add_test(NAME hist_filter COMMAND hist_filter rgba.png out.png)
+    add_test(NAME hist_filter COMMAND hist_filter ${IMAGE} out.png)
     set_tests_properties(
         hist_filter
         PROPERTIES

--- a/apps/iir_blur/CMakeLists.txt
+++ b/apps/iir_blur/CMakeLists.txt
@@ -44,8 +44,7 @@ if (EXISTS ${IMAGE})
         # Error: OpenCL error: CL_INVALID_COMMAND_QUEUE clFinish failed
         message(WARNING "Skipping Mullapudi2016's GPU auto-schedules for OpenCL target.")
     else ()
-        configure_file(${IMAGE} rgb.png COPYONLY)
-        add_test(NAME iir_blur_filter COMMAND iir_blur_filter rgb.png out.png)
+        add_test(NAME iir_blur_filter COMMAND iir_blur_filter ${IMAGE} out.png)
         set_tests_properties(
             iir_blur_filter
             PROPERTIES

--- a/apps/interpolate/CMakeLists.txt
+++ b/apps/interpolate/CMakeLists.txt
@@ -36,8 +36,7 @@ target_link_libraries(
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgba.png COPYONLY)
-    add_test(NAME interpolate_filter COMMAND interpolate_filter rgba.png out.png)
+    add_test(NAME interpolate_filter COMMAND interpolate_filter ${IMAGE} out.png)
     set_tests_properties(
         interpolate_filter
         PROPERTIES

--- a/apps/lens_blur/CMakeLists.txt
+++ b/apps/lens_blur/CMakeLists.txt
@@ -45,11 +45,7 @@ if (EXISTS ${IMAGE})
         # threads per block because of the register pressure in lens_blur's GPU kernel.
         message ("Pipeline lens_blur_auto_schedule skipped for target host-metal")
     else ()
-        configure_file(${IMAGE} rgb_small.png COPYONLY)
-        add_test(
-            NAME lens_blur_filter
-            COMMAND lens_blur_filter rgb_small.png 32 13 0.5 32 3 out.png
-        )
+        add_test(NAME lens_blur_filter COMMAND lens_blur_filter ${IMAGE} 32 13 0.5 32 3 out.png)
         set_tests_properties(
             lens_blur_filter
             PROPERTIES

--- a/apps/linear_blur/CMakeLists.txt
+++ b/apps/linear_blur/CMakeLists.txt
@@ -51,8 +51,7 @@ target_link_libraries(linear_blur_process PRIVATE Halide::ImageIO linear_blur si
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-    add_test(NAME linear_blur_test COMMAND linear_blur_process 1 rgb.png out.png)
+    add_test(NAME linear_blur_test COMMAND linear_blur_process 1 ${IMAGE} out.png)
     set_tests_properties(
         linear_blur_test
         PROPERTIES

--- a/apps/local_laplacian/CMakeLists.txt
+++ b/apps/local_laplacian/CMakeLists.txt
@@ -49,8 +49,7 @@ target_link_libraries(
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-    add_test(NAME local_laplacian_process COMMAND local_laplacian_process rgb.png 8 1 1 10 out.png)
+    add_test(NAME local_laplacian_process COMMAND local_laplacian_process ${IMAGE} 8 1 1 10 out.png)
     set_tests_properties(
         local_laplacian_process
         PROPERTIES

--- a/apps/max_filter/CMakeLists.txt
+++ b/apps/max_filter/CMakeLists.txt
@@ -31,8 +31,7 @@ target_link_libraries(max_filter_filter PRIVATE Halide::ImageIO max_filter max_f
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgba.png COPYONLY)
-    add_test(NAME max_filter_filter COMMAND max_filter_filter rgba.png out.png)
+    add_test(NAME max_filter_filter COMMAND max_filter_filter ${IMAGE} out.png)
     set_tests_properties(
         max_filter_filter
         PROPERTIES

--- a/apps/nl_means/CMakeLists.txt
+++ b/apps/nl_means/CMakeLists.txt
@@ -30,8 +30,7 @@ target_link_libraries(nl_means_process PRIVATE Halide::ImageIO nl_means nl_means
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-    add_test(NAME nl_means_process COMMAND nl_means_process rgb.png 7 7 0.12 10 out.png)
+    add_test(NAME nl_means_process COMMAND nl_means_process ${IMAGE} 7 7 0.12 10 out.png)
     set_tests_properties(
         nl_means_process
         PROPERTIES

--- a/apps/resize/CMakeLists.txt
+++ b/apps/resize/CMakeLists.txt
@@ -65,11 +65,9 @@ target_link_libraries(resize PRIVATE Halide::ImageIO ${FILTERS})
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-
     add_test(
         NAME resize_initial_downsample
-        COMMAND resize rgb.png rgb_small.png -i lanczos -t float32 -f 0.125
+        COMMAND resize ${IMAGE} rgb_small.png -i lanczos -t float32 -f 0.125
     )
 
     set_tests_properties(
@@ -91,7 +89,7 @@ if (EXISTS ${IMAGE})
             set(INPUT rgb_small.png)
         else ()
             set(F 0.5)
-            set(INPUT rgb.png)
+            set(INPUT ${IMAGE})
         endif ()
         add_test(
             NAME resize_${VARIANT}

--- a/apps/stencil_chain/CMakeLists.txt
+++ b/apps/stencil_chain/CMakeLists.txt
@@ -40,8 +40,7 @@ target_link_libraries(
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgb.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgb.png COPYONLY)
-    add_test(NAME stencil_chain_process COMMAND stencil_chain_process rgb.png 10 out.png)
+    add_test(NAME stencil_chain_process COMMAND stencil_chain_process ${IMAGE} 10 out.png)
     set_tests_properties(
         stencil_chain_process
         PROPERTIES

--- a/apps/unsharp/CMakeLists.txt
+++ b/apps/unsharp/CMakeLists.txt
@@ -30,8 +30,7 @@ target_link_libraries(unsharp_filter PRIVATE Halide::ImageIO unsharp unsharp_aut
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/rgba.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} rgba.png COPYONLY)
-    add_test(NAME unsharp_filter COMMAND unsharp_filter rgba.png out.png)
+    add_test(NAME unsharp_filter COMMAND unsharp_filter ${IMAGE} out.png)
     set_tests_properties(
         unsharp_filter
         PROPERTIES

--- a/apps/wavelet/CMakeLists.txt
+++ b/apps/wavelet/CMakeLists.txt
@@ -43,8 +43,7 @@ target_link_libraries(
 # Test that the app actually works!
 set(IMAGE ${CMAKE_CURRENT_LIST_DIR}/../images/gray.png)
 if (EXISTS ${IMAGE})
-    configure_file(${IMAGE} gray.png COPYONLY)
-    add_test(NAME wavelet COMMAND wavelet gray.png .)
+    add_test(NAME wavelet COMMAND wavelet ${IMAGE} .)
     set_tests_properties(
         wavelet
         PROPERTIES

--- a/cmake/HalidePackageConfigHelpers.cmake
+++ b/cmake/HalidePackageConfigHelpers.cmake
@@ -108,7 +108,7 @@ function(_Halide_install_pkgdeps)
         )
     endforeach ()
 
-    _Halide_install_code("configure_file(\"${depFile}.in\" \"${depFile}\" COPYONLY)")
+    _Halide_install_code("file(COPY_FILE \"${depFile}.in\" \"${depFile}\" ONLY_IF_DIFFERENT)")
 
     install(FILES "${depFile}" DESTINATION "${ARG_DESTINATION}" COMPONENT "${ARG_COMPONENT}")
 endfunction()

--- a/doc/CodeStyleCMake.md
+++ b/doc/CodeStyleCMake.md
@@ -191,24 +191,25 @@ If common properties need to be grouped together, use an INTERFACE target
 
 There are also several functions that are disallowed for other reasons:
 
-| Command                         | Reason                                                      | Alternative                                                                    |
-| ------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `aux_source_directory`          | Interacts poorly with incremental builds and Git            | List source files explicitly                                                   |
-| `build_command`                 | CTest internal function                                     | Use CTest build-and-test mode via [`CMAKE_CTEST_COMMAND`][cmake_ctest_command] |
-| `cmake_host_system_information` | Usually misleading information.                             | Inspect [toolchain][cmake-toolchains] variables and use generator expressions. |
-| `cmake_policy(... OLD)`         | OLD policies are deprecated by definition.                  | Instead, fix the code to work with the new policy.                             |
-| `create_test_sourcelist`        | We use our own unit testing solution                        | See the [adding tests](#adding-tests) section.                                 |
-| `define_property`               | Adds unnecessary complexity                                 | Use a cache variable. Exceptions under special circumstances.                  |
-| `enable_language`               | Halide is C/C++ only                                        | [`FindCUDAToolkit`][findcudatoolkit], appropriately guarded.                   |
-| `file(GLOB ...)`                | Interacts poorly with incremental builds and Git            | List source files explicitly. Allowed if not globbing for source files.        |
-| `fltk_wrap_ui`                  | Halide does not use FLTK                                    | None                                                                           |
-| `include_external_msproject`    | Halide must remain portable                                 | Write a CMake package config file or find module.                              |
-| `include_guard`                 | Use of recursive inclusion is not allowed                   | Write (recursive) functions.                                                   |
-| `include_regular_expression`    | Changes default dependency checking behavior                | None                                                                           |
-| `load_cache`                    | Superseded by [`ExternalProject`][externalproject]          | Write a vcpkg port or present a case for an exception.                         |
-| `macro`                         | CMake macros are not hygienic and are therefore error-prone | Use functions instead.                                                         |
-| `site_name`                     | Privacy: do not want leak host name information             | Provide a cache variable, generate a unique name.                              |
-| `variable_watch`                | Debugging helper                                            | None. Not needed in production.                                                |
+| Command                         | Reason                                                      | Alternative                                                                                                                                                                   |
+| ------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aux_source_directory`          | Interacts poorly with incremental builds and Git            | List source files explicitly                                                                                                                                                  |
+| `build_command`                 | CTest internal function                                     | Use CTest build-and-test mode via [`CMAKE_CTEST_COMMAND`][cmake_ctest_command]                                                                                                |
+| `cmake_host_system_information` | Usually misleading information.                             | Inspect [toolchain][cmake-toolchains] variables and use generator expressions.                                                                                                |
+| `cmake_policy(... OLD)`         | OLD policies are deprecated by definition.                  | Instead, fix the code to work with the new policy.                                                                                                                            |
+| `configure_file(... COPYONLY)`  | Forces a reconfigure whenever the copied file changes       | `file(COPY_FILE ...)` (one-shot, e.g. install scripts) or `add_custom_command` + `copy_if_different` (build-time); or reference the source path directly if no copy is needed |
+| `create_test_sourcelist`        | We use our own unit testing solution                        | See the [adding tests](#adding-tests) section.                                                                                                                                |
+| `define_property`               | Adds unnecessary complexity                                 | Use a cache variable. Exceptions under special circumstances.                                                                                                                 |
+| `enable_language`               | Halide is C/C++ only                                        | [`FindCUDAToolkit`][findcudatoolkit], appropriately guarded.                                                                                                                  |
+| `file(GLOB ...)`                | Interacts poorly with incremental builds and Git            | List source files explicitly. Allowed if not globbing for source files.                                                                                                       |
+| `fltk_wrap_ui`                  | Halide does not use FLTK                                    | None                                                                                                                                                                          |
+| `include_external_msproject`    | Halide must remain portable                                 | Write a CMake package config file or find module.                                                                                                                             |
+| `include_guard`                 | Use of recursive inclusion is not allowed                   | Write (recursive) functions.                                                                                                                                                  |
+| `include_regular_expression`    | Changes default dependency checking behavior                | None                                                                                                                                                                          |
+| `load_cache`                    | Superseded by [`ExternalProject`][externalproject]          | Write a vcpkg port or present a case for an exception.                                                                                                                        |
+| `macro`                         | CMake macros are not hygienic and are therefore error-prone | Use functions instead.                                                                                                                                                        |
+| `site_name`                     | Privacy: do not want leak host name information             | Provide a cache variable, generate a unique name.                                                                                                                             |
+| `variable_watch`                | Debugging helper                                            | None. Not needed in production.                                                                                                                                               |
 
 Do not introduce new dependencies without broader approval. Once approved, add
 dependencies to `vcpkg.json` or create a custom port, and consume them with

--- a/src/autoschedulers/adams2019/CMakeLists.txt
+++ b/src/autoschedulers/adams2019/CMakeLists.txt
@@ -7,11 +7,12 @@ set(COMMON_DIR "${Halide_SOURCE_DIR}/src/autoschedulers/common")
 # =================================================================
 # weights
 set(WF_CPP baseline.cpp)
-configure_file(baseline.weights baseline.weights COPYONLY)
 add_custom_command(
     OUTPUT ${WF_CPP}
-    COMMAND binary2cpp baseline_weights < baseline.weights > ${WF_CPP}
-    DEPENDS baseline.weights binary2cpp
+    COMMAND
+        binary2cpp baseline_weights < "$<SHELL_PATH:${CMAKE_CURRENT_SOURCE_DIR}/baseline.weights>" >
+        ${WF_CPP}
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/baseline.weights" binary2cpp
     VERBATIM
 )
 

--- a/src/autoschedulers/anderson2021/CMakeLists.txt
+++ b/src/autoschedulers/anderson2021/CMakeLists.txt
@@ -6,11 +6,12 @@ set(COMMON_DIR "${Halide_SOURCE_DIR}/src/autoschedulers/common")
 
 # weights
 set(WF_CPP baseline.cpp)
-configure_file(baseline.weights baseline.weights COPYONLY)
 add_custom_command(
     OUTPUT ${WF_CPP}
-    COMMAND binary2cpp baseline_weights < baseline.weights > ${WF_CPP}
-    DEPENDS baseline.weights binary2cpp
+    COMMAND
+        binary2cpp baseline_weights < "$<SHELL_PATH:${CMAKE_CURRENT_SOURCE_DIR}/baseline.weights>" >
+        ${WF_CPP}
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/baseline.weights" binary2cpp
     VERBATIM
 )
 

--- a/test/autoschedulers/adams2019/CMakeLists.txt
+++ b/test/autoschedulers/adams2019/CMakeLists.txt
@@ -73,7 +73,7 @@ add_halide_test(
     adams2019_test_apps_autoscheduler
     COMMAND
         adams2019_test_apps_autoscheduler $<TARGET_FILE:Halide_Adams2019>
-        $<TARGET_FILE_DIR:Halide_Adams2019>/baseline.weights
+        "${Halide_SOURCE_DIR}/src/autoschedulers/adams2019/baseline.weights"
     GROUPS adams2019 autoschedulers_cpu multithreaded
 )
 set_tests_properties(

--- a/tools/check_cmake_style.py
+++ b/tools/check_cmake_style.py
@@ -49,6 +49,11 @@ SPECIAL_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         "cmake_policy(... OLD) is deprecated; fix code for new policy",
     ),
     (
+        re.compile(r"\bconfigure_file\s*\([^)]*\bCOPYONLY\b", re.IGNORECASE),
+        "configure_file(... COPYONLY) forces a reconfigure on change; use file(COPY_FILE ...), "
+        "add_custom_command with copy_if_different, or reference the source path directly",
+    ),
+    (
         re.compile(r"\binclude\s*\(\s*FetchContent\s*\)", re.IGNORECASE),
         "include(FetchContent) is prohibited; use find_package instead",
     ),


### PR DESCRIPTION
I was noticing a dependency-scoping bug in #9347 that comes from using `configure_file(COPYONLY)`... I can't think of a time that's the right call anymore. Either:

1. You don't need a copy at all (or you need to adjust a program to use absolute paths)
2. You can copy at build time with `add_custom_command` and `cmake -E copy_if_different`.
3. You can copy on-demand with `file(COPY_FILE ... ONLY_IF_DIFFERENT)`.

Basically the issue is that `configure_file` establishes a dependency on _running CMake_ on the file... but if the file is `COPYONLY`, then there's no useful way configuration can depend on it (the contents are invariant to the CMake environment, unlike `@ONLY`, which substitutes variables).

We had one benign use in HalidePackageConfigHelpers.cmake, but I changed it to `file(COPY_FILE ... ONLY_IF_DIFFERENT)` to be more explicit.

Also updates the style guide and static check script to make sure we don't regress.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [x] Python bindings updated (if public API changed)
- [x] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>