### PR TITLE
[docs] Render Python-only tutorial lessons (lesson_15_runtime) in the docs

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -256,6 +256,17 @@ foreach (_pair IN LISTS _tutorial_source_targets)
     list(APPEND _tutorial_manifest_entries "  \"${_source}\": \"$<TARGET_FILE:${_target}>\"")
     list(APPEND _tutorial_source_files "${Halide_SOURCE_DIR}/tutorial/${_source}")
 endforeach ()
+
+# Python-only tutorial lessons (e.g. lesson_15_runtime, which demonstrates the
+# standalone halide.runtime module and has no C++ counterpart) aren't covered
+# by HALIDE_TUTORIAL_SOURCE_TARGETS -- that only tracks compiled lesson
+# binaries. List their sources explicitly (file(GLOB) is disallowed by this
+# repo's CMake style checks) so each still gets its own generated page; they
+# need no manifest entry, having no binary to run.
+list(APPEND _tutorial_source_files
+    "${Halide_SOURCE_DIR}/python_bindings/halide/tutorial/lesson_15_runtime.py"
+)
+
 list(JOIN _tutorial_manifest_entries ",\n" _tutorial_manifest_body)
 
 set(_tutorial_manifest_file "${CMAKE_CURRENT_BINARY_DIR}/tutorial_manifest.json")

--- a/doc/tutorial_website/cli.py
+++ b/doc/tutorial_website/cli.py
@@ -171,7 +171,7 @@ def _main_lesson(args: argparse.Namespace) -> int:
 
     available = capture.find_backends(args.gdb, args.lldb)
     backend = capture.pick_backend(available, args.prefer) if available else None
