### PR TITLE
Add scheduling directive to cap the max GPU registers

### DIFF
--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -98,7 +98,7 @@ public:
             output.dim(2).set_estimate(0, H);
             output.dim(3).set_estimate(0, N);
         } else if (get_target().has_gpu_feature()) {
-            // 0.034ms on an RTX 5060 Ti. This is about 2.4 TFlops, which is
+            // 0.032ms on an RTX 5060 Ti. This is about 2.5 TFlops, which is
             // not a very large fraction of peak. For comparison, pytorch 2.11
             // on the same card takes 0.036ms for the same pipeline when given
             // the same channels-innermost layout, and 0.079ms in its own
@@ -111,9 +111,9 @@ public:
             Var xi, yi, di, dii, xii, yii;
             RVar ro, ri;
 
-            // The pointwise convolution kernel. Produces a 4x4 tile of output.
+            // The pointwise convolution kernel. Produces a 4x2 tile of output.
             Func(output)
-                .tile({d, x, y}, {di, xi, yi}, {16, 4, 4})
+                .tile({d, x, y}, {di, xi, yi}, {16, 4, 2})
                 .tile({di, xi, yi}, {dii, xii, yii}, {1, 2, 2})
                 .gpu_threads(di, xi, yi)
                 .fuse(y, b, b)
@@ -121,11 +121,10 @@ public:
                 .unroll(xii)
                 .unroll(yii)
                 .unroll(dii);
-            // Left to itself ptxas gives each thread 56 registers, which fits
-            // 18 blocks on a processor. Asking for 80 fits only 12, and is
-            // worth 3% on an RTX 5060 Ti, so the occupancy is not what this
-            // kernel is short of.
-            output.gpu_max_registers(80);
+            // Worth 0.4% on an RTX 5060 Ti. Occupancy here is capped by how
+            // many blocks a processor will hold rather than by registers, so
+            // this only changes how ptxas schedules and spills.
+            output.gpu_max_registers(64);
 
             pointwise_convolved.compute_at(output, di)
                 .reorder(x, y, d)
@@ -160,11 +159,11 @@ public:
                 .unroll(x)
                 .unroll(y);
 
-            // The depthwise convolution kernel. Produces a 4x4 tile
+            // The depthwise convolution kernel. Produces a 4x2 tile
             // of intermediate state, storing the result in shared.
             depthwise_convolved.in()
                 .compute_at(output, d)
-                .tile({d, x, y}, {di, xi, yi}, {32, 4, 4}, TailStrategy::RoundUp)
+                .tile({d, x, y}, {di, xi, yi}, {32, 4, 2}, TailStrategy::RoundUp)
                 .tile({di, xi, yi}, {dii, xii, yii}, {2, 2, 2})
                 .gpu_threads(di, xi, yi)
                 .unroll(xii)

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -120,6 +120,11 @@ public:
                 .unroll(xii)
                 .unroll(yii)
                 .unroll(dii);
+            // Left to itself ptxas gives each thread 56 registers, which
+            // fits 18 blocks on a processor. Asking for 80 fits only 12, but
+            // holding more of the accumulator in registers is worth more here
+            // than the occupancy it costs. Measured on an RTX 5060 Ti: 3%.
+            Func(output).gpu_max_registers(80);
 
             pointwise_convolved.compute_at(output, di)
                 .reorder(x, y, d)

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -124,7 +124,7 @@ public:
             // fits 18 blocks on a processor. Asking for 80 fits only 12, but
             // holding more of the accumulator in registers is worth more here
             // than the occupancy it costs. Measured on an RTX 5060 Ti: 3%.
-            Func(output).gpu_max_registers(80);
+            output.gpu_max_registers(80);
 
             pointwise_convolved.compute_at(output, di)
                 .reorder(x, y, d)

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -98,10 +98,10 @@ public:
             output.dim(2).set_estimate(0, H);
             output.dim(3).set_estimate(0, N);
         } else if (get_target().has_gpu_feature()) {
-            // 0.066ms on a 2060 RTX super. This is about 1.2 TFlops,
-            // which is not a very large fraction of peak. For
-            // comparison though, tensorflow 2.3 achieves 0.13ms via
-            // cudnn 7. So we're twice as fast.
+            // 0.034ms on an RTX 5060 Ti. This is about 2.4 TFlops, which is
+            // not a very large fraction of peak. On a 2060 RTX super it took
+            // 0.066ms, where tensorflow 2.3 via cudnn 7 took 0.13ms, so we
+            // were twice as fast there.
 
             // This schedule fuses the depthwise conv into the pointwise
             // conv. The results of the depthwise conv are computed inside

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -121,9 +121,12 @@ public:
                 .unroll(xii)
                 .unroll(yii)
                 .unroll(dii);
-            // Worth 0.4% on an RTX 5060 Ti. Occupancy here is capped by how
-            // many blocks a processor will hold rather than by registers, so
-            // this only changes how ptxas schedules and spills.
+            // ptxas picks 80 registers here, and asking for 64 is worth 0.5%
+            // on an RTX 5060 Ti. It changes neither the work nor the
+            // occupancy: the same loads, stores and FFMAs, nothing spilled
+            // either way, and a processor holds 24 blocks regardless. All
+            // that differs is the register allocation and the order ptxas
+            // puts the instructions in.
             output.gpu_max_registers(64);
 
             pointwise_convolved.compute_at(output, di)

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -122,11 +122,12 @@ public:
                 .unroll(yii)
                 .unroll(dii);
             // ptxas picks 80 registers here, and asking for 64 is worth 0.5%
-            // on an RTX 5060 Ti. It changes neither the work nor the
-            // occupancy: the same loads, stores and FFMAs, nothing spilled
-            // either way, and a processor holds 24 blocks regardless. All
-            // that differs is the register allocation and the order ptxas
-            // puts the instructions in.
+            // on an RTX 5060 Ti. The work and the theoretical occupancy are
+            // the same either way - the same loads, stores and FFMAs, nothing
+            // spilled, and a processor holds 24 blocks regardless - but it
+            // keeps more warps in flight, 5.63 active warps per scheduler
+            // against 5.56. The effect is not monotonic in the number, so it
+            // is worth sweeping: 72 is worse than either.
             output.gpu_max_registers(64);
 
             pointwise_convolved.compute_at(output, di)

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -99,9 +99,10 @@ public:
             output.dim(3).set_estimate(0, N);
         } else if (get_target().has_gpu_feature()) {
             // 0.034ms on an RTX 5060 Ti. This is about 2.4 TFlops, which is
-            // not a very large fraction of peak. On a 2060 RTX super it took
-            // 0.066ms, where tensorflow 2.3 via cudnn 7 took 0.13ms, so we
-            // were twice as fast there.
+            // not a very large fraction of peak. For comparison, pytorch 2.11
+            // on the same card takes 0.036ms for the same pipeline when given
+            // the same channels-innermost layout, and 0.079ms in its own
+            // default layout.
 
             // This schedule fuses the depthwise conv into the pointwise
             // conv. The results of the depthwise conv are computed inside

--- a/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
+++ b/apps/depthwise_separable_conv/depthwise_separable_conv_generator.cpp
@@ -120,10 +120,10 @@ public:
                 .unroll(xii)
                 .unroll(yii)
                 .unroll(dii);
-            // Left to itself ptxas gives each thread 56 registers, which
-            // fits 18 blocks on a processor. Asking for 80 fits only 12, but
-            // holding more of the accumulator in registers is worth more here
-            // than the occupancy it costs. Measured on an RTX 5060 Ti: 3%.
+            // Left to itself ptxas gives each thread 56 registers, which fits
+            // 18 blocks on a processor. Asking for 80 fits only 12, and is
+            // worth 3% on an RTX 5060 Ti, so the occupancy is not what this
+            // kernel is short of.
             output.gpu_max_registers(80);
 
             pointwise_convolved.compute_at(output, di)

--- a/src/CodeGen_GPU_Dev.h
+++ b/src/CodeGen_GPU_Dev.h
@@ -25,6 +25,12 @@ struct CodeGen_GPU_Dev {
                             const std::string &name,
                             const std::vector<DeviceArgument> &args) = 0;
 
+    /** Cap the registers a thread of the next kernel added may use. Zero, the
+     * default, leaves it to the backend compiler. Only CUDA does anything with
+     * this; the other APIs offer no equivalent and ignore it. */
+    virtual void set_kernel_max_registers(int n) {
+    }
+
     /** (Re)initialize the GPU kernel module. This is separate from compile,
      * since a GPU device module will often have many kernels compiled into it
      * for a single pipeline. */

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -295,9 +295,9 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
                  << "x" << block_size.extent[2] << "\n";
     }
 
