### PR TITLE
Fix win_amd64 pip CI: skip all free-threaded builds, not just cp314t

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -180,7 +180,7 @@ jobs:
           package-dir: python_bindings/halide
         env:
           CIBW_BUILD: "cp3*-${{ matrix.platform_tag }}"
-          CIBW_SKIP: "cp3{5,6,7,8,9}* cp314t-*"
+          CIBW_SKIP: "cp3{5,6,7,8,9}* cp3??t-*"
           CIBW_ENVIRONMENT_LINUX: >
             PIP_FIND_LINKS=/project/dist-bin
             SETUPTOOLS_SCM_OVERRIDES_FOR_HALIDE='{local_scheme="no-local-version"}'
@@ -290,7 +290,7 @@ jobs:
           package-dir: python_bindings/halide-runtime
         env:
           CIBW_BUILD: "cp3*-${{ matrix.platform_tag }}"
-          CIBW_SKIP: "cp3{5,6,7,8,9}* cp314t-*"
+          CIBW_SKIP: "cp3{5,6,7,8,9}* cp3??t-*"
           CIBW_ENVIRONMENT_LINUX: >
             PIP_FIND_LINKS=/project/dist-bin
             SETUPTOOLS_SCM_OVERRIDES_FOR_HALIDE_RUNTIME='{local_scheme="no-local-version"}'


### PR DESCRIPTION
## Summary
- `Build halide-runtime wheels for win_amd64` (and `Build Halide wheels for win_amd64`) started failing on 2026-08-31 after #9402 bumped cibuildwheel to 4.2.0, which added recognition of CPython 3.15's free-threaded `cp315t-win_amd64` build target.
- That target hits the same MSVC link failure previously seen on `cp314t-win_amd64` (`LINK1104: cannot open file 'python315.lib'`), since CMake's `FindPython`/pybind11 machinery probes for the non-`t` import lib name that doesn't exist for free-threaded interpreters.
- This was already fixed generically once, in #9298, by changing the skip pattern from the version-pinned `cp314t-*` to the version-agnostic `cp3??t-*`. However, #9272 (the halide-bin/halide/halide-runtime package split) branched before that fix landed, and its rewrite of `pip.yml` reintroduced the narrower `cp314t-*` pattern in both new jobs — silently regressing the fix until cibuildwheel 4.2.0 made `cp315t` buildable again.
- This PR restores `cp3??t-*` in both `CIBW_SKIP` lines so all free-threaded Windows variants are excluded regardless of Python version.

## Test plan
- [ ] CI: confirm `Build halide-runtime wheels for win_amd64` and `Build Halide wheels for win_amd64` pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)