### PR TITLE
Add Claude skills for writing and verifying simplifier rules

### DIFF
--- a/.claude/skills/simplifier-rules/SKILL.md
+++ b/.claude/skills/simplifier-rules/SKILL.md
@@ -1,0 +1,129 @@
+---
+description: Discover new simplifier rules to further simplify Expr when needed.
+---
+
+You are an expert Halide Expr simplifier. Your task is to figure out correct simplification rewrite
+rules.
+
+You produce rules in the form of:
+
+```cpp
+rewrite(original_expr, rewritten_expr, optional_predicate) ||
+```
+or
+```cpp
+rewrite(original_expr, rewritten_expr) ||
+```
+
+Where you can make use of IRMatch wildcards x, y, z for general expressions, and c0, c1, c2, c3, c4,
+c5 for constants.
+
+## What makes a rule valid
+
+**It must be true.** Non-negotiable, and the only property that holds in every context. Everything
+else below is about where the rule may live and whether it terminates.
+
+**It must obey the reduction order.** The rewrite must make the expression strictly smaller under the
+ordering below. This is what stops the fixed-point rewriter from rewriting in circles forever. The one
+exception is `SimplifyCorrelatedDifferences.cpp`, which is a single bottom-up pass rather than a
+fixed-point rewriter, and is explicitly allowed to *increase* expression size and to ignore the
+reduction order — its purpose is not to simplify but to produce forms whose bounds are easier to infer.
+
+**The RHS must be in Halide's canonical form.** The second argument to `rewrite()` has to look the way
+the simplifier itself would leave it.
+
+**Every wildcard on the RHS must be bound by the LHS.** A rule whose RHS mentions a variable the LHS
+never matches is an "implicit rule" and is rejected. The same goes for constant wildcards appearing on
+the RHS that the LHS never binds.
+
+**Placement follows the root IR node.** Every Expr belongs in exactly one `Simplify_xxx.cpp`, chosen
+by the node at the root of the LHS: a `Sub` at the root belongs in `Simplify_Sub.cpp`, a `Min` in
+`Simplify_Min.cpp`, and so on.
+
+**Commutative variants are not free.** The matcher does not match commutatively, so each operand
+ordering you care about must be written out as its own rule, even though they are the same identity.
+
+**It must not be subsumed.** If a more general rule already in the same file matches everything yours
+does, and its predicate covers yours, yours is redundant ("too specific"). An exact duplicate LHS with
+an identical predicate is likewise dropped. The exception is again
+`SimplifyCorrelatedDifferences.cpp`, where the non-commutative matcher means each ordering is needed
+even though they are logically equivalent.
+
+**Decide the overflow regime.** Assess whether the rule is valid under defined-behavior
+two's-complement (wrapping) ints, or whether it holds only when overflow cannot happen — the latter
+belongs in the `no_overflow()` guarded sections. Do not assume; this is checked explicitly during
+verification (see below). Note also that Halide's integer division with a positive denominator rounds
+towards negative infinity, and modulo is Euclidean: `0 <= a%b < |b|`.
+
+**Keep the rule verifiable.** Casts between widths are not modelled, so a rule mixing types comes back
+*unverifiable* rather than proved. So does a rule using an intrinsic the SMT conversion does not know.
+Prefer formulations that stay inside one type and use ordinary operators.
+
+## The reduction order, precisely
+
+The verifier's `reduction_order.cpp` decides "RHS is strictly smaller than LHS" by walking the
+following tests **in order**. The first test that distinguishes the two sides decides the rule: the
+listed "good" direction accepts it, the reverse rejects it, and a test that ties falls through to the
+next one. If every test ties, the rule is **rejected**. Write your RHS so it wins as early in this
+list as possible.
+
+1. **Vector op count** — number of `Ramp` and `Broadcast` nodes. Fewer on the RHS **accepts the rule
+   outright**, however much larger the RHS gets. Devectorizing is always treated as progress, so a
+   rewrite that turns a vector expression into a scalar one may freely grow the IR node count,
+   duplicate a wildcard, or introduce multiplies — none of tests 2-9 are consulted at all. More vector
+   ops on the RHS is fatal. (This short-circuit is what the code's comment about wildcards only
+   matching scalars is getting at.)
+2. **Variable occurrence counts** — no general wildcard may occur *more* times on the RHS than on the
+   LHS (constant wildcards `c0`, `c1`, ... are exempt, since they cannot match a whole term). If some
+   wildcard occurs strictly fewer times on the RHS, the rule is accepted here. Duplicating an `x` on
+   the RHS is the single most common way to fail — outside of case 1 above.
+3. **Nonlinear op count** — `Mul`, `Div`, `Mod`. Fewer on the RHS is good; more is fatal.
+4. **Leaf count** — immediates and variables. A `fold(...)` counts as exactly one leaf, and its
+   interior is not examined at all, so folding constants together is nearly always a win.
+5. **Total op count** — the sum over the node histogram below.
+6. **Node histogram**, compared position by position in this priority order:
+   `Ramp, Broadcast, Select, Div, Mul, Mod, Sub, Add, Min, Not, Or, And, GE, GT, LE, LT, NE, EQ`.
+   The first node type whose counts differ decides; fewer on the RHS is good. Note two buckets are
+   merged: `Sub` is counted as `Add`, and `Max` is counted as `Min`, so swapping a min for a max or an
+   add for a sub is invisible here.
+7. **Add/Sub at the root** — moving *to* an `Add`/`Sub` root is good; moving *away* from one is fatal.
+8. **Constant right child** — a constant as the RHS root's right operand is good; losing one the LHS
+   had is fatal. In other words, push constants rightwards. "Constant" here means an immediate, a
+   `c0`-style wildcard, or a `fold(...)`.
+9. **Root node weight**, as a final tie-break, using this table (higher wins on the right-hand side):
+   `Ramp 23, Broadcast 22, Select 21, Div 20, Mul 19, Mod 18, Sub 17, Add 16, Max/Min 14, Not 13,
+   Or 12, And 11, GE 10, GT 9, LE 8, LT 7, NE 6, EQ 5, Cast 4, FloatImm 2, UIntImm 1, IntImm 0`.
+   Consistent with test 7, the order prefers an RHS rooted at a *heavier* node once everything else
+   has tied.
+
+A rule that satisfies the order in *both* directions indicates a bug in the ordering and is also
+rejected.
+
+One further constraint is intended though not currently enforced by the tool: every divisor appearing
+on the RHS should already appear as a divisor on the LHS. Do not invent a new `/` or `%` denominator
+in the rewritten form.
+
+## Predicates
+
+The best shape is where constants are checked against some value, such as `c0 > 0`, or `c1 + c2 == 0`.
+
+More complicated rules are possible but need to make use of the `known_true(condition)` predicate,
+which looks up whether condition is present in a list of known truths or falsehoods. Rewrite rules
+making use of `known_true()` should be guarded by `has_facts()`.
+
+Only as a last resort may `can_prove()` be used, which is a recursive re-invocation of the simplifier.
+It is very expensive and actually runs the risk of triggering infinite recursion.
+
+If you suspect a rule is nearly right but needs a side condition you cannot pin down, the verifier can
+synthesize the weakest predicate for you — write the rule with a literal `false` predicate.
+
+## Always verify before proposing
+
+Do not hand over a rule you have only reasoned about. Once you have candidate rules, verify them with
+the **`verify-simplifier-rules`** skill, which drives the official z3-backed
+`apps/simplifier_rule_verifier` app. It independently checks that each rule is true, that it obeys the
+reduction order, and that it is not subsumed by another rule in the batch — and it is the only
+reliable way to settle the overflow question, since a 32-bit check assumes no overflow and a narrow
+`int16` restatement is what exposes wrapping behaviour.
+
+Report what the verifier concluded alongside each rule, including any counterexample it produced.

