### PR TITLE
Print the actual Expr for an add_requirement() that fails.

### DIFF
--- a/python_bindings/halide/test/correctness/basics.py
+++ b/python_bindings/halide/test/correctness/basics.py
@@ -410,12 +410,13 @@ def test_requirements():
     delta.set(1)
     p.realize([10])
 
-    with assert_throws(hl.HalideError, r"Requirement Failed: \(false\)"):
+    with assert_throws(hl.HalideError, r"Requirement Failed: \(\(delta != 0\)\)"):
         delta.set(0)
         p.realize([10])
 
     with assert_throws(
-        hl.HalideError, r"Requirement Failed: \(false\) negative values are bad -1"
+        hl.HalideError,
+        r"Requirement Failed: \(\(delta > 0\)\) negative values are bad -1",
     ):
         delta.set(-1)
         p.realize([10])

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1283,7 +1283,7 @@ Expr unwrap_tags(const Expr &e) {
     return e;
 }
 
-Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args) {
+Expr requirement_failed_error(const Expr &condition, const std::vector<Expr> &args) {
     std::stringstream cond_str;
     cond_str << condition;
     return Call::make(Int(32),

--- a/src/IROperator.cpp
+++ b/src/IROperator.cpp
@@ -1284,9 +1284,11 @@ Expr unwrap_tags(const Expr &e) {
 }
 
 Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args) {
+    std::stringstream cond_str;
+    cond_str << condition;
     return Call::make(Int(32),
                       "halide_error_requirement_failed",
-                      {stringify({std::move(condition)}), combine_strings(args)},
+                      {cond_str.str(), combine_strings(args)},
                       Call::Extern);
 }
 

--- a/src/IROperator.h
+++ b/src/IROperator.h
@@ -411,7 +411,7 @@ inline HALIDE_NO_USER_CODE_INLINE void collect_print_args(std::vector<Expr> &arg
     collect_print_args(args, std::forward<Args>(more_args)...);
 }
 
-Expr requirement_failed_error(Expr condition, const std::vector<Expr> &args);
+Expr requirement_failed_error(const Expr &condition, const std::vector<Expr> &args);
 
 Expr memoize_tag_helper(Expr result, const std::vector<Expr> &cache_key_values);
 


### PR DESCRIPTION
Cherry picked from #9337.

A requirement that fails got simplified to `false` before being turned into a string.
This PR stringifies the Expr upon registering the requirement. This is way more meaningful than reading `false` at all times.

## Checklist

- [x] Tests added or updated (not required for docs, CI config, or typo fixes)
- [ ] Documentation updated (if public API changed)
- [ ] Python bindings updated (if public API changed)
- [ ] Benchmarks are included here if the change is intended to affect performance.
- [x] Commits include AI attribution where applicable (see Code of Conduct)
