### PR TITLE
Fix async thread-pool deadlock from semaphore-blocked B-team workers

### DIFF
--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -161,9 +161,23 @@ struct work_queue_t {
     // must signal or broadcast the appropriate condition variable.
     halide_cond_with_spinning wake_a_team, wake_b_team, wake_owners;
 
+    // A separate channel for workers that found a job they could run but
+    // for an unavailable semaphore. This is distinct from the A/B teams,
+    // which model idle capacity (no runnable work): a worker here is
+    // blocked on an external event, not idle. Keeping it separate lets a
+    // semaphore release wake exactly the workers waiting on a semaphore,
+    // without a thundering herd of genuinely-idle workers waking only to
+    // rescan and go back to sleep.
+    halide_cond_with_spinning wake_from_semaphore;
+
     // The number of sleeping workers and owners. An over-estimate - a
     // waking-up thread may not have decremented this yet.
     int workers_sleeping, owners_sleeping;
+
+    // The number of workers parked on wake_from_semaphore. A subset of
+    // workers_sleeping (those threads are also counted there, so the A/B
+    // team bookkeeping is undisturbed).
+    int workers_parked_on_semaphore;
 
     // Keep track of threads so they can be joined at shutdown
     halide_thread *threads[MAX_THREADS];
@@ -261,10 +275,26 @@ WEAK void worker_thread_idle() {
     work_queue.workers_sleeping--;
 }
 
+// A worker that found runnable work blocked only on an unavailable
+// semaphore. Unlike an idle worker, it must be woken by a semaphore
+// release, so it waits on its own channel rather than the A/B teams.
+WEAK void worker_thread_blocked_on_semaphore() {
+    work_queue.workers_sleeping++;
+    work_queue.workers_parked_on_semaphore++;
+    work_queue.wake_from_semaphore.wait(&work_queue.mutex);
+    work_queue.workers_parked_on_semaphore--;
+    work_queue.workers_sleeping--;
+}
+
 WEAK void worker_thread_already_locked(work *owned_job) {
     while (owned_job ? owned_job->running() : !work_queue.shutdown) {
         work *job = work_queue.jobs;
         work **prev_ptr = &work_queue.jobs;
+
+        // Did we pass over a job that we could otherwise run, but for an
+        // unavailable semaphore? If so, a future semaphore release (not
+        // just newly-enqueued work) can make us runnable.
+        bool blocked_on_semaphore = false;
 
         if (owned_job) {
             if (owned_job->exit_status != halide_error_code_success) {
@@ -330,6 +360,7 @@ WEAK void worker_thread_already_locked(work *owned_job) {
                     break;
                 } else {
                     log_message("Cannot acquire semaphores for " << job->task.name);
+                    blocked_on_semaphore = true;
                 }
             }
             prev_ptr = &(job->next_job);
@@ -343,6 +374,8 @@ WEAK void worker_thread_already_locked(work *owned_job) {
             // is very informative when profiling.
             if (owned_job) {
                 worker_thread_stall(owned_job);
+            } else if (blocked_on_semaphore) {
+                worker_thread_blocked_on_semaphore();
             } else {
                 worker_thread_idle();
             }
@@ -594,6 +627,13 @@ WEAK void enqueue_work_already_locked(int num_jobs, work *jobs, work *task_paren
         }
     }
 
+    // Workers blocked on a semaphore wait on their own channel, so the
+    // broadcasts above don't reach them. Wake them too: they may be able
+    // to steal this newly-enqueued work.
+    if (work_queue.workers_parked_on_semaphore) {
+        work_queue.wake_from_semaphore.broadcast();
+    }
+
     if (job_has_acquires || job_may_block) {
         if (task_parent != nullptr) {
             task_parent->threads_reserved--;
@@ -742,6 +782,7 @@ WEAK void halide_shutdown_thread_pool() {
         work_queue.wake_owners.broadcast();
         work_queue.wake_a_team.broadcast();
         work_queue.wake_b_team.broadcast();
+        work_queue.wake_from_semaphore.broadcast();
         halide_mutex_unlock(&work_queue.mutex);
 
         // Wait until they leave
@@ -767,12 +808,14 @@ WEAK int halide_default_semaphore_init(halide_semaphore_t *s, int n) {
 WEAK int halide_default_semaphore_release(halide_semaphore_t *s, int n) {
     halide_semaphore_impl_t *sem = (halide_semaphore_impl_t *)s;
     int old_val = Halide::Runtime::Internal::Synchronization::atomic_fetch_add_acquire_release(&sem->value, n);
-    // TODO(abadams|zvookin): Is this correct if an acquire can be for say count of 2 and the releases are 1 each?
-    if (old_val == 0 && n != 0) {  // Don't wake if nothing released.
-        // We may have just made a job runnable
+    if (n != 0) {
         halide_mutex_lock(&work_queue.mutex);
-        work_queue.wake_a_team.broadcast();
-        work_queue.wake_owners.broadcast();
+        if (work_queue.workers_parked_on_semaphore) {
+            work_queue.wake_from_semaphore.broadcast();
+        }
+        if (work_queue.owners_sleeping) {
+            work_queue.wake_owners.broadcast();
+        }
         halide_mutex_unlock(&work_queue.mutex);
     }
     return old_val + n;

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -443,6 +443,7 @@ tests(
     assertion_failure_in_parallel_for.cpp
     async.cpp
     async_copy_chain.cpp
+    async_deadlock.cpp
     async_order.cpp
     atomic_tuples.cpp
     atomics.cpp

--- a/test/correctness/async_deadlock.cpp
+++ b/test/correctness/async_deadlock.cpp
@@ -1,0 +1,96 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+// Regression test for a lost-wakeup deadlock in the async/thread-pool
+// runtime, reduced from async_copy_chain.cpp. A worker blocked because a
+// semaphore it needed was unavailable went to sleep on one of the two idle
+// worker condition variables (the "A team" / "B team"), chosen by pool-size
+// bookkeeping unrelated to why it slept. A semaphore release only ever woke
+// the A team, so a semaphore-blocked worker that happened to be on the B
+// team was never woken by the release that made its job runnable, and every
+// thread ended up parked forever.
+//
+// The bug is a genuine race, so it does not reproduce reliably from a single
+// realization. It reproduces most readily when this specific sequence of
+// nested-async pipeline shapes runs one after another in the same process,
+// so we repeat the whole sequence to raise the probability of hitting it. A
+// reintroduced deadlock hangs forever, so CI's watchdog will catch it even
+// at a modest iteration count.
+//
+// The race requires a semaphore-blocked worker to be demoted to the B team,
+// which only happens when the pool is small enough to keep reshuffling teams
+// under load. A large pool stays entirely on the A team and never exposes
+// the bug, so we pin the thread count low, where the reintroduced deadlock
+// reproduces on the vast majority of runs.
+static constexpr int num_threads = 3;
+
+Var x, y;
+
+void make_pipeline(Func &A, Func &B) {
+    A(x, y) = x + y;
+    B(x, y) = A(x, y);
+}
+
+void check(Func f, const Target &target) {
+    Buffer<int> out = f.realize({256, 256}, target);
+    out.for_each_element([&](int x, int y) {
+        if (out(x, y) != x + y) {
+            printf("out(%d, %d) = %d instead of %d\n", x, y, out(x, y), x + y);
+            exit(1);
+        }
+    });
+}
+
+int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment().with_feature(Target::EnableBacktraces);
+    if (target.arch == Target::WebAssembly) {
+        printf("[SKIP] WebAssembly does not support async() yet.\n");
+        return 0;
+    }
+
+    Halide::Internal::JITSharedRuntime::set_num_threads(num_threads);
+
+    const int iterations = 25;
+    for (int i = 0; i < iterations; i++) {
+        {
+            Func A, B;
+            make_pipeline(A, B);
+            A.store_root().compute_at(B, y).fold_storage(y, 2).async();
+            check(B, target);
+        }
+        {
+            Func A, B;
+            make_pipeline(A, B);
+            A.store_root().compute_at(B, y).fold_storage(y, 2).async();
+            A.in().store_root().compute_at(B, y).fold_storage(y, 2).async().copy_to_host();
+            check(B, target);
+        }
+        {
+            Func A, B;
+            make_pipeline(A, B);
+            A.store_root().compute_at(A.in(), Var::outermost()).fold_storage(y, 2).async();
+            A.in().store_root().compute_at(B, y).fold_storage(y, 2).async().copy_to_host();
+            check(B, target);
+        }
+        {
+            Func A, B;
+            make_pipeline(A, B);
+            A.store_root().compute_at(B, y).fold_storage(y, 2).async();
+            A.in().store_root().compute_at(B, y).fold_storage(y, 2).copy_to_host().async();
+            A.in().in().store_root().compute_at(B, y).fold_storage(y, 2).copy_to_host().async();
+            check(B, target);
+        }
+        {
+            Func A, B;
+            make_pipeline(A, B);
+            A.store_root().compute_at(A.in(), Var::outermost()).fold_storage(y, 2).async();
+            A.in().store_root().compute_at(A.in().in(), Var::outermost()).fold_storage(y, 2).copy_to_host().async();
+            A.in().in().store_root().compute_at(B, y).fold_storage(y, 2).copy_to_host().async();
+            check(B, target);
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
A worker that found a job it could run but for an unavailable semaphore went to sleep on one of the two idle worker condition variables (the A/B teams), chosen by pool-size bookkeeping unrelated to why it slept. A semaphore release only ever broadcast wake_a_team, so a semaphore-blocked worker demoted to the B team was never woken by the release that made its job runnable, and the pipeline could deadlock with every thread parked.

The A/B teams model idle capacity (no runnable work), which is a different state from being blocked on an external event. Give blocked-on-semaphore workers their own wait channel and wake it on every release, alongside stalled owners. Genuinely-idle A/B-team workers are never waiting on a semaphore, so they are left undisturbed.

This also removes the old 0 -> 1-transition gate on the release wakeup, which was independently unsound for acquires of count > 1 satisfied by several count-1 releases in a row.

Adds test/correctness/async_deadlock.cpp, pinned to a low thread count (where the pool reshuffles teams and reliably exposes the bug).

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)
