### PR TITLE
Work around intermittent vcpkg z-applocal failures on Windows CI

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,6 +25,7 @@
         "FETCHCONTENT_FULLY_DISCONNECTED": "ON",
         "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchain.${presetName}.cmake",
         "VCPKG_MANIFEST_FEATURES": "developer",
+        "VCPKG_USE_LEGACY_APPLOCAL": "ON",
         "Halide_BUILDING_IN_CI": "ON"
       }
     },


### PR DESCRIPTION
## Summary
- Windows CI has been hitting intermittent failures from vcpkg-tool's native `z-applocal` deployment step (microsoft/vcpkg-tool#2076): concurrent binary deployment into a shared output directory races and produces "Access is denied" / sharing-violation errors.
- Set `VCPKG_USE_LEGACY_APPLOCAL=ON` in the shared `ci` CMake preset (inherited by all `ci-*` presets, including the two Windows ones) to fall back to the older `applocal.ps1`-based deployment, which does not exhibit the race. This is a no-op on non-Windows presets.

## Test plan
- [x] `cmake --list-presets` still enumerates all presets correctly.
- [x] `pre-commit run --files CMakePresets.json` passes (JSON validity, formatting).
- [ ] Watch the next few Windows CI runs on this PR for absence of the intermittent applocal failure.