-    // A schedule can ask for fewer registers per thread than ptxas would
-    // choose. That lets more blocks be resident at once, and stops it covering
-    // the latency of a load by issuing it far ahead of its use.
+    // A schedule can ask ptxas for a different number of registers per thread
+    // than it would choose for itself, trading how many blocks fit on a
+    // processor against how much it must spill.
     if (kernel_max_registers > 0) {
         function->addFnAttr("nvvm.maxnreg", std::to_string(kernel_max_registers));
         debug(2) << "Kernel " << name << " is capped at "

--- a/src/CodeGen_PTX_Dev.cpp
+++ b/src/CodeGen_PTX_Dev.cpp
@@ -47,6 +47,8 @@ public:
                     const std::string &name,
                     const std::vector<DeviceArgument> &args) override;
 
+    void set_kernel_max_registers(int n) override;
+
     static void test();
 
     std::vector<char> compile_to_src() override;
@@ -62,6 +64,9 @@ public:
 
 protected:
     using CodeGen_LLVM::visit;
+
+    /** What the schedule asked for, if anything. Zero leaves it to ptxas. */
+    int kernel_max_registers = 0;
 
     /** (Re)initialize the PTX module. This is separate from compile, since
      * a PTX device module will often have many kernels compiled into it for
@@ -194,6 +199,10 @@ public:
     bool known = true;
 };
 
+void CodeGen_PTX_Dev::set_kernel_max_registers(int n) {
+    kernel_max_registers = n;
+}
+
 void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
                                  const std::string &name,
                                  const std::vector<DeviceArgument> &args) {
@@ -284,6 +293,15 @@ void CodeGen_PTX_Dev::add_kernel(Stmt stmt,
         debug(2) << "Kernel " << name << " has block size "
                  << block_size.extent[0] << "x" << block_size.extent[1]
                  << "x" << block_size.extent[2] << "\n";
+    }
+
+    // A schedule can ask for fewer registers per thread than ptxas would
+    // choose. That lets more blocks be resident at once, and stops it covering
+    // the latency of a load by issuing it far ahead of its use.
+    if (kernel_max_registers > 0) {
+        function->addFnAttr("nvvm.maxnreg", std::to_string(kernel_max_registers));
+        debug(2) << "Kernel " << name << " is capped at "
+                 << kernel_max_registers << " registers per thread\n";
     }
 
     // Now verify the function is ok

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2615,6 +2615,14 @@ Func &Func::store_in(MemoryType t) {
     return *this;
 }
 
+Func &Func::gpu_max_registers(int n) {
+    invalidate_cache();
+    user_assert(n > 0) << "gpu_max_registers must be given a positive number of "
+                       << "registers, but " << name() << " was given " << n << ".\n";
+    func.schedule().gpu_max_registers() = n;
+    return *this;
+}
+
 Func &Func::stream_loads() {
     invalidate_cache();
     Stage(func, func.definition(), 0).stream_loads();

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -2617,8 +2617,9 @@ Func &Func::store_in(MemoryType t) {
 
 Func &Func::gpu_max_registers(int n) {
     invalidate_cache();
-    user_assert(n > 0) << "gpu_max_registers must be given a positive number of "
-                       << "registers, but " << name() << " was given " << n << ".\n";
+    user_assert(n >= 0) << "gpu_max_registers must be given a non-negative number "
+                        << "of registers, but " << name() << " was given " << n
+                        << ".\n";
     func.schedule().gpu_max_registers() = n;
     return *this;
 }

--- a/src/Func.h
+++ b/src/Func.h
@@ -2728,14 +2728,18 @@ public:
      * on MemoryType for more detail. */
     Func &store_in(MemoryType memory_type);
 
