### PR TITLE
Deprecate TailStrategy::Predicate in favor of GuardWithIf

### DIFF
--- a/apps/hannk/halide/depthwise_conv_generator.cpp
+++ b/apps/hannk/halide/depthwise_conv_generator.cpp
@@ -261,7 +261,7 @@ public:
         const int vector_size = natural_vector_size<uint8_t>();
 
         output_.compute_root()
-            .vectorize(c, vector_size, TailStrategy::Predicate);
+            .vectorize(c, vector_size, TailStrategy::GuardWithIf);
 
         output_.specialize(factor_ == 8);
         // In this case, we should be reading scalars and broadcasting them.

--- a/apps/hannk/halide/elementwise_generator.cpp
+++ b/apps/hannk/halide/elementwise_generator.cpp
@@ -42,7 +42,7 @@ public:
         const int vector_size = natural_vector_size<uint8_t>();
 
         output_.compute_root()
-            .vectorize(x, vector_size * 2, TailStrategy::Predicate);
+            .vectorize(x, vector_size * 2, TailStrategy::GuardWithIf);
 
         // Support broadcasting in the c dimension for either input.
         input1_.dim(0).set_stride(Expr());
@@ -90,7 +90,7 @@ public:
         const int vector_size = natural_vector_size<uint8_t>();
 
         output_.compute_root()
-            .vectorize(x, vector_size * 2, TailStrategy::Predicate);
+            .vectorize(x, vector_size * 2, TailStrategy::GuardWithIf);
 
         // Support broadcasting in the c dimension for either input.
         input1_.dim(0).set_stride(Expr());
@@ -201,7 +201,7 @@ public:
 
         // Schedule.
         output_.compute_root()
-            .vectorize(x, natural_vector_size<uint8_t>(), TailStrategy::Predicate);
+            .vectorize(x, natural_vector_size<uint8_t>(), TailStrategy::GuardWithIf);
 
         // Only allow this many instructions per input, so we can store scratch
         // on the real stack. This is a lame heuristic.

--- a/apps/hannk/halide/normalizations_generator.cpp
+++ b/apps/hannk/halide/normalizations_generator.cpp
@@ -40,7 +40,7 @@ public:
         const int vector_size = natural_vector_size<uint8_t>();
 
         output_.compute_root()
-            .vectorize(x, vector_size, TailStrategy::Predicate);
+            .vectorize(x, vector_size, TailStrategy::GuardWithIf);
 
         inv_sqrt.compute_at(output_, y);
 
@@ -118,7 +118,7 @@ public:
         // Schedule.
         const int vector_size = natural_vector_size<uint8_t>();
 
-        output_.vectorize(x, vector_size, TailStrategy::Predicate);
+        output_.vectorize(x, vector_size, TailStrategy::GuardWithIf);
 
         max_x.compute_at(output_, y)
             .update()

