### PR TITLE
Fix color printing to debug(n) streams

### DIFF
--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -182,6 +182,24 @@ const DebugSink &debug_sink() {
     return sink;
 }
 
+// A process-wide unique id in std::ios_base's array of user-defined tags
+// (iword/xalloc). We tag DebugStreams with their current output destination
+// (cerr/cout/file). Non-DebugStreams have empty tags.
+int debug_stream_sink_xalloc() {
+    static const int idx = std::ios_base::xalloc();
+    return idx;
+}
+
+DebugStreamSink current_debug_stream_sink() {
+    return std::visit(LambdaOverloads{
+                          [](int) { return DebugStreamSink::File; },
+                          [](auto osr) {
+                              return &osr.get() == &std::cout ? DebugStreamSink::Cout : DebugStreamSink::Cerr;
+                          },
+                      },
+                      debug_sink());
+}
+
 // Writes as much of [data, data + size) as the OS accepts in one call. A
 // single write() to a regular file normally consumes the whole request; the
 // loop only guards against the rare partial write (e.g. an EINTR-interrupted
@@ -209,6 +227,15 @@ void write_all(int fd, const char *data, size_t size) {
 }
 
 }  // namespace
+
+DebugStreamSink debug_stream_sink(std::ostream &os) {
+    const long tag = os.iword(debug_stream_sink_xalloc());
+    return tag ? static_cast<DebugStreamSink>(tag) : DebugStreamSink::None;
+}
+
+DebugStream::DebugStream() {
+    iword(debug_stream_sink_xalloc()) = static_cast<long>(current_debug_stream_sink());
+}
 
 DebugStream::~DebugStream() {
     if (std::string s = str(); !s.empty()) {

--- a/src/Debug.h
+++ b/src/Debug.h
@@ -35,6 +35,16 @@ std::ostream &operator<<(std::ostream &, const LoweredFunc &);
 
 bool debug_is_active_impl(int verbosity, const char *file, const char *function, int line);
 
+/** Ask an arbitrary std::ostream whether it is a DebugStream and,
+ * if so, where the output is being routed to. */
+enum class DebugStreamSink {
+    None,
+    Cout,
+    Cerr,
+    File,
+};
+DebugStreamSink debug_stream_sink(std::ostream &os);
+
 /** Backs the debug() macro. Buffers everything written to it in memory, then
  * emits the whole statement's accumulated output as a single write when the
  * temporary is destroyed (i.e. at the end of the debug(n) << ...; statement).
@@ -45,7 +55,7 @@ bool debug_is_active_impl(int verbosity, const char *file, const char *function,
  * use the debug(n) macro. */
 class DebugStream : public std::ostringstream {
 public:
-    DebugStream() = default;
+    DebugStream();
     ~DebugStream() override;
 
     /** Exposes this object as a plain std::ostream&, so every `<<` in a

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -7,6 +7,7 @@
 #include "Associativity.h"
 #include "Closure.h"
 #include "ConstantInterval.h"
+#include "Debug.h"
 #include "Expr.h"
 #include "IROperator.h"
 #include "Interval.h"
@@ -519,9 +520,11 @@ std::ostream &operator<<(std::ostream &out, const ModulusRemainder &c) {
 }
 
 namespace {
-bool supports_ansi(std::ostream &os) {
-    const char *term = getenv("TERM");
-    if (term) {
+bool supports_ansi(const std::ostream *os) {
+    if (!os) {
+        return false;
+    }
+    if (const char *term = getenv("TERM")) {
         // Check if the terminal supports colors
         if (!(strstr(term, "color") || strstr(term, "xterm"))) {
             return false;
@@ -529,9 +532,9 @@ bool supports_ansi(std::ostream &os) {
     }
 #if _WIN32
     HANDLE h;
-    if (&os == &std::cout) {
+    if (os == &std::cout) {
         h = GetStdHandle(STD_OUTPUT_HANDLE);
-    } else if (&os == &std::cerr) {
+    } else if (os == &std::cerr) {
         h = GetStdHandle(STD_ERROR_HANDLE);
     } else {
         return false;
@@ -541,9 +544,9 @@ bool supports_ansi(std::ostream &os) {
     return GetConsoleMode(h, &mode) &&
            SetConsoleMode(h, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 #else
-    if (&os == &std::cout) {
+    if (os == &std::cout) {
         return isatty(fileno(stdout));
-    } else if (&os == &std::cerr) {
+    } else if (os == &std::cerr) {
         return isatty(fileno(stderr));
     }
     return false;
@@ -554,15 +557,11 @@ bool supports_ansi(std::ostream &os) {
 IRPrinter::IRPrinter(ostream &s)
     : stream(s) {
     s.setf(std::ios::fixed, std::ios::floatfield);
-    if (&stream == &std::cout || &stream == &std::cerr) {
-        bool use_colors = false;
-        const char *opt = getenv("HL_COLORS");
-        if (opt) {
-            int val = std::atoi(opt);
-            use_colors = val != 0;
-        } else {
-            use_colors = supports_ansi(stream);
-        }
+
+    auto detect_color = [&](const std::ostream *terminal) {
+        std::string opt = get_env_variable("HL_COLORS");
+        bool use_colors = !opt.empty() ? opt == "1" : supports_ansi(terminal);
+
         if (use_colors) {
             ansi = true;
             // Simple palette using standard VGA colors.
@@ -581,6 +580,26 @@ IRPrinter::IRPrinter(ostream &s)
             ansi_reset     = "\033[0m";
             // clang-format on
         }
+    };
+
+    switch (debug_stream_sink(stream)) {
+    case DebugStreamSink::Cout:
+        detect_color(&std::cout);
+        break;
+    case DebugStreamSink::Cerr:
+        detect_color(&std::cerr);
+        break;
+    case DebugStreamSink::File:
+        // A shared log file: never auto-detect colors, but still honor an
+        // explicit HL_COLORS override.
+        detect_color(nullptr);
+        break;
+    case DebugStreamSink::None:
+        // It's not a DebugStream. Is it cout or cerr identically?
+        if (&stream == &std::cout || &stream == &std::cerr) {
+            detect_color(&stream);
+        }
+        break;
     }
 }
 

--- a/test/correctness/debug_helpers.cpp
+++ b/test/correctness/debug_helpers.cpp
@@ -1,9 +1,55 @@
 #include "Halide.h"
 
+#include <cstdlib>
+#include <sstream>
+
 using namespace Halide;
 using namespace Halide::Internal;
 
+namespace {
+void set_env(const char *name, const char *val) {
+#ifdef _WIN32
+    _putenv_s(name, val);
+#else
+    setenv(name, val, /*overwrite*/ 1);
+#endif
+}
+}  // namespace
+
 int main(int argc, char **argv) {
+    // debug_stream_sink() looks up where a DebugStream's contents will
+    // really end up
+    {
+        std::ostringstream unrelated;
+        internal_assert(debug_stream_sink(unrelated) == DebugStreamSink::None);
+        internal_assert(debug_stream_sink(std::cout) == DebugStreamSink::None);
+        internal_assert(debug_stream_sink(std::cerr) == DebugStreamSink::None);
+
+        // With HL_DEBUG_CODEGEN_LOG_FILE unset, debug() output defaults to
+        // stderr, so a fresh DebugStream should report that
+        DebugStream stream;
+        std::ostream &os = stream.stream();
+        internal_assert(&os != &std::cerr);
+        internal_assert(debug_stream_sink(os) == DebugStreamSink::Cerr);
+    }
+
+    // End-to-end: IRPrinter must actually emit ANSI color codes when writing
+    // into a DebugStream, not just when writing directly to std::cout/cerr.
+    // HL_COLORS is read fresh on every IRPrinter construction (unlike
+    // HL_DEBUG_CODEGEN_LOG_FILE, which is cached process-wide), so setting it
+    // here takes effect immediately without needing a child process.
+    {
+        set_env("HL_COLORS", "1");
+        DebugStream stream;
+        Var x;
+        stream.stream() << (x + 1);
+        std::string printed = stream.str();
+        stream.str("");  // Discard before the destructor flushes to stderr.
+        internal_assert(printed.find('\033') != std::string::npos)
+            << "expected ANSI color codes in: " << printed;
+        set_env("HL_COLORS", "0");
+    }
+
     // A bare verbosity matches purely on level, at any location.
     internal_assert(debug_spec_accepts("2", 0, "any.cpp", "any", 1));
     internal_assert(debug_spec_accepts("2", 2, "any.cpp", "any", 1));


### PR DESCRIPTION
## Summary

Introducing `DebugStream` (#9361) broke ANSI color output for `debug(n)`-routed IR printing. `IRPrinter`'s constructor detected a color-capable terminal by comparing `&stream` against `&std::cout`/`&std::cerr`, but `debug(n)` now expands to a `DebugStream` (an in-memory `std::ostringstream` buffer) whose `.stream()` returns itself, not `cout`/`cerr` — even though the buffered text is flushed to one of them (or a log file) once the statement ends. The identity check therefore always failed, silently disabling colors for all `debug()` output.

- Add `DebugStreamSink` (`None`/`Cout`/`Cerr`/`File`) and `debug_stream_sink(std::ostream&)` to `Debug.h`/`.cpp`. Each `DebugStream` tags itself via `std::ios_base::xalloc()`/`iword()` (RTTI-free, since `Halide_ENABLE_RTTI` is optional) with where `debug()` output is currently routed.
- `IRPrinter`'s constructor now consults `debug_stream_sink()` first, reusing the existing terminal-detection logic (including the Windows `ENABLE_VIRTUAL_TERMINAL_PROCESSING` step) against the real destination. `HL_COLORS` remains an explicit override (`0`/`1`) that replaces auto-detection rather than only ever adding to it; a shared log-file destination never auto-detects colors but still honors an explicit override.
- Add regression tests to `test/correctness/debug_helpers.cpp` covering `debug_stream_sink()` resolution and an end-to-end check that `IRPrinter` emits ANSI codes when writing into a `DebugStream`.

## Test plan

- [x] `ctest --test-dir build -R correctness_debug_helpers` passes
- [x] Manually verified under a real pty: `HL_COLORS=0` suppresses colors, `HL_COLORS=1` forces them (even when piped), and unset auto-detects based on the real destination
- [x] `pre-commit run --all-files` on touched files