### PR TITLE
[docs] Clarify Halide_WASM_BACKEND is a JIT-only, optional dependency

### DIFF
--- a/doc/BuildingHalideWithCMake.md
+++ b/doc/BuildingHalideWithCMake.md
@@ -110,16 +110,16 @@ the PATH.
 The following is a complete list of required and optional dependencies for
 building the core pieces of Halide.
 
-| Dependency    | Version            | Required when...           | Notes                                               |
-| ------------- | ------------------ | -------------------------- | --------------------------------------------------- |
-| [LLVM]        | _see policy below_ | _always_                   | WebAssembly and X86 targets are required.           |
-| [Clang]       | `==LLVM`           | _always_                   |                                                     |
-| [LLD]         | `==LLVM`           | _always_                   |                                                     |
-| [flatbuffers] | `~=23.5.26`        | `WITH_SERIALIZATION=ON`    |                                                     |
-| [wabt]        | `==1.0.39`         | `Halide_WASM_BACKEND=wabt` | Does not have a stable API; exact version required. |
-| [V8]          | trunk              | `Halide_WASM_BACKEND=V8`   | Difficult to build. See [WebAssembly.md]            |
-| [Python]      | `>=3.10`           | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
-| [pybind11]    | `~=2.11.1`         | `WITH_PYTHON_BINDINGS=ON`  |                                                     |
+| Dependency    | Version            | Required when...           | Notes                                                                                     |
+| ------------- | ------------------ | -------------------------- | ----------------------------------------------------------------------------------------- |
+| [LLVM]        | _see policy below_ | _always_                   | WebAssembly and X86 targets are required.                                                 |
+| [Clang]       | `==LLVM`           | _always_                   |                                                                                           |
+| [LLD]         | `==LLVM`           | _always_                   |                                                                                           |
+| [flatbuffers] | `~=23.5.26`        | `WITH_SERIALIZATION=ON`    |                                                                                           |
+| [wabt]        | `==1.0.39`         | `Halide_WASM_BACKEND=wabt` | In-process Wasm JIT only, never AOT (see below). Unstable API; exact version required.    |
+| [V8]          | trunk              | `Halide_WASM_BACKEND=V8`   | In-process Wasm JIT only, never AOT (see below). Difficult to build. See [WebAssembly.md] |
+| [Python]      | `>=3.10`           | `WITH_PYTHON_BINDINGS=ON`  |                                                                                           |
+| [pybind11]    | `~=2.11.1`         | `WITH_PYTHON_BINDINGS=ON`  |                                                                                           |
 
 Halide maintains the following compatibility policy with LLVM: Halide version
 `N` supports LLVM versions `N`, `N-1`, and `N-2`. Our binary distributions
@@ -467,11 +467,16 @@ apply when `WITH_TESTS=ON`:
 | `WITH_TEST_RUNTIME`       | `ON`       | enable testing the runtime modules    |
 | `WITH_TEST_WARNING`       | `ON`       | enable the expected-warning tests     |
 
-The following option selects the execution engine for in-process WASM testing:
+The following option selects the engine used to **JIT-execute** WebAssembly
+in-process. This only affects Halide's WebAssembly _JIT_ (used by the self-tests
+and by JIT users targeting Wasm); it has **no effect on AOT compilation**, which
+emits a Wasm object file that runs in an external engine and needs neither wabt
+nor V8. If you don't plan to run Wasm via JIT, set `Halide_WASM_BACKEND=OFF` to
+drop the wabt/V8 dependency entirely — AOT Wasm codegen is unaffected.
 
-| Option                | Default | Description                                                                              |
-| --------------------- | ------- | ---------------------------------------------------------------------------------------- |
-| `Halide_WASM_BACKEND` | `wabt`  | Select the backend for WASM testing. Can be `wabt`, `V8` or a false value such as `OFF`. |
+| Option                | Default | Description                                                                                                                                                           |
+| --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Halide_WASM_BACKEND` | `wabt`  | Backend for the in-process Wasm JIT. Can be `wabt`, `V8`, or a false value such as `OFF`. `OFF` builds Halide without a Wasm JIT engine (and without its dependency). |
 
 ### Installing
 

--- a/doc/WebAssembly.md
+++ b/doc/WebAssembly.md
@@ -81,14 +81,22 @@ environment and are disabled).
 In sum: don't plan on using Halide JIT mode with Wasm unless you are working on
 the Halide library itself.
 
+The interpreter is a *JIT-only* facility. Which engine is used (and whether one
+is built at all) is controlled by the `Halide_WASM_BACKEND` CMake option, which
+defaults to `wabt`. This is the sole reason libHalide depends on wabt (or V8):
+if you don't intend to JIT-execute Wasm, set `-DHalide_WASM_BACKEND=OFF` to
+build without that dependency. Doing so has **no effect on AOT compilation** —
+Halide still generates Wasm object files exactly as before; they simply run in
+an external engine (e.g. Node or a browser) rather than the in-process
+interpreter.
+
 ### Using V8 as the interpreter
 
 There is experimental support for using V8 as the interpreter in JIT mode,
-rather than WABT. This is enabled by the CMake command line options
-`-DWITH_V8=ON -DWITH_WABT=OFF` (only one of them can be used at a time). You
-must build V8 locally V8, then specify the path to the library and headers as
-CMake options. This is currently only tested on x86-64-Linux and requires v8
-version 9.8.177 as a minimum.
+rather than WABT. This is selected with the CMake command line option
+`-DHalide_WASM_BACKEND=V8`. You must build V8 locally, then specify the path to
+the library and headers as CMake options. This is currently only tested on
+x86-64-Linux and requires v8 version 9.8.177 as a minimum.
 
 The canonical instructions to build V8 are at
 [v8.dev](https://v8.dev/docs/build), and
@@ -125,8 +133,7 @@ $ cd /path/to/halide
 $ export HL_TARGET=wasm-32-wasmrt-wasm_simd128
 $ export HL_JIT_TARGET=${HL_TARGET}
 $ cmake -G Ninja \
-      -DWITH_WABT=OFF \
-      -DWITH_V8=ON \
+      -DHalide_WASM_BACKEND=V8 \
       -DV8_INCLUDE_DIR=$HOME/v8/v8/include \
       -DV8_LIBRARY=$HOME/v8/v8/out.gn/x64.release.sample/obj/libv8_monolith.a \
       -DHalide_TARGET=${HL_TARGET} \


### PR DESCRIPTION
The use of wabt/V8 are only needed for the in-process WebAssembly JIT executor, not AOT compilation. 

- Documented that Halide_WASM_BACKEND=OFF drops the dependency without affecting AOT.
- Fixed the stale -DWITH_WABT/-DWITH_V8 CMake flags in doc/WebAssembly.md (the current option is Halide_WASM_BACKEND).

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [X] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