-    /** Cap the registers a thread may use in the kernel this Func's loop over
-     * gpu blocks becomes. Fewer registers per thread lets more blocks be
-     * resident on one of the GPU's processors, and stops the backend compiler
+    /** Set how many registers a thread may use in the kernel this Func's loop
+     * over gpu blocks becomes. This is a budget in both directions, not just a
+     * cap: left alone, the backend compiler picks a number that fits a certain
+     * number of blocks on one of the GPU's processors, and this overrides that
+     * choice in whichever direction you ask for.
+     *
+     * Fewer registers per thread fits more blocks, and stops the compiler
      * covering the latency of a load by issuing it far ahead of its use and
-     * holding the result in a register until then. It costs whatever that
-     * scheduling freedom was buying, so it is worth measuring rather than
-     * guessing: the fastest setting is not always the smallest, and a cap that
-     * doesn't change how many blocks fit is all cost and no benefit.
+     * holding the result in a register until then. More registers fits fewer
+     * blocks, but keeps more of the working set in registers. Either can win,
+     * so measure rather than guess. A number that doesn't change how many
+     * blocks fit is all cost and no benefit.
      *
      * Only has an effect when compiling for CUDA, and only when the PTX
      * version in use has the .maxnreg directive. Other GPU APIs offer no

--- a/src/Func.h
+++ b/src/Func.h
@@ -2736,7 +2736,8 @@ public:
      *
      * Leaving this unset does not mean no limit. It means the GPU driver picks
      * a value automatically, so asking for more registers than it would have
-     * chosen is also a meaningful thing to do.
+     * chosen is also a meaningful thing to do. Zero asks for that automatic
+     * choice, which is what an unscheduled Func gets.
      *
      * Only has an effect when compiling for CUDA, and only when the PTX
      * version in use has the .maxnreg directive. Other GPU APIs offer no

--- a/src/Func.h
+++ b/src/Func.h
@@ -2728,18 +2728,15 @@ public:
      * on MemoryType for more detail. */
     Func &store_in(MemoryType memory_type);
 
