### PR TITLE
Add HL_DEBUG_CODEGEN_LOG_FILE to redirect debug() logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,11 @@ with rules separated by `;` and OR-ed together (filenames and function names are
 matched as suffixes). For example, `HL_DEBUG_CODEGEN=3,Simplify.cpp:100-180`
 prints verbosity-3 output only from lines 100–180 of `Simplify.cpp`. See
 [doc/Testing.md](doc/Testing.md) for more, including the LLDB/GDB debugger
-helpers.
+helpers. `HL_DEBUG_CODEGEN` output goes to stderr by default; set
+`HL_DEBUG_CODEGEN_LOG_FILE=<path>` to append it to a file instead (the file is
+never truncated). The values `/dev/stdout` and `/dev/stderr` are recognized
+explicitly and remapped to `std::cout`/`std::cerr` on all platforms, including
+Windows, which has no `/dev` filesystem to fall back on.
 
 `HL_NUM_THREADS=...` specifies the number of threads to create for the thread
 pool. When the async scheduling directive is used, more threads than this number

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -8,11 +8,11 @@
 #include <iostream>
 #include <optional>
 
-#ifdef _WIN32
 #include <fcntl.h>
+
+#ifdef _WIN32
 #include <io.h>
 #else
-#include <fcntl.h>
 #include <unistd.h>
 #endif
 