-    if backend is None and lesson.cpp.interesting_lines:
+    if backend is None and lesson.cpp is not None and lesson.cpp.interesting_lines:
         print(
             f"warning: no gdb/lldb backend available; rendering {lesson.slug} "
             "without captured C++ output",

--- a/doc/tutorial_website/lesson.py
+++ b/doc/tutorial_website/lesson.py
@@ -56,10 +56,16 @@ class SourceVariant:
 
 @dataclass
 class Lesson:
+    """A single tutorial lesson. Most lessons have a C++ (or shell) source and,
+    where one exists, a same-stem Python translation. A few lessons are
+    Python-only (e.g. lesson_15_runtime, which demonstrates the standalone
+    halide.runtime module and has no C++ equivalent): those have `cpp=None`.
+    At least one of `cpp`/`python` is always set."""
+
     number: int
     slug: str
     title: str
-    cpp: SourceVariant
+    cpp: SourceVariant | None = None
     binary_path: Path | None = None
     python: SourceVariant | None = None
 
@@ -74,11 +80,25 @@ def _next_blank_line(lines: list[str], from_line: int) -> int:
     return len(lines)
 
 
+def _python_tutorial_dir(tutorial_dir: Path) -> Path:
+    return tutorial_dir.parent / "python_bindings" / "halide" / "tutorial"
+
+
 def _python_source(tutorial_dir: Path, slug: str) -> Path | None:
-    candidate = (
-        tutorial_dir.parent / "python_bindings" / "halide" / "tutorial" / f"{slug}.py"
-    )
+    candidate = _python_tutorial_dir(tutorial_dir) / f"{slug}.py"
     return candidate if candidate.exists() else None
+
+
+def _lesson_title(variant: SourceVariant, default: str) -> str:
+    """Extracts the title from a lesson's `Halide tutorial lesson N: Title`
+    comment. That comment isn't necessarily the first line -- shell-script
+    lessons lead with a shebang -- so scan near the top rather than assuming
+    lines[0]. Falls back to `default` (the slug) when there is no such comment."""
+    for line in variant.lines[:5]:
+        title_match = TITLE_RE.match(line)
+        if title_match:
+            return title_match.group(1)
+    return default
 
 
 def _scan_source(source_path: Path, number: int) -> SourceVariant:
@@ -142,16 +162,6 @@ def discover_lessons(tutorial_dir: Path, manifest: dict[str, Path]) -> list[Less
 
         cpp = _scan_source(source_path, number)
 
-        title = source_path.stem
-        # The title comment isn't necessarily the first line -- shell-script
-        # lessons lead with a shebang -- so scan for it near the top instead
-        # of assuming lines[0].
-        for line in cpp.lines[:5]:
-            title_match = TITLE_RE.match(line)
-            if title_match:
-                title = title_match.group(1)
-                break
-
         python_source_path = _python_source(tutorial_dir, source_path.stem)
         python_variant = (
             _scan_source(python_source_path, number) if python_source_path else None
@@ -161,10 +171,37 @@ def discover_lessons(tutorial_dir: Path, manifest: dict[str, Path]) -> list[Less
             Lesson(
                 number=number,
                 slug=source_path.stem,
-                title=title,
+                title=_lesson_title(cpp, source_path.stem),
                 cpp=cpp,
                 binary_path=manifest.get(source_path.name),
                 python=python_variant,
             )
         )
+
+    # Python-only lessons: a lesson_*.py with no same-stem C++/shell source
+    # above is a lesson in its own right (e.g. lesson_15_runtime, which covers
+    # the standalone halide.runtime module and has no C++ counterpart). Render
+    # it from its Python source alone.
+    known_slugs = {lesson.slug for lesson in lessons}
+    for python_path in sorted(_python_tutorial_dir(tutorial_dir).glob("lesson_*.py")):
+        number_match = NUMBER_RE.match(python_path.name)
+        if not number_match or python_path.stem in known_slugs:
+            continue
+        number = int(number_match.group(1))
+        python_variant = _scan_source(python_path, number)
+        lessons.append(
+            Lesson(
+                number=number,
+                slug=python_path.stem,
+                title=_lesson_title(python_variant, python_path.stem),
+                python=python_variant,
+            )
+        )
+
+    # Group pages are built by grouping *consecutive* same-number lessons
+    # (render.py's _group_by_number), so every lesson sharing a number must be
+    # contiguous. Sorting by (number, slug) keeps the existing C++/shell order
+    # (their filenames are already number- then name-sorted) while slotting
+    # each python-only lesson in beside its same-numbered siblings.
+    lessons.sort(key=lambda lesson: (lesson.number, lesson.slug))
     return lessons

--- a/doc/tutorial_website/render.py
+++ b/doc/tutorial_website/render.py
@@ -153,9 +153,7 @@ def lesson_asset_paths(lesson: Lesson, asset_root: Path) -> list[Path]:
     page after the asset is later added, without depending on the whole
     figures directory.
     """
-    variants = [lesson.cpp]
-    if lesson.python is not None:
-        variants.append(lesson.python)
+    variants = [v for v in (lesson.cpp, lesson.python) if v is not None]
     return sorted(
         {
             asset_root / figure_ref
@@ -173,9 +171,7 @@ def lesson_input_paths(lesson: Lesson, asset_root: Path) -> list[Path]:
     Python translations run to capture their output. Keep missing paths too,
     so Ninja retries a page when a newly referenced image is added.
     """
-    variants = [lesson.cpp]
-    if lesson.python is not None:
-        variants.append(lesson.python)
+    variants = [v for v in (lesson.cpp, lesson.python) if v is not None]
     return sorted(
         {
             asset_root / "images" / name
@@ -346,7 +342,13 @@ def render_lesson_page(
 ) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    if lesson.python is None:
+    if lesson.cpp is None:
+        # Python-only lesson: no C++/Python tab-set, just the Python source.
+        body = "\n".join(
+            _block_to_myst(block)
+            for block in _variant_blocks(lesson.python, python_snippets, output_dir)
+        )
+    elif lesson.python is None:
         body = "\n".join(
             _block_to_myst(block)
             for block in _variant_blocks(lesson.cpp, snippets, output_dir)

--- a/python_bindings/halide/tutorial/lesson_15_runtime.py
+++ b/python_bindings/halide/tutorial/lesson_15_runtime.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Halide tutorial lesson 15.
+# Halide tutorial lesson 15: Generators: running AOT code with the standalone runtime
 
 # This lesson demonstrates how to load and call a precompiled, ahead-of-time
 # (AOT) compiled Halide pipeline at runtime using the standalone "halide.runtime"


### PR DESCRIPTION
The Sphinx tutorial generator discovered lessons from C++/shell sources and attached a Python translation only by matching stems, so the one Python-only lesson -- lesson_15_runtime, covering the standalone halide.runtime module -- was never rendered. Teach discover_lessons() to also pick up lesson_*.py files with no C++ counterpart and render them as Python-only pages, register lesson_15_runtime as a tutorial source in doc/CMakeLists.txt so a page is generated for it, and complete its title comment to match the `lesson N: Title` convention.

## Checklist

- [ ] Tests added or updated (not required for docs, CI config, or typo fixes)
- [X] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [ ] Commits include AI attribution where applicable (see Code of Conduct)
