### PR TITLE
Use em++ instead of emcc for wasm AOT test executables

### DIFF
--- a/test/generator/CMakeLists.txt
+++ b/test/generator/CMakeLists.txt
@@ -31,7 +31,7 @@ function(add_wasm_executable TARGET)
     #     target_link_libraries(${TARGET} PRIVATE ${args_DEPS})
     # endif ()
 
-    find_program(EMCC emcc REQUIRED PATH_SUFFIXES upstream/emscripten HINTS ENV EMSDK)
+    find_program(EMCXX em++ REQUIRED PATH_SUFFIXES upstream/emscripten HINTS ENV EMSDK)
 
     # TODO: this is currently hardcoded to settings that are sensible for most of Halide's
     # internal purposes. Consider adding ways to customize this as appropriate.
@@ -82,8 +82,8 @@ function(add_wasm_executable TARGET)
         OUTPUT
             "${TARGET}.wasm"
             "${TARGET}.js"
-        COMMAND ${EMCC} ${EMCC_FLAGS} ${INCLUDES} ${SRCS} ${DEPS} -o "${TARGET}.js"
-        DEPENDS ${EMCC} ${SRCS} ${DEPS}
+        COMMAND ${EMCXX} ${EMCC_FLAGS} ${INCLUDES} ${SRCS} ${DEPS} -o "${TARGET}.js"
+        DEPENDS ${EMCXX} ${SRCS} ${DEPS}
         VERBATIM
     )
 


### PR DESCRIPTION
## Summary

CI has been intermittently failing to build wasm AOT test executables on macOS x86-64, with `wasm-ld` errors like `undefined symbol: operator new[](unsigned long)` and `operator delete[](void*)`.

`add_wasm_executable()` (`test/generator/CMakeLists.txt`) invokes the bare `emcc` binary directly on `.cpp` sources. `emcc` is the C driver; it historically auto-linked `libc++` for C++ inputs anyway, but Emscripten 6.0.6 disabled that implicit behavior (`DEFAULT_TO_CXX`), matching `gcc`/`g++` semantics — `em++` is now required for C++ sources, or the link fails with undefined C++ symbols.

Since our macOS CI installs emscripten unpinned (`brew install emscripten`), and Homebrew rolls out bottles per-architecture independently, the same commit can see different emscripten versions on `arm-64` vs `x86-64` runners in the same workflow run — which is why this only showed up on x86-64: that runner's Homebrew bottle picked up 6.0.8 (post-regression) while arm-64 was still serving 6.0.4.

All sources built by `add_wasm_executable()` are `.cpp`, so this switches it to use `em++` directly, which links correctly on both old and new Emscripten releases.

## Test plan

- [x] Reproduced the exact CI failure locally against emscripten 6.0.8 (via `~/dev/emsdk`) with a minimal repro: bare `emcc` on a C++ source with an escaping heap allocation fails with the same `undefined symbol: operator new[]/delete[]` error and the same missing-`libc++`-in-sysroot signature seen in CI logs.
- [x] Confirmed `em++` links and runs correctly against the same repro on both emscripten 6.0.4 and 6.0.8.
- [ ] CI (this PR) — will confirm the actual wasm generator AOT tests build cleanly on both `arm-64` and `x86-64` runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)