### PR TITLE
Reject failed generator-cache output replacement

### DIFF
--- a/src/GeneratorCache.cpp
+++ b/src/GeneratorCache.cpp
@@ -637,6 +637,14 @@ bool GeneratorCache::try_restore(const std::string &key,
         if (ec) {
             // Fall back to a copy if rename across the tmp/dest pair failed.
             fs::copy_file(p.first, p.second, fs::copy_options::overwrite_existing, ec);
+            if (ec) {
+                const std::string message = ec.message();
+                for (const auto &pending_file : pending) {
+                    fs::remove(pending_file.first, ec);
+                }
+                user_error << "GeneratorCache: failed to restore " << p.second.string()
+                           << ": " << message << "\n";
+            }
             fs::remove(p.first, ec);
         }
     }

--- a/src/GeneratorCache.h
+++ b/src/GeneratorCache.h
@@ -79,8 +79,9 @@ struct GeneratorCache {
 
     /** If a complete entry for `key` exists in the cache, copy each cached
      * file into the destination path given by `output_files` and return
-     * true. Otherwise leave the filesystem untouched and return false. A
-     * partial or corrupt entry is treated as a miss. */
+     * true only if all outputs were restored. An output replacement failure
+     * is reported as a user error; some outputs may already have been replaced.
+     * A partial or corrupt entry is treated as a miss. */
     static bool try_restore(const std::string &key,
                             const std::map<OutputFileType, std::string> &output_files);
 

--- a/test/correctness/generator_cache.cpp
+++ b/test/correctness/generator_cache.cpp
@@ -162,6 +162,25 @@ int main(int argc, char **argv) {
     check(read_all(obj_c) != sentinel);
     check(read_all(obj_c) != real_obj);
 
+    // A complete cache entry is not a hit if its output cannot be replaced.
+    // A nonempty directory blocks both rename and copy on every platform,
+    // including when the test runs with permission to write read-only files.
+    const fs::path blocked_dir = tmp / "blocked";
+    const fs::path blocked_obj = blocked_dir / ("cache_add" + obj_ext);
+    fs::create_directories(blocked_obj);
+    { std::ofstream marker(blocked_obj / "keep"); }
+    const int blocked_status = Internal::run_process(
+        {self, "--gen", blocked_dir.string(), "2"});
+    check(blocked_status != 0);
+    check(fs::exists(blocked_obj / "keep"));
+    check(!fs::exists(blocked_obj.string() + ".hlcache.tmp"));
+    check(!fs::exists((blocked_dir / "cache_add.h").string() + ".hlcache.tmp"));
+
+    // Once the obstruction is removed, the cached implementation restores.
+    fs::remove_all(blocked_obj);
+    check(Internal::run_process({self, "--gen", blocked_dir.string(), "2"}) == 0);
+    check(read_all(blocked_obj) == read_all(obj_c));
+
     // 4. Corrupt every cache entry (drop manifests): the next offset=1 run must
     //    treat the entry as a miss and recompile the real object.
     for (const auto &e : fs::recursive_directory_iterator(entries)) {

--- a/test/correctness/generator_cache.cpp
+++ b/test/correctness/generator_cache.cpp
@@ -51,7 +51,16 @@ int generate_one(const std::string &outdir, const std::string &offset) {
     args.targets = {get_host_target()};
     args.generator_name = "cache_add";
     args.generator_params = {{"offset", offset}};
-    Internal::execute_generator(args);
+#ifdef HALIDE_WITH_EXCEPTIONS
+    try {
+#endif
+        Internal::execute_generator(args);
+#ifdef HALIDE_WITH_EXCEPTIONS
+    } catch (const CompileError &e) {
+        std::cerr << e.what();
+        return 1;
+    }
+#endif
     return 0;
 }
 


### PR DESCRIPTION
Fixes #9437.

A cache hit can currently leave an older pipeline's output on disk and still return success. When rename fails, `try_restore` does not check whether its fallback copy succeeded.

We investigated this after a Windows OpenCL AOT build appeared to keep an earlier implementation despite rebuilding the generator, prompting us to disable semantic caching. This reproducer demonstrates a mechanism that can produce that symptom; it does not establish the cause of the original incident.

Check that copy, preserve the error message, clean pending temporary files, and fail the generator before it can report a hit. Successful rename and copy-fallback restores retain their behavior; cache keys and the cache format are unchanged. The existing correctness test gains a nonempty-directory obstruction and verifies restoration after removing it.

The [standalone CPU reproducer](https://gist.github.com/gregcotten/8a7b98e6553089c5b3dda037b6d0cb14) demonstrates the bug with Windows sharing locks. The same shared restore defect was also reproduced on macOS with an immutable archive.

Local Windows verification before rebasing: a **full shared Halide build** passed `correctness_generator_cache`, `correctness_compile_to`, and `correctness_compile_to_multitarget`. The normal CMake `test/integration/cache` project passes both its generated-code execution test and cache-population check. The standalone reproducer against that full DLL reports nonzero status and no hit for locked objects/archives, then restores the requested bytes after unlocking. Successful control objects and archives are byte-identical to the original wheel's controls.

The new regression also fails against the original `halide-bin==22.0.0.dev390` wheel. Earlier focused-fixture checks cover temporary-file cleanup and successful copy fallback. `clang-format` 21.1.8 and `git diff --check` pass. Full-build environment: Windows x64, C++20, MSVC 19.42 compiler, isolated 14.44 linker/CRT libraries, Windows SDK 10.0.22621.0, LLVM 22.1.8, serialization enabled. The newer link libraries are needed by the LLVM binary distribution; no installed toolchain was modified.

**Remaining validation:** static Halide linkage and patched macOS/Linux runs have not been tested locally. The branch includes #9436; CI and coverage results for the updated head are pending.

An output replacement failure is reported as a user error rather than a cache miss. Recompilation is not a reliable recovery in the presence of the separate Windows COFF archive writer defect in #9439, which ignores stream errors. Its producer-side fix is proposed in #9440. This PR handles restoration of an existing cache entry; #9440 handles fresh archive generation. The two fixes have been tested independently and together.

The test child reports `CompileError` as a nonzero exit so expected failures retain coverage profiles. Instrumented Windows verification confirmed that the failing child's profile was previously lost and is now written, while all cache checks still pass. This changes only the test harness; production error handling is unchanged.
