### PR TITLE
verify serialized buffer before accessing it in the deserializer

### DIFF
--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -1446,6 +1446,13 @@ Pipeline Deserializer::deserialize(std::istream &in) {
 }
 
 Pipeline Deserializer::deserialize(const std::vector<uint8_t> &data) {
+    // The accessors below chase offsets straight out of the buffer, so the
+    // buffer has to be structurally sound before we touch it. flatbuffers does
+    // not check that unless we ask; without this a malformed .hlpipe reads out
+    // of bounds (Finish() writes no file identifier, so verify without one).
+    flatbuffers::Verifier verifier(data.data(), data.size());
+    user_assert(verifier.VerifyBuffer<Serialize::Pipeline>())
+        << "malformed serialized pipeline: failed flatbuffer verification\n";
     const auto *pipeline_obj = Serialize::GetPipeline(data.data());
     if (pipeline_obj == nullptr) {
         user_warning << "deserialized pipeline is empty\n";
@@ -1573,6 +1580,9 @@ std::map<std::string, Parameter> Deserializer::deserialize_parameters(std::istre
 
 std::map<std::string, Parameter> Deserializer::deserialize_parameters(const std::vector<uint8_t> &data) {
     std::map<std::string, Parameter> external_parameters_by_name;
+    flatbuffers::Verifier verifier(data.data(), data.size());
+    user_assert(verifier.VerifyBuffer<Serialize::Pipeline>())
+        << "malformed serialized pipeline: failed flatbuffer verification\n";
     const auto *pipeline_obj = Serialize::GetPipeline(data.data());
     if (pipeline_obj == nullptr) {
         user_warning << "deserialized pipeline is empty\n";


### PR DESCRIPTION
deserialize() and deserialize_parameters() in src/Deserialization.cpp call Serialize::GetPipeline(data.data()) and then chase table, vector, and string offsets straight out of the buffer with no structural check, so a malformed .hlpipe reads out of bounds (ASAN reports a heap-buffer-overflow read while walking output_names on a buffer with a corrupted root offset). Run a flatbuffers::Verifier over the data first and reject anything that fails before any accessor runs. Finish() writes no file identifier, so this verifies with VerifyBuffer<Pipeline>() rather than the generated VerifyPipelineBuffer, which checks for the 'HLDE' identifier and would reject every valid file; valid pipelines verify and deserialize unchanged.