### PR TITLE
[python] Test: disable incremental linking for Windows AOT runtime test modules

### DIFF
--- a/python_bindings/halide-runtime/test/CMakeLists.txt
+++ b/python_bindings/halide-runtime/test/CMakeLists.txt
@@ -29,6 +29,15 @@ function(add_runtime_test_kernel MOD)
     add_library(${MOD}_module MODULE aot_module_stub.c)
     target_link_libraries(${MOD}_module PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,${MOD}_aot>")
     set_target_properties(${MOD}_module PROPERTIES PREFIX "" OUTPUT_NAME ${MOD})
+
+    if (MSVC)
+        # link.exe's incremental linker can corrupt a /WHOLEARCHIVE module
+        # (LNK1236: corrupt or invalid COFF sections) when relinking it against
+        # a changed archive in an existing build tree. These modules are only
+        # ever built once per configuration, so incremental linking buys us
+        # nothing and isn't worth the risk.
+        target_link_options(${MOD}_module PRIVATE /INCREMENTAL:NO)
+    endif ()
 endfunction()
 
 # A tiny kernel: load, call, and Buffer interop.


### PR DESCRIPTION
## Summary

This is a **test**, not a confirmed fix. Opening as draft to see whether it actually resolves the flake before merging.

Our Windows CI buildbots have been intermittently failing `python_bindings/halide-runtime/test/CMakeLists.txt`'s `runtimeadd.dll` link with:

```
runtimeadd_aot.lib(runtimeadd_aot.obj) : fatal error LNK1236: corrupt or invalid COFF sections
```

This always occurs on the last target reconfigure in the CI matrix (`x86-64-windows` → `x86-64-windows-sse41`), always on the `runtimeadd` module specifically (never `callconv`/`callconv_xor`, which are built the same way), and so far only on one of our two Windows workers. The CI recipe reconfigures and rebuilds the same build tree in place for ~9 different `Halide_TARGET`s, so this module gets relinked with `/INCREMENTAL` against a changed `/WHOLEARCHIVE` static library many times per job — a pattern with a documented history of tripping MSVC's incremental linker.

This PR disables incremental linking for these MSVC module targets. They're one-shot build artifacts (loaded by a Python test, never iterated on interactively), so incremental linking buys nothing.

Since this flake is intermittent and worker-specific, we don't yet know if this is the actual root cause or just a plausible contributor — keeping this as a draft until we've seen enough CI runs to tell.

## Test plan

- [ ] Watch several CI runs on the Windows builders and confirm `LNK1236` no longer occurs on the previously-affected worker.
- [ ] If it recurs, investigate other causes (e.g. environment differences between the two Windows workers) before merging.
