### PR TITLE
LLVM21: ARM64 sve2 vector reduce recursion fix

### DIFF
--- a/src/CodeGen_ARM.cpp
+++ b/src/CodeGen_ARM.cpp
@@ -2840,6 +2840,18 @@ bool CodeGen_ARM::codegen_across_vector_reduce(const VectorReduce *op, const Exp
         return false;
     }
 
+    // Before LLVM 22, CodeGen_LLVM::codegen_vector_reduce refuses to lower
+    // VectorReduce::Mul to the native "llvm.vector.reduce.mul" intrinsic on
+    // scalable (SVE) targets, and instead decomposes it into halving stages
+    // whose intermediate results are themselves non-native-width
+    // VectorReduce nodes. Padding those up to a native-width multiply
+    // reduce here would be pointless (the intrinsic still can't be used)
+    // and, since the padded result routes back through this same override,
+    // would never converge. Defer to the base class's decomposition instead.
+    if (op->op == VectorReduce::Mul && LLVM_VERSION < 220) {
+        return false;
+    }
+
     Expr val = op->value;
     const int output_lanes = op->type.lanes();
     const int native_lanes = natural_vector_size(op->type);

--- a/test/correctness/vector_reductions.cpp
+++ b/test/correctness/vector_reductions.cpp
@@ -160,16 +160,6 @@ void add_tasks(const Target &target, std::vector<Task> &tasks) {
 int main(int argc, char **argv) {
     Target target = get_jit_target_from_environment();
 
-    // The reduce-padding recursion in CodeGen_ARM::codegen_across_vector_reduce
-    // can fail to converge for some SVE2 vector-reduce shapes under LLVM < 22,
-    // hanging the compiler indefinitely rather than failing outright.
-    if (Internal::get_llvm_version() < 220 &&
-        target.has_feature(Target::SVE2)) {
-        printf("[SKIP] LLVM %d has known SVE backend bugs for this test.\n",
-               Internal::get_llvm_version());
-        return 0;
-    }
-
     // TODO(https://github.com/halide/Halide/issues/8985): LLVM's JIT emits
     // misaligned jump tables on arm-32 with arm_fp16, causing SIGILL.
     if (target.arch == Target::ARM && target.bits == 32 &&


### PR DESCRIPTION
Claude Sonnet:

> Before LLVM 22, LLVM's llvm.vector.reduce.mul intrinsic lowering isn't
> available for scalable (SVE) vectors, so CodeGen_LLVM::codegen_vector_reduce
> always falls back to decomposing VectorReduce::Mul into halving stages for
> this case (see the `mul_ok` check there). CodeGen_ARM::codegen_across_vector_reduce
> doesn't know about this: whenever it's re-entered on one of those halving
> stages, it sees a lane count that isn't a multiple of the native vector
> width (because the "width" is really an intermediate reduce result, not
> raw data) and pads it up to a native-width multiply-reduce, which routes
> back into the same halving decomposition. Padding and halving alternate
> forever without ever reaching a terminating case, hanging the compiler.

See commit message for more info.

Fixes the hang rediscovered in #9374 

## Breaking changes

_Un_-breaking: LLVM 21 works now *more*?

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)