-    /** Set how many registers a thread may use in the kernel this Func's loop
-     * over gpu blocks becomes. This is a budget in both directions, not just a
-     * cap: left alone, the backend compiler picks a number that fits a certain
-     * number of blocks on one of the GPU's processors, and this overrides that
-     * choice in whichever direction you ask for.
+    /** Tell the GPU shader compiler to fit the kernel this Func's loop over gpu
+     * blocks becomes under a given number of registers per thread. A smaller
+     * budget allows more blocks to be resident on one of the GPU's processors
+     * at once, but constrains the compiler's instruction scheduling, and may
+     * make it spill values to memory.
      *
-     * Fewer registers per thread fits more blocks, and stops the compiler
-     * covering the latency of a load by issuing it far ahead of its use and
-     * holding the result in a register until then. More registers fits fewer
-     * blocks, but keeps more of the working set in registers. Either can win,
-     * so measure rather than guess. A number that doesn't change how many
-     * blocks fit is all cost and no benefit.
+     * Leaving this unset does not mean no limit. It means the GPU driver picks
+     * a value automatically, so asking for more registers than it would have
+     * chosen is also a meaningful thing to do.
      *
      * Only has an effect when compiling for CUDA, and only when the PTX
      * version in use has the .maxnreg directive. Other GPU APIs offer no

--- a/src/Func.h
+++ b/src/Func.h
@@ -2728,6 +2728,20 @@ public:
      * on MemoryType for more detail. */
     Func &store_in(MemoryType memory_type);
 
