### PR TITLE
clamp vsnprintf result before copying in log_printf

### DIFF
--- a/src/runtime/hexagon_remote/qurt/log.cpp
+++ b/src/runtime/hexagon_remote/qurt/log.cpp
@@ -66,6 +66,14 @@ void log_printf(const char *fmt, ...) {
     va_start(ap, fmt);
     int message_size = vsnprintf(message, sizeof(message) - 1, fmt, ap);
     va_end(ap);
+    if (message_size < 0) {
+        return;
+    }
+    // vsnprintf returns the length the message would have been, not the number
+    // of bytes written, so clamp to what actually fit before copying it out.
+    if (message_size > (int)sizeof(message) - 1) {
+        message_size = sizeof(message) - 1;
+    }
     global_log.write(message, message_size);
 }
 

--- a/src/runtime/hexagon_remote/qurt/log.cpp
+++ b/src/runtime/hexagon_remote/qurt/log.cpp
@@ -59,19 +59,17 @@ public:
 Log global_log(1024 * 64);
 
 void log_printf(const char *fmt, ...) {
-    char message[1024] = {
-        0,
-    };
+    char message[1024];
     va_list ap;
     va_start(ap, fmt);
-    int message_size = vsnprintf(message, sizeof(message) - 1, fmt, ap);
+    int message_size = vsnprintf(message, sizeof(message), fmt, ap);
     va_end(ap);
     if (message_size < 0) {
         return;
     }
-    // vsnprintf returns the length the message would have been, not the number
-    // of bytes written, so clamp to what actually fit before copying it out.
-    if (message_size > (int)sizeof(message) - 1) {
+    // vsnprintf returns the length the message would have been if untruncated,
+    // not the number of bytes actually written, so clamp before copying it out.
+    if (message_size >= (int)sizeof(message)) {
         message_size = sizeof(message) - 1;
     }
     global_log.write(message, message_size);


### PR DESCRIPTION
1. vsnprintf returns the length the message would have been, not the number of bytes written into the 1024-byte stack buffer, so a formatted string longer than that leaves message_size pointing past the buffer.
2. global_log.write() then copies message[0..message_size-1] out of the buffer, and those bytes are handed back to the host through halide_hexagon_remote_poll_log.
Clamp message_size to the bytes that actually fit (and bail on the negative error return) before the copy. log_printf backs halide_print/halide_error on the DSP, so an over-long printed or error string reaches it.