### PR TITLE
Raise flatbuffers verifier max_depth for pipeline deserialization

### DIFF
--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -1446,6 +1446,18 @@ Pipeline Deserializer::deserialize(std::istream &in) {
 }
 
 Pipeline Deserializer::deserialize(const std::vector<uint8_t> &data) {
+    // The accessors below chase offsets straight out of the buffer with no
+    // structural check unless we ask for one, so a malformed .hlpipe can read
+    // out of bounds (Finish() writes no file identifier, so verify without
+    // one). Each IR node is one flatbuffer table, and deserialize_stmt/
+    // deserialize_expr recurse to a depth matching the buffer's nesting, so
+    // max_depth is raised well past the default of 64 -- enough for deeply
+    // nested Exprs, but still a real bound on that recursion.
+    flatbuffers::Verifier::Options verifier_options;
+    verifier_options.max_depth = 1000;
+    flatbuffers::Verifier verifier(data.data(), data.size(), verifier_options);
+    user_assert(verifier.VerifyBuffer<Serialize::Pipeline>())
+        << "malformed serialized pipeline: failed flatbuffer verification\n";
     const auto *pipeline_obj = Serialize::GetPipeline(data.data());
     if (pipeline_obj == nullptr) {
         user_warning << "deserialized pipeline is empty\n";
@@ -1573,6 +1585,12 @@ std::map<std::string, Parameter> Deserializer::deserialize_parameters(std::istre
 
 std::map<std::string, Parameter> Deserializer::deserialize_parameters(const std::vector<uint8_t> &data) {
     std::map<std::string, Parameter> external_parameters_by_name;
+    // See the matching verifier in deserialize() above for why max_depth is raised.
+    flatbuffers::Verifier::Options verifier_options;
+    verifier_options.max_depth = 1000;
+    flatbuffers::Verifier verifier(data.data(), data.size(), verifier_options);
+    user_assert(verifier.VerifyBuffer<Serialize::Pipeline>())
+        << "malformed serialized pipeline: failed flatbuffer verification\n";
     const auto *pipeline_obj = Serialize::GetPipeline(data.data());
     if (pipeline_obj == nullptr) {
         user_warning << "deserialized pipeline is empty\n";

--- a/test/correctness/CMakeLists.txt
+++ b/test/correctness/CMakeLists.txt
@@ -314,6 +314,7 @@ tests(
     runtime_prefixes.cpp
     saturating_casts.cpp
     scatter.cpp
+    serialization.cpp
     set_custom_trace.cpp
     shadowed_bound.cpp
     shared_self_references.cpp
@@ -571,4 +572,5 @@ set_target_properties(
 if (WITH_SERIALIZATION)
     target_compile_definitions(correctness_streaming PRIVATE TEST_WITH_SERIALIZATION)
     target_compile_definitions(correctness_generator_cache PRIVATE TEST_WITH_SERIALIZATION)
+    target_compile_definitions(correctness_serialization PRIVATE TEST_WITH_SERIALIZATION)
 endif ()

--- a/test/correctness/serialization.cpp
+++ b/test/correctness/serialization.cpp
@@ -1,0 +1,92 @@
+#include "Halide.h"
+#include <cstdio>
+
+using namespace Halide;
+
+#ifdef TEST_WITH_SERIALIZATION
+
+#include <map>
+#include <vector>
+
+namespace {
+
+// A pipeline whose Expr tree nests deeper than flatbuffers::Verifier's
+// default max_depth (64), to make sure legitimate pipelines aren't rejected
+// by the verifier that guards deserialize().
+Pipeline make_deeply_nested_pipeline(Var x, Var y) {
+    Expr e = x + y;
+    for (int i = 0; i < 300; i++) {
+        e = e + i * (x - y);
+    }
+    Func f("deeply_nested");
+    f(x, y) = e;
+    return Pipeline(f);
+}
+
+}  // namespace
+
+int main() {
+    Var x("x"), y("y");
+
+    // A pipeline nested well past the verifier's default table-depth limit
+    // round-trips through serialize/deserialize without error.
+    {
+        Pipeline pipeline = make_deeply_nested_pipeline(x, y);
+
+        std::vector<uint8_t> data;
+        std::map<std::string, Parameter> params;
+        serialize_pipeline(pipeline, data, params);
+
+        Pipeline deserialized = deserialize_pipeline(data, params);
+        Buffer<int> result = deserialized.realize({4, 4});
+
+        Buffer<int> expected = pipeline.realize({4, 4});
+        for (int j = 0; j < 4; j++) {
+            for (int i = 0; i < 4; i++) {
+                if (result(i, j) != expected(i, j)) {
+                    printf("Mismatch at (%d, %d): expected %d, got %d\n",
+                           i, j, expected(i, j), result(i, j));
+                    return 1;
+                }
+            }
+        }
+    }
+
+    // A corrupted buffer is still rejected: raising max_depth must not
+    // disable the structural verification #9395 added.
+    {
+        Func f("f");
+        f(x, y) = x + y;
+
+        std::vector<uint8_t> data;
+        std::map<std::string, Parameter> params;
+        serialize_pipeline(Pipeline(f), data, params);
+
+        for (size_t i = data.size() / 2; i < data.size() / 2 + 32 && i < data.size(); i++) {
+            data[i] ^= 0xff;
+        }
+
+        bool rejected = false;
+        try {
+            deserialize_pipeline(data, params);
+        } catch (const Error &) {
+            rejected = true;
+        }
+        if (!rejected) {
+            printf("Deserializing a corrupted buffer should have thrown an error\n");
+            return 1;
+        }
+    }
+
+    printf("Success!\n");
+    return 0;
+}
+
+#else
+
+int main() {
+    printf("[SKIP] Halide was compiled without serialization support.\n");
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary

#9395 added flatbuffer verification before deserializing a pipeline, but used the verifier's default `max_depth` of 64. Each `Stmt`/`Expr` node serializes as one flatbuffer table, so any pipeline with a moderately deep expression nests past that and gets rejected as "malformed" even though it's valid. This is what broke the serialization round-trip CI bot (`arm-64 / coverage`, which only runs the roundtrip flag on push to `main`, not on PRs) and led to the revert in #9426.

This is a fix-forward: raise `max_depth` to 1000 at both verification call sites instead of leaving verification out entirely.

- Reproduced the exact CI failures from the `arm-64 / coverage` job logs: `correctness_align_bounds`, `correctness_code_explosion`, `correctness_integer_powers`, `correctness_loop_carry`, `correctness_lots_of_loop_invariants`, `correctness_many_inlined_selects` — all build a single Expr nested past depth 64 (e.g. summing 100+ loop invariants into one `Add` tree).
- 1000 is a judgment call, not a derived constant: comfortably above the deepest failing test (~200-400) and the coverage bot doesn't exercise apps/performance tests, so the deepest real pipelines are untested against this bound. It's also well within safe recursion depth for `deserialize_stmt`/`deserialize_expr`, which recurse to a depth matching the buffer's nesting.
- Verified a corrupted buffer is still rejected, so this doesn't disable the ASAN-motivated protection #9395 was added for — it only widens what counts as structurally valid.

## Test plan

- [x] Reproduced all 6 originally-failing correctness tests locally under `WITH_SERIALIZATION_JIT_ROUNDTRIP_TESTING`, confirmed they pass with this fix
- [x] Added `test/correctness/serialization.cpp`: round-trips a pipeline with an Expr nested past the old default depth, and confirms a corrupted buffer still throws
- [x] Confirmed the new test fails without the fix and passes with it
- [x] `correctness_streaming` and `correctness_generator_cache` (the existing tests that exercise real serialize/deserialize round-trips) still pass
- [x] `pre-commit run` passes on all changed files

Co-authored-by: nashit hayat <nashit@bugqore.com>
Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>