### PR TITLE
bound .mat array name length in halide_debug_to_file

### DIFF
--- a/src/runtime/write_debug_image.cpp
+++ b/src/runtime/write_debug_image.cpp
@@ -371,6 +371,9 @@ WEAK extern "C" int halide_debug_to_file(void *user_context, const char *filenam
         }
         uint32_t name_size = (uint32_t)(end - start);
         char array_name[256];
+        if (name_size > sizeof(array_name)) {
+            return halide_error_code_debug_to_file_failed;
+        }
         char *dst = array_name;
         while (start != end) {
             *dst++ = *start++;


### PR DESCRIPTION
The .mat writer in halide_debug_to_file builds an array name from the filename's base name (the text between the last slash and the extension) and copies it into a fixed char array_name[256] with no length check, so a filename whose base name is longer than 256 bytes overflows the stack buffer. Reject an oversized name before the copy, using the same halide_error_code_debug_to_file_failed return the writer already uses for oversized headers and payloads.