--- a/python_bindings/halide/src/halide_/PyEnums.cpp
+++ b/python_bindings/halide/src/halide_/PyEnums.cpp
@@ -72,16 +72,27 @@ void define_enums(py::module &m) {
         .value("Text", StmtOutputFormat::Text)
         .value("HTML", StmtOutputFormat::HTML);
 
-    py::enum_<TailStrategy>(m, "TailStrategy")
+    py::enum_<TailStrategy> tail_strategy(m, "TailStrategy");
+    tail_strategy
         .value("RoundUp", TailStrategy::RoundUp)
         .value("GuardWithIf", TailStrategy::GuardWithIf)
-        .value("Predicate", TailStrategy::Predicate)
         .value("PredicateLoads", TailStrategy::PredicateLoads)
         .value("PredicateStores", TailStrategy::PredicateStores)
         .value("ShiftInwards", TailStrategy::ShiftInwards)
         .value("ShiftInwardsAndBlend", TailStrategy::ShiftInwardsAndBlend)
         .value("RoundUpAndBlend", TailStrategy::RoundUpAndBlend)
         .value("Auto", TailStrategy::Auto);
+
+    // Predicate is deprecated in C++ (identical to GuardWithIf), but the
+    // Python binding is kept for one release for backwards compatibility.
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    tail_strategy.value("Predicate", TailStrategy::Predicate);
+#if defined(__clang__) || defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     py::enum_<Target::OS>(m, "TargetOS")
         .value("OSUnknown", Target::OS::OSUnknown)

--- a/src/ApplySplit.cpp
+++ b/src/ApplySplit.cpp
@@ -51,7 +51,6 @@ vector<ApplySplitResult> apply_split(const Split &split, const string &prefix,
             // The split factor trivially divides the old extent,
             // but we know nothing new about the outer dimension.
         } else if (tail == TailStrategy::GuardWithIf ||
-                   tail == TailStrategy::Predicate ||
                    tail == TailStrategy::PredicateLoads ||
                    tail == TailStrategy::PredicateStores) {
             // It's an exact split but we failed to prove that the
@@ -72,12 +71,6 @@ vector<ApplySplitResult> apply_split(const Split &split, const string &prefix,
             ApplySplitResult::Type predicate_type, substitution_type;
             switch (tail) {
             case TailStrategy::GuardWithIf:
-                substitution_type = ApplySplitResult::Substitution;
-                predicate_type = ApplySplitResult::Predicate;
-                break;
-            case TailStrategy::Predicate:
-                // This is identical to GuardWithIf, but maybe it makes
-                // sense to keep it anyways?
                 substitution_type = ApplySplitResult::Substitution;
                 predicate_type = ApplySplitResult::Predicate;
                 break;

--- a/src/Deserialization.cpp
+++ b/src/Deserialization.cpp
@@ -345,7 +345,9 @@ TailStrategy Deserializer::deserialize_tail_strategy(Serialize::TailStrategy tai
     case Serialize::TailStrategy::GuardWithIf:
         return TailStrategy::GuardWithIf;
     case Serialize::TailStrategy::Predicate:
-        return TailStrategy::Predicate;
+        // Predicate is deprecated and identical to GuardWithIf; old
+        // serialized pipelines that used it deserialize to GuardWithIf.
+        return TailStrategy::GuardWithIf;
     case Serialize::TailStrategy::PredicateLoads:
         return TailStrategy::PredicateLoads;
     case Serialize::TailStrategy::PredicateStores:

--- a/src/Func.cpp
+++ b/src/Func.cpp
@@ -1325,9 +1325,9 @@ void Stage::split(const string &old, const string &outer, const string &inner, c
     }
 
     if (exact) {
-        user_assert(tail == TailStrategy::GuardWithIf || tail == TailStrategy::Predicate)
+        user_assert(tail == TailStrategy::GuardWithIf)
             << "When splitting Var " << old_name
-            << " the tail strategy must be GuardWithIf, Predicate, or Auto. "
+            << " the tail strategy must be GuardWithIf or Auto. "
             << "Anything else may change the meaning of the algorithm\n";
     }
 

--- a/src/IRPrinter.cpp
+++ b/src/IRPrinter.cpp
@@ -187,9 +187,6 @@ std::ostream &operator<<(std::ostream &out, const TailStrategy &t) {
     case TailStrategy::GuardWithIf:
         out << "GuardWithIf";
         break;
-    case TailStrategy::Predicate:
-        out << "Predicate";
-        break;
     case TailStrategy::PredicateLoads:
         out << "PredicateLoads";
         break;

--- a/src/Schedule.h
+++ b/src/Schedule.h
@@ -51,14 +51,9 @@ enum class TailStrategy {
      * case to handle the if statement. */
     GuardWithIf,
 
-    /** Guard the loads and stores in the loop with an if statement
-     * that prevents evaluation beyond the original extent. Always
-     * legal. The if statement is treated like a boundary condition,
-     * and factored out into a loop epilogue if possible.
-     * Pros: no redundant re-evaluation; does not constrain input or
-     * output sizes. Cons: increases code size due to separate
-     * tail-case handling. */
-    Predicate,
+    /** Identical to GuardWithIf. Kept only for backwards
+     * compatibility; use GuardWithIf instead. */
+    Predicate [[deprecated("Use TailStrategy::GuardWithIf instead. TailStrategy::Predicate is identical to it and will be removed in a future release.")]] = GuardWithIf,
 
     /** Guard the loads in the loop with an if statement that
      * prevents evaluation beyond the original extent. Only legal

--- a/src/Serialization.cpp
+++ b/src/Serialization.cpp
@@ -314,8 +314,6 @@ Serialize::TailStrategy Serializer::serialize_tail_strategy(const TailStrategy &
         return Serialize::TailStrategy::RoundUp;
     case TailStrategy::GuardWithIf:
         return Serialize::TailStrategy::GuardWithIf;
-    case TailStrategy::Predicate:
-        return Serialize::TailStrategy::Predicate;
     case TailStrategy::PredicateLoads:
         return Serialize::TailStrategy::PredicateLoads;
     case TailStrategy::PredicateStores:

--- a/test/correctness/force_onto_stack.cpp
+++ b/test/correctness/force_onto_stack.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf, TailStrategy::Predicate, TailStrategy::PredicateLoads}) {
+    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf, TailStrategy::PredicateLoads}) {
         // Another way in which a larger static allocation is
         // preferable to a smaller dynamic one is when you compute
         // something at a split guarded by an if. In the very last

--- a/test/correctness/fuzz_schedule.cpp
+++ b/test/correctness/fuzz_schedule.cpp
@@ -45,8 +45,8 @@ int main(int argc, char **argv) {
         local_sum(x, y) += input(x + r.x, y + r.y);
         blurry(x, y) = cast<int32_t>(local_sum(x, y) / 25);
         Var yo("yo"), yi("yi"), xo("xo"), xi("xi"), yo_x_f("yo_x_f"), yo_x_fo("yo_x_fo"), yo_x_fi("yo_x_fi");
-        blurry.split(y, yo, yi, 2, TailStrategy::RoundUp).fuse(yo, x, yo_x_f).vectorize(yi).split(yo_x_f, yo_x_fo, yo_x_fi, 2, TailStrategy::Predicate).reorder(yo_x_fo, yo_x_fi, yi);
-        input.split(y, yo, yi, 2, TailStrategy::PredicateStores).fuse(yo, x, yo_x_f).vectorize(yi).split(yo_x_f, yo_x_fo, yo_x_fi, 2, TailStrategy::Predicate).reorder(yo_x_fo, yo_x_fi, yi);
+        blurry.split(y, yo, yi, 2, TailStrategy::RoundUp).fuse(yo, x, yo_x_f).vectorize(yi).split(yo_x_f, yo_x_fo, yo_x_fi, 2, TailStrategy::GuardWithIf).reorder(yo_x_fo, yo_x_fi, yi);
+        input.split(y, yo, yi, 2, TailStrategy::PredicateStores).fuse(yo, x, yo_x_f).vectorize(yi).split(yo_x_f, yo_x_fo, yo_x_fi, 2, TailStrategy::GuardWithIf).reorder(yo_x_fo, yo_x_fi, yi);
         blurry.store_root();
         input.compute_at(blurry, yi);
         Pipeline p({blurry});
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
         local_sum(x, y) = 0;
         local_sum(x, y) += input(x + r.x, y + r.y);
         blurry(x, y) = cast<int32_t>(local_sum(x, y) / 25);
-        local_sum.split(y, yi, yo, 2, TailStrategy::GuardWithIf).split(x, xi, xo, 5, TailStrategy::Predicate).fuse(yo, xi, yofxi).split(yofxi, yofxio, yofxii, 8, TailStrategy::ShiftInwards).fuse(yofxii, yi, yofxiifyi).split(yofxio, yofxioo, yofxioi, 5, TailStrategy::ShiftInwards).vectorize(yofxiifyi).vectorize(yofxioi);
+        local_sum.split(y, yi, yo, 2, TailStrategy::GuardWithIf).split(x, xi, xo, 5, TailStrategy::GuardWithIf).fuse(yo, xi, yofxi).split(yofxi, yofxio, yofxii, 8, TailStrategy::ShiftInwards).fuse(yofxii, yi, yofxiifyi).split(yofxio, yofxioo, yofxioi, 5, TailStrategy::ShiftInwards).vectorize(yofxiifyi).vectorize(yofxioi);
         local_sum.update(0).unscheduled();
         blurry.split(x, xo, xi, 5, TailStrategy::Auto);
         Pipeline p({blurry});

--- a/test/correctness/gpu_async_copy_errors.cpp
+++ b/test/correctness/gpu_async_copy_errors.cpp
@@ -125,7 +125,7 @@ void scenario_predicated() {
         .store_in(MemoryType::GPUSharedAsync)
         .align_storage(x, 4)
         .gpu_threads(y)
-        .vectorize(x, 4, TailStrategy::Predicate);
+        .vectorize(x, 4, TailStrategy::GuardWithIf);
     out.compile_jit(async_target());
 }
 

--- a/test/correctness/multi_splits_with_diff_tail_strategies.cpp
+++ b/test/correctness/multi_splits_with_diff_tail_strategies.cpp
@@ -7,7 +7,7 @@ int main(int argc, char **argv) {
     // ApplySplit should respect the order of the application of substitutions/
     // predicates/lets; otherwise, this combination of tail strategies will
     // cause an access out of bound error.
-    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf, TailStrategy::Predicate, TailStrategy::PredicateLoads}) {
+    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf, TailStrategy::PredicateLoads}) {
         Func f("f"), input("input");
         Var x("x"), y("y"), c("c");
 

--- a/test/correctness/predicated_store_load.cpp
+++ b/test/correctness/predicated_store_load.cpp
@@ -70,7 +70,7 @@ public:
 
 int predicated_tail_test(const Target &t) {
     int size = 73;
-    for (auto i : {TailStrategy::Predicate, TailStrategy::PredicateLoads, TailStrategy::PredicateStores}) {
+    for (auto i : {TailStrategy::GuardWithIf, TailStrategy::PredicateLoads, TailStrategy::PredicateStores}) {
         Var x("x"), y("y");
         Func f("f"), g("g");
 
@@ -120,7 +120,7 @@ int predicated_tail_with_scalar_test(const Target &t) {
     f(x, y) = x + g(0);
 
     g.compute_at(f, y);
-    f.vectorize(x, 32, TailStrategy::Predicate);
+    f.vectorize(x, 32, TailStrategy::GuardWithIf);
     if (t.has_feature(Target::HVX)) {
         f.hexagon();
     }
@@ -181,7 +181,7 @@ int vectorized_dense_load_with_stride_minus_one_test(const Target &t) {
 
     f(x, y) = select(x < 23, g(size - x, y) * 2 + g(20 - x, y), undef<int>());
 
-    f.vectorize(x, 32, TailStrategy::Predicate);
+    f.vectorize(x, 32, TailStrategy::GuardWithIf);
     if (t.has_feature(Target::HVX)) {
         f.hexagon();
     }

--- a/test/correctness/transpose_idioms.cpp
+++ b/test/correctness/transpose_idioms.cpp
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
 
                 g
                     .never_partition(x, y)
-                    .split(x, x, xi, 13, TailStrategy::Predicate)
+                    .split(x, x, xi, 13, TailStrategy::GuardWithIf)
                     .split(y, y, yi, 11, TailStrategy::ShiftInwards)
                     .reorder(xi, yi, x, y)
                     .vectorize(xi)
@@ -216,7 +216,7 @@ int main(int argc, char **argv) {
             g
                 .never_partition(x, y)
                 .split(x, x, xi, 13, TailStrategy::ShiftInwards)
-                .split(y, y, yi, 11, TailStrategy::Predicate)
+                .split(y, y, yi, 11, TailStrategy::GuardWithIf)
                 .reorder(yi, xi, x, y)
                 .vectorize(xi)
                 .vectorize(yi);

--- a/test/correctness/vectorize_guard_with_if.cpp
+++ b/test/correctness/vectorize_guard_with_if.cpp
@@ -16,7 +16,7 @@ int my_trace(JITUserContext *user_context, const halide_trace_event_t *e) {
 }
 
 int main(int argc, char **argv) {
-    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf, TailStrategy::Predicate}) {
+    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf}) {
         Func f;
         Var x;
 
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
         }
     }
 
-    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf, TailStrategy::Predicate}) {
+    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf}) {
         const int w = 98, v = 8;
 
         Buffer<int> b(w / 2);

--- a/test/correctness/vectorize_nested.cpp
+++ b/test/correctness/vectorize_nested.cpp
@@ -30,7 +30,7 @@ int vectorize_2d_round_up() {
 }
 
 int vectorize_2d_guard_with_if_and_predicate() {
-    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf, TailStrategy::Predicate}) {
+    for (TailStrategy tail_strategy : {TailStrategy::GuardWithIf}) {
         const int width = 33;
         const int height = 22;
 


### PR DESCRIPTION
## Summary

First step of the deprecation plan in #9443:

- `TailStrategy::Predicate` now shares the same underlying enum value as `TailStrategy::GuardWithIf` (they have been behaviorally identical in `ApplySplit.cpp` for a while) and is marked `[[deprecated]]`.
- Switch statements over `TailStrategy` (`ApplySplit.cpp`, `IRPrinter.cpp`, `Serialization.cpp`) no longer need a separate `case` for `Predicate`, since it now compiles to the same value as `GuardWithIf`.
- `Deserialization.cpp` maps old serialized `Predicate` pipelines to `GuardWithIf` directly, without referencing the deprecated identifier.
- `Func.cpp`'s exact-split legality check is simplified accordingly.
- The Python binding keeps exposing `TailStrategy.Predicate` for this release (with the deprecation warning locally suppressed), per the plan to remove it for real only in the release after next.
- Updated the internal uses of `TailStrategy::Predicate` in a handful of tests and the hannk app to use `GuardWithIf` instead, so the codebase doesn't trigger its own new deprecation warning.

Closes #9443 (partially — the follow-up release will remove `Predicate` entirely).

## Test plan

- [x] `libHalide` builds clean (no warnings) with these changes
- [x] `Serialization.cpp`, `Deserialization.cpp`, and `PyEnums.cpp` individually syntax-checked with `-Wdeprecated-declarations`: none triggered
- [x] All touched test/app files compile
- [x] `clang-format --dry-run --Werror` clean on all touched files
- [x] `pre-commit run --all-files` passed on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)