### PR TITLE
[python] Fixing Python tutorial doc strings to address comments from PR 9272

### DIFF
--- a/python_bindings/halide/tutorial/lesson_15_runtime.py
+++ b/python_bindings/halide/tutorial/lesson_15_runtime.py
@@ -56,11 +56,14 @@ def compile_pipeline(directory):
     brighter[x, y] = hl.cast(hl.UInt(8), input[x, y] + offset)
     brighter.vectorize(x, 16).parallel(y)
 
-    # Compile to a static library. Unlike compile_to(object), a static library
-    # bundles a copy of the Halide runtime, so the shared library we link below
-    # is self-contained and, like halide.runtime itself, needs no libHalide.
+    # Compile to a static library using the host target for the current machine
+    # so we can run it right away. This will generate a static library which bundles 
+    # the necessary Halide runtime for the host. So the shared library we link 
+    # below will be self-contained won't require the compiler from libHalide.
     #
-    # We compile for this machine (get_host_target) so we can run it right away.
+    # Note: You can use the `no_runtime` target flag if you wish to create a 
+    #       stand-alone static library for just the kernel, but you would need 
+    #       to link in a matching runtime before you'd be able to run it.
     archive = os.path.join(directory, "brighter.a")
     brighter.compile_to(
         {hl.OutputFileType.static_library: archive},
@@ -82,6 +85,9 @@ def link_shared_library(archive, stem, name):
     # environment has no suitable linker.
     system = platform.system()
 
+    # In a real project, you'd want to use a build system to do the linkage for
+    # you, but for the sake of this tutorial, we'll try and invoke the various
+    # platform toolchain's directly so we have a running example.  
     if system == "Windows":
         # Use the MSVC linker (link.exe) if the Visual Studio toolchain is on the
         # PATH (e.g. from a Developer Command Prompt). We wrap the static library

--- a/python_bindings/halide/tutorial/lesson_15_runtime.py
+++ b/python_bindings/halide/tutorial/lesson_15_runtime.py
@@ -57,12 +57,12 @@ def compile_pipeline(directory):
     brighter.vectorize(x, 16).parallel(y)
 
     # Compile to a static library using the host target for the current machine
-    # so we can run it right away. This will generate a static library which bundles 
-    # the necessary Halide runtime for the host. So the shared library we link 
+    # so we can run it right away. This will generate a static library which bundles
+    # the necessary Halide runtime for the host. So the shared library we link
     # below will be self-contained won't require the compiler from libHalide.
     #
-    # Note: You can use the `no_runtime` target flag if you wish to create a 
-    #       stand-alone static library for just the kernel, but you would need 
+    # Note: You can use the `no_runtime` target flag if you wish to create a
+    #       stand-alone static library for just the kernel, but you would need
     #       to link in a matching runtime before you'd be able to run it.
     archive = os.path.join(directory, "brighter.a")
     brighter.compile_to(
@@ -87,7 +87,7 @@ def link_shared_library(archive, stem, name):
 
     # In a real project, you'd want to use a build system to do the linkage for
     # you, but for the sake of this tutorial, we'll try and invoke the various
-    # platform toolchain's directly so we have a running example.  
+    # platform toolchain's directly so we have a running example.
     if system == "Windows":
         # Use the MSVC linker (link.exe) if the Visual Studio toolchain is on the
         # PATH (e.g. from a Developer Command Prompt). We wrap the static library


### PR DESCRIPTION
Adjusting python tutorial 15 doc strings to address comments from review [#9272](https://github.com/halide/Halide/pull/9272#discussion_r3846123761)

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
