### PR TITLE
Fix deploy-docs.yml push permission and drop unused target_repo input

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,19 +5,12 @@ on:
     types: [ published ]
   workflow_dispatch:
     inputs:
-      target_repo:
-        description: >-
-          Repo to deploy to. Override with a personal fork (e.g.
-          your-username/halide.github.com) to rehearse a real push
-          without touching the live site.
-        default: halide/halide.github.com
-        required: false
       dry_run:
         description: >-
-          Build and diff only -- never push anywhere, even to target_repo
-          above. Uploads the generated docs/ as a workflow artifact instead,
-          for manual inspection. This is the safe default for testing changes
-          to this workflow or the generator itself.
+          Build and diff only -- never push to halide.github.com. Uploads
+          the generated docs/ as a workflow artifact instead, for manual
+          inspection. This is the safe default for testing changes to this
+          workflow or the generator itself.
         type: boolean
         default: true
 
@@ -25,7 +18,8 @@ permissions:
   contents: read
 
 env:
-  TARGET_REPO: ${{ github.event.inputs.target_repo || 'halide/halide.github.com' }}
+  TARGET_REPO_OWNER: halide
+  TARGET_REPO_NAME: halide.github.com
   # Only ever a real push for `release` events -- any workflow_dispatch run
   # defaults to a dry run unless explicitly opted out.
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
@@ -75,6 +69,13 @@ jobs:
         with:
           app-id: ${{ secrets.LLVM_UPDATER_ID }}
           private-key: ${{ secrets.LLVM_UPDATER_PRIVATE_KEY }}
+          # Without these, the action scopes the token to the *current*
+          # repo (halide/Halide) rather than halide.github.com, since
+          # that's where this workflow itself lives -- leaving it unable
+          # to push to halide.github.com despite the app being installed
+          # there.
+          owner: ${{ env.TARGET_REPO_OWNER }}
+          repositories: ${{ env.TARGET_REPO_NAME }}
 
       - name: Get GitHub App user ID
         id: get-user-id
@@ -82,10 +83,10 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Checkout ${{ env.TARGET_REPO }}
+      - name: Checkout ${{ env.TARGET_REPO_OWNER }}/${{ env.TARGET_REPO_NAME }}
         uses: actions/checkout@v7
         with:
-          repository: ${{ env.TARGET_REPO }}
+          repository: ${{ env.TARGET_REPO_OWNER }}/${{ env.TARGET_REPO_NAME }}
           ref: master
           token: ${{ steps.app-token.outputs.token }}
           path: halide.github.com


### PR DESCRIPTION
## Summary
- `actions/create-github-app-token` scopes the minted token to the *current* repo (`halide/Halide`) unless told otherwise -- regardless of which other repos the app is installed on. That meant the final `git push` to `halide.github.com` in `deploy-docs.yml` was always denied with a 403, even after granting the `halide-ci` GitHub App write access to `halide/halide.github.com`. Passing `owner`/`repositories` explicitly scopes the token correctly.
- Dropped the `target_repo` workflow_dispatch input: this workflow has only ever deployed to `halide/halide.github.com`, and rehearsing against a personal fork wasn't a realistic use case, so it's hardcoded now and the env/step wiring is simplified accordingly.

## Test plan
- [x] Dispatched a real (non-dry-run) run from this branch against `halide/halide.github.com` to confirm the push actually succeeds this time (see run linked in PR checks / comments).
- [x] `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)