### PR TITLE
Fix redundant IR re-traversal in LICM

### DIFF
--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -200,6 +200,12 @@ public:
 // The pass above can lift out the value of lets entirely, leaving
 // them as just renamings of other variables. Easier to substitute
 // them in as a post-pass rather than make the pass above more clever.
+//
+// Like LiftLoopInvariants above, this only needs to look at the lets
+// wrapping the current loop level: nested For loops get their own
+// SubstituteTrivialLets application when LICM's recursive descent
+// reaches them, so descending into them here too would just redo the
+// same substitution checks once per enclosing loop level.
 class SubstituteTrivialLets : public IRMutator {
 protected:
     using IRMutator::visit;
@@ -218,6 +224,10 @@ protected:
         } else {
             return IRMutator::visit(op);
         }
+    }
+
+    Stmt visit(const For *op) override {
+        return op;
     }
 };
 

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -153,23 +153,7 @@ protected:
         return visit_let(op);
     }
 
-    // The top-level For loop this instance was invoked on. Nested For
-    // loops are left alone here: LICM's own recursive descent (see
-    // LICM::visit(const For *) below) will construct a fresh
-    // LiftLoopInvariants for each of them. Descending into nested loops
-    // from here as well would redo the same (expensive: it simplifies
-    // and interns every lifted expr) work once per enclosing loop level,
-    // i.e. O(depth) times over the same nodes for deeply-nested loop
-    // nests. Invariants found this way still migrate all the way to
-    // their outermost legal loop, just one level per LICM recursion
-    // step instead of all at once.
-    bool at_top_level = true;
-
     Stmt visit(const For *op) override {
-        if (!at_top_level) {
-            return op;
-        }
-        at_top_level = false;
         ScopedBinding<> p(varying, op->name);
         return IRMutator::visit(op);
     }
@@ -200,12 +184,6 @@ public:
 // The pass above can lift out the value of lets entirely, leaving
 // them as just renamings of other variables. Easier to substitute
 // them in as a post-pass rather than make the pass above more clever.
-//
-// Like LiftLoopInvariants above, this only needs to look at the lets
-// wrapping the current loop level: nested For loops get their own
-// SubstituteTrivialLets application when LICM's recursive descent
-// reaches them, so descending into them here too would just redo the
-// same substitution checks once per enclosing loop level.
 class SubstituteTrivialLets : public IRMutator {
 protected:
     using IRMutator::visit;
@@ -224,10 +202,6 @@ protected:
         } else {
             return IRMutator::visit(op);
         }
-    }
-
-    Stmt visit(const For *op) override {
-        return op;
     }
 };
 

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -277,6 +277,18 @@ protected:
             // Lift invariants
             LiftLoopInvariants lifter;
             Stmt new_stmt = lifter(op);
+
+            if (lifter.lifted.empty()) {
+                // Nothing was lifted at this loop level, so all of the
+                // register-pressure-reduction bookkeeping below (which
+                // walks the entire loop body to collect variable names,
+                // regardless of whether there's anything to substitute)
+                // would be pure overhead. Just recurse.
+                const For *loop = new_stmt.as<For>();
+                internal_assert(loop);
+                return loop->with(loop->min, loop->max, mutate(loop->body));
+            }
+
             new_stmt = SubstituteTrivialLets()(new_stmt);
 
             // As an optimization to reduce register pressure, take

--- a/src/LICM.cpp
+++ b/src/LICM.cpp
@@ -153,7 +153,23 @@ protected:
         return visit_let(op);
     }
 