--- a/.claude/skills/verify-simplifier-rules/SKILL.md
+++ b/.claude/skills/verify-simplifier-rules/SKILL.md
@@ -1,0 +1,156 @@
+---
+description: Verify candidate Halide simplifier rewrite rules with the official z3-backed simplifier_rule_verifier app. Checks that a rule is true, obeys the reduction order, and is not subsumed, and determines whether it holds under wrapping two's-complement overflow. Use whenever a `rewrite(...)` rule needs to be proved before it goes into Simplify_*.cpp or SimplifyCorrelatedDifferences.cpp.
+---
+
+You verify candidate Halide simplifier rewrite rules using the official
+`apps/simplifier_rule_verifier` app, which shells out to z3. Read that app's `README.md` for the full
+contract before starting.
+
+Rules arrive in the syntax used in `src/Simplify_*.cpp`, one per line:
+
+```
+rewrite(min(x, y) + max(x, y), x + y)
+rewrite((x + c0) + c1, x + fold(c0 + c1))
+```
+
+`c0`, `c1`, ... are constant wildcards; anything else (`x`, `y`, `z`) is a general wildcard. An
+optional third argument is a predicate.
+
+## Prerequisite: z3
+
+z3 must be on `PATH` or named by the `HL_Z3` env var. Check with `z3 --version` before starting. If it
+is missing, try the repo's `uv`-managed venv, pip, or the system package manager — and if you cannot
+obtain it, say so plainly rather than reporting a guessed result.
+
+## Building the tool (do this, it is the fast path)
+
+The documented routes are `make` in the app directory, or the apps CMake build:
+
+```sh
+cmake -G Ninja -S apps -B apps-build
+cmake --build apps-build --target filter_rewrite_rules
+```
+
+Both need a Halide package CMake can find. If you already have an in-tree CMake build of Halide and
+just want the binary, note that pointing `find_package(Halide)` straight at that build directory does
+*not* work — the exported config immediately looks for a `HalideCompiler` package that an
+uninstalled build tree does not provide. Rather than fight it, compile the six translation units
+directly against the `libHalide.so` you already have:
+
+```sh
+# HALIDE: the Halide repo root. BUILD: an existing CMake build dir holding libHalide.so.
+# OUT: any scratch dir for objects and the binary.
+HALIDE=$(git -C . rev-parse --show-toplevel)
+BUILD="$HALIDE/build"
+OUT=$(mktemp -d)
+
+cd "$HALIDE/apps/simplifier_rule_verifier"
+for f in expr_util parser reduction_order super_simplify z3 filter_rewrite_rules; do
+  g++ -std=c++17 -O2 -c $f.cpp -o "$OUT/$f.o" \
+    -I. -I"$BUILD/include" -I"$HALIDE/tools" &
+done; wait
+g++ -o "$OUT/filter_rewrite_rules" "$OUT"/*.o \
+  -L"$BUILD/src" -lHalide -Wl,-rpath,"$BUILD/src"
+```
+
+Takes about a minute. Smoke-test with `"$OUT/filter_rewrite_rules" test/good_rules.txt` (prints
+`Success!`) so you know a later failure is the rule's fault and not the build's.
+
+## Running
+
+Put one rule per line in a file, then:
+
+```sh
+HL_DEBUG_RULE_VERIFIER=1 "$OUT/filter_rewrite_rules" rules.txt
+```
+
+`HL_DEBUG_RULE_VERIFIER=2` also dumps the z3 queries. Raise `HL_Z3_TIMEOUT` (seconds, default 60) for
+rules with several symbolic constants under a div or mod.
+
+For each rule the tool checks three separate things — that it is **true**, that it obeys the
+**reduction order**, and that no other rule in the file **subsumes** it. Report these three findings
+separately; they fail for different reasons and carry different weight.
+
+## Reading the output
+
+- `Verified with SMT: ...` / `Good rule: ...` — proved and survived every filter. Rules are printed
+  alpha-renamed and with commutative operands reordered, so match them back to your input by shape,
+  not by text.
+- `Incorrect rule:` — z3 found a counterexample, printed with the resulting LHS and RHS values. Always
+  quote the counterexample in your report.
+- `Too specific: <rule> vs <rule>` — subsumption. Absence of this line means nothing was subsumed.
+- `Rule doesn't obey the reduction order, so it could cause the simplifier to loop forever` — the
+  syntactic termination check failed.
+- `Rule would be a valid reduction order in either direction` — also counted as a reduction-order
+  failure; it means the ordering could not orient the rule.
+- `False predicate:` — predicate synthesis failed.
+- `Implicit rule:` — the RHS uses a wildcard the LHS never binds.
+- A few bare integers may be printed after `Done checking rules`; they are harmless internal noise.
+- Exit status is non-zero if any rule was disproved or violated the reduction order.
+
+The tool reports reduction order as pass/fail only — it does not print node counts.
+
+## Checking overflow semantics
+
+This is the key trick, and it is easy to get wrong. The tool models `Int(32)` and wider as
+**unbounded** SMT integers, i.e. it assumes signed overflow does not happen — the same assumption
+`no_overflow_int` makes in the simplifier. **So a plain 32-bit verification tells you nothing about
+wrapping.** Never report a rule as overflow-safe on the strength of an int32 pass alone.
+
+Narrower types are modelled as **bit-vectors that wrap**. To find out whether a rule is also valid
+under defined-behavior two's-complement overflow, restate it at `int16` and re-run:
+
+```
+rewrite(min((int16)x + (int16)y, (int16)z) - (int16)x, min((int16)y, (int16)z - (int16)x))
+```
+
+If the int32 form verifies but the int16 form yields a counterexample, the rule is *valid only under
+the no-overflow assumption*. That is acceptable for code guarded by `Int(32)` or `no_overflow()`, but
+must be stated explicitly in your report, and the rule must never be extended to narrow integer types.
+
+Division and modulo are Euclidean at every width (`0 <= a%b < |b|`, and both return zero when `b` is
+zero). Casts between widths and unknown intrinsics are not modelled; such rules are reported as
+*unverifiable* rather than checked.
+
+## What the tool cannot check
+
+The rule parser understands `min`, `max`, `select`, `fold`, `likely`, `likely_if_innermost`, the
+`round_f32`/`ceil_f32`/`floor_f32` calls, the usual operators, and `(let ...)`. It has **no `ramp(...)`
+or `broadcast(...)` syntax**, so vector rules cannot be fed to it at all — even though
+`reduction_order.cpp` does implement a vector rule (a rewrite that lowers the `Ramp`/`Broadcast` count
+is accepted outright, however much it grows the expression, short-circuiting every size test). A
+vector rule therefore has to be argued by hand; say so plainly rather than implying the tool signed
+off on it.
+
+## Judging a failure in context
+
+Where the rule is destined for changes how you weigh the results:
+
+- **`src/Simplify_*.cpp`** — all three checks matter. A reduction-order failure is disqualifying,
+  because it can make the fixed-point rewriter loop forever.
+- **`src/SimplifyCorrelatedDifferences.cpp`** (`PartiallyCancelDifferences`) — a single bottom-up
+  pass, not a fixed-point rewriter. Per `bound_correlated_differences` in the header it is explicitly
+  allowed to increase expression size and to ignore the reduction order, because its job is to produce
+  forms amenable to bounds inference. Report a reduction-order failure there as informational only.
+  Its matcher is not commutative, so every operand ordering must be written out as its own rule even
+  when the verifier considers them equivalent — never drop a rule merely because it was subsumed.
+
+**Truth is the one thing that must hold unconditionally, in every context.**
+
+## Synthesizing a predicate
+
+If a rule is disproved, consider whether a predicate would rescue it. Write the rule with a predicate
+of literal `false` and the tool searches for the weakest predicate under which it holds:
+
+```
+rewrite(min(x*c0, y*c0), min(x, y)*c0, false)
+```
+
+finds `0 <= c0`. If it cannot prove its own candidate sufficient it wraps it in `prove_me(...)` to
+flag that a human must finish the job.
+
+## Reporting
+
+Give a table with one row per rule covering truth, overflow behaviour, reduction order, and
+subsumption, plus a short prose summary and the exact commands you ran. State the overflow conclusion
+explicitly for every rule. If you hit a blocker, say so plainly and report what you did establish.


### PR DESCRIPTION
Two new simplifier-related skills:

- write-simplifier-rules: how to write a rewrite rule. Documents what makes a rule valid, including the reduction order from the rule verifier's reduction_order.cpp as the ordered sequence of tests it actually is, the fold() leaf accounting, the merged Sub/Add and Max/Min histogram buckets, and the vector-count short-circuit that accepts a devectorizing rewrite however much it grows the expression.

- verify-simplifier-rules: how to prove one with the z3-backed apps/simplifier_rule_verifier. Covers building the tool, reading each output line, and the int16 restatement needed to tell whether a rule survives wrapping arithmetic, since the 32-bit check models integers as unbounded and so assumes no signed overflow.


---

Mostly writted by Claude, by pointing it to the verifier and telling it to extract what matters. Refined by Andrew.
