### PR TITLE
Revert "verify serialized buffer before accessing it in the deserializer"

### DIFF
--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -1446,13 +1446,6 @@ Pipeline Deserializer::deserialize(std::istream &in) {
 }
 
 Pipeline Deserializer::deserialize(const std::vector<uint8_t> &data) {
-    // The accessors below chase offsets straight out of the buffer, so the
-    // buffer has to be structurally sound before we touch it. flatbuffers does
-    // not check that unless we ask; without this a malformed .hlpipe reads out
-    // of bounds (Finish() writes no file identifier, so verify without one).
-    flatbuffers::Verifier verifier(data.data(), data.size());
-    user_assert(verifier.VerifyBuffer<Serialize::Pipeline>())
-        << "malformed serialized pipeline: failed flatbuffer verification\n";
     const auto *pipeline_obj = Serialize::GetPipeline(data.data());
     if (pipeline_obj == nullptr) {
         user_warning << "deserialized pipeline is empty\n";
@@ -1580,9 +1573,6 @@ std::map<std::string, Parameter> Deserializer::deserialize_parameters(std::istre
 
 std::map<std::string, Parameter> Deserializer::deserialize_parameters(const std::vector<uint8_t> &data) {
     std::map<std::string, Parameter> external_parameters_by_name;
-    flatbuffers::Verifier verifier(data.data(), data.size());
-    user_assert(verifier.VerifyBuffer<Serialize::Pipeline>())
-        << "malformed serialized pipeline: failed flatbuffer verification\n";
     const auto *pipeline_obj = Serialize::GetPipeline(data.data());
     if (pipeline_obj == nullptr) {
         user_warning << "deserialized pipeline is empty\n";


### PR DESCRIPTION
Reverts halide/Halide#9395

Unfortunately the original PR didn't run on the one bot that tests serialization, and our round-trip testing shows that in a bunch of cases our flatbuffers fail to verify. This is obviously not a good thing, but we should temporarily revert this while figuring it out in order to keep CI green.