### PR TITLE
Fix deploy-docs.yml API reference generation on CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -43,7 +43,23 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpng-dev libjpeg-dev doxygen gdb
+          sudo apt-get install -y libpng-dev libjpeg-dev gdb
+
+      - name: Install Doxygen
+        env:
+          DOXYGEN_VERSION: 1.18.0
+          DOXYGEN_SHA256: 14fa81bdc34171edb5f1f02b1d60e74802f0439b77fa44e592565d517d72df90
+        run: |
+          # Ubuntu 24.04's apt package is stuck on Doxygen 1.9.8, which
+          # emits an empty <name/> for anonymous enums instead of a
+          # synthetic "@N" name -- generate_api_reference.py only handles
+          # the latter. Install upstream's official prebuilt binary
+          # instead of waiting on the distro package to catch up.
+          curl -fsSL -o doxygen.tar.gz \
+            "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
+          echo "${DOXYGEN_SHA256}  doxygen.tar.gz" | sha256sum -c -
+          tar xzf doxygen.tar.gz
+          echo "${GITHUB_WORKSPACE}/doxygen-${DOXYGEN_VERSION}/bin" >> "$GITHUB_PATH"
 
       - name: Sync CI environment
         run: |

--- a/doc/generate_api_reference.py
+++ b/doc/generate_api_reference.py
@@ -158,7 +158,10 @@ def _member_names(xml_dir: Path, container_refid: str, member_kinds, name_prefix
             continue
         for memberdef in sectiondef.findall("memberdef"):
             name = memberdef.find("name").text
-            if "@" in name:
+            # Anonymous enums get a synthetic "@N" name on newer Doxygen, but
+            # an empty <name/> (None here) on older ones (e.g. 1.9.8) -- both
+            # mean the same "no real name" thing and should be skipped.
+            if not name or "@" in name:
                 continue
             location = memberdef.find("location")
             file = location.get("file") if location is not None else "unknown"


### PR DESCRIPTION
## Summary
- `doc/generate_api_reference.py`'s `_member_names()` crashed with `TypeError: argument of type 'NoneType' is not iterable` when run against Doxygen 1.9.8 (Ubuntu 24.04's apt package): anonymous enums get an empty `<name/>` there, vs. a synthetic `"@N"` string on newer Doxygen (which is what local dev machines typically have, so this only showed up on CI).
- Handle both forms in `_member_names()`.
- Also stop depending on the stale apt-packaged Doxygen in `deploy-docs.yml` — install upstream's official 1.18.0 Linux binary instead (checksum-pinned), so CI isn't stuck on 1.9.8 going forward.

## Test plan
- [x] Reproduced the crash locally against Doxygen 1.9.8 XML output (built via Docker on `ubuntu:24.04`) for the specific anonymous enum in `HalideRuntime.h` that triggers it.
- [x] Confirmed the fix handles both the empty `<name/>` (1.9.8) and synthetic `@N` (1.18.0) forms, regenerated from real Doxygen XML in each case.
- [x] Verified the pinned Doxygen 1.18.0 Linux binary executes correctly on `ubuntu:24.04` under Docker.
- [x] `pre-commit run --all-files` passes on both changed files.
- [ ] CI run on this PR builds `deploy-docs.yml` successfully (dry run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)