### PR TITLE
Constrain build-time numpy version to fix CI hash-mismatch and Python-version conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,14 @@ conflicts = [
     { package = "halide-workspace", group = "ci-llvm-21" },
   ],
 ]
-# numpy 2.4.6 only has piwheels ARM wheels locked; without this constraint uv
-# may pick it to satisfy ml-dtypes' build-time numpy requirement even on
-# platforms (e.g. linux-32) that need to build numpy from sdist, and then
-# fail hash verification against the ARM wheel's hash. numpy 2.4.2 has a full
-# sdist + wheel set locked for every platform.
-build-constraint-dependencies = ["numpy==2.4.2"]
+# numpy 2.4.6 and 2.5.2 only have piwheels ARM wheels locked; without this
+# constraint uv may pick one of them to satisfy ml-dtypes' build-time numpy
+# requirement even on platforms (e.g. linux-32) that need to build numpy from
+# sdist, and then fail hash verification against the ARM wheel's hash.
+# Excluding just those two lets uv fall back to whichever already
+# fully-locked numpy version (2.2.6 or 2.4.2, depending on Python version)
+# applies to the current platform.
+build-constraint-dependencies = ["numpy!=2.4.6,!=2.5.2"]
 
 # Package builds use build-backend hooks to resolve sibling requirements from
 # the SCM-derived version. Supplying the resolution metadata here lets uv resolve

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ conflicts = [
     { package = "halide-workspace", group = "ci-llvm-21" },
   ],
 ]
+# numpy 2.4.6 only has piwheels ARM wheels locked; without this constraint uv
+# may pick it to satisfy ml-dtypes' build-time numpy requirement even on
+# platforms (e.g. linux-32) that need to build numpy from sdist, and then
+# fail hash verification against the ARM wheel's hash. numpy 2.4.2 has a full
+# sdist + wheel set locked for every platform.
+build-constraint-dependencies = ["numpy==2.4.2"]
 
 # Package builds use build-backend hooks to resolve sibling requirements from
 # the SCM-derived version. Supplying the resolution metadata here lets uv resolve

--- a/uv.lock
+++ b/uv.lock
@@ -24,8 +24,8 @@ members = [
     "halide-workspace",
 ]
 build-constraints = [
-    { name = "numpy", marker = "platform_machine != 'armv7l' and platform_machine != 'armv8l'", specifier = "==2.4.2" },
-    { name = "numpy", marker = "platform_machine == 'armv7l' or platform_machine == 'armv8l'", specifier = "==2.4.2", index = "https://piwheels.org/simple" },
+    { name = "numpy", marker = "platform_machine != 'armv7l' and platform_machine != 'armv8l'", specifier = "!=2.4.6,!=2.5.2" },
+    { name = "numpy", marker = "platform_machine == 'armv7l' or platform_machine == 'armv8l'", specifier = "!=2.4.6,!=2.5.2", index = "https://piwheels.org/simple" },
 ]
 
 [[manifest.dependency-metadata]]

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,10 @@ members = [
     "halide-runtime",
     "halide-workspace",
 ]
+build-constraints = [
+    { name = "numpy", marker = "platform_machine != 'armv7l' and platform_machine != 'armv8l'", specifier = "==2.4.2" },
+    { name = "numpy", marker = "platform_machine == 'armv7l' or platform_machine == 'armv8l'", specifier = "==2.4.2", index = "https://piwheels.org/simple" },
+]
 
 [[manifest.dependency-metadata]]
 name = "halide"


### PR DESCRIPTION
## Summary

`linux-32` CI (`ci-llvm-main`/`22`/`21`) started failing with a `uv sync` error:

```
Failed to download and build `ml-dtypes==0.5.4`
  Failed to install requirements from `build-system.requires`
  Failed to download and build `numpy==2.4.6`
    Hash mismatch for `numpy==2.4.6`
```

Root cause: `numpy==2.4.6` (and `2.5.2`) only have piwheels **ARM** wheels recorded in `uv.lock` (they're only needed there via `platform_machine == 'armv7l'/'armv8l'` markers). Since `uv 0.12.11` ([changelog](https://github.com/astral-sh/uv/releases/tag/0.12.11): "Verify source archives against hashes recorded in `uv.lock` before reading their metadata or running their build backends"), when `uv` resolves `ml-dtypes`'s build-time `numpy` requirement on a platform with no native numpy wheel (`linux-32`/i686) and has to build numpy from its PyPI sdist, it validates that sdist against the *only* hash it has on file for that version — the ARM wheel's — which is a different artifact entirely. Hence the mismatch.

This isn't a numpy-side change (2.4.6 has been on PyPI since 2026-05-18, unchanged) and `uv.lock` itself hadn't changed since #9272 (2026-08-24) until this PR — bisecting merged PRs shows this passed through `uv 0.12.10` (2026-09-07) and started failing under `uv 0.12.12` (2026-09-10), bracketing the regression to `uv 0.12.11`.

Rather than pin the `uv` version (which would require every contributor to carefully track a specific `uv` release), this adds a `build-constraint-dependencies` entry under `[tool.uv]` excluding just the two ARM-only-locked numpy versions (`!=2.4.6,!=2.5.2`). This scope grew over the course of the PR:

- The first attempt used an exact `numpy==2.4.2` constraint. That fixed `linux-32` but broke `windows-32`, since that job runs Python 3.10.20 and `numpy==2.4.2` requires Python>=3.11 — the exact pin made `ml-dtypes`'s build-time `numpy` requirement unsatisfiable there.
- The current version excludes just the two problematic versions instead, so `uv` falls back to whichever already fully-locked numpy version applies for the current Python version (`2.2.6` for Python<3.11, `2.4.2` for Python>=3.11) on every affected platform, rather than forcing one specific version everywhere.

## Test plan

- [x] `uv lock` regenerates `uv.lock` deterministically with the new `build-constraints` entries (confirmed identical output when relocked under uv 0.12.5, 0.12.9, and 0.12.12)
- [x] `pre-commit run uv-lock` passes
- [x] `uv sync --frozen --group ci-base --no-install-workspace --python 3.10` locally resolves `numpy==2.2.6`
- [x] `uv sync --frozen --group ci-llvm-main --no-install-workspace --python 3.11` and `--python 3.13` locally resolve `numpy==2.4.2`
- [ ] CI green on `linux-32` and `windows-32` for `ci-llvm-main`/`22`/`21` (can't reproduce the i686/win32 sdist-build paths locally on macOS/ARM to verify directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)