+    /** Cap the registers a thread may use in the kernel this Func's loop over
+     * gpu blocks becomes. Fewer registers per thread lets more blocks be
+     * resident on one of the GPU's processors, and stops the backend compiler
+     * covering the latency of a load by issuing it far ahead of its use and
+     * holding the result in a register until then. It costs whatever that
+     * scheduling freedom was buying, so it is worth measuring rather than
+     * guessing: the fastest setting is not always the smallest, and a cap that
+     * doesn't change how many blocks fit is all cost and no benefit.
+     *
+     * Only has an effect when compiling for CUDA, and only when the PTX
+     * version in use has the .maxnreg directive. Other GPU APIs offer no
+     * equivalent, and ignore this. */
+    Func &gpu_max_registers(int n);
+
     /** Use non-temporal (streaming) loads for every direct read this Func's
      * pure (initial) definition makes of another Func. Equivalent to calling
      * stream_loads() on Stage 0; see \ref Stage::stream_loads. To stream the

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -2319,6 +2319,7 @@ public:
     HALIDE_FORWARD_METHOD(Func, fuse)
     HALIDE_FORWARD_METHOD(Func, gpu)
     HALIDE_FORWARD_METHOD(Func, gpu_blocks)
+    HALIDE_FORWARD_METHOD(Func, gpu_max_registers)
     HALIDE_FORWARD_METHOD(Func, gpu_single_thread)
     HALIDE_FORWARD_METHOD(Func, gpu_threads)
     HALIDE_FORWARD_METHOD(Func, gpu_tile)

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -496,7 +496,7 @@ void lower_impl(const vector<Function> &output_funcs,
 
     if (t.has_gpu_feature()) {
         debug(1) << "Offloading GPU loops...\n";
-        s = inject_gpu_offload(s, t, any_strict_float);
+        s = inject_gpu_offload(s, t, any_strict_float, env);
         debug(2) << "Lowering after splitting off GPU loops:\n"
                  << s << "\n\n";
     } else {

--- a/src/OffloadGPULoops.cpp
+++ b/src/OffloadGPULoops.cpp
@@ -96,6 +96,7 @@ protected:
     map<string, bool> state_needed;
 
     const Target &target;
+    const std::map<std::string, Function> &env;
 
     Expr get_state_var(const string &name) {
         // Expr v = Variable::make(type_of<void *>(), name);
@@ -172,10 +173,28 @@ protected:
         // compile the kernel
         string kernel_name = c_print_name(unique_name("kernel_" + loop->name));
 
+        // The loop the kernel is made from is named after the Func it came
+        // from, so the schedule that asked for a register cap can be found
+        // again here, where the kernel is handed to the backend.
+        int max_registers = 0;
+        {
+            const std::string &n = loop->name;
+            for (size_t i = 0; i + 2 < n.size(); i++) {
+                if (n[i] == '.' && n[i + 1] == 's' && isdigit(n[i + 2])) {
+                    auto it = env.find(n.substr(0, i));
+                    if (it != env.end()) {
+                        max_registers = it->second.schedule().gpu_max_registers();
+                    }
+                    break;
+                }
+            }
+        }
+
         CodeGen_GPU_Dev *gpu_codegen = cgdev[loop->device_api].get();
         user_assert(gpu_codegen != nullptr)
             << "Loop is scheduled on device " << loop->device_api
             << " which does not appear in target " << target.to_string() << "\n";
+        gpu_codegen->set_kernel_max_registers(max_registers);
         gpu_codegen->add_kernel(loop, kernel_name, closure_args);
 
         // get the actual name of the generated kernel for this loop
@@ -247,8 +266,9 @@ protected:
     }
 
 public:
-    InjectGpuOffload(const Target &target, bool any_strict_float)
-        : target(target) {
+    InjectGpuOffload(const Target &target, bool any_strict_float,
+                     const std::map<std::string, Function> &env)
+        : target(target), env(env) {
         Target device_target = target;
         // For the GPU target we just want to pass the flags, to avoid the
         // generated kernel code unintentionally having any dependence on the
@@ -383,9 +403,10 @@ class FlattenAliasedAllocations : public IRMutator {
 
 }  // namespace
 
-Stmt inject_gpu_offload(const Stmt &s, const Target &host_target, bool any_strict_float) {
+Stmt inject_gpu_offload(const Stmt &s, const Target &host_target, bool any_strict_float,
+                        const std::map<std::string, Function> &env) {
     Stmt flattened = FlattenAliasedAllocations()(s);
-    return InjectGpuOffload(host_target, any_strict_float).inject(flattened);
+    return InjectGpuOffload(host_target, any_strict_float, env).inject(flattened);
 }
 
 }  // namespace Internal

--- a/src/OffloadGPULoops.h
+++ b/src/OffloadGPULoops.h
@@ -7,7 +7,11 @@
  * appropriate host runtime module.
  */
 
+#include <map>
+#include <string>
+
 #include "Expr.h"
+#include "Function.h"
 
 namespace Halide {
 
@@ -17,7 +21,8 @@ namespace Internal {
 
 /** Pull loops marked with GPU device APIs to a separate
  * module, and call them through the appropriate host runtime module. */
-Stmt inject_gpu_offload(const Stmt &s, const Target &host_target, bool any_strict_float);
+Stmt inject_gpu_offload(const Stmt &s, const Target &host_target, bool any_strict_float,
+                        const std::map<std::string, Function> &env);
 
 }  // namespace Internal
 }  // namespace Halide

