### PR TITLE
Only use the even/odd/thirds lets for whole-vector extracts

### DIFF
--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -294,23 +294,27 @@ private:
         } else {
 
             Type t = op->type.with_lanes(new_lanes);
-            if (external_lets.contains(op->name) &&
+            // These lets are defined by the mutator below, which splits a
+            // vector let into exactly two halves or exactly three thirds. A
+            // partial extract doesn't correspond to any of them.
+            const bool whole = new_lanes * lane_stride == op->type.lanes();
+            if (whole && external_lets.contains(op->name) &&
                 starting_lane == 0 &&
                 lane_stride == 2) {
                 return Variable::make(t, op->name + ".even_lanes", op->image, op->param, op->reduction_domain);
-            } else if (external_lets.contains(op->name) &&
+            } else if (whole && external_lets.contains(op->name) &&
                        starting_lane == 1 &&
                        lane_stride == 2) {
                 return Variable::make(t, op->name + ".odd_lanes", op->image, op->param, op->reduction_domain);
-            } else if (external_lets.contains(op->name) &&
+            } else if (whole && external_lets.contains(op->name) &&
                        starting_lane == 0 &&
                        lane_stride == 3) {
                 return Variable::make(t, op->name + ".lanes_0_of_3", op->image, op->param, op->reduction_domain);
-            } else if (external_lets.contains(op->name) &&
+            } else if (whole && external_lets.contains(op->name) &&
                        starting_lane == 1 &&
                        lane_stride == 3) {
                 return Variable::make(t, op->name + ".lanes_1_of_3", op->image, op->param, op->reduction_domain);
-            } else if (external_lets.contains(op->name) &&
+            } else if (whole && external_lets.contains(op->name) &&
                        starting_lane == 2 &&
                        lane_stride == 3) {
                 return Variable::make(t, op->name + ".lanes_2_of_3", op->image, op->param, op->reduction_domain);

--- a/src/Deinterleave.cpp
+++ b/src/Deinterleave.cpp
@@ -293,28 +293,31 @@ private:
             return op;
         } else {
 
+            // The lets below are defined by the mutator further down, which
+            // splits a vector let into exactly two halves or exactly three
+            // thirds. A partial extract doesn't correspond to any of them.
+            if (new_lanes * lane_stride != op->type.lanes()) {
+                return give_up_and_shuffle(op);
+            }
+
             Type t = op->type.with_lanes(new_lanes);
-            // These lets are defined by the mutator below, which splits a
-            // vector let into exactly two halves or exactly three thirds. A
-            // partial extract doesn't correspond to any of them.
-            const bool whole = new_lanes * lane_stride == op->type.lanes();
-            if (whole && external_lets.contains(op->name) &&
+            if (external_lets.contains(op->name) &&
                 starting_lane == 0 &&
                 lane_stride == 2) {
                 return Variable::make(t, op->name + ".even_lanes", op->image, op->param, op->reduction_domain);
-            } else if (whole && external_lets.contains(op->name) &&
+            } else if (external_lets.contains(op->name) &&
                        starting_lane == 1 &&
                        lane_stride == 2) {
                 return Variable::make(t, op->name + ".odd_lanes", op->image, op->param, op->reduction_domain);
-            } else if (whole && external_lets.contains(op->name) &&
+            } else if (external_lets.contains(op->name) &&
                        starting_lane == 0 &&
                        lane_stride == 3) {
                 return Variable::make(t, op->name + ".lanes_0_of_3", op->image, op->param, op->reduction_domain);
-            } else if (whole && external_lets.contains(op->name) &&
+            } else if (external_lets.contains(op->name) &&
                        starting_lane == 1 &&
                        lane_stride == 3) {
                 return Variable::make(t, op->name + ".lanes_1_of_3", op->image, op->param, op->reduction_domain);
-            } else if (whole && external_lets.contains(op->name) &&
+            } else if (external_lets.contains(op->name) &&
                        starting_lane == 2 &&
                        lane_stride == 3) {
                 return Variable::make(t, op->name + ".lanes_2_of_3", op->image, op->param, op->reduction_domain);

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -92,6 +92,7 @@ tests(
     deep_inline_chain.cpp
     deferred_loop_level.cpp
     deinterleave4.cpp
+    deinterleave_lets.cpp
     deinterleave_vector.cpp
     device_buffer_copies_with_profile.cpp
     device_buffer_copy.cpp

--- a/test/correctness/deinterleave_lets.cpp
+++ b/test/correctness/deinterleave_lets.cpp
@@ -1,0 +1,28 @@
+#include "Halide.h"
+#include <stdio.h>
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+int main(int argc, char **argv) {
+    Expr x = Variable::make(Int(32), "x");
+
+    // rewrite_interleavings gives every vector let a pair of extra lets holding
+    // its even and odd lanes. Those hold half as many lanes as the let they
+    // come from, so a deinterleave that wants some other number of lanes must
+    // not be rewritten to use them. Here b reads two of a's four lanes, so
+    // b.even_lanes wants a single lane, which a.even_lanes cannot provide.
+    Expr a = Variable::make(Int(32).with_lanes(4), "a");
+    Expr b = Variable::make(Int(32).with_lanes(2), "b");
+
+    Stmt s = Store::make("buf", b, Ramp::make(x, 1, 2));
+    s = LetStmt::make("b", Shuffle::make({a}, {0, 2}), s);
+    s = LetStmt::make("a", Ramp::make(x, 1, 4), s);
+
+    // Simplifying checks that every variable matches the type of the let that
+    // defines it.
+    simplify(rewrite_interleavings(s));
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
rewrite_interleavings gives each vector let a pair of extra lets holding its even and odd lanes (or three holding every third lane). Those hold half or a third as many lanes as the let they come from, so a deinterleave asking for any other number of lanes must not be rewritten to use them.

visit(Shuffle) reaches exactly that case: when it extracts a single lane it narrows starting_lane but leaves lane_stride and new_lanes alone, so recursing into a vector of a different width leaves the two out of sync. The result was a variable bound to a value of the wrong type.

This path is apparently not reachable directly from front-end code, but it's a latent bug that popped up when I started messing with the simplifier.