### PR TITLE
fix out-of-bounds color_dim coordinate read in HalideTraceViz

### DIFF
--- a/util/HalideTraceViz.cpp
+++ b/util/HalideTraceViz.cpp
@@ -1410,7 +1410,12 @@ int run(bool ignore_trace_tags, FlagProcessor flag_processor) {
                     // Convert to 8-bit color.
                     uint8_t int_value = (uint8_t)value;
 
-                    if (fi.config.color_dim < 0) {
+                    // color_dim comes from a trace tag or the command line and
+                    // is not bounded by the packet's dimensionality, so a value
+                    // past the coordinates in this packet renders as grayscale
+                    // rather than indexing coords out of range.
+                    if (fi.config.color_dim < 0 ||
+                        fi.config.color_dim >= p.dimensions / p.lanes) {
                         // Grayscale
                         image_color = (int_value * 0x00010101) | 0xff000000;
                     } else {


### PR DESCRIPTION
The load/store handler in HalideTraceViz picks a color channel with `coords[color_dim * lanes + lane]`, but `color_dim` is copied straight from a `FuncConfig` trace tag (`merge_from` keeps any value >= -1) and is never checked against the packet's dimensionality. A trace whose tag sets `color_dim` past the func's dimension count reads the coordinates array out of bounds, which ASAN reports as a stack-buffer-overflow read at the indexing site. Treating an out-of-range `color_dim` as grayscale keeps the index in bounds; in-range color configs are unaffected.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
