### PR TITLE
Simplify slices of broadcasts

### DIFF
--- a/src/Simplify_Shuffle.cpp
+++ b/src/Simplify_Shuffle.cpp
@@ -115,6 +115,20 @@ Expr Simplify::visit(const Shuffle *op, ExprInfo *info) {
         }
     }
 
+    // Simplify a slice of a broadcast, where the slice lies within a single
+    // copy of the value being broadcast, into a slice of that value.
+    if (op->is_slice() && new_vectors.size() == 1) {
+        if (const Broadcast *b = new_vectors[0].as<Broadcast>()) {
+            int lanes = b->value.type().lanes();
+            int first = op->indices.front(), last = op->indices.back();
+            if (first / lanes == last / lanes) {
+                return mutate(Shuffle::make_slice(b->value, first % lanes, op->slice_stride(),
+                                                  (int)op->indices.size()),
+                              info);
+            }
+        }
+    }
+
     if (op->is_interleave()) {
         int terms = (int)new_vectors.size();
 

--- a/test/correctness/extract_concat_bits.cpp
+++ b/test/correctness/extract_concat_bits.cpp
@@ -72,6 +72,46 @@ int main(int argc, char **argv) {
         }
     }
 
+    {
+        // Same as above, but arranged so that the base of the load's index
+        // ramp is a constant.
+        Func f("f"), g("g"), h("h");
+        Var x("x"), t("t");
+
+        f(x, t) = cast<uint64_t>(x + t) * 12345;
+        g(x, t) = extract_bits<uint32_t>(f(x / 2, t), 32 * (x % 2));
+        h(x, t) = g(x, t);
+
+        h.vectorize(x, 64);
+        h.output_buffer().dim(0).set_min(0).set_extent(64);
+        f.compute_at(h, t).vectorize(x);
+        g.compute_at(h, t).vectorize(x);
+
+        CountOps counter;
+        h.add_custom_lowering_pass(&counter, nullptr);
+
+        Buffer<uint32_t> out = h.realize({64, 4});
+
+        if (counter.extracts > 0) {
+            printf("Saw an unwanted extract_bits call in lowered code\n");
+            return 1;
+        } else if (counter.reinterprets == 0) {
+            printf("Did not see a vector reinterpret in lowered code\n");
+            return 1;
+        }
+
+        for (int t = 0; t < out.height(); t++) {
+            for (int x = 0; x < out.width(); x++) {
+                uint64_t wide = (uint64_t)(x / 2 + t) * 12345;
+                uint32_t correct = (uint32_t)(wide >> (32 * (x % 2)));
+                if (out(x, t) != correct) {
+                    printf("out(%d, %d) = %u instead of %u\n", x, t, out(x, t), correct);
+                    return 1;
+                }
+            }
+        }
+    }
+
     for (bool vectorize : {false, true}) {
         // Reinterpret an array of a narrow type as a smaller array of a wide type
         Func f, g;


### PR DESCRIPTION
`extract_bits` is supposed to give you free vector reinterprets if you follow the pattern in `test/correctness/extract_concat_bits.cpp`, but it fails when the base of the load's index ramp is a constant.

In that case the duplicated-lane load `f(x/2)` becomes a broadcast of a dense load, `rewrite_interleavings` splits the `extract_bits` into even and odd lanes, and each half ends up as a slice of that broadcast. Each slice is just the dense load, but nothing cancelled a slice against a broadcast, so the interleave-of-`extract_bits` rule in `Simplify_Shuffle` saw unequal bases and never fired. The pipeline was left doing a shuffle plus two `extract_bits` calls instead of one vector reinterpret.

This adds a simplifier rule: a slice of a broadcast whose lanes all land within a single copy of the value being broadcast becomes a slice of that value. Structured shuffle in, structured shuffle out — no general shuffle is ever created, so instruction selection isn't disturbed.

A constant-base case is added to `correctness_extract_concat_bits`, checking that no `extract_bits` survives lowering, that a widening reinterpret appears, and that the values are correct.

`make test_correctness` passes, apart from `simd_op_check_sve2`, which fails identically before this change (`LLVM ERROR: Don't know how to legalize this scalable vector type` on LLVM 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)