### PR TITLE
Add FuncVec convenience type

### DIFF
--- a/apps/camera_pipe/camera_pipe_generator.cpp
+++ b/apps/camera_pipe/camera_pipe_generator.cpp
@@ -207,7 +207,7 @@ public:
 
 private:
     // Intermediate stencil stages to schedule
-    vector<Func> intermediates;
+    FuncVec intermediates;
 };
 
 class CameraPipe : public Halide::Generator<CameraPipe> {

--- a/apps/interpolate/interpolate_generator.cpp
+++ b/apps/interpolate/interpolate_generator.cpp
@@ -2,14 +2,6 @@
 
 namespace {
 
-std::vector<Halide::Func> func_vector(const std::string &name, int size) {
-    std::vector<Halide::Func> funcs;
-    for (int i = 0; i < size; i++) {
-        funcs.emplace_back(Halide::Func{name + "_" + std::to_string(i)});
-    }
-    return funcs;
-}
-
 class Interpolate : public Halide::Generator<Interpolate> {
 public:
     GeneratorParam<int> levels{"levels", 10};
@@ -23,11 +15,11 @@ public:
         // Input must have four color channels - rgba
         input.dim(2).set_bounds(0, 4);
 
-        auto downsampled = func_vector("downsampled", levels);
-        auto downx = func_vector("downx", levels);
-        auto interpolated = func_vector("interpolated", levels);
-        auto upsampled = func_vector("upsampled", levels);
-        auto upsampledx = func_vector("upsampledx", levels);
+        FuncVec downsampled("downsampled_", levels);
+        FuncVec downx("downx_", levels);
+        FuncVec interpolated("interpolated_", levels);
+        FuncVec upsampled("upsampled_", levels);
+        FuncVec upsampledx("upsampledx_", levels);
 
         Func clamped = Halide::BoundaryConditions::repeat_edge(input);
 

--- a/apps/lens_blur/lens_blur_generator.cpp
+++ b/apps/lens_blur/lens_blur_generator.cpp
@@ -51,7 +51,7 @@ public:
         // Do a push-pull thing to blur the cost volume with an
         // exponential-decay type thing to inpaint over regions with low
         // confidence.
-        Func cost_pyramid_push[8];
+        FuncVec cost_pyramid_push("cost_pyramid_push", 8);
         cost_pyramid_push[0](x, y, z, c) =
             mux(c, {cost(x, y, z) * cost_confidence(x, y), cost_confidence(x, y)});
 
@@ -63,7 +63,7 @@ public:
             cost_pyramid_push[i] = BoundaryConditions::repeat_edge(cost_pyramid_push[i], {{0, w}, {0, h}});
         }
 
-        Func cost_pyramid_pull[8];
+        FuncVec cost_pyramid_pull("cost_pyramid_pull", 8);
         cost_pyramid_pull[7](x, y, z, c) = cost_pyramid_push[7](x, y, z, c);
         for (int i = 6; i >= 0; i--) {
             cost_pyramid_pull[i](x, y, z, c) = lerp(upsample(cost_pyramid_pull[i + 1])(x, y, z, c),

--- a/apps/local_laplacian/local_laplacian_generator.cpp
+++ b/apps/local_laplacian/local_laplacian_generator.cpp
@@ -36,7 +36,7 @@ public:
         gray(x, y) = 0.299f * floating(x, y, 0) + 0.587f * floating(x, y, 1) + 0.114f * floating(x, y, 2);
 
         // Make the processed Gaussian pyramid.
-        Func gPyramid[maxJ];
+        FuncVec gPyramid("gPyramid", J);
         // Do a lookup into a lut with 256 entries per intensity level
         Expr level = k * (1.0f / (levels - 1));
         Expr idx = gray(x, y) * cast<float>(levels - 1) * 256.0f;
@@ -47,21 +47,21 @@ public:
         }
 
         // Get its laplacian pyramid
-        Func lPyramid[maxJ];
+        FuncVec lPyramid("lPyramid", J);
         lPyramid[J - 1](x, y, k) = gPyramid[J - 1](x, y, k);
         for (int j = J - 2; j >= 0; j--) {
             lPyramid[j](x, y, k) = gPyramid[j](x, y, k) - upsample(gPyramid[j + 1])(x, y, k);
         }
 
         // Make the Gaussian pyramid of the input
-        Func inGPyramid[maxJ];
+        FuncVec inGPyramid("inGPyramid", J);
         inGPyramid[0](x, y) = gray(x, y);
         for (int j = 1; j < J; j++) {
             inGPyramid[j](x, y) = downsample(inGPyramid[j - 1])(x, y);
         }
 
         // Make the laplacian pyramid of the output
-        Func outLPyramid[maxJ];
+        FuncVec outLPyramid("outLPyramid", J);
         for (int j = 0; j < J; j++) {
             // Split input pyramid value into integer and floating parts
             Expr level = inGPyramid[j](x, y) * cast<float>(levels - 1);
@@ -72,7 +72,7 @@ public:
         }
 
         // Make the Gaussian pyramid of the output
-        Func outGPyramid[maxJ];
+        FuncVec outGPyramid("outGPyramid", J);
         outGPyramid[J - 1](x, y) = outLPyramid[J - 1](x, y);
         for (int j = J - 2; j >= 0; j--) {
             outGPyramid[j](x, y) = upsample(outGPyramid[j + 1])(x, y) + outLPyramid[j](x, y);

--- a/apps/onnx/model.cpp
+++ b/apps/onnx/model.cpp
@@ -49,7 +49,7 @@ HalideModel convert_onnx_model(
     result.model = std::make_shared<Model>(
         convert_model(onnx_model, expected_dim_sizes, layout));
 
-    std::vector<Halide::Func> funcs;
+    Halide::FuncVec funcs;
     for (const auto &output : onnx_model.graph().output()) {
         const auto &tensor = result.model->outputs.at(output.name());
         funcs.push_back(tensor.rep);

--- a/apps/onnx/onnx_converter.cc
+++ b/apps/onnx/onnx_converter.cc
@@ -1850,7 +1850,7 @@ Node convert_concat_node(
     }
 
     Halide::Var concat_axis = tgt_indices[axis];
-    std::vector<Halide::Func> concat_funcs;
+    Halide::FuncVec concat_funcs;
     concat_funcs.resize(inputs.size());
     concat_funcs[0](tgt_indices) = inputs[0].rep(tgt_indices);
     Halide::Expr concat_offset = 0;

--- a/apps/stencil_chain/stencil_chain_generator.cpp
+++ b/apps/stencil_chain/stencil_chain_generator.cpp
@@ -11,24 +11,20 @@ public:
 
     void generate() {
 
-        std::vector<Func> stages;
+        FuncVec stages("stage_", (int)stencils + 1);
 
         Var x("x"), y("y");
 
-        Func f = Halide::BoundaryConditions::repeat_edge(input);
+        stages[0] = Halide::BoundaryConditions::repeat_edge(input);
 
-        stages.push_back(f);
-
-        for (int s = 0; s < (int)stencils; s++) {
-            Func f("stage_" + std::to_string(s));
+        for (int s = 1; s <= (int)stencils; s++) {
             Expr e = cast<uint16_t>(0);
             for (int i = -2; i <= 2; i++) {
                 for (int j = -2; j <= 2; j++) {
-                    e += ((i + 3) * (j + 3)) * stages.back()(x + i, y + j);
+                    e += ((i + 3) * (j + 3)) * stages[s - 1](x + i, y + j);
                 }
             }
-            f(x, y) = e;
-            stages.push_back(f);
+            stages[s](x, y) = e;
         }
 
         output(x, y) = stages.back()(x, y);

--- a/python_bindings/halide/src/halide_/PyPipeline.cpp
+++ b/python_bindings/halide/src/halide_/PyPipeline.cpp
@@ -70,15 +70,12 @@ void define_pipeline(py::module &m) {
             .def(py::init<Func>())
             .def(py::init<const std::vector<Func> &>())
 
-            .def("outputs", &Pipeline::outputs)
+            .def("outputs", [](const Pipeline &p) {
+                return std::vector<Func>(p.outputs());
+            })
 
-            .def("apply_autoscheduler", &Pipeline::apply_autoscheduler,
-                 py::arg("target"), py::arg("autoscheduler_params"))
-            .def(
-                "apply_runtime_prefixes", [](Pipeline &p, const Target &target, const std::map<RuntimeLinkage, std::string> &namespace_map) {
-                    p.apply_runtime_prefixes(target, RuntimePrefixParams(namespace_map));
-                },
-                py::arg("target"), py::arg("namespace_map"))
+            .def("apply_autoscheduler", &Pipeline::apply_autoscheduler, py::arg("target"), py::arg("autoscheduler_params"))
+            .def("apply_runtime_prefixes", [](Pipeline &p, const Target &target, const std::map<RuntimeLinkage, std::string> &namespace_map) { p.apply_runtime_prefixes(target, RuntimePrefixParams(namespace_map)); }, py::arg("target"), py::arg("namespace_map"))
             .def("get_func", &Pipeline::get_func, py::arg("index"))
             .def("print_loop_nest", &Pipeline::print_loop_nest)
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -99,6 +99,20 @@ Func::Func(Function f)
         << "Can't construct Func from undefined Function";
 }
 
+FuncVec::FuncVec(const string &base_name, size_t count) {
+    reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        emplace_back(base_name + std::to_string(i));
+    }
+}
+
+FuncVec::operator Func() const {
+    user_assert(size() == 1)
+        << "Cannot convert a FuncVec of size " << size()
+        << " to a Func; exactly one Func is required.\n";
+    return front();
+}
+
 const string &Func::name() const {
     return func.name();
 }

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -99,10 +99,10 @@ Func::Func(Function f)
         << "Can't construct Func from undefined Function";
 }
 
-FuncVec::FuncVec(const string &base_name, size_t count) {
+FuncVec::FuncVec(const string &base_name, size_t count, const string &suffix) {
     reserve(count);
     for (size_t i = 0; i < count; ++i) {
-        emplace_back(count == 1 ? base_name : base_name + std::to_string(i));
+        emplace_back((count == 1 ? base_name : base_name + std::to_string(i)) + suffix);
     }
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -102,7 +102,7 @@ Func::Func(Function f)
 FuncVec::FuncVec(const string &base_name, size_t count, const string &suffix) {
     reserve(count);
     for (size_t i = 0; i < count; ++i) {
-        emplace_back((count == 1 ? base_name : base_name + std::to_string(i)) + suffix);
+        emplace_back(count == 1 ? concat_strings(base_name, suffix) : concat_strings(base_name, i, suffix));
     }
 }
 

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -102,7 +102,7 @@ Func::Func(Function f)
 FuncVec::FuncVec(const string &base_name, size_t count) {
     reserve(count);
     for (size_t i = 0; i < count; ++i) {
-        emplace_back(base_name + std::to_string(i));
+        emplace_back(count == 1 ? base_name : base_name + std::to_string(i));
     }
 }
 

--- a/src/Func.h
+++ b/src/Func.h
@@ -2817,6 +2817,31 @@ public:
     }
 };
 
+/** A vector of Funcs with conveniences for constructing and consuming
+ * collections of Funcs. */
+class FuncVec : public std::vector<Func> {
+    using Base = std::vector<Func>;
+
+public:
+    using Base::Base;
+    using Base::operator=;
+
+    FuncVec() = default;
+    FuncVec(const Base &funcs)
+        : Base(funcs) {
+    }
+    FuncVec(Base &&funcs)
+        : Base(std::move(funcs)) {
+    }
+
+    /** Construct count undefined Funcs named base_name + their index. */
+    FuncVec(const std::string &base_name, size_t count);
+
+    /** Convert a singleton FuncVec to its sole Func. It is a user error if
+     * the FuncVec does not contain exactly one Func. */
+    operator Func() const;
+};
+
 template<typename... Args>
 HALIDE_NO_USER_CODE_INLINE std::enable_if_t<Internal::all_are_convertible<Func, Args...>::value, Stage &>
 Stage::eager_inline(const Func &first, Args &&...args) {

--- a/src/Func.h
+++ b/src/Func.h
@@ -2834,7 +2834,8 @@ public:
         : Base(std::move(funcs)) {
     }
 
-    /** Construct count undefined Funcs named base_name + their index. */
+    /** Construct count undefined Funcs. A singleton is named base_name; otherwise
+     * the Funcs are named base_name + their index. */
     FuncVec(const std::string &base_name, size_t count);
 
     /** Convert a singleton FuncVec to its sole Func. It is a user error if

--- a/src/Func.h
+++ b/src/Func.h
@@ -2835,8 +2835,9 @@ public:
     }
 
     /** Construct count undefined Funcs. A singleton is named base_name; otherwise
-     * the Funcs are named base_name + their index. */
-    FuncVec(const std::string &base_name, size_t count);
+     * the Funcs are named base_name + their index. suffix, if given, is appended
+     * after the name. */
+    FuncVec(const std::string &base_name, size_t count, const std::string &suffix = "");
 
     /** Convert a singleton FuncVec to its sole Func. It is a user error if
      * the FuncVec does not contain exactly one Func. */

--- a/src/Generator.h
+++ b/src/Generator.h
@@ -3089,6 +3089,7 @@ protected:
     using EvictionKey = Halide::EvictionKey;
     using ExternFuncArgument = Halide::ExternFuncArgument;
     using Func = Halide::Func;
+    using FuncVec = Halide::FuncVec;
     using GeneratorContext = Halide::GeneratorContext;
     using ImageParam = Halide::ImageParam;
     using LoopLevel = Halide::LoopLevel;

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -219,8 +219,8 @@ Pipeline::Pipeline(const std::vector<Func> &outputs, const std::vector<Internal:
     }
 }
 
-vector<Func> Pipeline::outputs() const {
-    vector<Func> funcs;
+FuncVec Pipeline::outputs() const {
+    FuncVec funcs;
     for (const Function &f : contents->outputs) {
         funcs.emplace_back(f);
     }

--- a/src/Pipeline.h
+++ b/src/Pipeline.h
@@ -25,6 +25,7 @@ namespace Halide {
 struct Argument;
 class Callable;
 class Func;
+class FuncVec;
 struct PipelineContents;
 
 /** Special the Autoscheduler to be used (if any), along with arbitrary
@@ -205,7 +206,7 @@ public:
     std::vector<Argument> infer_arguments(const Internal::Stmt &body);
 
     /** Get the Funcs this pipeline outputs. */
-    std::vector<Func> outputs() const;
+    FuncVec outputs() const;
 
     /** Get the requirements of this pipeline. */
     std::vector<Internal::Stmt> requirements() const;

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -139,6 +139,7 @@ tests(
     force_onto_stack.cpp
     func_lifetime.cpp
     func_lifetime_2.cpp
+    func_vec.cpp
     fuse.cpp
     fuse_gpu_threads.cpp
     fused_where_inner_extent_is_zero.cpp

--- a/test/correctness/func_vec.cpp
+++ b/test/correctness/func_vec.cpp
@@ -36,6 +36,10 @@ int main(int argc, char **argv) {
         success &= check(named[i].name() == expected, "named constructor created an incorrect Func name");
     }
 
+    FuncVec singleton_named("func_vec_singleton", 1);
+    success &= check(singleton_named[0].name() == "func_vec_singleton",
+                     "singleton named constructor should preserve its base name");
+
     Func a("func_vec_a");
     Func b("func_vec_b");
     FuncVec funcs{a};

--- a/test/correctness/func_vec.cpp
+++ b/test/correctness/func_vec.cpp
@@ -40,6 +40,17 @@ int main(int argc, char **argv) {
     success &= check(singleton_named[0].name() == "func_vec_singleton",
                      "singleton named constructor should preserve its base name");
 
+    FuncVec suffixed("func_vec_suffixed_", 2, "_s");
+    success &= check(suffixed.size() == 2, "suffixed constructor created the wrong number of Funcs");
+    for (size_t i = 0; i < suffixed.size(); ++i) {
+        const std::string expected = "func_vec_suffixed_" + std::to_string(i) + "_s";
+        success &= check(suffixed[i].name() == expected, "suffixed constructor created an incorrect Func name");
+    }
+
+    FuncVec singleton_suffixed("func_vec_singleton_suffixed", 1, "_s");
+    success &= check(singleton_suffixed[0].name() == "func_vec_singleton_suffixed_s",
+                     "singleton suffixed constructor should append the suffix after its base name");
+
     Func a("func_vec_a");
     Func b("func_vec_b");
     FuncVec funcs{a};

--- a/test/correctness/func_vec.cpp
+++ b/test/correctness/func_vec.cpp
@@ -1,0 +1,77 @@
+#include "Halide.h"
+#include "expect_user_error.h"
+
+#include <cstdio>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+using namespace Halide;
+
+namespace {
+
+bool check(bool condition, const char *message) {
+    if (!condition) {
+        std::printf("FAIL: %s\n", message);
+    }
+    return condition;
+}
+
+size_t vector_size(const std::vector<Func> &funcs) {
+    return funcs.size();
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    static_assert(std::is_base_of_v<std::vector<Func>, FuncVec>);
+    static_assert(std::is_convertible_v<FuncVec, Func>);
+
+    bool success = true;
+
+    FuncVec named("func_vec_stage_", 3);
+    success &= check(named.size() == 3, "named constructor created the wrong number of Funcs");
+    for (size_t i = 0; i < named.size(); ++i) {
+        const std::string expected = "func_vec_stage_" + std::to_string(i);
+        success &= check(named[i].name() == expected, "named constructor created an incorrect Func name");
+    }
+
+    Func a("func_vec_a");
+    Func b("func_vec_b");
+    FuncVec funcs{a};
+    funcs.push_back(b);
+    success &= check(vector_size(funcs) == 2, "FuncVec is not usable as a std::vector<Func>");
+
+    std::vector<Func> base{a};
+    FuncVec copied(base);
+    FuncVec assigned;
+    assigned = base;
+    std::vector<Func> round_trip = copied;
+    success &= check(assigned.size() == 1 && round_trip.size() == 1,
+                     "FuncVec conversion to or from std::vector<Func> failed");
+
+    Func singleton = copied;
+    success &= check(singleton.name() == a.name(), "singleton FuncVec converted to the wrong Func");
+
+    Pipeline pipeline(copied);
+    Func pipeline_output = pipeline.outputs();
+    success &= check(pipeline_output.name() == a.name(), "Pipeline::outputs() did not decay to its singleton Func");
+
+#if HALIDE_WITH_EXCEPTIONS
+    FuncVec empty;
+    success &= expect_user_error("empty_func_vec", "size 0", [&]() {
+        Func f = empty;
+        (void)f;
+    });
+    success &= expect_user_error("multi_func_vec", "size 2", [&]() {
+        Func f = funcs;
+        (void)f;
+    });
+#endif
+
+    if (!success) {
+        return 1;
+    }
+    std::printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
Supersedes #9387, which was auto-closed as a no-op merge into `alexreinking/rfactor-hoisting` while the stack was being reordered (funcvecs moved to the bottom of the stack, below rfactor-hoisting). Added a name suffix relative to #9387 — see that PR for prior review history.