### PR TITLE
Warn instead of erroring on asserts inside GPU kernels (Metal, Vulkan)

### DIFF
--- a/src/CodeGen_Metal_Dev.cpp
+++ b/src/CodeGen_Metal_Dev.cpp
@@ -142,6 +142,7 @@ protected:
         void visit(const Cast *op) override;
         void visit(const VectorReduce *op) override;
         void visit(const Atomic *op) override;
+        void visit(const AssertStmt *op) override;
         void visit(const FloatImm *op) override;
     };
 
@@ -593,6 +594,10 @@ void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const Atomic *op) {
     // It might be possible to support atomic but this is not trivial.
     // Metal requires atomic data types to be wrapped in an atomic integer data type.
     user_assert(false) << "Atomic updates are not supported inside Metal kernels";
+}
+
+void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const AssertStmt *op) {
+    user_warning << "Ignoring assertion inside Metal kernel: " << op->condition << "\n";
 }
 
 void CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const FloatImm *op) {

--- a/src/CodeGen_Vulkan_Dev.cpp
+++ b/src/CodeGen_Vulkan_Dev.cpp
@@ -1682,6 +1682,7 @@ void CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(const AssertStmt *stmt) {
     debug(2) << "CodeGen_Vulkan_Dev::SPIRV_Emitter::visit(AssertStmt): "
              << "condition=" << stmt->condition << " "
              << "message=" << stmt->message << "\n";
+    user_warning << "Ignoring assertion inside Vulkan kernel: " << stmt->condition << "\n";
 }
 
 namespace {

--- a/test/warning/CMakeLists.txt
+++ b/test/warning/CMakeLists.txt
@@ -2,6 +2,7 @@ tests(
     GROUPS warning
     SOURCES
     hidden_pure_definition.cpp
+    metal_assertion_in_kernel.cpp
     require_const_false.cpp
     sliding_vectors.cpp
     unscheduled_update_def.cpp

--- a/test/warning/metal_assertion_in_kernel.cpp
+++ b/test/warning/metal_assertion_in_kernel.cpp
@@ -1,0 +1,30 @@
+#include "Halide.h"
+
+using namespace Halide;
+
+int main(int argc, char **argv) {
+    // This mirrors test/correctness/gpu_assertion_in_kernel.cpp: unrolling a
+    // bounded Var that is compute_at'd inside a GPU loop causes a
+    // bounds-safety assertion to be emitted inside the device kernel body.
+    //
+    // Assertions cannot be represented inside a Metal kernel, so the Metal
+    // backend should warn and drop the assertion (like the OpenCL backend
+    // does), instead of emitting Metal source that fails to compile.
+    Func f, g;
+    Var c, x, xi;
+    f(c, x) = x + c + 3;
+    f.bound(c, 0, 3).unroll(c);
+
+    g(c, x) = f(c, x) * 8;
+
+    g.gpu_tile(x, xi, 8);
+    f.compute_at(g, x).gpu_threads(x);
+
+    Target t = get_jit_target_from_environment();
+    t.set_feature(Target::Metal);
+
+    g.compile_to_module(g.infer_arguments(), "g", t);
+
+    printf("Success!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- The Metal backend fell through to `CodeGen_C`'s generic `AssertStmt` handling, which emits `return <error code>;` inside the kernel body. Metal kernel entry points can't return a value, so this either failed to compile as Metal source or hit an internal_assert in `CodeGen_GPU_Dev.cpp` when codegen tried to lower the error-reporting call for the device.
- Fixed by adding `CodeGen_Metal_Dev::CodeGen_Metal_C::visit(const AssertStmt*)` that warns and drops the assertion, matching the existing OpenCL backend behavior.
- Applied the same fix to the Vulkan backend (`CodeGen_Vulkan_Dev.cpp`), which silently dropped assertions without warning the user.

Fixes #9444.

## Test plan
- [x] Added `test/warning/metal_assertion_in_kernel.cpp`, which triggers a bounds-safety assertion inside a Metal-targeted GPU kernel and checks for the `Warning:` line.
- [x] Verified the test crashes with an internal error on the pre-fix code and passes with the fix.
- [x] `clang-format --dry-run --Werror` and `pre-commit` checks pass on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)