### PR TITLE
Use a 64-bit compiler for the 32-bit Windows build

### DIFF
--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -43,7 +43,9 @@ jobs:
         uv_group: [ "ci-llvm-main", "ci-llvm-22", "ci-llvm-21" ]
         include:
           - bits: 32
-            arch: x86
+            # A 64-bit compiler targeting x86, rather than the 32-bit one, so
+            # that large translation units don't exhaust its address space.
+            arch: amd64_x86
             python: cpython-3.10.20-windows-x86-none
           # - bits: 64  # Intentionally not 64, as we haven't configured self-hosted runners for it yet.
           #   arch: x64


### PR DESCRIPTION
The Windows CI matrix passes `arch: x86` to `msvc-dev-cmd`, which selects `Hostx86\x86\cl.exe` — a compiler that is itself a 32-bit process. Large translation units exhaust its address space:

```
Simplify_LT.cpp(62) : fatal error C1002: compiler is out of heap space in pass 2
```

`amd64_x86` is the cross toolchain: the same compiler built for 64 bits, still targeting x86. It gives `Hostx64\x86\cl.exe`, so the emitted binaries are unchanged and 32-bit coverage is unaffected. The runner is already 64-bit, so no new infrastructure is needed.

This is a one-word change to the `arch` matrix entry. The `bits: 32` matrix and the `i686-pc-windows-msvc` LLVM wheel are untouched — only the host compiler changes.

Without this, the 32-bit host stays a standing constraint on how large any single translation unit in `src/` may become, which has already required splitting rule blocks in the simplifier to work around.