+    // The top-level For loop this instance was invoked on. Nested For
+    // loops are left alone here: LICM's own recursive descent (see
+    // LICM::visit(const For *) below) will construct a fresh
+    // LiftLoopInvariants for each of them. Descending into nested loops
+    // from here as well would redo the same (expensive: it simplifies
+    // and interns every lifted expr) work once per enclosing loop level,
+    // i.e. O(depth) times over the same nodes for deeply-nested loop
+    // nests. Invariants found this way still migrate all the way to
+    // their outermost legal loop, just one level per LICM recursion
+    // step instead of all at once.
+    bool at_top_level = true;
+
     Stmt visit(const For *op) override {
+        if (!at_top_level) {
+            return op;
+        }
+        at_top_level = false;
         ScopedBinding<> p(varying, op->name);
         return IRMutator::visit(op);
     }

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -121,6 +121,15 @@ public:
         timings.emplace_back(diff.count() * 1000, message);
     }
 
+    // For front-of-pipeline setup steps that run before there's an initial
+    // Stmt to pass to operator().
+    void mark_untimed_step(const string &message) {
+        auto t = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> diff = t - last_time;
+        last_time = t;
+        timings.emplace_back(diff.count() * 1000, message);
+    }
+
     ~LoweringLogger() {
         if (time_lowering_passes) {
             double total = 0.0;
@@ -147,28 +156,36 @@ void lower_impl(const vector<Function> &output_funcs,
                 Module &result_module) {
     size_t initial_lowered_function_count = result_module.functions().size();
 
+    // Timed from here so the front-of-pipeline setup steps below (which run
+    // before there's an initial Stmt to log) show up in HL_TIME_LOWERING_PASSES
+    // too, rather than being silently folded into process startup time.
+    LoweringLogger log;
+
     // Create a deep-copy of the entire graph of Funcs.
     auto [outputs, env] = deep_copy(output_funcs, build_environment(output_funcs));
+    log.mark_untimed_step("Lowering after deep-copying the Func graph");
 
     lower_target_query_ops(env, t);
 
     bool any_strict_float = strictify_float(env, t);
     result_module.set_any_strict_float(any_strict_float);
+    log.mark_untimed_step("Lowering after lowering target query ops and strictifying float");
 
     // Finalize all the LoopLevels
     for (auto &iter : env) {
         iter.second.lock_loop_levels();
     }
+    log.mark_untimed_step("Lowering after locking loop levels");
 
     // Compute a realization order and determine group of functions which loops
     // are to be fused together
     auto [order, fused_groups] = realization_order(outputs, env);
+    log.mark_untimed_step("Lowering after computing realization order");
 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions
     simplify_specializations(env);
-
-    LoweringLogger log;
+    log.mark_untimed_step("Lowering after simplifying specializations");
 
     debug(1) << "Creating initial loop nests...\n";
     bool any_memoized = false;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -123,7 +123,7 @@ public:
 
     // For front-of-pipeline setup steps that run before there's an initial
     // Stmt to pass to operator().
-    void mark_untimed_step(const string &message) {
+    void mark_step(const string &message) {
         auto t = std::chrono::high_resolution_clock::now();
         std::chrono::duration<double> diff = t - last_time;
         last_time = t;
@@ -163,29 +163,29 @@ void lower_impl(const vector<Function> &output_funcs,
 
     // Create a deep-copy of the entire graph of Funcs.
     auto [outputs, env] = deep_copy(output_funcs, build_environment(output_funcs));
-    log.mark_untimed_step("Lowering after deep-copying the Func graph");
+    log.mark_step("Lowering after deep-copying the Func graph");
 
     lower_target_query_ops(env, t);
 
     bool any_strict_float = strictify_float(env, t);
     result_module.set_any_strict_float(any_strict_float);
-    log.mark_untimed_step("Lowering after lowering target query ops and strictifying float");
+    log.mark_step("Lowering after lowering target query ops and strictifying float");
 
     // Finalize all the LoopLevels
     for (auto &iter : env) {
         iter.second.lock_loop_levels();
     }
-    log.mark_untimed_step("Lowering after locking loop levels");
+    log.mark_step("Lowering after locking loop levels");
 
     // Compute a realization order and determine group of functions which loops
     // are to be fused together
     auto [order, fused_groups] = realization_order(outputs, env);
-    log.mark_untimed_step("Lowering after computing realization order");
+    log.mark_step("Lowering after computing realization order");
 
     // Try to simplify the RHS/LHS of a function definition by propagating its
     // specializations' conditions
     simplify_specializations(env);
-    log.mark_untimed_step("Lowering after simplifying specializations");
+    log.mark_step("Lowering after simplifying specializations");
 
     debug(1) << "Creating initial loop nests...\n";
     bool any_memoized = false;

--- a/src/Lower.cpp
+++ b/src/Lower.cpp
@@ -379,6 +379,7 @@ void lower_impl(const vector<Function> &output_funcs,
 
     debug(1) << "Partitioning loops to simplify boundary conditions...\n";
     s = partition_loops(s);
+    log("Lowering after partitioning loops (partition_loops):", s);
     s = simplify(s);
     log("Lowering after partitioning loops:", s);
 
@@ -442,8 +443,11 @@ void lower_impl(const vector<Function> &output_funcs,
 
     debug(1) << "Removing dead allocations and moving loop invariant code...\n";
     s = remove_dead_allocations(s);
+    log("Lowering after removing dead allocations (remove_dead_allocations):", s);
     s = simplify(s);
+    log("Lowering after removing dead allocations (simplify):", s);
     s = hoist_loop_invariant_values(s);
+    log("Lowering after removing dead allocations (hoist_loop_invariant_values):", s);
     s = hoist_loop_invariant_if_statements(s);
     log("Lowering after removing dead allocations and hoisting loop invariants:", s);
 
@@ -457,6 +461,7 @@ void lower_impl(const vector<Function> &output_funcs,
     // Must be run after the last simplification, because it turns
     // divisions into shifts, which the simplifier reverses.
     s = simplify(s);
+    log("Lowering after finding intrinsics (simplify):", s);
     s = find_intrinsics(s);
     log("Lowering after finding intrinsics:", s);
 


### PR DESCRIPTION
## Summary
- `LICM::visit(For)` skips its register-pressure dedup bookkeeping (a full-body variable-collection walk plus a joint CSE pass) when nothing was actually lifted at that loop level -- previously this ran unconditionally even when there was nothing to substitute.
- Added finer-grained timing under the existing `HL_TIME_LOWERING_PASSES` instrumentation, splitting previously-bundled report lines (partition_loops+simplify, the pre-find_intrinsics simplify, the remove_dead_allocations/simplify/hoist_loop_invariant_* group) and timing front-of-pipeline setup steps, so the actual hot sub-step is visible instead of a coarse aggregate.

An earlier version of this PR also tried to stop `LiftLoopInvariants`/`SubstituteTrivialLets` from descending into nested `For` loops, to avoid redundantly re-walking/re-simplifying/re-interning the same subtree once per enclosing loop level. That change was **reverted**: it broke multi-level loop-invariant hoisting, since LICM's own recursion visits loops outer-to-inner and never revisits an outer loop after processing its interior -- an invariant found only inside a nested loop's body would get hoisted just one level and then stay trapped inside the enclosing loop forever, re-executing once per outer-loop iteration instead of once overall. This was caught by `correctness/loop_invariant_extern_calls` (a pure extern call nested inside an `x` loop within a parallel `y` loop was being called 32 times instead of being hoisted out of both loops down to 1 call).

## Motivation
Investigating lowering-time performance (excluding LLVM codegen) on `apps/lens_blur`, `HL_TIME_LOWERING_PASSES` pointed at `hoist_loop_invariant_values` as a disproportionately expensive line item.

## Correctness
Verified via a minimal harness calling `lens_blur` directly (pixel-checksum output is bit-identical before and after) and via `test/correctness/loop_invariant_extern_calls` plus related parallel/loop-carry/register-shuffle correctness tests, all passing.

## Performance
The remaining change (skip dedup bookkeeping when nothing was lifted) is a small, safe win, not a headline speedup -- most of the earlier measured improvement came from the now-reverted (and incorrect) recursion change. Filed as a correctness-preserving cleanup with useful new instrumentation for future lowering-performance investigation.