### PR TITLE
Split multi-term reductions in hoist_invariants

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -207,7 +207,7 @@ public:
 
 private:
     // Intermediate stencil stages to schedule
-    vector<Func> intermediates;
+    FuncVec intermediates;
 };
 
 class CameraPipe : public Halide::Generator<CameraPipe> {

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -2,14 +2,6 @@
 
 namespace {
 
-std::vector<Halide::Func> func_vector(const std::string &name, int size) {
-    std::vector<Halide::Func> funcs;
-    for (int i = 0; i < size; i++) {
-        funcs.emplace_back(Halide::Func{name + "_" + std::to_string(i)});
-    }
-    return funcs;
-}
-
 class Interpolate : public Halide::Generator<Interpolate> {
 public:
     GeneratorParam<int> levels{"levels", 10};
@@ -23,11 +15,11 @@ public:
         // Input must have four color channels - rgba
         input.dim(2).set_bounds(0, 4);
 
-        auto downsampled = func_vector("downsampled", levels);
-        auto downx = func_vector("downx", levels);
-        auto interpolated = func_vector("interpolated", levels);
-        auto upsampled = func_vector("upsampled", levels);
-        auto upsampledx = func_vector("upsampledx", levels);
+        FuncVec downsampled("downsampled_", levels);
+        FuncVec downx("downx_", levels);
+        FuncVec interpolated("interpolated_", levels);
+        FuncVec upsampled("upsampled_", levels);
+        FuncVec upsampledx("upsampledx_", levels);
 
         Func clamped = Halide::BoundaryConditions::repeat_edge(input);
 

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -51,7 +51,7 @@ public:
         // Do a push-pull thing to blur the cost volume with an
         // exponential-decay type thing to inpaint over regions with low
         // confidence.
-        Func cost_pyramid_push[8];
+        FuncVec cost_pyramid_push("cost_pyramid_push", 8);
         cost_pyramid_push[0](x, y, z, c) =
             mux(c, {cost(x, y, z) * cost_confidence(x, y), cost_confidence(x, y)});
 
@@ -63,7 +63,7 @@ public:
             cost_pyramid_push[i] = BoundaryConditions::repeat_edge(cost_pyramid_push[i], {{0, w}, {0, h}});
         }
 
-        Func cost_pyramid_pull[8];
+        FuncVec cost_pyramid_pull("cost_pyramid_pull", 8);
         cost_pyramid_pull[7](x, y, z, c) = cost_pyramid_push[7](x, y, z, c);
         for (int i = 6; i >= 0; i--) {
             cost_pyramid_pull[i](x, y, z, c) = lerp(upsample(cost_pyramid_pull[i + 1])(x, y, z, c),

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -36,7 +36,7 @@ public:
         gray(x, y) = 0.299f * floating(x, y, 0) + 0.587f * floating(x, y, 1) + 0.114f * floating(x, y, 2);
 
         // Make the processed Gaussian pyramid.
-        Func gPyramid[maxJ];
+        FuncVec gPyramid("gPyramid", J);
         // Do a lookup into a lut with 256 entries per intensity level
         Expr level = k * (1.0f / (levels - 1));
         Expr idx = gray(x, y) * cast<float>(levels - 1) * 256.0f;
@@ -47,21 +47,21 @@ public:
         }
 
         // Get its laplacian pyramid
-        Func lPyramid[maxJ];
+        FuncVec lPyramid("lPyramid", J);
         lPyramid[J - 1](x, y, k) = gPyramid[J - 1](x, y, k);
         for (int j = J - 2; j >= 0; j--) {
             lPyramid[j](x, y, k) = gPyramid[j](x, y, k) - upsample(gPyramid[j + 1])(x, y, k);
         }
 
         // Make the Gaussian pyramid of the input
-        Func inGPyramid[maxJ];
+        FuncVec inGPyramid("inGPyramid", J);
         inGPyramid[0](x, y) = gray(x, y);
         for (int j = 1; j < J; j++) {
             inGPyramid[j](x, y) = downsample(inGPyramid[j - 1])(x, y);
         }
 
         // Make the laplacian pyramid of the output
-        Func outLPyramid[maxJ];
+        FuncVec outLPyramid("outLPyramid", J);
         for (int j = 0; j < J; j++) {
             // Split input pyramid value into integer and floating parts
             Expr level = inGPyramid[j](x, y) * cast<float>(levels - 1);
@@ -72,7 +72,7 @@ public:
         }
 
         // Make the Gaussian pyramid of the output
-        Func outGPyramid[maxJ];
+        FuncVec outGPyramid("outGPyramid", J);
         outGPyramid[J - 1](x, y) = outLPyramid[J - 1](x, y);
         for (int j = J - 2; j >= 0; j--) {
             outGPyramid[j](x, y) = upsample(outGPyramid[j + 1])(x, y) + outLPyramid[j](x, y);

--- a/apps/onnx/model.cpp
+++ b/apps/onnx/model.cpp
@@ -49,7 +49,7 @@ HalideModel convert_onnx_model(
     result.model = std::make_shared<Model>(
         convert_model(onnx_model, expected_dim_sizes, layout));
 
-    std::vector<Halide::Func> funcs;
+    Halide::FuncVec funcs;
     for (const auto &output : onnx_model.graph().output()) {
         const auto &tensor = result.model->outputs.at(output.name());
         funcs.push_back(tensor.rep);

--- a/apps/onnx/onnx_converter.cc
+++ b/apps/onnx/onnx_converter.cc
@@ -1850,7 +1850,7 @@ Node convert_concat_node(
     }
 
     Halide::Var concat_axis = tgt_indices[axis];
-    std::vector<Halide::Func> concat_funcs;
+    Halide::FuncVec concat_funcs;
     concat_funcs.resize(inputs.size());
     concat_funcs[0](tgt_indices) = inputs[0].rep(tgt_indices);
     Halide::Expr concat_offset = 0;

--- a/apps/stencil_chain/stencil_chain_generator.cpp
+++ b/apps/stencil_chain/stencil_chain_generator.cpp
@@ -11,24 +11,20 @@ public:
 
     void generate() {
 
-        std::vector<Func> stages;
+        FuncVec stages("stage_", (int)stencils + 1);
 
         Var x("x"), y("y");
 
-        Func f = Halide::BoundaryConditions::repeat_edge(input);
+        stages[0] = Halide::BoundaryConditions::repeat_edge(input);
 
-        stages.push_back(f);
-
-        for (int s = 0; s < (int)stencils; s++) {
-            Func f("stage_" + std::to_string(s));
+        for (int s = 1; s <= (int)stencils; s++) {
             Expr e = cast<uint16_t>(0);
             for (int i = -2; i <= 2; i++) {
                 for (int j = -2; j <= 2; j++) {
-                    e += ((i + 3) * (j + 3)) * stages.back()(x + i, y + j);
+                    e += ((i + 3) * (j + 3)) * stages[s - 1](x + i, y + j);
                 }
             }
-            f(x, y) = e;
-            stages.push_back(f);
+            stages[s](x, y) = e;
         }
 
         output(x, y) = stages.back()(x, y);

--- a/python_bindings/halide/src/halide_/PyPipeline.cpp
+++ b/python_bindings/halide/src/halide_/PyPipeline.cpp
@@ -70,15 +70,12 @@ void define_pipeline(py::module &m) {
             .def(py::init<Func>())
             .def(py::init<const std::vector<Func> &>())
 
-            .def("outputs", &Pipeline::outputs)
+            .def("outputs", [](const Pipeline &p) {
+                return std::vector<Func>(p.outputs());
+            })
 
-            .def("apply_autoscheduler", &Pipeline::apply_autoscheduler,
-                 py::arg("target"), py::arg("autoscheduler_params"))
-            .def(
-                "apply_runtime_prefixes", [](Pipeline &p, const Target &target, const std::map<RuntimeLinkage, std::string> &namespace_map) {
-                    p.apply_runtime_prefixes(target, RuntimePrefixParams(namespace_map));
-                },
-                py::arg("target"), py::arg("namespace_map"))
+            .def("apply_autoscheduler", &Pipeline::apply_autoscheduler, py::arg("target"), py::arg("autoscheduler_params"))
+            .def("apply_runtime_prefixes", [](Pipeline &p, const Target &target, const std::map<RuntimeLinkage, std::string> &namespace_map) { p.apply_runtime_prefixes(target, RuntimePrefixParams(namespace_map)); }, py::arg("target"), py::arg("namespace_map"))
             .def("get_func", &Pipeline::get_func, py::arg("index"))
             .def("print_loop_nest", &Pipeline::print_loop_nest)
 

--- a/python_bindings/halide/src/halide_/PyStage.cpp
+++ b/python_bindings/halide/src/halide_/PyStage.cpp
@@ -23,7 +23,9 @@ void define_stage(py::module &m) {
                  py::arg("preserved"))
             .def("rfactor", static_cast<Func (Stage::*)(const RVar &, const Var &)>(&Stage::rfactor),
                  py::arg("r"), py::arg("v"))
-            .def("hoist_invariants", &Stage::hoist_invariants)
+            .def("hoist_invariants", [](Stage &stage) {
+                return std::vector<Func>(stage.hoist_invariants());
+            })
 
             .def("eager_inline", (Stage & (Stage::*)(const std::vector<Func> &)) & Stage::eager_inline, py::arg("fs"))
             .def("eager_inline", [](Stage &stage, const py::args &args) -> Stage & {

--- a/python_bindings/halide/src/halide_/PyStage.cpp
+++ b/python_bindings/halide/src/halide_/PyStage.cpp
@@ -23,6 +23,7 @@ void define_stage(py::module &m) {
                  py::arg("preserved"))
             .def("rfactor", static_cast<Func (Stage::*)(const RVar &, const Var &)>(&Stage::rfactor),
                  py::arg("r"), py::arg("v"))
+            .def("hoist_invariants", &Stage::hoist_invariants)
 
             .def("eager_inline", (Stage & (Stage::*)(const std::vector<Func> &)) & Stage::eager_inline, py::arg("fs"))
             .def("eager_inline", [](Stage &stage, const py::args &args) -> Stage & {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -99,6 +99,20 @@ Func::Func(Function f)
         << "Can't construct Func from undefined Function";
 }
 
+FuncVec::FuncVec(const string &base_name, size_t count) {
+    reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        emplace_back(base_name + std::to_string(i));
+    }
+}
+
+FuncVec::operator Func() const {
+    user_assert(size() == 1)
+        << "Cannot convert a FuncVec of size " << size()
+        << " to a Func; exactly one Func is required.\n";
+    return front();
+}
+
 const string &Func::name() const {
     return func.name();
 }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -754,6 +754,41 @@ pair<ReductionDomain, SubstitutionMap> project_rdom(const vector<Dim> &dims, con
     return {new_rdom, dim_projection};
 }
 
+// A semiring distributive law used by hoist_invariants(): `inner` distributes
+// over the outer (reduction) op, so a loop-invariant operand of `inner` can be
+// hoisted out of the reduction.
+struct DistributiveLaw {
+    IRNodeType outer_op;
+    IRNodeType inner_op;
+};
+
+constexpr DistributiveLaw distributive_laws[] = {
+    {IRNodeType::Add, IRNodeType::Mul},  // sum_k(s * x_k) = s * sum_k(x_k)
+    {IRNodeType::Min, IRNodeType::Add},  // min_k(c + x_k) = c + min_k(x_k)
+    {IRNodeType::Max, IRNodeType::Add},  // max_k(c + x_k) = c + max_k(x_k)
+    {IRNodeType::Or, IRNodeType::And},   // or_k(p && x_k)  = p && or_k(x_k)
+    {IRNodeType::And, IRNodeType::Or},   // and_k(p || x_k) = p || and_k(x_k)
+};
+
+bool distributive_law_valid_for_type(const DistributiveLaw &law, Type t) {
+    if (law.outer_op == IRNodeType::Min || law.outer_op == IRNodeType::Max) {
+        // Hoisting min/max over addition relies on addition being order-preserving.
+        // This is not true for unsigned or narrow signed integer wraparound.
+        return !t.can_overflow();
+    }
+    return true;
+}
+
+// nullopt if no law's outer_op matches, or if the matching law is invalid for `op`'s type.
+optional<DistributiveLaw> distributive_law_for(const Expr &op) {
+    for (const DistributiveLaw &law : distributive_laws) {
+        if (law.outer_op == op.node_type()) {
+            return distributive_law_valid_for_type(law, op.type()) ? std::make_optional(law) : std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
 // If `e` is a binary op of node type `op` and exactly one of its two operands
 // satisfies `is_selected`, returns {selected operand, other operand}. Returns
 // nullopt if `e` isn't a binary `op`, or if neither/both operands match.
@@ -770,6 +805,115 @@ optional<pair<Expr, Expr>> select_binary_operand(const Expr &e, IRNodeType op, P
         return std::nullopt;
     }
     return a_sel ? std::make_pair(a, b) : std::make_pair(b, a);
+}
+
+// Collect the leaves of a chain of `op`-typed binary nodes.
+// E.g., flatten (a*b)*(c*d) into [a, b, c, d]
+void flatten_associative_chain(const Expr &e, IRNodeType op, vector<Expr> &leaves) {
+    if (e.node_type() == op) {
+        auto [a, b] = *as_binary_operands(e);
+        flatten_associative_chain(a, op, leaves);
+        flatten_associative_chain(b, op, leaves);
+    } else {
+        leaves.push_back(e);
+    }
+}
+
+struct HoistedFactor {
+    IRNodeType op;
+    Expr factor;      // The loop-invariant distributable factor, expressed in
+                      // the preserved update's coordinate system.
+    Expr inner_body;  // The remaining body after removing the factor. It keeps
+                      // its natural type; changing the accumulation type is the
+                      // job of the separate change_type() directive.
+};
+
+// Given the non-self-reference increment from an update body and the
+// distributive law of the outer associative op, extract a loop-invariant factor
+// that distributes over the outer op. `reduction_vars` is the set of RVar names
+// the factor must not reference.
+// TODO: if we flatten by the outer op here we can make tuple-valued reductions
+//   for things like: f(r) += a * g(r) + b * h(r)
+optional<HoistedFactor> extract_factor(const Expr &increment,
+                                       const DistributiveLaw &law,
+                                       const Scope<> &reduction_vars) {
+    auto is_rvar_free = [&](const Expr &e) {
+        return !expr_uses_vars(e, reduction_vars);
+    };
+
+    // An invariant factor may be nested arbitrarily deep in an
+    // associative/commutative chain, so flatten the whole chain
+    // into leaves and partition by invariance. This is just
+    // commutative-ring algebra: l1*l2*...*lN can always be regrouped
+    // as (product of invariant leaves) * (product of dependent leaves),
+    // regardless of how the multiplication was parenthesized.
+    vector<Expr> leaves;
+    flatten_associative_chain(increment, law.inner_op, leaves);
+
+    vector<Expr> invariant_leaves, dependent_leaves;
+    for (const Expr &leaf : leaves) {
+        if (is_rvar_free(leaf)) {
+            invariant_leaves.push_back(leaf);
+        } else {
+            dependent_leaves.push_back(leaf);
+        }
+    }
+    if (invariant_leaves.empty() || dependent_leaves.empty()) {
+        // Nothing to hoist, or the entire increment is invariant (a
+        // degenerate case not worth special-casing here).
+        return std::nullopt;
+    }
+
+    Expr factor;
+    for (const Expr &leaf : invariant_leaves) {
+        factor = factor.defined() ? make_binary_op(law.inner_op, factor, leaf) : leaf;
+    }
+    Expr body;
+    for (const Expr &leaf : dependent_leaves) {
+        body = body.defined() ? make_binary_op(law.inner_op, body, leaf) : leaf;
+    }
+
+    return HoistedFactor{law.inner_op, factor, body};
+}
+
+vector<optional<HoistedFactor>> extract_hoisted_factors(const vector<Expr> &values,
+                                                        const AssociativeOp &prover_result,
+                                                        const string &func_name,
+                                                        const Scope<> &reduction_vars) {
+    vector<optional<HoistedFactor>> result(values.size());
+
+    auto is_orig_self_ref = [&](const Expr &e) {
+        const Call *c = e.as<Call>();
+        return c && c->name == func_name && c->call_type == Call::Halide;
+    };
+
+    auto extract_increment = [&](const Expr &val, const DistributiveLaw &law) -> optional<Expr> {
+        optional<pair<Expr, Expr>> split = select_binary_operand(val, law.outer_op, is_orig_self_ref);
+        return split ? std::make_optional(split->second) : std::nullopt;
+    };
+
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (optional<DistributiveLaw> law = distributive_law_for(prover_result.pattern.ops[i])) {
+            // The value may be wrapped in Let nodes (e.g. an rfactor of this same
+            // update introduced promise_clamped bindings for a preserved RVar).
+            // Inline them so the outer op is visible to the pattern match.
+            Expr value = substitute_in_all_lets(values[i]);
+            if (optional<Expr> increment = extract_increment(value, *law)) {
+                result[i] = extract_factor(*increment, *law, reduction_vars);
+            }
+        }
+    }
+    return result;
+}
+
+// Re-apply the hoisted factor to the intermediate's result at the write-back
+// step. The intermediate accumulates the inner body at its natural type (the
+// same type as the outer op), so no cast is needed.
+Expr apply_hoisted_factor(const Expr &r, const optional<HoistedFactor> &factor) {
+    if (!factor) {
+        return r;
+    }
+    return make_binary_op(factor->op, factor->factor, r);
 }
 
 }  // namespace
@@ -1078,6 +1222,104 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
         definition.predicate() = preserved_rdom.predicate();
         definition.schedule().dims() = to_preserved(reducing_dims);
         definition.schedule().rvars() = preserved_rdom.domain();
+        definition.schedule().splits() = var_splits;
+    }
+
+    return intm;
+}
+
+Func Stage::hoist_invariants() {
+    user_assert(!definition.is_init()) << "hoist_invariants() must be called on an update definition\n";
+
+    definition.schedule().touched() = true;
+
+    // Check whether the operator is associative and determine the operator and
+    // its identity for each value in the definition if it is a Tuple.
+    const auto &prover_result = prove_associativity(function.name(), definition.args(), definition.values());
+    const auto &[var_splits, _] = rfactor_validate_args({}, prover_result);
+
+    const vector<Expr> dim_vars_exprs(dim_vars.begin(), dim_vars.end());
+
+    Scope<> reduction_vars;
+    Scope<Interval> reduction_bounds;
+    for (const auto &[var, min, extent] : definition.schedule().rvars()) {
+        reduction_vars.push(var);
+        reduction_bounds.push(var, Interval{min, min + extent - 1});
+    }
+    vector<optional<HoistedFactor>> hoisted_factors =
+        extract_hoisted_factors(definition.values(), prover_result,
+                                function.name(), reduction_vars);
+    const bool any_hoisted = std::any_of(hoisted_factors.begin(), hoisted_factors.end(),
+                                         [](const auto &f) { return f.has_value(); });
+    user_assert(any_hoisted)
+        << "hoist_invariants() could not find a distributable loop-invariant "
+        << "factor in the update definition of " << function.name() << ".\n";
+
+    Func intm(function.name() + "_intm");
+    intm(dim_vars_exprs) = Tuple(prover_result.pattern.identities);
+
+    // Define the factor-free intermediate reduction.
+    {
+        vector<Expr> values = definition.values();
+        for (size_t i = 0; i < values.size(); ++i) {
+            if (hoisted_factors[i]) {
+                Expr self_ref = Call::make(hoisted_factors[i]->inner_body.type(), function.name(),
+                                           dim_vars_exprs, Call::Halide, FunctionPtr(), (int)i);
+                values[i] = make_binary_op(prover_result.pattern.ops[i].node_type(),
+                                           self_ref, hoisted_factors[i]->inner_body);
+            }
+        }
+        values = substitute_self_reference(values, function.name(), intm.function(), {});
+
+        // The args and values still refer to the original RDom, so define_update()
+        // discovers and reuses it. The entire update schedule transfers unchanged.
+        intm.function().define_update(definition.args(), values);
+        intm.function().update(0).schedule() = definition.schedule().get_copy();
+    }
+
+    // Replace the original reduction with a factor-applying write-back update.
+    {
+        SubstitutionMap writeback_map;
+        for (size_t i = 0; i < definition.values().size(); ++i) {
+            if (!prover_result.ys[i].var.empty()) {
+                Expr r = (definition.values().size() == 1) ? Expr(intm(dim_vars_exprs)) : Expr(intm(dim_vars_exprs)[i]);
+                r = apply_hoisted_factor(r, hoisted_factors[i]);
+                add_let(writeback_map, prover_result.ys[i].var, r);
+            }
+
+            if (!prover_result.xs[i].var.empty()) {
+                Expr prev_val = Call::make(function.output_types()[i], function.name(),
+                                           dim_vars_exprs, Call::Halide,
+                                           FunctionPtr(), (int)i);
+                add_let(writeback_map, prover_result.xs[i].var, prev_val);
+            } else {
+                user_warning << "Update definition of " << name() << " at index " << i
+                             << " doesn't depend on the previous value. This isn't a"
+                             << " reduction operation\n";
+            }
+        }
+
+        vector<Dim> writeback_dims;
+        for (const Dim &dim : definition.schedule().dims()) {
+            if (!dim.is_rvar()) {
+                writeback_dims.push_back(dim);
+            }
+        }
+        // Add pure vars not referenced by the original update just before
+        // outermost, as rfactor() does for histogram-style updates.
+        for (size_t i = 0; i < dim_vars.size(); i++) {
+            if (!expr_uses_var(definition.args()[i], dim_vars[i].name())) {
+                Dim d = {dim_vars[i].name(), ForType::Serial, DeviceAPI::None,
+                         DimType::PureVar, Partition::Auto};
+                writeback_dims.insert(writeback_dims.end() - 1, d);
+            }
+        }
+
+        definition.args() = dim_vars_exprs;
+        definition.values() = substitute(writeback_map, prover_result.pattern.ops);
+        definition.predicate() = or_condition_over_domain(definition.predicate(), reduction_bounds);
+        definition.schedule().dims() = std::move(writeback_dims);
+        definition.schedule().rvars().clear();
         definition.schedule().splits() = var_splits;
     }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -582,58 +582,6 @@ std::string Stage::dump_argument_list() const {
     return dump_dim_list(definition.schedule().dims());
 }
 
-namespace {
-
-class SubstituteSelfReference : public IRMutator {
-    using IRMutator::visit;
-
-    const string func;
-    const Function substitute;
-    const vector<Var> new_args;
-
-    Expr visit(const Call *c) override {
-        Expr expr = IRMutator::visit(c);
-        c = expr.as<Call>();
-        internal_assert(c);
-
-        if ((c->call_type == Call::Halide) && (func == c->name)) {
-            debug(4) << "...Replace call to Func \"" << c->name << "\" with "
-                     << "\"" << substitute.name() << "\"\n";
-            vector<Expr> args;
-            args.insert(args.end(), c->args.begin(), c->args.end());
-            args.insert(args.end(), new_args.begin(), new_args.end());
-            // This rewrites a Func's self-reference into a self-reference of
-            // the rfactor intermediate, so it must not follow global wrappers.
-            expr = Call::make(substitute, args, c->value_index,
-                              /*follow_global_wrappers=*/false);
-        }
-        return expr;
-    }
-
-public:
-    SubstituteSelfReference(const string &func, const Function &substitute,
-                            const vector<Var> &new_args)
-        : func(func), substitute(substitute), new_args(new_args) {
-        internal_assert(substitute.get_contents().defined());
-    }
-};
-
-/** Substitute all self-reference calls to 'func' with 'substitute' which
- * args (LHS) is the old args (LHS) plus 'new_args' in that order.
- * Expect this method to be called on the value (RHS) of an update definition. */
-vector<Expr> substitute_self_reference(const vector<Expr> &values, const string &func,
-                                       const Function &substitute, const vector<Var> &new_args) {
-    SubstituteSelfReference subs(func, substitute, new_args);
-    vector<Expr> result;
-    result.reserve(values.size());
-    for (const auto &val : values) {
-        result.push_back(subs(val));
-    }
-    return result;
-}
-
-}  // anonymous namespace
-
 Func Stage::rfactor(const RVar &r, const Var &v) {
     definition.schedule().touched() = true;
     return rfactor({{r, v}});
@@ -641,6 +589,32 @@ Func Stage::rfactor(const RVar &r, const Var &v) {
 
 // Helpers for rfactor implementation
 namespace {
+
+// Replace self-references to `func_name` with calls to the intermediate `intm`,
+// appending the preserved vars to the call's args. Expected to be called on the
+// values (RHS) of an update definition.
+vector<Expr> substitute_self_reference(vector<Expr> values,
+                                       const string &func_name,
+                                       const Function &intm,
+                                       const vector<Var> &preserved_vars) {
+    for (Expr &v : values) {
+        v = mutate_with(v, [&](auto *self, const Call *c) -> Expr {
+            Expr expr = self->visit_base(c);
+            c = expr.as<Call>();
+            internal_assert(c);
+            if (c->call_type == Call::Halide && func_name == c->name) {
+                vector<Expr> args(c->args);
+                args.insert(args.end(), preserved_vars.begin(), preserved_vars.end());
+                // This rewrites a Func's self-reference into a self-reference of
+                // the rfactor intermediate, so it must not follow global wrappers.
+                expr = Call::make(intm, args, c->value_index,
+                                  /*follow_global_wrappers=*/false);
+            }
+            return expr;
+        });
+    }
+    return values;
+}
 
 optional<Dim> find_dim(const vector<Dim> &items, const VarOrRVar &v) {
     const auto has_v = std::find_if(items.begin(), items.end(), [&](auto &x) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -102,7 +102,7 @@ Func::Func(Function f)
 FuncVec::FuncVec(const string &base_name, size_t count) {
     reserve(count);
     for (size_t i = 0; i < count; ++i) {
-        emplace_back(base_name + std::to_string(i));
+        emplace_back(count == 1 ? base_name : base_name + std::to_string(i));
     }
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -842,12 +842,16 @@ struct HoistedFactor {
                       // job of the separate change_type() directive.
 };
 
+struct HoistedTerm {
+    optional<HoistedFactor> factor;
+    Expr body;
+    size_t intermediate_index;
+};
+
 // Given the non-self-reference increment from an update body and the
 // distributive law of the outer associative op, extract a loop-invariant factor
 // that distributes over the outer op. `reduction_vars` is the set of RVar names
 // the factor must not reference.
-// TODO: if we flatten by the outer op here we can make tuple-valued reductions
-//   for things like: f(r) += a * g(r) + b * h(r)
 optional<HoistedFactor> extract_factor(const Expr &increment,
                                        const DistributiveLaw &law,
                                        const Scope<> &reduction_vars) {
@@ -890,20 +894,16 @@ optional<HoistedFactor> extract_factor(const Expr &increment,
     return HoistedFactor{law.inner_op, factor, body};
 }
 
-vector<optional<HoistedFactor>> extract_hoisted_factors(const vector<Expr> &values,
-                                                        const AssociativeOp &prover_result,
-                                                        const string &func_name,
-                                                        const Scope<> &reduction_vars) {
-    vector<optional<HoistedFactor>> result(values.size());
+vector<vector<HoistedTerm>> extract_hoisted_terms(const vector<Expr> &values,
+                                                  const AssociativeOp &prover_result,
+                                                  const string &func_name,
+                                                  const Scope<> &reduction_vars) {
+    vector<vector<HoistedTerm>> result(values.size());
 
-    auto is_orig_self_ref = [&](const Expr &e) {
+    auto is_orig_self_ref = [&](const Expr &e, size_t value_index) {
         const Call *c = e.as<Call>();
-        return c && c->name == func_name && c->call_type == Call::Halide;
-    };
-
-    auto extract_increment = [&](const Expr &val, const DistributiveLaw &law) -> optional<Expr> {
-        optional<pair<Expr, Expr>> split = select_binary_operand(val, law.outer_op, is_orig_self_ref);
-        return split ? std::make_optional(split->second) : std::nullopt;
+        return c && c->name == func_name && c->call_type == Call::Halide &&
+               c->value_index == (int)value_index;
     };
 
     for (size_t i = 0; i < values.size(); ++i) {
@@ -912,8 +912,29 @@ vector<optional<HoistedFactor>> extract_hoisted_factors(const vector<Expr> &valu
             // update introduced promise_clamped bindings for a preserved RVar).
             // Inline them so the outer op is visible to the pattern match.
             Expr value = substitute_in_all_lets(values[i]);
-            if (optional<Expr> increment = extract_increment(value, *law)) {
-                result[i] = extract_factor(*increment, *law, reduction_vars);
+            vector<Expr> outer_leaves;
+            flatten_associative_chain(value, law->outer_op, outer_leaves);
+            const auto self = std::find_if(outer_leaves.begin(), outer_leaves.end(),
+                                           [&](const Expr &e) { return is_orig_self_ref(e, i); });
+            if (self != outer_leaves.end() &&
+                std::find_if(std::next(self), outer_leaves.end(),
+                             [&](const Expr &e) { return is_orig_self_ref(e, i); }) == outer_leaves.end()) {
+                for (const Expr &term : outer_leaves) {
+                    if (!is_orig_self_ref(term, i)) {
+                        optional<HoistedFactor> factor = extract_factor(term, *law, reduction_vars);
+                        result[i].push_back({factor, factor ? factor->inner_body : term, 0});
+                    }
+                }
+            }
+        } else {
+            // A tuple component without a distributive law must still be carried
+            // through an intermediate if another component is being hoisted.
+            Expr value = substitute_in_all_lets(values[i]);
+            const IRNodeType outer_op = prover_result.pattern.ops[i].node_type();
+            optional<pair<Expr, Expr>> split = select_binary_operand(
+                value, outer_op, [&](const Expr &e) { return is_orig_self_ref(e, i); });
+            if (split) {
+                result[i].push_back({std::nullopt, split->second, 0});
             }
         }
     }
@@ -1242,7 +1263,7 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
     return intm;
 }
 
-Func Stage::hoist_invariants() {
+FuncVec Stage::hoist_invariants() {
     user_assert(!definition.is_init()) << "hoist_invariants() must be called on an update definition\n";
 
     definition.schedule().touched() = true;
@@ -1260,35 +1281,46 @@ Func Stage::hoist_invariants() {
         reduction_vars.push(var);
         reduction_bounds.push(var, Interval{min, min + extent - 1});
     }
-    vector<optional<HoistedFactor>> hoisted_factors =
-        extract_hoisted_factors(definition.values(), prover_result,
-                                function.name(), reduction_vars);
-    const bool any_hoisted = std::any_of(hoisted_factors.begin(), hoisted_factors.end(),
-                                         [](const auto &f) { return f.has_value(); });
-    user_assert(any_hoisted)
-        << "hoist_invariants() could not find a distributable loop-invariant "
-        << "factor in the update definition of " << function.name() << ".\n";
+    vector<vector<HoistedTerm>> hoisted_terms =
+        extract_hoisted_terms(definition.values(), prover_result,
+                              function.name(), reduction_vars);
+    const bool any_hoisted = std::any_of(hoisted_terms.begin(), hoisted_terms.end(),
+                                         [](const auto &terms) {
+                                             return std::any_of(terms.begin(), terms.end(),
+                                                                [](const HoistedTerm &term) {
+                                                                    return term.factor.has_value();
+                                                                });
+                                         });
+    const bool any_split = std::any_of(hoisted_terms.begin(), hoisted_terms.end(),
+                                       [](const auto &terms) { return terms.size() > 1; });
+    user_assert(any_hoisted || any_split)
+        << "hoist_invariants() could not find multiple reduction terms or a "
+        << "distributable loop-invariant factor in the update definition of "
+        << function.name() << ".\n";
 
-    Func intm(function.name() + "_intm");
-    intm(dim_vars_exprs) = Tuple(prover_result.pattern.identities);
-
-    // Define the factor-free intermediate reduction.
-    {
-        vector<Expr> values = definition.values();
-        for (size_t i = 0; i < values.size(); ++i) {
-            if (hoisted_factors[i]) {
-                Expr self_ref = Call::make(hoisted_factors[i]->inner_body.type(), function.name(),
-                                           dim_vars_exprs, Call::Halide, FunctionPtr(), (int)i);
-                values[i] = make_binary_op(prover_result.pattern.ops[i].node_type(),
-                                           self_ref, hoisted_factors[i]->inner_body);
-            }
+    size_t intermediate_count = 0;
+    for (auto &terms : hoisted_terms) {
+        for (HoistedTerm &term : terms) {
+            term.intermediate_index = intermediate_count++;
         }
-        values = substitute_self_reference(values, function.name(), intm.function(), {});
+    }
+    FuncVec intms(function.name() + "_intm", intermediate_count);
 
-        // The args and values still refer to the original RDom, so define_update()
-        // discovers and reuses it. The entire update schedule transfers unchanged.
-        intm.function().define_update(definition.args(), values);
-        intm.function().update(0).schedule() = definition.schedule().get_copy();
+    // Define one factor-free scalar intermediate reduction per outer term.
+    for (size_t i = 0; i < hoisted_terms.size(); ++i) {
+        for (const HoistedTerm &term : hoisted_terms[i]) {
+            Func &intm = intms[term.intermediate_index];
+            intm(dim_vars_exprs) = prover_result.pattern.identities[i];
+
+            Expr self_ref = Call::make(term.body.type(), intm.name(), dim_vars_exprs,
+                                       Call::Halide, FunctionPtr());
+            Expr value = make_binary_op(prover_result.pattern.ops[i].node_type(), self_ref, term.body);
+
+            // The args and value still refer to the original RDom, so define_update()
+            // discovers and reuses it. The entire update schedule transfers unchanged.
+            intm.function().define_update(definition.args(), {value});
+            intm.function().update(0).schedule() = definition.schedule().get_copy();
+        }
     }
 
     // Replace the original reduction with a factor-applying write-back update.
@@ -1296,8 +1328,13 @@ Func Stage::hoist_invariants() {
         SubstitutionMap writeback_map;
         for (size_t i = 0; i < definition.values().size(); ++i) {
             if (!prover_result.ys[i].var.empty()) {
-                Expr r = (definition.values().size() == 1) ? Expr(intm(dim_vars_exprs)) : Expr(intm(dim_vars_exprs)[i]);
-                r = apply_hoisted_factor(r, hoisted_factors[i]);
+                Expr r;
+                for (const HoistedTerm &term : hoisted_terms[i]) {
+                    Expr term_result = intms[term.intermediate_index](dim_vars_exprs);
+                    term_result = apply_hoisted_factor(term_result, term.factor);
+                    r = r.defined() ? make_binary_op(prover_result.pattern.ops[i].node_type(), r, term_result) : term_result;
+                }
+                internal_assert(r.defined());
                 add_let(writeback_map, prover_result.ys[i].var, r);
             }
 
@@ -1337,7 +1374,7 @@ Func Stage::hoist_invariants() {
         definition.schedule().splits() = var_splits;
     }
 
-    return intm;
+    return intms;
 }
 
 void Stage::split(const string &old, const string &outer, const string &inner, const Expr &factor_arg, bool exact, TailStrategy tail) {

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -668,17 +668,27 @@ string dequalify(string name) {
     return name;
 }
 
-vector<Dim> subst_dims(const SubstitutionMap &substitution_map, const vector<Dim> &dims) {
-    auto new_dims = dims;
-    for (auto &dim : new_dims) {
-        if (const auto it = substitution_map.find(dim.var); it != substitution_map.end()) {
-            const Variable *new_var = it->second.as<Variable>();
-            internal_assert(new_var);
-            dim.var = new_var->name;
-        }
+struct RFactorProjection {
+    const SubstitutionMap &rdom_promises;
+    const SubstitutionMap &vars;
+
+    template<typename T>
+    T operator()(const T &x) const {
+        return substitute(vars, substitute(rdom_promises, x));
     }
-    return new_dims;
-}
+
+    vector<Dim> operator()(const vector<Dim> &dims) const {
+        auto new_dims = dims;
+        for (auto &dim : new_dims) {
+            if (const auto it = vars.find(dim.var); it != vars.end()) {
+                const Variable *new_var = it->second.as<Variable>();
+                internal_assert(new_var);
+                dim.var = new_var->name;
+            }
+        }
+        return new_dims;
+    }
+};
 
 pair<ReductionDomain, SubstitutionMap> project_rdom(const vector<Dim> &dims, const ReductionDomain &rdom, const vector<Split> &splits) {
     // The bounds projections maps expressions that reference the old RDom
@@ -922,6 +932,9 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
     // Project the RDom into each side
     ReductionDomain intermediate_rdom, preserved_rdom;
     SubstitutionMap intermediate_map, preserved_map;
+    RFactorProjection to_intermediate{rdom_promises, intermediate_map};
+    RFactorProjection to_preserved{rdom_promises, preserved_map};
+
     {
         // Intermediate
         std::tie(intermediate_rdom, intermediate_map) = project_rdom(intermediate_rdims, rdom, rvar_splits);
@@ -930,9 +943,7 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
         }
 
         {
-            Expr pred = intermediate_rdom.predicate();
-            pred = substitute(rdom_promises, pred);
-            pred = substitute(intermediate_map, pred);
+            Expr pred = to_intermediate(intermediate_rdom.predicate());
             intermediate_rdom.set_predicate(simplify(pred));
         }
 
@@ -945,9 +956,7 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
             intm_rdom.push(var, Interval{min, min + extent - 1});
         }
         {
-            Expr pred = preserved_rdom.predicate();
-            pred = substitute(rdom_promises, pred);
-            pred = substitute(preserved_map, pred);
+            Expr pred = to_preserved(preserved_rdom.predicate());
             pred = or_condition_over_domain(pred, intm_rdom);
             preserved_rdom.set_predicate(pred);
         }
@@ -967,13 +976,11 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
     {
         vector<Expr> args = definition.args();
         args.insert(args.end(), preserved_vars.begin(), preserved_vars.end());
-        args = substitute(rdom_promises, args);
-        args = substitute(intermediate_map, args);
+        args = to_intermediate(args);
 
         vector<Expr> values = definition.values();
         values = substitute_self_reference(values, function.name(), intm.function(), preserved_vars);
-        values = substitute(rdom_promises, values);
-        values = substitute(intermediate_map, values);
+        values = to_intermediate(values);
         intm.function().define_update(args, values, intermediate_rdom);
 
         // Intermediate schedule
@@ -1007,7 +1014,7 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
         }
 
         intm.function().update(0).schedule() = definition.schedule().get_copy();
-        intm.function().update(0).schedule().dims() = subst_dims(intermediate_map, intm_dims);
+        intm.function().update(0).schedule().dims() = to_intermediate(intm_dims);
         intm.function().update(0).schedule().rvars() = intermediate_rdom.domain();
         intm.function().update(0).schedule().splits() = var_splits;
     }
@@ -1067,9 +1074,9 @@ Func Stage::rfactor(const vector<pair<RVar, Var>> &preserved) {
         }
 
         definition.args() = dim_vars_exprs;
-        definition.values() = substitute(preserved_map, substitute(rdom_promises, prover_result.pattern.ops));
+        definition.values() = to_preserved(prover_result.pattern.ops);
         definition.predicate() = preserved_rdom.predicate();
-        definition.schedule().dims() = subst_dims(preserved_map, reducing_dims);
+        definition.schedule().dims() = to_preserved(reducing_dims);
         definition.schedule().rvars() = preserved_rdom.domain();
         definition.schedule().splits() = var_splits;
     }

--- a/src/Func.h
+++ b/src/Func.h
@@ -2873,7 +2873,8 @@ public:
         : Base(std::move(funcs)) {
     }
 
-    /** Construct count undefined Funcs named base_name + their index. */
+    /** Construct count undefined Funcs. A singleton is named base_name; otherwise
+     * the Funcs are named base_name + their index. */
     FuncVec(const std::string &base_name, size_t count);
 
     /** Convert a singleton FuncVec to its sole Func. It is a user error if

--- a/src/Func.h
+++ b/src/Func.h
@@ -18,6 +18,7 @@
 #include "Var.h"
 
 #include <map>
+#include <type_traits>
 #include <utility>
 
 namespace Halide {
@@ -212,6 +213,44 @@ public:
     HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<Func, Args...>::value, Stage &>
     eager_inline(const Func &first, Args &&...args);
     // @}
+
+    /** Hoist a loop-invariant factor out of an associative reduction by applying
+     * the distributive law of a semiring. Like rfactor(), this must be called on
+     * an update definition; it splits the update into an intermediate that
+     * accumulates the factor-free reduction over all of the update's RVars and a
+     * write-back that applies the hoisted factor once. The intermediate Func is
+     * returned.
+     *
+     * A factor is hoistable if it does not depend on any RVar being reduced. It
+     * may be nested at any depth of an associative/commutative chain. The valid
+     * hoistings are:
+     *
+     *   Outer op    Inner combine   Law
+     *   ---------   -------------   ---
+     *   + (sum)     *               sum_k(s * x_k) = s * sum_k(x_k)
+     *   min         +               min_k(c + x_k) = c + min_k(x_k)
+     *   max         +               max_k(c + x_k) = c + max_k(x_k)
+     *   || (bool)   &&              or_k(p && x_k) = p && or_k(x_k)
+     *   && (bool)   ||              and_k(p || x_k) = p || and_k(x_k)
+     *
+     * For example, hoist_invariants() rewrites a pipeline like this:
+     * \code
+     * f(x) = 0;
+     * f(x) += s(x) * g(x, r);
+     * \endcode
+     * into a pipeline like this:
+     * \code
+     * f_intm(x) = 0;
+     * f_intm(x) += g(x, r);
+     *
+     * f(x) = 0;
+     * f(x) += s(x) * f_intm(x);
+     * \endcode
+     *
+     * This reduces the number of factor applications from |R| to one per pure
+     * point. It is an error if no distributable invariant factor is found.
+     */
+    Func hoist_invariants();
 
     /** Schedule the iteration over this stage to be fused with another
      * stage 's' from outermost loop to a given LoopLevel. 'this' stage will

--- a/src/Func.h
+++ b/src/Func.h
@@ -2856,6 +2856,31 @@ public:
     }
 };
 
+/** A vector of Funcs with conveniences for constructing and consuming
+ * collections of Funcs. */
+class FuncVec : public std::vector<Func> {
+    using Base = std::vector<Func>;
+
+public:
+    using Base::Base;
+    using Base::operator=;
+
+    FuncVec() = default;
+    FuncVec(const Base &funcs)
+        : Base(funcs) {
+    }
+    FuncVec(Base &&funcs)
+        : Base(std::move(funcs)) {
+    }
+
+    /** Construct count undefined Funcs named base_name + their index. */
+    FuncVec(const std::string &base_name, size_t count);
+
+    /** Convert a singleton FuncVec to its sole Func. It is a user error if
+     * the FuncVec does not contain exactly one Func. */
+    operator Func() const;
+};
+
 template<typename... Args>
 HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<Func, Args...>::value, Stage &>
 Stage::eager_inline(const Func &first, Args &&...args) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -59,6 +59,7 @@ struct VarOrRVar {
 };
 
 class ImageParam;
+class FuncVec;
 
 namespace Internal {
 struct AssociativeOp;
@@ -214,12 +215,13 @@ public:
     eager_inline(const Func &first, Args &&...args);
     // @}
 
-    /** Hoist a loop-invariant factor out of an associative reduction by applying
+    /** Hoist loop-invariant factors out of an associative reduction by applying
      * the distributive law of a semiring. Like rfactor(), this must be called on
      * an update definition; it splits the update into an intermediate that
-     * accumulates the factor-free reduction over all of the update's RVars and a
-     * write-back that applies the hoisted factor once. The intermediate Func is
-     * returned.
+     * accumulates one factor-free outer term over all of the update's RVars and
+     * a write-back that applies the hoisted factors once. The intermediate Funcs
+     * are returned in a FuncVec. For tuple-valued reductions, they are ordered
+     * by tuple output index, then by outer-term order.
      *
      * A factor is hoistable if it does not depend on any RVar being reduced. It
      * may be nested at any depth of an associative/commutative chain. The valid
@@ -236,21 +238,25 @@ public:
      * For example, hoist_invariants() rewrites a pipeline like this:
      * \code
      * f(x) = 0;
-     * f(x) += s(x) * g(x, r);
+     * f(x) += a(x) * g(x, r) + b(x) * h(x, r);
      * \endcode
      * into a pipeline like this:
      * \code
-     * f_intm(x) = 0;
-     * f_intm(x) += g(x, r);
+     * f_intm0(x) = 0;
+     * f_intm0(x) += g(x, r);
+     * f_intm1(x) = 0;
+     * f_intm1(x) += h(x, r);
      *
      * f(x) = 0;
-     * f(x) += s(x) * f_intm(x);
+     * f(x) += a(x) * f_intm0(x) + b(x) * f_intm1(x);
      * \endcode
      *
      * This reduces the number of factor applications from |R| to one per pure
-     * point. It is an error if no distributable invariant factor is found.
+     * point. Terms without a hoistable factor are still split into separate
+     * intermediates. It is an error if there is neither a distributable invariant
+     * factor nor more than one outer term to split.
      */
-    Func hoist_invariants();
+    FuncVec hoist_invariants();
 
     /** Schedule the iteration over this stage to be fused with another
      * stage 's' from outermost loop to a given LoopLevel. 'this' stage will

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3089,6 +3089,7 @@ protected:
     using EvictionKey = Halide::EvictionKey;
     using ExternFuncArgument = Halide::ExternFuncArgument;
     using Func = Halide::Func;
+    using FuncVec = Halide::FuncVec;
     using GeneratorContext = Halide::GeneratorContext;
     using ImageParam = Halide::ImageParam;
     using LoopLevel = Halide::LoopLevel;

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -219,8 +219,8 @@ Pipeline::Pipeline(const std::vector<Func> &outputs, const std::vector<Internal:
     }
 }
 
-vector<Func> Pipeline::outputs() const {
-    vector<Func> funcs;
+FuncVec Pipeline::outputs() const {
+    FuncVec funcs;
     for (const Function &f : contents->outputs) {
         funcs.emplace_back(f);
     }

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -25,6 +25,7 @@ namespace Halide {
 struct Argument;
 class Callable;
 class Func;
+class FuncVec;
 struct PipelineContents;
 
 /** Special the Autoscheduler to be used (if any), along with arbitrary
@@ -205,7 +206,7 @@ public:
     std::vector<Argument> infer_arguments(const Internal::Stmt &body);
 
     /** Get the Funcs this pipeline outputs. */
-    std::vector<Func> outputs() const;
+    FuncVec outputs() const;
 
     /** Get the requirements of this pipeline. */
     std::vector<Internal::Stmt> requirements() const;

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -139,6 +139,7 @@ tests(
     force_onto_stack.cpp
     func_lifetime.cpp
     func_lifetime_2.cpp
+    func_vec.cpp
     fuse.cpp
     fuse_gpu_threads.cpp
     fused_where_inner_extent_is_zero.cpp

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -196,6 +196,7 @@ tests(
     hexagon_scatter.cpp
     histogram.cpp
     histogram_equalize.cpp
+    hoist_invariants.cpp
     hoist_loop_invariant_if_statements.cpp
     hoist_storage.cpp
     host_alignment.cpp

--- a/test/correctness/func_vec.cpp
+++ b/test/correctness/func_vec.cpp
@@ -36,6 +36,10 @@ int main(int argc, char **argv) {
         success &= check(named[i].name() == expected, "named constructor created an incorrect Func name");
     }
 
+    FuncVec singleton_named("func_vec_singleton", 1);
+    success &= check(singleton_named[0].name() == "func_vec_singleton",
+                     "singleton named constructor should preserve its base name");
+
     Func a("func_vec_a");
     Func b("func_vec_b");
     FuncVec funcs{a};

--- a/test/correctness/func_vec.cpp
+++ b/test/correctness/func_vec.cpp
@@ -1,0 +1,77 @@
+#include "Halide.h"
+#include "expect_user_error.h"
+
+#include <cstdio>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+using namespace Halide;
+
+namespace {
+
+bool check(bool condition, const char *message) {
+    if (!condition) {
+        std::printf("FAIL: %s\n", message);
+    }
+    return condition;
+}
+
+size_t vector_size(const std::vector<Func> &funcs) {
+    return funcs.size();
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    static_assert(std::is_base_of_v<std::vector<Func>, FuncVec>);
+    static_assert(std::is_convertible_v<FuncVec, Func>);
+
+    bool success = true;
+
+    FuncVec named("func_vec_stage_", 3);
+    success &= check(named.size() == 3, "named constructor created the wrong number of Funcs");
+    for (size_t i = 0; i < named.size(); ++i) {
+        const std::string expected = "func_vec_stage_" + std::to_string(i);
+        success &= check(named[i].name() == expected, "named constructor created an incorrect Func name");
+    }
+
+    Func a("func_vec_a");
+    Func b("func_vec_b");
+    FuncVec funcs{a};
+    funcs.push_back(b);
+    success &= check(vector_size(funcs) == 2, "FuncVec is not usable as a std::vector<Func>");
+
+    std::vector<Func> base{a};
+    FuncVec copied(base);
+    FuncVec assigned;
+    assigned = base;
+    std::vector<Func> round_trip = copied;
+    success &= check(assigned.size() == 1 && round_trip.size() == 1,
+                     "FuncVec conversion to or from std::vector<Func> failed");
+
+    Func singleton = copied;
+    success &= check(singleton.name() == a.name(), "singleton FuncVec converted to the wrong Func");
+
+    Pipeline pipeline(copied);
+    Func pipeline_output = pipeline.outputs();
+    success &= check(pipeline_output.name() == a.name(), "Pipeline::outputs() did not decay to its singleton Func");
+
+#if HALIDE_WITH_EXCEPTIONS
+    FuncVec empty;
+    success &= expect_user_error("empty_func_vec", "size 0", [&]() {
+        Func f = empty;
+        (void)f;
+    });
+    success &= expect_user_error("multi_func_vec", "size 2", [&]() {
+        Func f = funcs;
+        (void)f;
+    });
+#endif
+
+    if (!success) {
+        return 1;
+    }
+    std::printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/hoist_invariants.cpp
+++ b/test/correctness/hoist_invariants.cpp
@@ -1,0 +1,527 @@
+#include "Halide.h"
+#include "check_call_graphs.h"
+#include "test_sharding.h"
+
+#include <cmath>
+#include <map>
+
+namespace {
+
+using std::map;
+using std::string;
+
+using namespace Halide;
+using namespace Halide::Internal;
+
+// hoist_invariants() lifts a loop-invariant factor out of a sum reduction:
+//   sum_k(scale(i,j) * inner(i,j,k)) = scale(i,j) * sum_k(inner(i,j,k))
+// It does not change any types: the returned intermediate accumulates the
+// factor-free body at its natural type. (Retyping the accumulation for a
+// dot-product-friendly integer type is the job of change_type().)
+int hoist_invariants_test() {
+    ImageParam A{Int(8), 2, "A"};
+    ImageParam B{Int(8), 2, "B"};
+    ImageParam As{Float(16), 1, "As"};
+    ImageParam Bs{Float(16), 1, "Bs"};
+
+    Var i{"i"}, j{"j"};
+    RDom k({{0, A.dim(1).extent() / 4 * 4}}, "k");
+    RVar ko{"ko"}, ki{"ki"};
+
+    Func C{"C"};
+    C(i, j) += widening_mul(As(i), Bs(j)) * cast(Int(32), widening_mul(A(i, k), B(j, k)));
+    C.bound(i, 0, A.dim(0).extent());
+    C.bound(j, 0, B.dim(0).extent());
+    C.update().split(k, ko, ki, 4);
+
+    // widening_mul(As(i), Bs(j)) is invariant in k, so hoisting moves it out of
+    // the reduction: the intermediate accumulates only the inner product and the
+    // scale is applied once during write-back. The body's type (Float(32)) is
+    // unchanged.
+    Func C_intm = C.update().hoist_invariants();
+
+    internal_assert(C_intm.types()[0] == Float(32))
+        << "hoist_invariants: expected C_intm to keep its natural Float(32) type, got "
+        << C_intm.types()[0] << "\n";
+
+    // Numerical correctness: result must match a reference that applies the full
+    // non-hoisted reduction.
+    const int M = 8, N = 8, K = 16;
+    Buffer<int8_t> a_buf(M, K), b_buf(N, K);
+    Buffer<float16_t> as_buf(M), bs_buf(N);
+    for (int m = 0; m < M; m++) {
+        for (int n_k = 0; n_k < K; n_k++) {
+            a_buf(m, n_k) = (int8_t)((m + n_k) % 7 - 3);
+        }
+        as_buf(m) = float16_t((float)(m + 1) * 0.5f);
+    }
+    for (int n = 0; n < N; n++) {
+        for (int n_k = 0; n_k < K; n_k++) {
+            b_buf(n, n_k) = (int8_t)((n + n_k + 1) % 5 - 2);
+        }
+        bs_buf(n) = float16_t((float)(n + 1) * 0.25f);
+    }
+    A.set(a_buf);
+    B.set(b_buf);
+    As.set(as_buf);
+    Bs.set(bs_buf);
+
+    Buffer<float> result = C.realize({M, N});
+
+    // Reference: plain reduction without hoisting.
+    Buffer<float> ref(M, N);
+    ref.fill(0.f);
+    for (int m = 0; m < M; m++) {
+        for (int n = 0; n < N; n++) {
+            for (int kk = 0; kk < K; kk++) {
+                ref(m, n) += (float)as_buf(m) * (float)bs_buf(n) *
+                             (float)((int32_t)(int16_t)((int16_t)a_buf(m, kk) * (int16_t)b_buf(n, kk)));
+            }
+        }
+    }
+
+    for (int m = 0; m < M; m++) {
+        for (int n = 0; n < N; n++) {
+            internal_assert(std::abs(result(m, n) - ref(m, n)) < 1e-6f)
+                << "hoist_invariants mismatch at (" << m << ", " << n << "): "
+                << result(m, n) << " vs ref " << ref(m, n) << "\n";
+        }
+    }
+
+    return 0;
+}
+
+// An invariant factor may be nested inside its own sub-product rather than
+// sitting as one of a Mul's two immediate operands:
+//   (scaleA(i) * castA) * (scaleB(i) * castB)
+// -- the way two independently-scaled operands naturally compose. Finding both
+// scales requires flattening the whole multiplicative chain into leaves and
+// partitioning each one by invariance, not just checking a binary node's two
+// immediate children.
+int hoist_invariants_scattered_factors_test() {
+    const int K = 64;
+    ImageParam A{Int(8), 1, "A"};
+    ImageParam B{Int(8), 1, "B"};
+    ImageParam ScaleA{Float(32), 1, "ScaleA"};
+    ImageParam ScaleB{Float(32), 1, "ScaleB"};
+
+    Var i{"i"};
+    RDom r(0, K, "r");
+
+    Func Acc{"Acc"};
+    Acc(i) = 0.0f;
+    Acc(i) += (cast<float>(A(r)) * ScaleA(i)) * (cast<float>(B(r)) * ScaleB(i));
+
+    Func Acc_intm = Acc.update().hoist_invariants();
+    internal_assert(Acc_intm.types()[0] == Float(32))
+        << "hoist_invariants: expected the intermediate to keep Float(32), got "
+        << Acc_intm.types()[0] << "\n";
+    Acc_intm.compute_root();
+
+    Buffer<int8_t> a_buf(K), b_buf(K);
+    Buffer<float> scale_a_buf(1), scale_b_buf(1);
+    for (int k = 0; k < K; k++) {
+        a_buf(k) = 127;
+        b_buf(k) = 127;
+    }
+    scale_a_buf(0) = 2.0f;
+    scale_b_buf(0) = 3.0f;
+    A.set(a_buf);
+    B.set(b_buf);
+    ScaleA.set(scale_a_buf);
+    ScaleB.set(scale_b_buf);
+
+    Buffer<float> result = Acc.realize({1});
+    const float expected = 2.0f * 3.0f * (float)K * 127.0f * 127.0f;
+    internal_assert(result(0) == expected)
+        << "hoist_invariants scattered factors: got " << result(0) << ", expected " << expected << "\n";
+
+    return 0;
+}
+
+// Same shape as hoist_invariants_scattered_factors_test, but with UInt(8)
+// operands, to exercise the unsigned path.
+int hoist_invariants_scattered_factors_unsigned_test() {
+    const int K = 64;
+    ImageParam A{UInt(8), 1, "A"};
+    ImageParam B{UInt(8), 1, "B"};
+    ImageParam ScaleA{Float(32), 1, "ScaleA"};
+    ImageParam ScaleB{Float(32), 1, "ScaleB"};
+
+    Var i{"i"};
+    RDom r(0, K, "r");
+
+    Func Acc{"Acc"};
+    Acc(i) = 0.0f;
+    Acc(i) += (cast<float>(A(r)) * ScaleA(i)) * (cast<float>(B(r)) * ScaleB(i));
+
+    Func Acc_intm = Acc.update().hoist_invariants();
+    internal_assert(Acc_intm.types()[0] == Float(32))
+        << "hoist_invariants: expected the intermediate to keep Float(32), got "
+        << Acc_intm.types()[0] << "\n";
+    Acc_intm.compute_root();
+
+    Buffer<uint8_t> a_buf(K), b_buf(K);
+    Buffer<float> scale_a_buf(1), scale_b_buf(1);
+    for (int k = 0; k < K; k++) {
+        a_buf(k) = 255;
+        b_buf(k) = 255;
+    }
+    scale_a_buf(0) = 2.0f;
+    scale_b_buf(0) = 3.0f;
+    A.set(a_buf);
+    B.set(b_buf);
+    ScaleA.set(scale_a_buf);
+    ScaleB.set(scale_b_buf);
+
+    Buffer<float> result = Acc.realize({1});
+    const float expected = 2.0f * 3.0f * (float)K * 255.0f * 255.0f;
+    internal_assert(result(0) == expected)
+        << "hoist_invariants scattered factors (unsigned): got " << result(0) << ", expected " << expected << "\n";
+
+    return 0;
+}
+
+// hoist_invariants() with outer Min and additive factor:
+//   min_k(offset(i) + body(i, k)) = offset(i) + min_k(body(i, k))
+// The intermediate accumulates min without the offset; write-back adds it once.
+int hoist_invariants_min_test() {
+    ImageParam offset_p{Float(32), 1, "offset_p"};
+    ImageParam data_p{Float(32), 2, "data_p"};
+
+    Var i{"i"};
+    const int K = 16;
+    RDom k(0, K, "k");
+
+    Func C{"C"};
+    C(i) = Float(32).max();
+    C(i) = min(C(i), offset_p(i) + data_p(i, k));
+
+    Func C_intm = C.update().hoist_invariants();
+    C_intm.compute_root();
+
+    const int M = 8;
+    Buffer<float> off(M), dat(M, K);
+    for (int m = 0; m < M; m++) {
+        off(m) = (float)(m + 1);
+        for (int kk = 0; kk < K; kk++) {
+            dat(m, kk) = (float)(((m * K + kk) % 7) - 3);
+        }
+    }
+    offset_p.set(off);
+    data_p.set(dat);
+
+    Buffer<float> result = C.realize({M});
+
+    Buffer<float> ref(M);
+    for (int m = 0; m < M; m++) {
+        float v = std::numeric_limits<float>::max();
+        for (int kk = 0; kk < K; kk++) {
+            v = std::min(v, off(m) + dat(m, kk));
+        }
+        ref(m) = v;
+    }
+
+    for (int m = 0; m < M; m++) {
+        internal_assert(result(m) == ref(m))
+            << "hoist_invariants min mismatch at " << m << ": "
+            << result(m) << " vs ref " << ref(m) << "\n";
+    }
+    return 0;
+}
+
+// hoist_invariants() with outer Or (bool) and And factor:
+//   or_k(mask(i) && check(i, k)) = mask(i) && or_k(check(i, k))
+// The intermediate accumulates or without the mask; write-back applies it once.
+int hoist_invariants_or_test() {
+    ImageParam mask_p{Bool(), 1, "mask_p"};
+    ImageParam check_p{Bool(), 2, "check_p"};
+
+    Var i{"i"};
+    const int K = 16;
+    RDom k(0, K, "k");
+
+    Func valid{"valid"};
+    valid(i) = cast<bool>(false);
+    valid(i) = valid(i) || (mask_p(i) && check_p(i, k));
+
+    Func valid_intm = valid.update().hoist_invariants();
+    valid_intm.compute_root();
+
+    const int M = 8;
+    Buffer<bool> mask(M), chk(M, K);
+    for (int m = 0; m < M; m++) {
+        mask(m) = (m % 2 == 0);
+        for (int kk = 0; kk < K; kk++) {
+            chk(m, kk) = ((m + kk) % 3 == 0);
+        }
+    }
+    mask_p.set(mask);
+    check_p.set(chk);
+
+    Buffer<bool> result = valid.realize({M});
+
+    for (int m = 0; m < M; m++) {
+        bool ref = false;
+        for (int kk = 0; kk < K; kk++) {
+            ref = ref || (mask(m) && chk(m, kk));
+        }
+        internal_assert(result(m) == ref)
+            << "hoist_invariants or mismatch at " << m << ": "
+            << (int)result(m) << " vs ref " << (int)ref << "\n";
+    }
+    return 0;
+}
+
+// hoist_invariants() must not disturb strict_float: the reduction below rounds
+// each term to float before summing, and both the reference and the hoisted
+// intermediate must observe that same rounding (giving exactly 0).
+int hoist_invariants_strict_float_test() {
+    Buffer<int32_t> data(2);
+    data(0) = 16777217;
+    data(1) = -16777216;
+
+    RDom k(0, 2, "k");
+
+    Func f{"f"};
+    f() = 0.0f;
+    f() += 1.5f * strict_float(cast<float>(data(k)));
+
+    Func intm = f.update().hoist_invariants();
+    intm.compute_root();
+
+    internal_assert(intm.types()[0] == Float(32))
+        << "hoist_invariants strict_float: expected intm to remain Float(32), got "
+        << intm.types()[0] << "\n";
+
+    Buffer<float> result = f.realize();
+    internal_assert(result() == 0.0f)
+        << "hoist_invariants strict_float mismatch: " << result()
+        << " vs ref 0\n";
+
+    return 0;
+}
+
+// A loop-invariant RDom predicate must be preserved on the write-back update.
+// When enabled is false, the original reduction executes no iterations, so the
+// hoisted factor (and its failing require) must not be evaluated.
+int hoist_invariants_predicated_rdom_test() {
+    Param<bool> enabled{"enabled"};
+    RDom r(0, 4, "r");
+    r.where(enabled);
+
+    Func f{"f"};
+    f() = 0;
+    f() += require(enabled, 2, "hoisted factor evaluated outside RDom predicate") * (r + 1);
+
+    Func intm = f.update().hoist_invariants();
+    intm.compute_root();
+
+    Module module = f.compile_to_module(f.infer_arguments(), "hoist_invariants_predicated_rdom");
+    bool inside_predicate = false;
+    bool found_writeback = false;
+    for (const LoweredFunc &lowered_func : module.functions()) {
+        visit_with(
+            lowered_func.body,
+            [&](auto *self, const IfThenElse *op) {
+                const bool old_inside_predicate = inside_predicate;
+                inside_predicate |= expr_uses_var(op->condition, enabled.name());
+                (*self)(op->then_case);
+                inside_predicate = old_inside_predicate;
+
+                if (op->else_case.defined()) {
+                    (*self)(op->else_case);
+                }
+            },
+            [&](auto *self, const Store *op) {
+                const bool predicated =
+                    inside_predicate || expr_uses_var(op->predicate, enabled.name());
+                if (op->name == f.name() && predicated) {
+                    visit_with(op->value, [&](auto *, const Load *load) {
+                        found_writeback |= load->name == intm.name();
+                    });
+                }
+                self->visit_base(op);
+            });
+    }
+    internal_assert(found_writeback)
+        << "hoist_invariants predicated RDom: lowered pipeline had no write-back "
+        << "guarded by " << enabled.name() << " that reads " << intm.name() << "\n";
+
+    enabled.set(false);
+    Buffer<int> disabled_result = f.realize();
+    internal_assert(disabled_result() == 0)
+        << "hoist_invariants predicated RDom: disabled result was "
+        << disabled_result() << ", expected 0\n";
+
+    enabled.set(true);
+    Buffer<int> enabled_result = f.realize();
+    internal_assert(enabled_result() == 20)
+        << "hoist_invariants predicated RDom: enabled result was "
+        << enabled_result() << ", expected 20\n";
+
+    return 0;
+}
+
+// hoist_invariants() composes with rfactor(): rfactor first preserves r.y as a
+// pure Var u, so scale(u) becomes invariant over the intermediate's remaining
+// reduction over r.x and can then be hoisted from that intermediate.
+int hoist_invariants_after_rfactor_test() {
+    ImageParam scale_p{Float(32), 1, "scale_p"};
+    ImageParam data_p{Int(32), 2, "data_p"};
+
+    Var u{"u"};
+    const int X = 8, Y = 4;
+    RDom r(0, X, 0, Y, "r");
+
+    Func f{"f"};
+    f() = 0.0f;
+    f() += scale_p(r.y) * data_p(r.x, r.y);
+
+    // Preserve r.y as u; the intermediate now reduces only over r.x, and
+    // scale_p(u) is invariant across that reduction.
+    Func intm = f.update().rfactor({{r.y, u}});
+    Func intm2 = intm.update().hoist_invariants();
+    intm.compute_root();
+    intm2.compute_root();
+
+    Buffer<float> scale(Y);
+    Buffer<int> data(X, Y);
+    for (int y = 0; y < Y; y++) {
+        scale(y) = (float)(y + 1);
+        for (int x = 0; x < X; x++) {
+            data(x, y) = (x + 2 * y) % 7 - 3;
+        }
+    }
+    scale_p.set(scale);
+    data_p.set(data);
+
+    Buffer<float> result = f.realize();
+
+    float ref = 0.0f;
+    for (int y = 0; y < Y; y++) {
+        int partial = 0;
+        for (int x = 0; x < X; x++) {
+            partial += data(x, y);
+        }
+        ref += scale(y) * (float)partial;
+    }
+
+    internal_assert(result() == ref)
+        << "hoist_invariants after rfactor mismatch: "
+        << result() << " vs ref " << ref << "\n";
+
+    return 0;
+}
+
+// The min/max + add hoisting law is only valid for integer types where addition
+// has no defined wraparound behavior. For UInt(8), hoisting the invariant 250
+// would incorrectly turn min_k((250 + x_k) mod 256) into (250 + min_k(x_k)) mod
+// 256, so hoist_invariants() must refuse rather than silently miscompile.
+int hoist_invariants_invalid_law_rejected_test() {
+    if (!Halide::exceptions_enabled()) {
+        return 0;
+    }
+
+    Buffer<uint8_t> data(2);
+    data(0) = 1;
+    data(1) = 10;
+
+    RDom k(0, 2, "k");
+
+    Func f{"f"};
+    f() = UInt(8).max();
+    f() = min(f(), cast<uint8_t>(250) + data(k));
+
+    bool error = false;
+    try {
+        f.update().hoist_invariants();
+    } catch (const Halide::CompileError &e) {
+        error = true;
+        const string expected =
+            "hoist_invariants() could not find a distributable loop-invariant "
+            "factor in the update definition of " +
+            f.name() + ".";
+        if (string(e.what()).find(expected) == string::npos) {
+            printf("Unexpected error for unsigned min hoisting:\n%s\n", e.what());
+            return 1;
+        }
+    }
+    if (!error) {
+        printf("hoist_invariants should have rejected the unsigned min law!\n");
+        return 1;
+    }
+    return 0;
+}
+
+// hoist_invariants() errors when there is no distributable invariant factor to
+// hoist, rather than silently behaving like a plain rfactor().
+int hoist_invariants_nothing_to_hoist_rejected_test() {
+    if (!Halide::exceptions_enabled()) {
+        return 0;
+    }
+
+    ImageParam data_p{Int(32), 2, "data_p"};
+    Var i{"i"};
+    RDom k(0, 8, "k");
+
+    Func f{"f"};
+    f(i) = 0;
+    f(i) += data_p(i, k);
+
+    bool error = false;
+    try {
+        f.update().hoist_invariants();
+    } catch (const Halide::CompileError &e) {
+        error = true;
+        const string expected =
+            "hoist_invariants() could not find a distributable loop-invariant "
+            "factor in the update definition of " +
+            f.name() + ".";
+        if (string(e.what()).find(expected) == string::npos) {
+            printf("Unexpected error when no invariant is hoistable:\n%s\n", e.what());
+            return 1;
+        }
+    }
+    if (!error) {
+        printf("hoist_invariants should have errored when there is nothing to hoist!\n");
+        return 1;
+    }
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    struct Task {
+        std::string desc;
+        std::function<int()> fn;
+    };
+
+    std::vector<Task> tasks = {
+        {"hoist_invariants test (add/mul)", hoist_invariants_test},
+        {"hoist_invariants test (add/mul, scattered factors)", hoist_invariants_scattered_factors_test},
+        {"hoist_invariants test (add/mul, scattered factors, unsigned)", hoist_invariants_scattered_factors_unsigned_test},
+        {"hoist_invariants test (min/add)", hoist_invariants_min_test},
+        {"hoist_invariants test (or/and)", hoist_invariants_or_test},
+        {"hoist_invariants test (strict_float preserved)", hoist_invariants_strict_float_test},
+        {"hoist_invariants test (predicated RDom)", hoist_invariants_predicated_rdom_test},
+        {"hoist_invariants test (after rfactor)", hoist_invariants_after_rfactor_test},
+        {"hoist_invariants test (invalid law rejected)", hoist_invariants_invalid_law_rejected_test},
+        {"hoist_invariants test (nothing to hoist rejected)", hoist_invariants_nothing_to_hoist_rejected_test},
+    };
+
+    using Sharder = Halide::Internal::Test::Sharder;
+    Sharder sharder;
+    for (size_t t = 0; t < tasks.size(); t++) {
+        if (!sharder.should_run(t)) continue;
+        const auto &task = tasks.at(t);
+        std::cout << task.desc << "\n";
+        if (task.fn() != 0) {
+            return 1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/hoist_invariants.cpp
+++ b/test/correctness/hoist_invariants.cpp
@@ -182,6 +182,104 @@ int hoist_invariants_scattered_factors_unsigned_test() {
     return 0;
 }
 
+// A sum reduction can contain independently scaled terms. Each outer addend
+// gets its own scalar intermediate, and the write-back applies the scale while
+// merging those intermediates into the original accumulator.
+int hoist_invariants_multiple_terms_test() {
+    const int K = 16;
+    RDom r(0, K, "r");
+
+    Func f{"multiple_terms"};
+    f() = 0;
+    f() += 2 * (r + 1) + 3 * (2 * r + 1);
+
+    FuncVec intms = f.update().hoist_invariants();
+    internal_assert(intms.size() == 2)
+        << "hoist_invariants multiple terms: expected two intermediates, got "
+        << intms.size() << "\n";
+    internal_assert(intms[0].name() == f.name() + "_intm0" &&
+                    intms[1].name() == f.name() + "_intm1")
+        << "hoist_invariants multiple terms: unexpected intermediate names\n";
+    for (Func &intm : intms) {
+        intm.compute_root();
+    }
+
+    Buffer<int> result = f.realize();
+    int expected = 0;
+    for (int k = 0; k < K; ++k) {
+        expected += 2 * (k + 1) + 3 * (2 * k + 1);
+    }
+    internal_assert(result() == expected)
+        << "hoist_invariants multiple terms: got " << result()
+        << ", expected " << expected << "\n";
+    return 0;
+}
+
+// Splitting outer terms is useful even when none has an invariant factor.
+// Each term is reduced independently and merged at the original accumulator.
+int hoist_invariants_unscaled_terms_test() {
+    const int K = 16;
+    Var x{"x"};
+    RDom r(0, K, "r");
+
+    Func g{"unscaled_g"}, h{"unscaled_h"}, f{"unscaled_terms"};
+    g(x) = x + 1;
+    h(x) = x * x + 3;
+    f() = 0;
+    f() += g(r) + h(r);
+
+    FuncVec intms = f.update().hoist_invariants();
+    internal_assert(intms.size() == 2)
+        << "hoist_invariants unscaled terms: expected two intermediates, got "
+        << intms.size() << "\n";
+    for (Func &intm : intms) {
+        intm.compute_root();
+    }
+
+    Buffer<int> result = f.realize();
+    int expected = 0;
+    for (int k = 0; k < K; ++k) {
+        expected += (k + 1) + (k * k + 3);
+    }
+    internal_assert(result() == expected)
+        << "hoist_invariants unscaled terms: got " << result()
+        << ", expected " << expected << "\n";
+    return 0;
+}
+
+// Tuple outputs are flattened independently. The FuncVec is ordered by tuple
+// output index, then by the order of that output's flattened outer terms.
+int hoist_invariants_tuple_terms_test() {
+    const int K = 8;
+    RDom r(0, K, "r");
+
+    Func f{"tuple_terms"};
+    f() = Tuple(0, 0);
+    f() = Tuple(f()[0] + 2 * (r + 1) + 3 * (r + 2),
+                f()[1] + 4 * (r + 3));
+
+    FuncVec intms = f.update().hoist_invariants();
+    internal_assert(intms.size() == 3)
+        << "hoist_invariants tuple terms: expected three intermediates, got "
+        << intms.size() << "\n";
+    for (size_t i = 0; i < intms.size(); ++i) {
+        internal_assert(intms[i].name() == f.name() + "_intm" + std::to_string(i))
+            << "hoist_invariants tuple terms: unexpected intermediate ordering\n";
+        intms[i].compute_root();
+    }
+
+    Realization result = f.realize();
+    int expected0 = 0, expected1 = 0;
+    for (int k = 0; k < K; ++k) {
+        expected0 += 2 * (k + 1) + 3 * (k + 2);
+        expected1 += 4 * (k + 3);
+    }
+    internal_assert(result[0].as<int>()() == expected0 &&
+                    result[1].as<int>()() == expected1)
+        << "hoist_invariants tuple terms: incorrect result\n";
+    return 0;
+}
+
 // hoist_invariants() with outer Min and additive factor:
 //   min_k(offset(i) + body(i, k)) = offset(i) + min_k(body(i, k))
 // The intermediate accumulates min without the offset; write-back adds it once.
@@ -439,8 +537,8 @@ int hoist_invariants_invalid_law_rejected_test() {
     } catch (const Halide::CompileError &e) {
         error = true;
         const string expected =
-            "hoist_invariants() could not find a distributable loop-invariant "
-            "factor in the update definition of " +
+            "hoist_invariants() could not find multiple reduction terms or a "
+            "distributable loop-invariant factor in the update definition of " +
             f.name() + ".";
         if (string(e.what()).find(expected) == string::npos) {
             printf("Unexpected error for unsigned min hoisting:\n%s\n", e.what());
@@ -454,8 +552,8 @@ int hoist_invariants_invalid_law_rejected_test() {
     return 0;
 }
 
-// hoist_invariants() errors when there is no distributable invariant factor to
-// hoist, rather than silently behaving like a plain rfactor().
+// hoist_invariants() errors when there is neither an invariant factor to hoist
+// nor multiple outer terms to split, rather than behaving like plain rfactor().
 int hoist_invariants_nothing_to_hoist_rejected_test() {
     if (!Halide::exceptions_enabled()) {
         return 0;
@@ -475,8 +573,8 @@ int hoist_invariants_nothing_to_hoist_rejected_test() {
     } catch (const Halide::CompileError &e) {
         error = true;
         const string expected =
-            "hoist_invariants() could not find a distributable loop-invariant "
-            "factor in the update definition of " +
+            "hoist_invariants() could not find multiple reduction terms or a "
+            "distributable loop-invariant factor in the update definition of " +
             f.name() + ".";
         if (string(e.what()).find(expected) == string::npos) {
             printf("Unexpected error when no invariant is hoistable:\n%s\n", e.what());
@@ -502,6 +600,9 @@ int main(int argc, char **argv) {
         {"hoist_invariants test (add/mul)", hoist_invariants_test},
         {"hoist_invariants test (add/mul, scattered factors)", hoist_invariants_scattered_factors_test},
         {"hoist_invariants test (add/mul, scattered factors, unsigned)", hoist_invariants_scattered_factors_unsigned_test},
+        {"hoist_invariants test (multiple terms)", hoist_invariants_multiple_terms_test},
+        {"hoist_invariants test (unscaled terms)", hoist_invariants_unscaled_terms_test},
+        {"hoist_invariants test (tuple terms)", hoist_invariants_tuple_terms_test},
         {"hoist_invariants test (min/add)", hoist_invariants_min_test},
         {"hoist_invariants test (or/and)", hoist_invariants_or_test},
         {"hoist_invariants test (strict_float preserved)", hoist_invariants_strict_float_test},

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -29,6 +29,7 @@ tests(
     realize_overhead.cpp
     rgb_interleaved.cpp
     tiled_matmul.cpp
+    tiled_matmul_arm_neon.cpp
     vectorize.cpp
     wrap.cpp
     # keep-sorted end

--- a/test/performance/tiled_matmul_arm_neon.cpp
+++ b/test/performance/tiled_matmul_arm_neon.cpp
@@ -1,0 +1,222 @@
+#include "Halide.h"
+#include "halide_benchmark.h"
+
+using namespace Halide;
+
+// Quantized (int8 x int8 -> int32) mat-vec with a per-row weight scale and a
+// per-vector scale, targeting ARM's SDOT instruction, scheduled by composing
+// four directives: eager_inline(), hoist_invariants(), rfactor(), and
+// change_type().
+//
+// WtPacked(k, i, blk) = Wt(blk*reduce+k, i): the weight matrix, repacked so
+// the dimension being vectorized across (i) sits next to the reduction chunk
+// (k), not behind the block index. That makes each sdot operand load a
+// single contiguous 16-byte read instead of a gather across K-byte strides.
+//
+// Two variants are compared. The Hoisted variant (a) eager_inline()s Wt and
+// VecDq into Acc's update so the scale factors buried inside them -- WtScale(i)
+// and VecScale -- surface as explicit leaves of the update expression, which
+// (b) hoist_invariants() then lifts out of the reduction as the invariant
+// product WtScale(i) * VecScale, (c) rfactor() splits the now scale-free
+// reduction by block, and (d) change_type(Int(32)) retypes the innermost
+// per-block dot product to Int(32), yielding a pure i32(widening_mul(i8, i8))
+// accumulation that CodeGen_ARM matches to SDOT. PlainRfactor uses the same
+// split/atomic/vectorize schedule
+// but without hoisting or retyping, so the scale multiply stays inline in every
+// term of the per-block reduction: the partial-sum intermediate is
+// Float(32)-typed, and CodeGen_ARM's i32(widening_mul(i8, i8)) pattern can't
+// match it, so no sdot is generated even though the reduction is still turned
+// into a horizontal vector reduce.
+
+int main(int argc, char **argv) {
+    Target target = get_jit_target_from_environment();
+    if (!target.has_feature(Target::ARMDotProd)) {
+        printf("[SKIP] This test requires ARM's SDOT instruction.\n");
+        return 0;
+    }
+
+    const int M = 1024;    // output rows
+    const int K = 1024;    // reduction extent
+    const int reduce = 4;  // SDOT contracts 4 int8 lanes per output lane
+
+    enum { Hoisted,
+           PlainRfactor,
+           NumVariants };
+    double times[NumVariants];
+    Buffer<float> outs[NumVariants];
+
+    for (int variant = 0; variant < NumVariants; variant++) {
+        Var i{"i"}, j{"j"}, u{"u"};
+        RDom r(0, K, "r");
+
+        ImageParam WtPacked(Int(8), 3, "WtPacked");   // WtPacked(k, i, blk) = Wt(blk*reduce+k, i)
+        ImageParam WtScale(Float(32), 1, "WtScale");  // WtScale(i): per-row weight scale
+        ImageParam Vec(Int(8), 1, "Vec");             // Vec(k): quantized vector
+        Param<float> VecScale("VecScale");            // single scale for the vector
+
+        // Without this, WtPacked's row stride is an opaque runtime value (an
+        // ImageParam doesn't otherwise promise anything about it), so the
+        // simplifier can't prove that 4 consecutive rows' data is *also*
+        // contiguous with the reduction dimension -- it's forced to build each
+        // sdot operand via a scalar gather-and-insert instead of a single dense
+        // vld1q_s8. Declaring the true packed strides lets it prove the combined
+        // (k, i) index is one flat dense ramp.
+        WtPacked.dim(0).set_stride(1);
+        WtPacked.dim(1).set_stride(reduce);
+
+        Func Wt("Wt");
+        Wt(i, j) = WtScale(i) * WtPacked(j % reduce, i, j / reduce);
+
+        Func VecDq("VecDq");
+        VecDq(i) = VecScale * Vec(i);
+
+        Func Acc("Acc");
+        Acc(i) = 0.0f;
+        Acc(i) += Wt(i, r) * VecDq(r);
+
+        // ro: which block of `reduce` elements a term belongs to; ri: its
+        // position within that block.
+        RVar ro{"ro"}, ri{"ri"};
+        Acc.update().split(r, ro, ri, reduce);
+
+        const int panel = target.natural_vector_size<int8_t>() * 4;
+
+        Func Result("Result");
+        Result(i) = Acc(i);
+
+        Var io, ii;
+        Result.bound(i, 0, M);
+        Result.split(i, io, ii, panel).vectorize(ii, panel);
+
+        if (variant == Hoisted) {
+            // Compose the directives. hoist_invariants() only analyzes Acc's
+            // update expression; it can't see inside the Funcs that expression
+            // calls. As written, Acc(i) += Wt(i, r) * VecDq(r) is a product of two
+            // opaque Calls that both depend on r, so the scale factors -- which
+            // are invariant across r -- are invisible, hidden in the definitions
+            // of Wt and VecDq.
+            //
+            // eager_inline(Wt, VecDq), called on Acc's update stage, substitutes
+            // those definitions into that update now, at schedule time, so it
+            // becomes
+            //   Acc(i) += (WtScale(i) * WtPacked(...)) * (VecScale * Vec(r)).
+            // WtScale(i) (depends only on i) and VecScale (a Param) are now
+            // explicit leaves of the update expression, so hoist_invariants() can
+            // recognize them as loop-invariant and lift their product out of the
+            // reduction: Acc_wb accumulates the scale-free product over all of K
+            // and Acc's own update collapses to one multiply per row,
+            // Acc(i) = WtScale(i) * VecScale * Acc_wb(i). Acc_wb still accumulates
+            // at Float(32) at this point.
+            Func Acc_wb = Acc.update().eager_inline(Wt, VecDq).hoist_invariants();
+
+            // Second, factor Acc_wb's own (now scale-free) reduction by block.
+            // Preserving ro turns it into a new dimension u of Acc_dot, so
+            // Acc_dot(u, i) holds one block's partial dot product (reduced over
+            // ri only), while Acc_wb sums Acc_dot(ro, i) across blocks.
+            Func Acc_dot = Acc_wb.update().rfactor(ro, u);
+
+            // Third, retype the innermost per-block dot product to Int(32).
+            // change_type() proves K int8 x int8 terms can't overflow Int(32),
+            // rewrites Acc_dot into an Int(32) accumulation (a pure
+            // i32(widening_mul(i8, i8)) dot product that CodeGen_ARM matches to
+            // SDOT), and leaves the original Acc_dot as an inline cast back to
+            // Float(32) so Acc_wb is unaffected. Schedule the returned Int(32)
+            // Func -- it holds the real reduction now.
+            Func Acc_dot_i32 = Acc_dot.change_type(Int(32));
+
+            // Compute a whole panel of rows through every stage before moving to
+            // the next panel: Acc and Acc_wb are computed_at the panel loop, and
+            // Acc_dot_i32 is fused one level deeper still, into Acc_wb's own
+            // per-block reduction loop, so it only ever needs panel-many
+            // elements -- small enough to live in registers.
+            Acc_wb.compute_at(Result, io)
+                .vectorize(i, panel)
+                .update()
+                .vectorize(i, panel);
+
+            // Acc_dot_i32's row dimension (i) is deliberately left unvectorized:
+            // fused this deep inside Acc_wb's own per-block reduction loop,
+            // vectorizing it makes the vectorizer conflate the two loops and
+            // build a wildly oversized (and out-of-bounds) vector expression.
+            // The sdot reduction itself is still atomic-vectorized over ri, so
+            // this costs nothing.
+            Acc_dot_i32.compute_at(Acc_wb, ro)
+                .update()
+                .reorder(ri, i, u)
+                .atomic()
+                .vectorize(ri, reduce)
+                .unroll(ri);
+        } else {
+            // No invariant factor to hoist out this time, so a single
+            // rfactor preserving ro is enough: Acc_dot(u, i) holds one
+            // block's partial sum of WtScale(i) * VecScale * term(ri, i)
+            // (Float(32), since the scale multiply is still inline), and
+            // Acc sums Acc_dot(ro, i) across blocks directly -- there's no
+            // separate write-back stage, since Acc's own combine was never
+            // factored out.
+            Func Acc_dot = Acc.update().rfactor(ro, u);
+
+            Acc_dot.compute_at(Acc, ro)
+                .update()
+                .reorder(ri, i, u)
+                .atomic()
+                .vectorize(ri, reduce)
+                .unroll(ri);
+        }
+
+        Acc.compute_at(Result, io)
+            .vectorize(i, panel)
+            .update()
+            .vectorize(i, panel);
+
+        Buffer<int8_t> wt_packed(reduce, M, K / reduce);
+        for (int blk = 0; blk < K / reduce; blk++) {
+            for (int y = 0; y < M; y++) {
+                for (int k = 0; k < reduce; k++) {
+                    wt_packed(k, y, blk) = (int8_t)((((reduce * blk + k) + y) % 15) - 7);
+                }
+            }
+        }
+
+        Buffer<float> wt_scale_buf(M);
+        for (int y = 0; y < M; y++) {
+            wt_scale_buf(y) = 0.01f * ((y % 7) + 1);
+        }
+
+        Buffer<int8_t> vec_buf(K);
+        for (int x = 0; x < K; x++) {
+            vec_buf(x) = (int8_t)((x % 13) - 6);
+        }
+
+        WtPacked.set(wt_packed);
+        WtScale.set(wt_scale_buf);
+        Vec.set(vec_buf);
+        VecScale.set(0.5f);
+
+        Buffer<float> out(M);
+        Result.realize(out, target);
+        outs[variant] = out;
+
+        times[variant] = Tools::benchmark([&] {
+            Result.realize(out, target);
+        });
+    }
+
+    for (int y = 0; y < M; y++) {
+        float ref = outs[PlainRfactor](y);
+        if (std::abs(ref - outs[Hoisted](y)) > 1e-3f * std::abs(ref)) {
+            printf("Quantized mat-vec mismatch at %d: %f (plain) vs %f (hoisted)\n", y, ref, outs[Hoisted](y));
+            return 1;
+        }
+    }
+
+    printf("Quantized mat-vec (int8 x int8 -> f32, SDOT)\n"
+           "Time with non-hoisting rfactor:  %0.4f ms\n"
+           "Time with hoisted rfactor:       %0.4f ms (%0.2fx vs non-hoisting)\n",
+           times[PlainRfactor] * 1000,
+           times[Hoisted] * 1000,
+           times[PlainRfactor] / times[Hoisted]);
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Adjusts `hoist_invariants` (below in the stack) to return a `FuncVec`, where each entry is a separate handle to a parallel subterm, e.g. `f() += a * g(r) + b * h(r)` returns two intermediates (one for g, one for h), and replaces `f` with `f() += a * f_intm0() + b * f_intm1()` (i.e. scales are still hoisted).

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [x] Documentation updated (if public API changed)
- [x] Python bindings updated (if public API changed)
- [x] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>