--- a/src/Schedule.cpp
+++ b/src/Schedule.cpp
@@ -239,6 +239,7 @@ struct FuncScheduleContents {
     std::vector<Bound> estimates;
     std::map<std::string, Internal::FunctionPtr> wrappers;
     MemoryType memory_type = MemoryType::Auto;
+    int gpu_max_registers = 0;
     bool memoized = false;
     bool async = false;
     // This is an extent of the ring buffer and expected to be a positive integer.
@@ -375,6 +376,7 @@ FuncSchedule FuncSchedule::deep_copy(
     copy.contents->bounds = contents->bounds;
     copy.contents->estimates = contents->estimates;
     copy.contents->memory_type = contents->memory_type;
+    copy.contents->gpu_max_registers = contents->gpu_max_registers;
     copy.contents->memoized = contents->memoized;
     copy.contents->memoize_eviction_key = contents->memoize_eviction_key;
     copy.contents->async = contents->async;
@@ -400,6 +402,14 @@ MemoryType FuncSchedule::memory_type() const {
 
 MemoryType &FuncSchedule::memory_type() {
     return contents->memory_type;
+}
+
+int FuncSchedule::gpu_max_registers() const {
+    return contents->gpu_max_registers;
+}
+
+int &FuncSchedule::gpu_max_registers() {
+    return contents->gpu_max_registers;
 }
 
 bool &FuncSchedule::memoized() {

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -631,6 +631,13 @@ public:
     // @{
     MemoryType memory_type() const;
     MemoryType &memory_type();
+
+    /** The most registers a thread of the kernel this Func's loop over gpu
+     * blocks becomes may use. Zero means let the backend decide. */
+    // @{
+    int gpu_max_registers() const;
+    int &gpu_max_registers();
+    // @}
     // @}
 
     /** You may explicitly bound some of the dimensions of a function,

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -167,6 +167,7 @@ tests(
     gpu_jit_explicit_copy_to_device.cpp
     gpu_large_alloc.cpp
     gpu_many_kernels.cpp
+    gpu_max_registers.cpp
     gpu_metal_completion_handler_error_check.cpp
     gpu_mixed_dimensionality.cpp
     gpu_mixed_shared_mem_types.cpp

--- a/test/correctness/gpu_max_registers.cpp
+++ b/test/correctness/gpu_max_registers.cpp
@@ -1,0 +1,119 @@
+// Exercises Func::gpu_max_registers, which caps the registers a thread of the
+// kernel may use. The cap is a hint to the backend compiler about a tradeoff it
+// would otherwise make on its own, so what is checked here is that it reaches
+// the generated code, that it does not change the answer, and that a
+// nonsensical cap is rejected.
+
+#include "Halide.h"
+#include "expect_user_error.h"
+#include "halide_test_dirs.h"
+#include <stdio.h>
+#include <fstream>
+#include <sstream>
+
+using namespace Halide;
+
+namespace {
+
+// A kernel with enough live values to have an opinion about registers.
+Func make_pipeline(Var x, Var y) {
+    Func f("f");
+    Expr e = cast<float>(x + y);
+    for (int i = 0; i < 8; i++) {
+        e = e * e + cast<float>(x - i) - cast<float>(y + i);
+    }
+    f(x, y) = e;
+    return f;
+}
+
+float expected(int x, int y) {
+    float e = (float)(x + y);
+    for (int i = 0; i < 8; i++) {
+        e = e * e + (float)(x - i) - (float)(y + i);
+    }
+    return e;
+}
+
+// Compiling for CUDA embeds the PTX in the host assembly, so the .maxnreg
+// directive is visible there. No device is needed to check this.
+std::string assembly_for(int max_registers) {
+    Var x("x"), y("y"), xi("xi"), yi("yi");
+    Func f = make_pipeline(x, y);
+    f.gpu_tile(x, y, xi, yi, 8, 8);
+    if (max_registers > 0) {
+        f.gpu_max_registers(max_registers);
+    }
+    Target t = get_host_target()
+                   .with_feature(Target::CUDA)
+                   .with_feature(Target::CUDACapability80);
+    std::string path = Internal::get_test_tmp_dir() + "gpu_max_registers.s";
+    f.compile_to_assembly(path, {}, "f", t);
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+bool check_directive_reaches_ptx() {
+    if (assembly_for(0).find("maxnreg") != std::string::npos) {
+        printf("FAIL: .maxnreg appeared without being asked for\n");
+        return false;
+    }
+    if (assembly_for(40).find("maxnreg 40") == std::string::npos) {
+        printf("FAIL: .maxnreg 40 did not reach the generated PTX\n");
+        return false;
+    }
+    return true;
+}
+
+bool check_answer() {
+    Target t = get_jit_target_from_environment();
+    if (!t.has_feature(Target::CUDA)) {
+        printf("[SKIP] Not running the pipeline: target has no CUDA feature.\n");
+        return true;
+    }
+    Var x("x"), y("y"), xi("xi"), yi("yi");
+    Func f = make_pipeline(x, y);
+    f.gpu_tile(x, y, xi, yi, 8, 8).gpu_max_registers(32);
+    Buffer<float> out = f.realize({64, 64}, t);
+    for (int y = 0; y < out.height(); y++) {
+        for (int x = 0; x < out.width(); x++) {
+            float want = expected(x, y);
+            if (out(x, y) != want) {
+                printf("FAIL: out(%d, %d) = %f, expected %f\n", x, y, out(x, y), want);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    if (!check_directive_reaches_ptx()) {
+        return 1;
+    }
+    if (!check_answer()) {
+        return 1;
+    }
+
+#if HALIDE_WITH_EXCEPTIONS
+    // A cap has to be a number of registers, so zero and negatives are
+    // rejected rather than silently meaning "no cap".
+    bool ok = true;
+    for (int bad : {0, -8}) {
+        ok &= expect_user_error("gpu_max_registers", "gpu_max_registers", [&]() {
+            Var x("x"), y("y"), xi("xi"), yi("yi");
+            Func f = make_pipeline(x, y);
+            f.gpu_tile(x, y, xi, yi, 8, 8).gpu_max_registers(bad);
+        });
+    }
+    if (!ok) {
+        return 1;
+    }
+#endif
+
+    printf("Success!\n");
+    return 0;
+}

--- a/test/correctness/gpu_max_registers.cpp
+++ b/test/correctness/gpu_max_registers.cpp
@@ -7,9 +7,9 @@
 #include "Halide.h"
 #include "expect_user_error.h"
 #include "halide_test_dirs.h"
-#include <stdio.h>
 #include <fstream>
 #include <sstream>
+#include <stdio.h>
 
 using namespace Halide;
 

--- a/test/correctness/gpu_max_registers.cpp
+++ b/test/correctness/gpu_max_registers.cpp
@@ -40,7 +40,7 @@ std::string assembly_for(int max_registers) {
     Var x("x"), y("y"), xi("xi"), yi("yi");
     Func f = make_pipeline(x, y);
     f.gpu_tile(x, y, xi, yi, 8, 8);
-    if (max_registers > 0) {
+    if (max_registers >= 0) {
         f.gpu_max_registers(max_registers);
     }
     Target t = get_host_target()
@@ -55,12 +55,17 @@ std::string assembly_for(int max_registers) {
 }
 
 bool check_directive_reaches_ptx() {
-    if (assembly_for(0).find("maxnreg") != std::string::npos) {
+    if (assembly_for(-1).find("maxnreg") != std::string::npos) {
         printf("FAIL: .maxnreg appeared without being asked for\n");
         return false;
     }
     if (assembly_for(40).find("maxnreg 40") == std::string::npos) {
         printf("FAIL: .maxnreg 40 did not reach the generated PTX\n");
+        return false;
+    }
+    // Zero asks for the automatic choice, which is the same as not asking.
+    if (assembly_for(0).find("maxnreg") != std::string::npos) {
+        printf("FAIL: gpu_max_registers(0) still capped the registers\n");
         return false;
     }
     return true;
@@ -99,10 +104,10 @@ int main(int argc, char **argv) {
     }
 
 #if HALIDE_WITH_EXCEPTIONS
-    // A cap has to be a number of registers, so zero and negatives are
-    // rejected rather than silently meaning "no cap".
+    // A negative number of registers means nothing, so it is rejected rather
+    // than quietly treated as zero.
     bool ok = true;
-    for (int bad : {0, -8}) {
+    for (int bad : {-1, -8}) {
         ok &= expect_user_error("gpu_max_registers", "gpu_max_registers", [&]() {
             Var x("x"), y("y"), xi("xi"), yi("yi");
             Func f = make_pipeline(x, y);


### PR DESCRIPTION
This used to be controlled by HL_CUDA_MAX_REGISTERS. Tuning it is still sadly necessary for some apps (not in main) despite the recent changes. The original comment on that env var said it should be a scheduling directive, so this PR makes it a scheduling directive. For the apps on main, it helps depthwise conv slightly, but has no significant effect elsewhere.

Unfortunately only cuda seems to offer this level of control over the generated code, so it does nothing in other GPU APIs. Rocm also supports it, but we have no rocm backend.