@@ -151,9 +151,6 @@ struct DebugSink {
 // single raw write() call: on a file opened O_APPEND, the kernel appends the
 // bytes of a single write() atomically, so concurrent processes/threads
 // sharing this log file can't tear each other's output mid-statement.
-// Buffered iostream writes give no such guarantee -- a large debug() dump
-// can be split across several underlying write() calls, letting another
-// writer's output land in the middle of it.
 int open_append_only(const std::string &path) {
 #ifdef _WIN32
     // _O_BINARY avoids CRLF translation, which would corrupt byte counts.
@@ -165,9 +162,8 @@ int open_append_only(const std::string &path) {
 
 DebugSink make_debug_sink() {
     const std::string log_file = get_env_variable("HL_DEBUG_CODEGEN_LOG_FILE");
-    // /dev/stdout and /dev/stderr are handled explicitly (rather than just
-    // opening them as ordinary paths) because Windows has no /dev
-    // filesystem, so opening them as ordinary paths would simply fail there.
+    // /dev/stdout and /dev/stderr are handled explicitly both for compatibility
+    // with Windows and for consistency with interleaved std::cout and std::cerr.
     if (log_file.empty() || log_file == "/dev/stderr") {
         return {DebugSinkKind::Cerr};
     }
@@ -194,21 +190,20 @@ const DebugSink &debug_sink() {
 // loop only guards against the rare partial write (e.g. an EINTR-interrupted
 // call), at the cost of the atomicity guarantee above in that rare case.
 void write_all(int fd, const char *data, size_t size) {
+    int n_retries = 16;
     while (size > 0) {
 #ifdef _WIN32
         const int n = _write(fd, data, (unsigned int)std::min<size_t>(size, INT_MAX));
-        if (n <= 0) {
-            break;
-        }
 #else
         const ssize_t n = ::write(fd, data, size);
         if (n < 0 && errno == EINTR) {
+            internal_assert(n_retries-- > 0) << "write_all() failed with EINTR too many times";
             continue;
         }
+#endif
         if (n <= 0) {
             break;
         }
-#endif
         data += n;
         size -= (size_t)n;
     }

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -3,8 +3,18 @@
 #include "Util.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <climits>
+#include <iostream>
 #include <optional>
+
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 namespace Halide::Internal {
 
@@ -127,7 +137,105 @@ bool rules_accept(const std::vector<DebugRule> &rules, const int verbosity,
     });
 }
 
+enum class DebugSinkKind { Cerr,
+                           Cout,
+                           File };
+
+struct DebugSink {
+    DebugSinkKind kind = DebugSinkKind::Cerr;
+    int fd = -1;  // Valid only when kind == File.
+};
+
+// Opened directly at the OS level (rather than via std::ofstream) so that
+// DebugStream's destructor can write each debug() statement's output with a
+// single raw write() call: on a file opened O_APPEND, the kernel appends the
+// bytes of a single write() atomically, so concurrent processes/threads
+// sharing this log file can't tear each other's output mid-statement.
+// Buffered iostream writes give no such guarantee -- a large debug() dump
+// can be split across several underlying write() calls, letting another
+// writer's output land in the middle of it.
+int open_append_only(const std::string &path) {
+#ifdef _WIN32
+    // _O_BINARY avoids CRLF translation, which would corrupt byte counts.
+    return _open(path.c_str(), _O_WRONLY | _O_CREAT | _O_APPEND | _O_BINARY, _S_IWRITE);
+#else
+    return ::open(path.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0644);
+#endif
+}
+
+DebugSink make_debug_sink() {
+    const std::string log_file = get_env_variable("HL_DEBUG_CODEGEN_LOG_FILE");
+    // /dev/stdout and /dev/stderr are handled explicitly (rather than just
+    // opening them as ordinary paths) because Windows has no /dev
+    // filesystem, so opening them as ordinary paths would simply fail there.
+    if (log_file.empty() || log_file == "/dev/stderr") {
+        return {DebugSinkKind::Cerr};
+    }
+    if (log_file == "/dev/stdout") {
+        return {DebugSinkKind::Cout};
+    }
+    const int fd = open_append_only(log_file);
+    if (fd < 0) {
+        issue_warning(("Warning: Could not open HL_DEBUG_CODEGEN_LOG_FILE: " + log_file +
+                       "; falling back to stderr\n")
+                          .c_str());
+        return {DebugSinkKind::Cerr};
+    }
+    return {DebugSinkKind::File, fd};
+}
+
+const DebugSink &debug_sink() {
+    static const DebugSink sink = make_debug_sink();
+    return sink;
+}
+
+// Writes as much of [data, data + size) as the OS accepts in one call. A
+// single write() to a regular file normally consumes the whole request; the
+// loop only guards against the rare partial write (e.g. an EINTR-interrupted
+// call), at the cost of the atomicity guarantee above in that rare case.
+void write_all(int fd, const char *data, size_t size) {
+    while (size > 0) {
+#ifdef _WIN32
+        const int n = _write(fd, data, (unsigned int)std::min<size_t>(size, INT_MAX));
+        if (n <= 0) {
+            break;
+        }
+#else
+        const ssize_t n = ::write(fd, data, size);
+        if (n < 0 && errno == EINTR) {
+            continue;
+        }
+        if (n <= 0) {
+            break;
+        }
+#endif
+        data += n;
+        size -= (size_t)n;
+    }
+}
+
 }  // namespace
+
+DebugStream::~DebugStream() {
+    const std::string s = str();
+    if (s.empty()) {
+        return;
+    }
+    const DebugSink &sink = debug_sink();
+    switch (sink.kind) {
+    case DebugSinkKind::Cerr:
+        std::cerr << s;
+        std::cerr.flush();
+        break;
+    case DebugSinkKind::Cout:
+        std::cout << s;
+        std::cout.flush();
+        break;
+    case DebugSinkKind::File:
+        write_all(sink.fd, s.data(), s.size());
+        break;
+    }
+}
 
 bool debug_is_active_impl(const int verbosity, const char *file, const char *function,
                           const int line) {

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -5,8 +5,10 @@
 #include <algorithm>
 #include <cerrno>
 #include <climits>
+#include <functional>
 #include <iostream>
 #include <optional>
+#include <variant>
 
 #include <fcntl.h>
 
@@ -137,14 +139,9 @@ bool rules_accept(const std::vector<DebugRule> &rules, const int verbosity,
     });
 }
 
-enum class DebugSinkKind { Cerr,
-                           Cout,
-                           File };
-
-struct DebugSink {
-    DebugSinkKind kind = DebugSinkKind::Cerr;
-    int fd = -1;  // Valid only when kind == File.
-};
+// Either a std::ostream to write to (cerr/cout) or a raw fd to write to (an
+// HL_DEBUG_CODEGEN_LOG_FILE opened via open_append_only).
+using DebugSink = std::variant<std::reference_wrapper<std::ostream>, int>;
 
 // Opened directly at the OS level (rather than via std::ofstream) so that
 // DebugStream's destructor can write each debug() statement's output with a
@@ -165,19 +162,19 @@ DebugSink make_debug_sink() {
     // /dev/stdout and /dev/stderr are handled explicitly both for compatibility
     // with Windows and for consistency with interleaved std::cout and std::cerr.
     if (log_file.empty() || log_file == "/dev/stderr") {
-        return {DebugSinkKind::Cerr};
+        return std::ref(std::cerr);
     }
     if (log_file == "/dev/stdout") {
-        return {DebugSinkKind::Cout};
+        return std::ref(std::cout);
     }
     const int fd = open_append_only(log_file);
     if (fd < 0) {
         issue_warning(("Warning: Could not open HL_DEBUG_CODEGEN_LOG_FILE: " + log_file +
                        "; falling back to stderr\n")
                           .c_str());
-        return {DebugSinkKind::Cerr};
+        return std::ref(std::cerr);
     }
-    return {DebugSinkKind::File, fd};
+    return fd;
 }
 
 const DebugSink &debug_sink() {
@@ -190,7 +187,9 @@ const DebugSink &debug_sink() {
 // loop only guards against the rare partial write (e.g. an EINTR-interrupted
 // call), at the cost of the atomicity guarantee above in that rare case.
 void write_all(int fd, const char *data, size_t size) {
+#ifndef _WIN32
     int n_retries = 16;
+#endif
     while (size > 0) {
 #ifdef _WIN32
         const int n = _write(fd, data, (unsigned int)std::min<size_t>(size, INT_MAX));
@@ -212,23 +211,12 @@ void write_all(int fd, const char *data, size_t size) {
 }  // namespace
 
 DebugStream::~DebugStream() {
-    const std::string s = str();
-    if (s.empty()) {
-        return;
-    }
-    const DebugSink &sink = debug_sink();
-    switch (sink.kind) {
-    case DebugSinkKind::Cerr:
-        std::cerr << s;
-        std::cerr.flush();
-        break;
-    case DebugSinkKind::Cout:
-        std::cout << s;
-        std::cout.flush();
-        break;
-    case DebugSinkKind::File:
-        write_all(sink.fd, s.data(), s.size());
-        break;
+    if (std::string s = str(); !s.empty()) {
+        std::visit(LambdaOverloads{
+                       [&](int fd) { write_all(fd, s.data(), s.size()); },
+                       [&](auto osr) { osr.get() << s << std::flush; },
+                   },
+                   debug_sink());
     }
 }
 

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -7,6 +7,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 namespace Halide {
@@ -34,6 +35,34 @@ std::ostream &operator<<(std::ostream &, const LoweredFunc &);
 
 bool debug_is_active_impl(int verbosity, const char *file, const char *function, int line);
 
+/** Backs the debug() macro. Buffers everything written to it in memory, then
+ * emits the whole statement's accumulated output as a single write when the
+ * temporary is destroyed (i.e. at the end of the debug(n) << ...; statement).
+ * This matters when HL_DEBUG_CODEGEN_LOG_FILE names a real file shared by
+ * multiple processes: writing statement-by-statement in one shot (rather
+ * than incrementally, as each `<<` arrives) keeps one process's debug dump
+ * from being interleaved mid-line with another's. Not for direct use --
+ * use the debug(n) macro. */
+class DebugStream : public std::ostringstream {
+public:
+    DebugStream() = default;
+    DebugStream(const DebugStream &) = delete;
+    DebugStream &operator=(const DebugStream &) = delete;
+    ~DebugStream();
+
+    /** Exposes this object as a plain std::ostream&, so every `<<` in a
+     * debug(n) statement resolves exactly as it would against std::cerr,
+     * rather than against DebugStream itself: some standard library
+     * implementations' rvalue-stream-insertion operator<< deduces the
+     * *exact* runtime type of its left operand, and the SFINAE trait it
+     * uses to test "is this ostreamable" can fail to find free-function
+     * operator<< overloads (e.g. for Halide's own IR types) once that type
+     * is something other than std::ostream itself. */
+    std::ostream &stream() {
+        return *this;
+    }
+};
+
 /** For optional debugging during codegen, use the debug macro as
  * follows:
  *
@@ -45,12 +74,13 @@ bool debug_is_active_impl(int verbosity, const char *file, const char *function,
  * stage, 2 should be used for more detail, and 3 should be used for
  * tracing everything that occurs. The verbosity with which to print
  * is determined by the value of the environment variable
- * HL_DEBUG_CODEGEN
+ * HL_DEBUG_CODEGEN. Output goes to stderr by default, but can be
+ * redirected via HL_DEBUG_CODEGEN_LOG_FILE (see DebugStream above).
  */
 
 #define debug(n)                                     \
     /* NOLINTNEXTLINE(bugprone-macro-parentheses) */ \
-    if (::Halide::Internal::debug_is_active_impl((n), __FILE__, __FUNCTION__, __LINE__)) std::cerr
+    if (::Halide::Internal::debug_is_active_impl((n), __FILE__, __FUNCTION__, __LINE__)) ::Halide::Internal::DebugStream().stream()
 
 /** Allow easily printing the contents of containers, or std::vector-like containers,
  *  in debug output. Used like so:

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -46,8 +46,6 @@ bool debug_is_active_impl(int verbosity, const char *file, const char *function,
 class DebugStream : public std::ostringstream {
 public:
     DebugStream() = default;
-    DebugStream(const DebugStream &) = delete;
-    DebugStream &operator=(const DebugStream &) = delete;
     ~DebugStream() override;
 
     /** Exposes this object as a plain std::ostream&, so every `<<` in a

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -48,7 +48,7 @@ public:
     DebugStream() = default;
     DebugStream(const DebugStream &) = delete;
     DebugStream &operator=(const DebugStream &) = delete;
-    ~DebugStream();
+    ~DebugStream() override;
 
     /** Exposes this object as a plain std::ostream&, so every `<<` in a
      * debug(n) statement resolves exactly as it would against std::cerr,

--- a/src/IR.h
+++ b/src/IR.h
@@ -18,21 +18,12 @@
 #include "PrefetchDirective.h"
 #include "Reduction.h"
 #include "Type.h"
+#include "Util.h"
 
 namespace Halide {
 namespace Internal {
 
 class Function;
-
-// The lambda-based IRVisitors and IRMutators use this helper to dispatch
-// to multiple lambdas via function overloading (of `operator()`).
-template<typename... Ts>
-struct LambdaOverloads : Ts... {
-    using Ts::operator()...;
-    explicit LambdaOverloads(Ts... ts)
-        : Ts(std::move(ts))... {
-    }
-};
 
 /** The actual IR nodes begin here. Remember that all the Expr nodes
  * also have a public "type" property. */

--- a/src/Util.h
+++ b/src/Util.h
@@ -89,6 +89,16 @@ void load_plugin(const std::string &lib_name);
 
 namespace Internal {
 
+// Dispatches to multiple lambdas via function overloading (of `operator()`),
+// e.g. for use with std::visit on a std::variant.
+template<typename... Ts>
+struct LambdaOverloads : Ts... {
+    using Ts::operator()...;
+    explicit LambdaOverloads(Ts... ts)
+        : Ts(std::move(ts))... {
+    }
+};
+
 /** Some numeric conversions are UB if the value won't fit in the result;
  * safe_numeric_cast<>() is meant as a drop-in replacement for a C/C++ cast
  * that adds well-defined behavior for the UB cases, attempting to mimic

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -85,6 +85,7 @@ tests(
     d3d12compute_strict_float.cpp
     dead_realization_in_specialization.cpp
     debug_helpers.cpp
+    debug_log_file.cpp
     debug_to_file.cpp
     debug_to_file_multiple_outputs.cpp
     debug_to_file_reorder.cpp

--- a/test/correctness/debug_log_file.cpp
+++ b/test/correctness/debug_log_file.cpp
@@ -1,0 +1,92 @@
+// Exercises HL_DEBUG_CODEGEN_LOG_FILE: debug() output can be redirected to a
+// file (appending, never truncating) instead of stderr, and /dev/stdout,
+// /dev/stderr are recognized explicitly so they work as values even on
+// platforms with no /dev filesystem to fall back on (e.g. Windows).
+//
+// The env var is read once per process (cached in a function-local static,
+// like HL_DEBUG_CODEGEN itself), so each scenario below runs in a freshly
+// spawned child process (by re-exec'ing this test with --child).
+
+#include "Halide.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <random>
+#include <string>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+namespace {
+
+namespace fs = std::filesystem;
+
+// Return 1 from main() on failure; the test harness treats that as a failure.
+// (assert() is compiled out in release builds, so we can't rely on it.)
+#define check(cond)                                                       \
+    do {                                                                  \
+        if (!(cond)) {                                                    \
+            std::cerr << "FAILED: " #cond " (line " << __LINE__ << ")\n"; \
+            return 1;                                                     \
+        }                                                                 \
+    } while (0)
+
+std::string read_all(const fs::path &p) {
+    std::ifstream f(p);
+    return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+}
+
+void set_env(const char *name, const std::string &val) {
+#ifdef _WIN32
+    _putenv_s(name, val.c_str());
+#else
+    setenv(name, val.c_str(), /*overwrite*/ 1);
+#endif
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    // Child mode: emit one line of debug(0) output, honoring
+    // HL_DEBUG_CODEGEN_LOG_FILE as inherited from the parent's environment.
+    if (argc == 2 && std::string(argv[1]) == "--child") {
+        debug(0) << "marker\n";
+        return 0;
+    }
+
+    const std::string self = fs::absolute(argv[0]).string();
+    const fs::path tmp =
+        fs::temp_directory_path() / ("hldbglog_" + std::to_string(std::random_device{}()));
+    fs::remove_all(tmp);
+    fs::create_directories(tmp);
+    const fs::path log = tmp / "log.txt";
+    const fs::path child_out = tmp / "child_stdout.txt";
+    const fs::path child_err = tmp / "child_stderr.txt";
+
+    // Redirecting to a file: the marker lands in the file, not on stderr.
+    set_env("HL_DEBUG_CODEGEN_LOG_FILE", log.string());
+    check(Internal::run_process({self, "--child"}, "", child_err.string()) == 0);
+    check(read_all(log) == "marker\n");
+    check(read_all(child_err).empty());
+
+    // A second run appends rather than truncating.
+    check(Internal::run_process({self, "--child"}, "", child_err.string()) == 0);
+    check(read_all(log) == "marker\nmarker\n");
+
+    // /dev/stdout and /dev/stderr are recognized explicitly, rather than
+    // treated as ordinary paths to open.
+    set_env("HL_DEBUG_CODEGEN_LOG_FILE", "/dev/stdout");
+    check(Internal::run_process({self, "--child"}, child_out.string(), "") == 0);
+    check(read_all(child_out) == "marker\n");
+
+    set_env("HL_DEBUG_CODEGEN_LOG_FILE", "/dev/stderr");
+    check(Internal::run_process({self, "--child"}, "", child_err.string()) == 0);
+    check(read_all(child_err) == "marker\n");
+
+    fs::remove_all(tmp);
+    std::cout << "Success!\n";
+    return 0;
+}


### PR DESCRIPTION
Applies globally, resolved at first debug() invocation. Maintains its own buffer so that it can send a whole chain of << outputs to the OS file descriptor in one atomic write. As long as the output buffer isn't exhausted, it is robust to parallel appends to files.

Remaps `/dev/stdout` to `std::cout` and `/dev/stderr` to `std::cerr` on all platforms (including Windows) both for compatibility and for less surprise when mixing `std::cerr` and `debug(0)`.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [x] Python bindings updated (if public API changed)
- [x] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)
