### PR TITLE
Bound stack depth from nested parallelism

### DIFF
--- a/src/runtime/thread_pool_common.h
+++ b/src/runtime/thread_pool_common.h
@@ -109,6 +109,26 @@ struct work {
     }
 };
 
+// A thread that stalls on a job it owns may start tasks belonging to other
+// parallel regions rather than idle, but doing so nests a new owned job inside
+// the one it is already waiting on, and that stack frame can't unwind until the
+// new job completes. Bounding how many jobs a thread may have stalled at once
+// lets it start one more instance of an outer loop it is already inside, but
+// not an unbounded number of them. Descending without stalling is already
+// bounded, because it can only go one level deeper into the loop nest.
+constexpr int max_stalled_jobs = 2;
+
+// Which entry of work_queue.stalled_jobs belongs to the calling thread. Thread
+// ids are dense on some platforms and multiples of four on others, so mix them
+// before taking the low bits. Two threads may share an entry, which can only
+// cause one of them to decline to start a job it could have run.
+ALWAYS_INLINE int stalled_jobs_slot() {
+    static_assert(MAX_THREADS <= 256 && (MAX_THREADS & (MAX_THREADS - 1)) == 0,
+                  "MAX_THREADS must be a power of two no greater than 256.");
+    const uint32_t id = (uint32_t)halide_current_thread_id();
+    return (int)(((id * (uint32_t)2654435761) >> 24) & (MAX_THREADS - 1));
+}
+
 ALWAYS_INLINE int clamp_num_threads(int threads) {
     if (threads > MAX_THREADS) {
         return MAX_THREADS;
@@ -177,6 +197,12 @@ struct work_queue_t {
     // the number of iterations of parallel for loops that are invoked so as
     // to prevent deadlock due to oversubscription of threads.
     int threads_reserved;
+
+    // For each thread, how many of the jobs it owns have stalled, indexed by
+    // stalled_jobs_slot(). Only maintained for jobs that stall, because
+    // finding the index can cost a syscall, and a stalled job has nothing
+    // better to do.
+    uint8_t stalled_jobs[MAX_THREADS];
 
     ALWAYS_INLINE bool running() const {
         return !shutdown;
@@ -262,6 +288,10 @@ WEAK void worker_thread_idle() {
 }
 
 WEAK void worker_thread_already_locked(work *owned_job) {
+    // Set the first time this job stalls. Threads that don't own a job are
+    // free to work on anything, so they never need it.
+    int slot = -1;
+
     while (owned_job ? owned_job->running() : !work_queue.shutdown) {
         work *job = work_queue.jobs;
         work **prev_ptr = &work_queue.jobs;
@@ -316,7 +346,19 @@ WEAK void worker_thread_already_locked(work *owned_job) {
             if (!enough_threads) {
                 log_message("Not enough threads for job " << job->task.name << " available: " << threads_available << " min_threads: " << job->task.min_threads);
             }
-            bool can_use_this_thread_stack = !owned_job || (job->siblings == owned_job->siblings) || job->task.min_threads == 0;
+            // Starting a job from another parallel region leaves the job we
+            // own waiting on our stack, so only do it for jobs that can't
+            // block, and only if we aren't already holding one that way.
+            bool can_use_this_thread_stack =
+                !owned_job || (job->siblings == owned_job->siblings);
+            if (!can_use_this_thread_stack && job->task.min_threads == 0) {
+                if (slot < 0) {
+                    slot = stalled_jobs_slot();
+                    work_queue.stalled_jobs[slot]++;
+                }
+                can_use_this_thread_stack =
+                    work_queue.stalled_jobs[slot] < max_stalled_jobs;
+            }
             if (!can_use_this_thread_stack) {
                 log_message("Cannot run job " << job->task.name << " on this thread.");
             }
@@ -466,6 +508,10 @@ WEAK void worker_thread_already_locked(work *owned_job) {
             // The job is done or some owned job failed via sibling linkage. Wake up the owner.
             work_queue.wake_owners.broadcast();
         }
+    }
+
+    if (slot >= 0) {
+        work_queue.stalled_jobs[slot]--;
     }
 }
 

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -545,6 +545,7 @@ set_target_properties(
     correctness_memoize
     correctness_memoize_cloned
     correctness_multiple_outputs_extern
+    correctness_nested_parallel_stack
     correctness_non_nesting_extern_bounds_query
     correctness_parallel_fork
     correctness_pipeline_set_jit_externs_func

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -464,6 +464,7 @@ tests(
     multiple_outputs_extern.cpp
     multiple_scatter.cpp
     named_updates.cpp
+    nested_parallel_stack.cpp
     nested_shiftinwards.cpp
     oddly_sized_output.cpp
     parallel.cpp

--- a/test/correctness/nested_parallel_stack.cpp
+++ b/test/correctness/nested_parallel_stack.cpp
@@ -1,0 +1,117 @@
+#include "Halide.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <stdio.h>
+#include <thread>
+
+using namespace Halide;
+
+// A minimal counting semaphore (std::counting_semaphore is C++20).
+class Semaphore {
+    std::mutex mutex;
+    std::condition_variable cond;
+    int count = 0;
+
+public:
+    void release() {
+        std::lock_guard<std::mutex> lock(mutex);
+        count++;
+        cond.notify_one();
+    }
+    void acquire() {
+        std::unique_lock<std::mutex> lock(mutex);
+        cond.wait(lock, [this] { return count > 0; });
+        count--;
+    }
+};
+
+// Two semaphores, selected by the parity of the extern's argument, so that the
+// test can control exactly which inner task is allowed to complete when.
+static Semaphore semaphores[2];
+
+extern "C" HALIDE_EXPORT_SYMBOL int nested_parallel_stack_acquire(int x) {
+    semaphores[x & 1].acquire();
+    return x;
+}
+HalideExtern_1(int, nested_parallel_stack_acquire, int);
+
+// Measure how deeply task execution nests on a single thread.
+static thread_local int t_depth = 0;
+static std::atomic<int> max_depth{0};
+
+static int counting_do_task(JITUserContext *user_context,
+                            int (*f)(JITUserContext *, int, uint8_t *),
+                            int idx, uint8_t *closure) {
+    int d = ++t_depth;
+    int prev = max_depth.load();
+    while (d > prev && !max_depth.compare_exchange_weak(prev, d)) {
+    }
+    int result = f(user_context, idx, closure);
+    --t_depth;
+    return result;
+}
+
+int main(int argc, char **argv) {
+    if (get_jit_target_from_environment().arch == Target::WebAssembly) {
+        printf("[SKIP] WebAssembly JIT does not support threads.\n");
+        return 0;
+    }
+
+    // An outer parallel loop over y wrapping an inner parallel loop over x.
+    // Each inner task blocks in the extern until released below.
+    Var x("x"), y("y");
+    Func g("g"), out("out");
+    g(x, y) = nested_parallel_stack_acquire(x);
+    out(x, y) = g(x, y);
+
+    out.parallel(y);
+    g.compute_at(out, y).parallel(x);
+
+    // Exactly two threads: one becomes the owner that keeps descending, the
+    // other clears each level behind it. The shared jit runtime is created
+    // lazily, so it must exist before we can set the thread count on it.
+    out.compile_jit();
+    Internal::JITSharedRuntime::set_num_threads(2);
+
+    const int N = 64;
+
+    // Drive completion order from a thread outside the pool. Each round,
+    // release the even inner task first, then the odd one. That makes the
+    // owner finish its first inner task and start another outer task while the
+    // odd task is still in flight, so it descends instead of unwinding.
+    std::thread poster([&]() {
+        for (int i = 0; i < N; i++) {
+            semaphores[0].release();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            semaphores[1].release();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        // Drain any stragglers so the pipeline can't hang. Over-releasing a
+        // counting semaphore is harmless.
+        for (int i = 0; i < 4 * N; i++) {
+            semaphores[0].release();
+            semaphores[1].release();
+        }
+    });
+
+    JITUserContext context;
+    context.handlers.custom_do_task = counting_do_task;
+    out.realize(&context, {2, N});
+    poster.join();
+
+    // The thread pool bounds how many jobs a thread may own at once, so the
+    // nesting depth should not grow with N.
+    const int limit = 8;
+    if (max_depth.load() > limit) {
+        printf("Nested parallel loops recursed %d deep (limit %d). A single "
+               "thread's stack accumulates one frame per outer task.\n",
+               max_depth.load(), limit);
+        return 1;
+    }
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
A thread that stalls waiting on a parallel loop it owns may run tasks from other parallel regions rather than idle. That is worth keeping: with a small inner loop, starting another instance of the outer loop is the only work available. But each one nests a new owned job inside the one already being waited on, and that stack frame cannot unwind until the new job completes, so a single thread could accumulate one frame per outer loop iteration.

Track how many of the jobs each thread owns have stalled, in an array indexed by a hash of the thread id, and let a stalled job start work from another region only while its thread is below the limit of two. A thread can still take one more instance of a loop it is already inside, but not an unbounded number of them. Descending without stalling is already bounded, since it can only go one level deeper into the loop nest, so per-thread stack depth is now bounded by the pipeline's static loop nest depth rather than by loop extents.

The thread id is only fetched when a job first looks outside its own region, which on Linux costs a syscall. A pipeline whose parallel loops aren't nested never gets that far.

Fixes #9377
